### PR TITLE
Fix Molstar preview controls layout

### DIFF
--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -477,7 +477,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fullscreen" title="Fullscreen">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
             </button>
-            <button class="buret-button buret-panel-toggle active" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
+            <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -40,11 +40,40 @@
   }
 
   const layoutState = {
-    left: 'collapsed',
+    left: 'hidden',
     right: 'hidden',
     top: 'hidden',
     bottom: 'hidden'
   };
+  const resizeState = {
+    viewer: null,
+    frame: 0,
+    timer: 0
+  };
+
+  function scheduleViewerResize(viewer, delayMs = 80) {
+    if (!viewer) return;
+    resizeState.viewer = viewer;
+    if (resizeState.frame) return;
+    resizeState.frame = requestAnimationFrame(() => {
+      resizeState.frame = 0;
+      clearTimeout(resizeState.timer);
+      resizeState.timer = setTimeout(() => {
+        const target = resizeState.viewer;
+        if (!target) return;
+        let handled = false;
+        try {
+          if (typeof target.handleResize === 'function') {
+            target.handleResize();
+            handled = true;
+          }
+        } catch (_) {}
+        if (!handled) {
+          try { target.plugin?.layout?.events?.updated?.next?.(); } catch (_) {}
+        }
+      }, delayMs);
+    });
+  }
 
   const DEFAULT_VIEWER_UI_SCALE = 0.86;
   const MIN_VIEWER_UI_SCALE = 0.72;
@@ -220,7 +249,7 @@
   }
 
   function toggleLayoutRegion(region, viewer) {
-    if (region === 'left') layoutState.left = layoutState.left === 'full' ? 'collapsed' : 'full';
+    if (region === 'left') layoutState.left = layoutState.left === 'full' ? 'hidden' : 'full';
     if (region === 'right') layoutState.right = layoutState.right === 'full' ? 'hidden' : 'full';
     if (region === 'sequence') layoutState.top = layoutState.top === 'full' ? 'hidden' : 'full';
     if (region === 'log') layoutState.bottom = layoutState.bottom === 'full' ? 'hidden' : 'full';
@@ -244,10 +273,7 @@
     }
 
     updateToolbarButtons();
-    requestAnimationFrame(() => {
-      try { viewer?.handleResize?.(); } catch (_) {}
-      try { viewer?.plugin?.layout?.events?.updated?.next?.(); } catch (_) {}
-    });
+    scheduleViewerResize(viewer, 40);
   }
 
   function updateToolbarButtons() {
@@ -384,15 +410,15 @@
       layoutShowSequence: true,
       layoutShowLog: true,
       layoutShowLeftPanel: true,
-      viewportShowReset: false,
-      viewportShowScreenshotControls: false,
-      viewportShowControls: false,
+      viewportShowReset: true,
+      viewportShowScreenshotControls: true,
+      viewportShowControls: true,
       viewportShowExpand: false,
       viewportShowToggleFullscreen: false,
-      viewportShowSelectionMode: false,
+      viewportShowSelectionMode: true,
       viewportShowAnimation: false,
       viewportShowTrajectoryControls: false,
-      viewportShowSettings: false,
+      viewportShowSettings: true,
       collapseLeftPanel: true,
       collapseRightPanel: true,
       pdbProvider: 'rcsb',
@@ -454,9 +480,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
 ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     window.MolstarQuickLookViewer = viewer;
     activeViewer = viewer;
-    window.MolstarQuickLookHandleResize = () => {
-      try { viewer.handleResize(); } catch (_) {}
-    };
+    window.MolstarQuickLookHandleResize = () => scheduleViewerResize(viewer, 60);
     applyViewerUIScale(viewer);
     initViewerKeyboardShortcuts(viewer);
     initBuretToolbar(viewer);
@@ -476,9 +500,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
       `Mol* timed out while parsing/rendering ${prepared.label} as ${prepared.format}.`
     );
 
-    window.addEventListener('resize', () => {
-      try { viewer.handleResize(); } catch (_) {}
-    });
+    window.addEventListener('resize', () => scheduleViewerResize(viewer, 100));
     await waitForAnimationFrame();
     try { viewer.handleResize(); } catch (_) {}
 


### PR DESCRIPTION
## Summary
- keep the Mol* left panel fully hidden by default instead of collapsed
- make the L toolbar toggle switch between hidden and full
- show the Mol* viewport controls that were hidden in Quick Look previews

## Verification
- node --check PreviewExtension/Web/viewer.js
- layout invariant check for hidden left panel and visible viewport controls
- ./scripts/build.sh /Users/nikolenko/Desktop/ltz_model.cif
- reloaded the in-app browser preview and verified the right-side controls and hidden left panel visually