### PR TITLE
Improve fullscreen preview performance

### DIFF
--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -4,6 +4,7 @@ import WebKit
 final class MoleculeViewerWindowController: NSWindowController, WKNavigationDelegate, WKScriptMessageHandler {
     private let fileURL: URL
     private let webView: WKWebView
+    private var restoredWindowFrame: NSRect?
 
     init(fileURL: URL) {
         self.fileURL = fileURL
@@ -72,11 +73,29 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
             return
         }
         if type == "action", (body["message"] as? String) == "fit" {
-            window?.toggleFullScreen(nil)
+            toggleFitToScreen()
             return
         }
         let text = (body["message"] as? String) ?? ""
         NSLog("[BurreteAppViewer] %@: %@ %@", fileURL.lastPathComponent, type, text)
+    }
+
+    private func toggleFitToScreen() {
+        guard let window, let screen = window.screen ?? NSScreen.main else { return }
+        if window.styleMask.contains(.fullScreen) {
+            window.toggleFullScreen(nil)
+            return
+        }
+        if let frame = restoredWindowFrame {
+            window.setFrame(frame, display: true, animate: false)
+            restoredWindowFrame = nil
+        } else {
+            restoredWindowFrame = window.frame
+            window.setFrame(screen.visibleFrame.insetBy(dx: 8, dy: 8), display: true, animate: false)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
+        }
     }
 
     private static func errorHTML(_ error: Error) -> String {

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -667,13 +667,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             return
         }
         if let frame = restoredWindowFrame {
-            window.setFrame(frame, display: true, animate: true)
+            window.setFrame(frame, display: true, animate: false)
             restoredWindowFrame = nil
         } else {
             restoredWindowFrame = window.frame
             let targetFrame = screen.visibleFrame.insetBy(dx: 8, dy: 8)
             if window.styleMask.contains(.resizable) {
-                window.setFrame(targetFrame, display: true, animate: true)
+                window.setFrame(targetFrame, display: true, animate: false)
             } else {
                 window.toggleFullScreen(nil)
             }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -79,6 +79,8 @@
   const MIN_VIEWER_UI_SCALE = 0.72;
   const MAX_VIEWER_UI_SCALE = 1.35;
   const VIEWER_UI_SCALE_STEP = 0.08;
+  const RENDER_PIXEL_SCALE = 0.75;
+  const PICK_PIXEL_SCALE = 0.2;
 
   let panelControlsVisible = window.BurretePanelControlsVisible !== false;
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
@@ -425,6 +427,9 @@
       emdbProvider: 'rcsb',
       preferWebgl1: true,
       disableAntialiasing: true,
+      resolutionMode: 'scaled',
+      pixelScale: RENDER_PIXEL_SCALE,
+      pickScale: PICK_PIXEL_SCALE,
       powerPreference: 'high-performance'
     };
   }


### PR DESCRIPTION
## Summary
- render Mol* previews with scaled canvas resolution to avoid Retina framebuffer blowups
- make Quick Look fit-to-screen resize instant instead of animated
- use instant fit-to-screen for the app viewer toolbar fullscreen action

## Verification
- node --check PreviewExtension/Web/viewer.js
- git diff --check
- ./scripts/build.sh