### PR TITLE
Add release CI and SDF grid previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate and Build
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Run CI
+        run: npm run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Publish Release
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate release version
+        run: npm run check:release
+
+      - name: Resolve version
+        id: version
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+          if git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Release tag ${tag} already exists. Bump package.json before merging another PR." >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Build app
+        run: ./scripts/build.sh samples/mini.sdf
+
+      - name: Package app
+        run: |
+          rm -rf release
+          mkdir -p release
+          cp -R build/Build/Products/Debug/Burrete.app release/Burrete.app
+          ditto -c -k --keepParent release/Burrete.app "Burrete-${{ steps.version.outputs.version }}.zip"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            "Burrete-${{ steps.version.outputs.version }}.zip" \
+            --title "Burrete ${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -69,10 +69,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installStatusItem() {
-        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = item.button {
             button.image = BurreteIcon.statusImage()
-            button.title = " Burrete"
+            button.title = ""
             button.toolTip = "Burrete"
         }
 

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -607,7 +607,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 34, weight: .bold))
                     .foregroundColor(.white.opacity(0.92))
-                Text("Version 0.10.1")
+                Text("Version 0.10.2")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.white.opacity(0.42))
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -168,6 +168,7 @@ private struct AppViewerRuntime {
             "uiScale": 0.86,
             "showPanelControls": UserDefaults.standard.object(forKey: "showPreviewPanelControls") as? Bool ?? true,
             "transparentBackground": transparentBackground,
+            "sdfGrid": format.molstarFormat == "sdf",
             "defaultLayoutState": [
                 "left": "collapsed",
                 "right": "hidden",

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -372,6 +372,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "uiScale": 0.86,
             "showPanelControls": preferences.showPanelControls,
             "transparentBackground": preferences.transparentBackground,
+            "sdfGrid": format.molstarFormat == "sdf",
             "defaultLayoutState": preferences.defaultLayoutState
         ]
         let jsonData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .withoutEscapingSlashes])

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2,6 +2,10 @@
   'use strict';
 
   const status = document.getElementById('status');
+  const MAX_SDF_GRID_MOLECULES = 64;
+  const MAX_SDF_GRID_ATOMS = 900;
+  const MAX_SDF_GRID_BONDS = 900;
+  const SDF_GRID_PADDING = 4.0;
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
   function post(type, message) {
@@ -394,12 +398,180 @@
         label: `${config.label || 'structure'} (core-CIF asymmetric unit)`
       };
     }
+    if (normalized === 'sdf') {
+      return prepareSdfStructure(rawStructureData({ ...config, binary: false }), config);
+    }
 
     return {
       data: rawStructureData(config),
       format: normalized,
       label: config.label || 'structure'
     };
+  }
+
+  function prepareSdfStructure(text, config) {
+    const label = config.label || 'structure';
+    const records = splitSdfRecords(text);
+    if (records.length <= 1 || config.sdfGrid !== true) {
+      return { data: text, format: 'sdf', label, loadPreset: records.length > 1 ? 'all-models' : 'default' };
+    }
+
+    const grid = buildSdfGrid(records, label);
+    if (grid) return grid;
+    return { data: text, format: 'sdf', label: `${label} (${records.length} molecules)`, loadPreset: 'all-models' };
+  }
+
+  function splitSdfRecords(text) {
+    return String(text || '')
+      .split(/\$\$\$\$\s*(?:\r?\n|$)/u)
+      .map(record => record.replace(/\s+$/u, ''))
+      .filter(record => record.trim().length > 0);
+  }
+
+  function buildSdfGrid(records, label) {
+    const molecules = [];
+    let atomTotal = 0;
+    let bondTotal = 0;
+
+    for (const record of records) {
+      if (molecules.length >= MAX_SDF_GRID_MOLECULES) break;
+      const molecule = parseV2000SdfRecord(record);
+      if (!molecule) continue;
+      if (atomTotal + molecule.atoms.length > MAX_SDF_GRID_ATOMS || bondTotal + molecule.bonds.length > MAX_SDF_GRID_BONDS) break;
+      molecules.push(molecule);
+      atomTotal += molecule.atoms.length;
+      bondTotal += molecule.bonds.length;
+    }
+    if (molecules.length < 2 || atomTotal < 1) return null;
+
+    const columns = Math.ceil(Math.sqrt(molecules.length));
+    const cellWidth = Math.max(2, ...molecules.map(m => Math.max(2, m.width))) + SDF_GRID_PADDING;
+    const cellHeight = Math.max(2, ...molecules.map(m => Math.max(2, m.height))) + SDF_GRID_PADDING;
+    const output = [
+      label,
+      'Burrete SDF grid',
+      `${molecules.length} of ${records.length} molecules`
+    ];
+    output.push(formatSdfCountsLine(atomTotal, bondTotal));
+
+    const bondLines = [];
+    let atomOffset = 0;
+    molecules.forEach((molecule, index) => {
+      const col = index % columns;
+      const row = Math.floor(index / columns);
+      const centerX = col * cellWidth;
+      const centerY = -row * cellHeight;
+      for (const atom of molecule.atoms) {
+        output.push(formatSdfAtomLine(atom, atom.x - molecule.centerX + centerX, atom.y - molecule.centerY + centerY, atom.z));
+      }
+      for (const bond of molecule.bonds) {
+        bondLines.push(formatSdfBondLine(bond, atomOffset));
+      }
+      atomOffset += molecule.atoms.length;
+    });
+
+    output.push(...bondLines, 'M  END', '$$$$', '');
+    return {
+      data: output.join('\n'),
+      format: 'sdf',
+      label: `${label} (grid: ${molecules.length} of ${records.length} molecules)`
+    };
+  }
+
+  function parseV2000SdfRecord(record) {
+    const lines = String(record || '').replace(/\r\n?/gu, '\n').split('\n');
+    if (lines.length < 4 || !/V2000/u.test(lines[3])) return null;
+    const atomCount = parseInt(lines[3].slice(0, 3), 10);
+    const bondCount = parseInt(lines[3].slice(3, 6), 10);
+    if (!Number.isFinite(atomCount) || !Number.isFinite(bondCount) || atomCount < 1 || bondCount < 0) return null;
+    if (lines.length < 4 + atomCount + bondCount) return null;
+
+    const atoms = [];
+    for (let i = 0; i < atomCount; i++) {
+      const atom = parseSdfAtomLine(lines[4 + i]);
+      if (!atom) return null;
+      atoms.push(atom);
+    }
+
+    const bonds = [];
+    for (let i = 0; i < bondCount; i++) {
+      const bond = parseSdfBondLine(lines[4 + atomCount + i]);
+      if (!bond) return null;
+      bonds.push(bond);
+    }
+
+    const xs = atoms.map(atom => atom.x);
+    const ys = atoms.map(atom => atom.y);
+    const minX = Math.min(...xs), maxX = Math.max(...xs);
+    const minY = Math.min(...ys), maxY = Math.max(...ys);
+    return {
+      atoms,
+      bonds,
+      centerX: (minX + maxX) / 2,
+      centerY: (minY + maxY) / 2,
+      width: maxX - minX,
+      height: maxY - minY
+    };
+  }
+
+  function parseSdfAtomLine(line) {
+    const fixed = {
+      x: Number(line.slice(0, 10)),
+      y: Number(line.slice(10, 20)),
+      z: Number(line.slice(20, 30)),
+      element: line.slice(31, 34).trim()
+    };
+    if (Number.isFinite(fixed.x) && Number.isFinite(fixed.y) && Number.isFinite(fixed.z) && fixed.element) return fixed;
+
+    const parts = line.trim().split(/\s+/u);
+    if (parts.length < 4) return null;
+    const atom = { x: Number(parts[0]), y: Number(parts[1]), z: Number(parts[2]), element: parts[3] };
+    return Number.isFinite(atom.x) && Number.isFinite(atom.y) && Number.isFinite(atom.z) && atom.element ? atom : null;
+  }
+
+  function parseSdfBondLine(line) {
+    const bond = {
+      a: parseInt(line.slice(0, 3), 10),
+      b: parseInt(line.slice(3, 6), 10),
+      order: parseInt(line.slice(6, 9), 10) || 1
+    };
+    if (Number.isFinite(bond.a) && Number.isFinite(bond.b) && bond.a > 0 && bond.b > 0) return bond;
+
+    const parts = line.trim().split(/\s+/u);
+    if (parts.length < 3) return null;
+    const fallback = { a: parseInt(parts[0], 10), b: parseInt(parts[1], 10), order: parseInt(parts[2], 10) || 1 };
+    return Number.isFinite(fallback.a) && Number.isFinite(fallback.b) && fallback.a > 0 && fallback.b > 0 ? fallback : null;
+  }
+
+  function formatSdfCountsLine(atomCount, bondCount) {
+    return `${padSdfInt(atomCount)}${padSdfInt(bondCount)}  0  0  0  0            999 V2000`;
+  }
+
+  function formatSdfAtomLine(atom, x, y, z) {
+    const element = atom.element.padEnd(3, ' ').slice(0, 3);
+    return `${formatSdfCoord(x)}${formatSdfCoord(y)}${formatSdfCoord(z)} ${element} 0  0  0  0  0  0  0  0  0  0  0  0`;
+  }
+
+  function formatSdfBondLine(bond, offset) {
+    return `${padSdfInt(bond.a + offset)}${padSdfInt(bond.b + offset)}${padSdfInt(bond.order)}  0  0  0`;
+  }
+
+  function formatSdfCoord(value) {
+    return Number(value).toFixed(4).padStart(10, ' ');
+  }
+
+  function padSdfInt(value) {
+    return String(value).padStart(3, ' ').slice(-3);
+  }
+
+  async function loadPreparedStructure(viewer, prepared) {
+    if (prepared.loadPreset === 'all-models') {
+      const data = await viewer.plugin.builders.data.rawData({ data: prepared.data, label: prepared.label });
+      const trajectory = await viewer.plugin.builders.structure.parseTrajectory(data, prepared.format);
+      await viewer.plugin.builders.structure.hierarchy.applyPreset(trajectory, 'all-models', { useDefaultIfSingleModel: true });
+      return;
+    }
+    await viewer.loadStructureFromData(prepared.data, prepared.format, { dataLabel: prepared.label });
   }
 
   function withTimeout(promise, timeoutMs, message) {
@@ -522,7 +694,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     setStatus(`[web] Parsing structure…\n${prepared.label} (${describeFormat(prepared.format, config.binary)})`);
 
     await withTimeout(
-      viewer.loadStructureFromData(prepared.data, prepared.format, { dataLabel: prepared.label }),
+      loadPreparedStructure(viewer, prepared),
       45000,
       `Mol* timed out while parsing/rendering ${prepared.label} as ${prepared.format}.`
     );

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">Finder-native molecular structure previews for macOS, powered by Mol*.</p>
 
 <p align="center">
-  <img alt="Version 0.10.1" src="https://img.shields.io/badge/version-0.10.1-0f8f72.svg?style=flat-square" />
+  <img alt="Version 0.10.2" src="https://img.shields.io/badge/version-0.10.2-0f8f72.svg?style=flat-square" />
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square" /></a>
   <img alt="macOS 12+" src="https://img.shields.io/badge/macOS-12%2B-blue.svg?style=flat-square" />
   <img alt="Quick Look" src="https://img.shields.io/badge/Quick%20Look-extension-57606a.svg?style=flat-square" />
@@ -109,6 +109,24 @@ conflicts while the product name stays Burrete.
 # Refresh vendored Mol* assets
 npm ci --ignore-scripts
 npm run vendor:molstar
+```
+
+## CI And Releases
+
+Pull requests run the full CI workflow on macOS: npm dependency restore, release
+version checks, JavaScript syntax checks, plist linting, and a local Xcode build.
+Every PR intended for merge must bump `package.json`, `package-lock.json`,
+`MARKETING_VERSION`, and the visible About version together.
+
+Merging to `main` builds the app and publishes a GitHub Release tagged with the
+same package version. If the tag already exists, the release workflow fails so
+the next PR cannot overwrite an existing release.
+
+Local hooks use lefthook:
+
+```bash
+npm ci --ignore-scripts
+npm run prepare
 ```
 
 Forced preview content types:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  parallel: true
+  commands:
+    release-version:
+      run: npm run check:release
+    js-syntax:
+      run: npm run check:js
+    plist:
+      run: plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
+
+pre-push:
+  commands:
+    ci:
+      run: npm run ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,17 @@
 {
   "name": "burrete",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "molstar": "5.7.0"
+      },
+      "devDependencies": {
+        "lefthook": "^2.1.6"
       }
     },
     "node_modules/@scarf/scarf": {
@@ -1890,6 +1893,169 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.6.tgz",
+      "integrity": "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.6",
+        "lefthook-darwin-x64": "2.1.6",
+        "lefthook-freebsd-arm64": "2.1.6",
+        "lefthook-freebsd-x64": "2.1.6",
+        "lefthook-linux-arm64": "2.1.6",
+        "lefthook-linux-x64": "2.1.6",
+        "lefthook-openbsd-arm64": "2.1.6",
+        "lefthook-openbsd-x64": "2.1.6",
+        "lefthook-windows-arm64": "2.1.6",
+        "lefthook-windows-x64": "2.1.6"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.6.tgz",
+      "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.6.tgz",
+      "integrity": "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.6.tgz",
+      "integrity": "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.6.tgz",
+      "integrity": "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.6.tgz",
+      "integrity": "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.6.tgz",
+      "integrity": "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.6.tgz",
+      "integrity": "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.6.tgz",
+      "integrity": "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,21 @@
 {
   "name": "burrete",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {
     "vendor:molstar": "node scripts/vendor-molstar.mjs",
     "build:macos": "bash scripts/build.sh",
-    "test:web": "bash scripts/test-web-preview.sh"
+    "test:web": "bash scripts/test-web-preview.sh",
+    "check:js": "node --check PreviewExtension/Web/viewer.js && node --check scripts/vendor-molstar.mjs && node --check scripts/check-release-version.mjs",
+    "check:release": "node scripts/check-release-version.mjs",
+    "ci": "bash scripts/ci.sh",
+    "prepare": "lefthook install"
   },
   "dependencies": {
     "molstar": "5.7.0"
+  },
+  "devDependencies": {
+    "lefthook": "^2.1.6"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,7 +55,7 @@ case "$ROOT" in *"/.Trash/"*|*"/Library/Mobile Documents/.Trash/"*)
 esac
 
 # Prevent accidentally running old v5/v6/v7/v8 folders.
-grep -q '"version": "0.10.1"' package.json || { echo "error: this is not v10; package.json version is:" >&2; grep '"version"' package.json >&2 || true; exit 1; }
+grep -Eq '"version": "0\.10\.[0-9]+"' package.json || { echo "error: this is not a v10 release package; package.json version is:" >&2; grep '"version"' package.json >&2 || true; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj || { echo "error: this Xcode project is not v10." >&2; exit 1; }
 grep -q 'com.local.burrete10.pdb' scripts/force-preview.sh || { echo "error: force-preview.sh is not v10." >&2; exit 1; }
 

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function readJSON(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+const packageVersion = readJSON('package.json').version;
+if (!/^\d+\.\d+\.\d+$/.test(packageVersion)) {
+  fail(`package.json version must be a plain semver release, got ${packageVersion}`);
+}
+
+const packageLockVersion = readJSON('package-lock.json').version;
+if (packageLockVersion !== packageVersion) {
+  fail(`package-lock.json version ${packageLockVersion} does not match package.json ${packageVersion}`);
+}
+
+const project = readFileSync('Burrete.xcodeproj/project.pbxproj', 'utf8');
+const marketingVersions = [...project.matchAll(/MARKETING_VERSION = ([0-9]+\.[0-9]+\.[0-9]+);/g)].map(match => match[1]);
+if (marketingVersions.length === 0) {
+  fail('no MARKETING_VERSION entries found in Xcode project');
+}
+const mismatchedMarketingVersion = marketingVersions.find(version => version !== packageVersion);
+if (mismatchedMarketingVersion) {
+  fail(`Xcode MARKETING_VERSION ${mismatchedMarketingVersion} does not match package.json ${packageVersion}`);
+}
+
+const contentView = readFileSync('App/ContentView.swift', 'utf8');
+if (!contentView.includes(`Text("Version ${packageVersion}")`)) {
+  fail(`App/ContentView.swift About panel does not show Version ${packageVersion}`);
+}
+
+if (process.env.GITHUB_EVENT_NAME === 'pull_request' && process.env.GITHUB_BASE_REF) {
+  const base = process.env.GITHUB_BASE_REF;
+  try {
+    git(['fetch', '--quiet', 'origin', `+refs/heads/${base}:refs/remotes/origin/${base}`, '--tags']);
+  } catch (error) {
+    fail(`could not fetch base branch ${base}: ${error.stderr || error.message}`);
+  }
+
+  const basePackage = JSON.parse(git(['show', `origin/${base}:package.json`]));
+  if (basePackage.version === packageVersion) {
+    fail(`every merged PR creates a release, so this PR must bump package.json beyond ${basePackage.version}`);
+  }
+
+  try {
+    git(['rev-parse', '--verify', `refs/tags/v${packageVersion}`]);
+    fail(`release tag v${packageVersion} already exists`);
+  } catch (error) {
+    if (error.status !== 1 && error.status !== 128) {
+      fail(`could not check release tag v${packageVersion}: ${error.stderr || error.message}`);
+    }
+  }
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+export npm_config_cache="$ROOT/build/npm-cache"
+
+npm ci --ignore-scripts
+npm run check:release
+npm run check:js
+plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
+./scripts/build.sh samples/mini.sdf

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -12,6 +12,6 @@ grep -n 'burrete' scripts/force-preview.sh || true
 echo "Trash check:"
 case "$ROOT" in *"/.Trash/"*|*"/Library/Mobile Documents/.Trash/"*) echo "ERROR: project is inside Trash"; exit 1;; *) echo "OK: not in Trash";; esac
 echo "Expected v10 markers:"
-grep -q '"version": "0.10.1"' package.json && echo "OK package 0.10.1" || { echo "ERROR package is not 0.10.1"; exit 1; }
+grep -Eq '"version": "0\.10\.[0-9]+"' package.json && echo "OK package v10" || { echo "ERROR package is not v10"; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj && echo "OK project v10" || { echo "ERROR project is not v10"; exit 1; }
 grep -q 'com.local.burrete10.pdb' scripts/force-preview.sh && echo "OK force-preview v10" || { echo "ERROR force-preview is not v10"; exit 1; }

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -49,7 +49,9 @@ const config = {
   label: path.basename(file),
   format,
   binary,
-  byteCount: data.length
+  byteCount: data.length,
+  transparentBackground: format === 'sdf',
+  sdfGrid: format === 'sdf'
 };
 fs.writeFileSync(configOut, 'window.BurreteConfig = ' + JSON.stringify(config, null, 2) + ';\n');
 fs.writeFileSync(dataOut, 'window.BurreteDataBase64 = "' + data.toString('base64') + '";\n');


### PR DESCRIPTION
## Summary
- add macOS CI, release publishing workflow, and lefthook local hooks
- enforce one release version per merged PR across package, lockfile, Xcode marketing version, and About text
- add SDF multi-record grid previews for Quick Look and standalone app viewer
- keep the menu bar item icon-only

## Verification
- npm run check:release
- npm run check:js
- plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
- npm run ci
- pre-commit hook via git commit
- pre-push hook via git push