### PR TITLE
Fix menu bar lifecycle and preview robustness

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -8,7 +8,7 @@ struct BurreteApp: App {
 
     var body: some Scene {
         Settings {
-            ContentView()
+            EmptyView()
         }
     }
 }
@@ -22,12 +22,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         updateActivationPolicy()
         installStatusItem()
-        BurreteFileAssociations.registerForUnsetDefaults()
+        BurreteFileAssociations.registerBundleOnly()
         Task { @MainActor in
             BurreteUpdater.shared.checkAutomaticallyIfNeeded()
         }
         if UserDefaults.standard.object(forKey: "openSettingsAtLaunch") == nil {
-            UserDefaults.standard.set(true, forKey: "openSettingsAtLaunch")
+            UserDefaults.standard.set(false, forKey: "openSettingsAtLaunch")
         }
         if UserDefaults.standard.bool(forKey: "openSettingsAtLaunch") {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
@@ -69,11 +69,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installStatusItem() {
-        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = item.button {
             button.image = BurreteIcon.statusImage()
-            button.title = ""
-            button.toolTip = "Burrete"
+            button.title = " Burrete"
+            button.toolTip = "Burrete - molecular Quick Look previews. Open Settings from this menu."
         }
 
         let menu = NSMenu()
@@ -109,7 +109,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         settingsWindow?.center()
-        showAsForegroundApp(activating: settingsWindow)
+        presentWindow(settingsWindow, activate: true)
     }
 
     @objc private func checkForUpdates() {
@@ -124,7 +124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let fileURL = url.standardizedFileURL
         if let existing = viewerWindows[fileURL] {
             existing.showWindow(nil)
-            showAsForegroundApp(activating: existing.window)
+            presentWindow(existing.window, activate: true)
             return
         }
 
@@ -143,20 +143,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller.load()
         controller.showWindow(nil)
         controller.window?.center()
-        showAsForegroundApp(activating: controller.window)
+        presentWindow(controller.window, activate: true)
     }
 
-    private func showAsForegroundApp(activating window: NSWindow?) {
-        NSApp.setActivationPolicy(.regular)
+    private func presentWindow(_ window: NSWindow?, activate: Bool) {
+        guard let window else { return }
+        NSApp.setActivationPolicy(.accessory)
         NSApp.unhide(nil)
-        window?.makeKeyAndOrderFront(nil)
-        window?.orderFrontRegardless()
-        NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
-        NSApp.activate(ignoringOtherApps: true)
-        DispatchQueue.main.async {
-            window?.makeKeyAndOrderFront(nil)
-            window?.orderFrontRegardless()
-            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        window.makeKeyAndOrderFront(nil)
+        if activate {
             NSApp.activate(ignoringOtherApps: true)
         }
     }
@@ -235,11 +230,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 enum BurreteFileAssociations {
     static let bundleIdentifier = "com.local.BurreteV10"
-    private static let legacyBundleIdentifiers = [
-        "com.local.molstarquicklook",
-        "com.local.molstarquicklookv8",
-        "com.local.molstarquicklookv10"
-    ]
     static let contentTypes = [
         "com.local.burrete10.pdb",
         "com.local.burrete10.cif",
@@ -296,22 +286,12 @@ enum BurreteFileAssociations {
         return "Some file types could not be updated: \(failures.prefix(3).joined(separator: "; "))"
     }
 
-    static func registerForUnsetDefaults() {
+    static func registerBundleOnly() {
         LSRegisterURL(Bundle.main.bundleURL as CFURL, true)
-        for contentType in contentTypes where shouldClaimDefaultHandler(for: contentType) {
-            LSSetDefaultRoleHandlerForContentType(contentType as CFString, .viewer, bundleIdentifier as CFString)
-        }
     }
 
     private static func defaultHandler(for contentType: String) -> String? {
         LSCopyDefaultRoleHandlerForContentType(contentType as CFString, .viewer)?.takeRetainedValue() as String?
-    }
-
-    private static func shouldClaimDefaultHandler(for contentType: String) -> Bool {
-        guard let handler = defaultHandler(for: contentType) else {
-            return true
-        }
-        return legacyBundleIdentifiers.contains(handler.lowercased())
     }
 }
 

--- a/App/BurreteUpdater.swift
+++ b/App/BurreteUpdater.swift
@@ -69,7 +69,7 @@ struct BurreteUpdateRelease: Decodable, Equatable {
         let installExtensions = [".dmg", ".zip", ".pkg"]
         let candidates = assets.filter { asset in
             let lower = asset.name.lowercased()
-            return installExtensions.contains { lower.hasSuffix($0) }
+            return asset.size > 0 && installExtensions.contains { lower.hasSuffix($0) }
         }
         return candidates.first {
             $0.name.localizedCaseInsensitiveContains("burrete")
@@ -91,11 +91,14 @@ final class BurreteUpdater: ObservableObject {
     @Published private(set) var isInstalling = false
     @Published private(set) var statusText: String
     @Published private(set) var availableRelease: BurreteUpdateRelease?
+    @Published private(set) var availableReleaseChannel: BurreteUpdateChannel?
     @Published private(set) var downloadedFileURL: URL?
 
     private let releasesURL = BurreteUpdateRepository.releasesURL
     private let defaults = UserDefaults.standard
     private let automaticCheckInterval: TimeInterval = 12 * 60 * 60
+    private let automaticFailureRetryInterval: TimeInterval = 60 * 60
+    private var activeUpdateRequestID = UUID()
 
     private init() {
         if defaults.object(forKey: "checkUpdatesAutomatically") == nil {
@@ -121,10 +124,10 @@ final class BurreteUpdater: ObservableObject {
         if isInstalling {
             return "Installing..."
         }
-        if availableRelease?.installAsset != nil {
+        if availableReleaseChannel == storedChannel(), availableRelease?.installAsset != nil {
             return "Download and Install..."
         }
-        if availableRelease != nil {
+        if availableReleaseChannel == storedChannel(), availableRelease != nil {
             return "Open Release Page..."
         }
         return "Check for Updates..."
@@ -132,9 +135,10 @@ final class BurreteUpdater: ObservableObject {
 
     func checkAutomaticallyIfNeeded() {
         guard defaults.bool(forKey: "checkUpdatesAutomatically") else { return }
-        let lastCheck = defaults.object(forKey: "lastAutomaticUpdateCheckAt") as? Date ?? .distantPast
-        guard Date().timeIntervalSince(lastCheck) >= automaticCheckInterval else { return }
-        defaults.set(Date(), forKey: "lastAutomaticUpdateCheckAt")
+        let lastSuccess = defaults.object(forKey: "lastAutomaticUpdateSuccessAt") as? Date ?? .distantPast
+        let lastFailure = defaults.object(forKey: "lastAutomaticUpdateFailureAt") as? Date ?? .distantPast
+        guard Date().timeIntervalSince(lastSuccess) >= automaticCheckInterval,
+              Date().timeIntervalSince(lastFailure) >= automaticFailureRetryInterval else { return }
         let channel = storedChannel()
         Task {
             await checkForUpdates(channel: channel, isAutomatic: true)
@@ -142,7 +146,7 @@ final class BurreteUpdater: ObservableObject {
     }
 
     func runPrimaryAction(channel: BurreteUpdateChannel) async {
-        if let release = availableRelease {
+        if let release = availableRelease, availableReleaseChannel == channel {
             if release.installAsset != nil {
                 await downloadAndInstallAvailableUpdate()
             } else {
@@ -153,8 +157,18 @@ final class BurreteUpdater: ObservableObject {
         await checkForUpdates(channel: channel, isAutomatic: false)
     }
 
+    func clearAvailableRelease() {
+        activeUpdateRequestID = UUID()
+        availableRelease = nil
+        availableReleaseChannel = nil
+        downloadedFileURL = nil
+        setStatus("Update channel changed. Check for updates again.")
+    }
+
     func checkForUpdates(channel: BurreteUpdateChannel, isAutomatic: Bool) async {
         guard !isChecking else { return }
+        let requestID = UUID()
+        activeUpdateRequestID = requestID
         isChecking = true
         if !isAutomatic {
             statusText = "Checking GitHub releases..."
@@ -164,17 +178,28 @@ final class BurreteUpdater: ObservableObject {
 
         do {
             let releases = try await fetchReleases()
+            guard isCurrentUpdateRequest(requestID, channel: channel) else { return }
             if let release = newestUpdate(in: releases, channel: channel) {
                 availableRelease = release
+                availableReleaseChannel = channel
                 let assetText = release.installAsset == nil ? " No downloadable app archive is attached to this release." : ""
                 setStatus("Update available: \(release.displayName) (\(release.tagName)).\(assetText)")
             } else {
                 availableRelease = nil
+                availableReleaseChannel = nil
                 setStatus("Burrete \(currentVersion) is up to date on \(channel.title).")
             }
+            if isAutomatic {
+                defaults.set(Date(), forKey: "lastAutomaticUpdateSuccessAt")
+                defaults.removeObject(forKey: "lastAutomaticUpdateFailureAt")
+            }
         } catch {
+            guard isCurrentUpdateRequest(requestID, channel: channel) else { return }
             if !isAutomatic {
                 availableRelease = nil
+                availableReleaseChannel = nil
+            } else {
+                defaults.set(Date(), forKey: "lastAutomaticUpdateFailureAt")
             }
             setStatus("Update check failed: \(error.localizedDescription)")
         }
@@ -242,6 +267,9 @@ final class BurreteUpdater: ObservableObject {
     }
 
     private func download(asset: BurreteUpdateAsset, from release: BurreteUpdateRelease) async throws -> URL {
+        guard asset.size > 0 else {
+            throw BurreteUpdateError.invalidAsset("Release asset \(asset.name) reports zero bytes.")
+        }
         var request = URLRequest(url: asset.browserDownloadURL)
         request.setValue("application/octet-stream", forHTTPHeaderField: "Accept")
         request.setValue("Burrete/\(currentVersion)", forHTTPHeaderField: "User-Agent")
@@ -258,6 +286,11 @@ final class BurreteUpdater: ObservableObject {
             try fileManager.removeItem(at: destination)
         }
         try fileManager.moveItem(at: temporaryURL, to: destination)
+        let downloadedSize = ((try? fileManager.attributesOfItem(atPath: destination.path)[.size]) as? NSNumber)?.intValue ?? 0
+        guard downloadedSize == asset.size else {
+            try? fileManager.removeItem(at: destination)
+            throw BurreteUpdateError.downloadedAssetSizeMismatch(expected: asset.size, actual: downloadedSize)
+        }
         return destination
     }
 
@@ -454,6 +487,10 @@ final class BurreteUpdater: ObservableObject {
         BurreteUpdateChannel(rawValue: defaults.string(forKey: "updateChannel") ?? "") ?? .stable
     }
 
+    private func isCurrentUpdateRequest(_ requestID: UUID, channel: BurreteUpdateChannel) -> Bool {
+        requestID == activeUpdateRequestID && storedChannel() == channel
+    }
+
     private func setStatus(_ status: String) {
         statusText = status
         defaults.set(status, forKey: "updateStatusText")
@@ -469,6 +506,8 @@ private enum BurreteUpdateError: LocalizedError {
     case invalidDownloadedApp(String)
     case processFailed(String, Int32)
     case installerLaunchFailed(String)
+    case invalidAsset(String)
+    case downloadedAssetSizeMismatch(expected: Int, actual: Int)
 
     var errorDescription: String? {
         switch self {
@@ -489,6 +528,10 @@ private enum BurreteUpdateError: LocalizedError {
             return "\(name) exited with status \(status)."
         case .installerLaunchFailed(let reason):
             return "Could not launch the updater helper: \(reason)"
+        case .invalidAsset(let message):
+            return message
+        case let .downloadedAssetSizeMismatch(expected, actual):
+            return "Downloaded update archive size mismatch: expected \(expected) bytes, got \(actual) bytes."
         }
     }
 }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -2,10 +2,10 @@ import AppKit
 import SwiftUI
 
 struct ContentView: View {
-    @AppStorage("openSettingsAtLaunch") private var openSettingsAtLaunch = true
-    @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
+    @AppStorage("openSettingsAtLaunch") private var openSettingsAtLaunch = false
     @AppStorage("showPreviewPanelControls") private var showPreviewPanelControls = true
     @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = true
+    @AppStorage("transparentSDFBackground") private var transparentSDFBackground = true
     @AppStorage("checkUpdatesAutomatically") private var checkUpdatesAutomatically = true
     @AppStorage("updateChannel") private var updateChannelRaw = BurreteUpdateChannel.stable.rawValue
     @StateObject private var updater = BurreteUpdater.shared
@@ -54,11 +54,10 @@ struct ContentView: View {
                     isOn: $openSettingsAtLaunch
                 )
                 SettingsDivider()
-                SettingsToggleRow(
-                    title: "Show menu bar icon",
-                    subtitle: "Burrete runs as a menu bar utility and stays out of the Dock.",
-                    isOn: $showMenuBarIcon,
-                    isDisabled: true
+                SettingsValueRow(
+                    icon: "menubar.rectangle",
+                    title: "Menu bar icon",
+                    subtitle: "Always shown so Settings, logs, cache tools, and Quit remain reachable."
                 )
             }
 
@@ -94,6 +93,14 @@ struct ContentView: View {
                 SettingsDivider()
                 SettingsValueRow(icon: "doc.richtext", title: "Formats", subtitle: "PDB, PDBx/mmCIF, BinaryCIF, SDF, MOL, and MOL2")
                 SettingsDivider()
+                SettingsToggleRow(
+                    title: "Transparent SDF background",
+                    subtitle: "Use a transparent canvas by default for SDF molecule files.",
+                    isOn: $transparentSDFBackground
+                )
+                SettingsDivider()
+                SettingsValueRow(icon: "square.grid.3x3", title: "SDF molecule grid", subtitle: "Multi-record SDF files are laid out as a visible grid when possible.")
+                SettingsDivider()
                 SettingsValueRow(icon: "bolt.horizontal", title: "Performance", subtitle: "Bundled assets, cached runtime previews, and WebGL fallback.")
             }
 
@@ -122,8 +129,8 @@ struct ContentView: View {
                 SettingsDivider()
                 SettingsValueRow(
                     icon: "arrow.up.left.and.arrow.down.right",
-                    title: "Fullscreen control",
-                    subtitle: "The fit button opens a larger viewer with a native window fallback."
+                    title: "Fit control",
+                    subtitle: "The fit button resizes the viewer within the visible screen and can restore its previous size."
                 )
             }
 
@@ -217,8 +224,8 @@ struct ContentView: View {
                     SettingsDivider()
                     SettingsActionRow(
                         icon: "folder",
-                        title: "Reveal Downloaded Update",
-                        subtitle: "Open the downloaded archive in Finder."
+                        title: "Reveal Downloaded Archive",
+                        subtitle: "Open the downloaded archive in Finder. Burrete is not installed automatically."
                     ) {
                         updater.revealDownloadedUpdate()
                     }
@@ -239,7 +246,10 @@ struct ContentView: View {
     private var updateChannelBinding: Binding<BurreteUpdateChannel> {
         Binding(
             get: { updateChannel },
-            set: { updateChannelRaw = $0.rawValue }
+            set: {
+                updateChannelRaw = $0.rawValue
+                updater.clearAvailableRelease()
+            }
         )
     }
 
@@ -290,6 +300,32 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .logs, .updates, .about: return "System"
         }
     }
+
+    var searchTerms: [String] {
+        switch self {
+        case .general:
+            return ["application", "launch", "startup", "menu bar", "icon", "dock", "preview window", "fit"]
+        case .viewer:
+            return ["molstar", "formats", "pdb", "cif", "sdf", "mol", "mol2", "xyz", "gro", "background", "transparent", "grid", "toolbar", "panels", "sequence", "log"]
+        case .files:
+            return ["finder", "default", "double-click", "open with", "quick look", "cache", "file", "extension"]
+        case .logs:
+            return ["diagnostics", "log", "logs", "folder", "clipboard", "path", "troubleshooting"]
+        case .updates:
+            return ["update", "updates", "release", "github", "stable", "beta", "download", "channel"]
+        case .about:
+            return ["about", "version", "release notes", "contact"]
+        }
+    }
+
+    func matchesSearch(_ query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        let lowercased = trimmed.lowercased()
+        return title.lowercased().contains(lowercased)
+            || (group?.lowercased().contains(lowercased) ?? false)
+            || searchTerms.contains { $0.localizedCaseInsensitiveContains(lowercased) }
+    }
 }
 
 private struct Sidebar: View {
@@ -298,7 +334,7 @@ private struct Sidebar: View {
 
     private var groupedSections: [(String?, [SettingsSection])] {
         var result: [(String?, [SettingsSection])] = []
-        for section in SettingsSection.allCases {
+        for section in SettingsSection.allCases where section.matchesSearch(searchText) {
             if !result.isEmpty, result[result.count - 1].0 == section.group {
                 result[result.count - 1].1.append(section)
             } else {
@@ -367,7 +403,8 @@ private struct SidebarRow: View {
             }
             .foregroundColor(.white)
             .padding(.horizontal, 10)
-            .frame(height: 36)
+            .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
+            .contentShape(Rectangle())
             .background(isSelected ? SettingsColors.selection : Color.clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -607,7 +644,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 34, weight: .bold))
                     .foregroundColor(.white.opacity(0.92))
-                Text("Version 0.10.3")
+                Text("Version 0.10.4")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.white.opacity(0.42))
             }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -109,6 +109,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>UTExportedTypeDeclarations</key>

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -5,6 +5,10 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     private let fileURL: URL
     private let webView: WKWebView
     private var restoredWindowFrame: NSRect?
+    private var currentViewerPageZoom: CGFloat = 0.86
+    private static let defaultViewerPageZoom: CGFloat = 0.86
+    private static let minViewerPageZoom: CGFloat = 0.72
+    private static let maxViewerPageZoom: CGFloat = 1.35
 
     init(fileURL: URL) {
         self.fileURL = fileURL
@@ -23,6 +27,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         }
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.pageZoom = Self.defaultViewerPageZoom
         self.webView = webView
 
         let window = NSWindow(
@@ -81,8 +86,22 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
             toggleFitToScreen()
             return
         }
+        if type == "viewerZoom", let value = body["value"] as? NSNumber {
+            setViewerPageZoom(CGFloat(value.doubleValue))
+            return
+        }
         let text = (body["message"] as? String) ?? ""
         NSLog("[BurreteAppViewer] %@: %@ %@", fileURL.lastPathComponent, type, text)
+    }
+
+    private func setViewerPageZoom(_ scale: CGFloat) {
+        let clamped = min(max(scale, Self.minViewerPageZoom), Self.maxViewerPageZoom)
+        guard abs(currentViewerPageZoom - clamped) > 0.001 else { return }
+        currentViewerPageZoom = clamped
+        webView.pageZoom = clamped
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
+        }
     }
 
     private func toggleFitToScreen() {
@@ -166,9 +185,10 @@ private struct AppViewerRuntime {
             "quickLookBuild": "burrete-app",
             "debug": false,
             "uiScale": 0.86,
+            "transparentBackground": format.prefersTransparentBackground &&
+                (UserDefaults.standard.object(forKey: "transparentSDFBackground") as? Bool ?? true),
+            "sdfGrid": true,
             "showPanelControls": UserDefaults.standard.object(forKey: "showPreviewPanelControls") as? Bool ?? true,
-            "transparentBackground": transparentBackground,
-            "sdfGrid": format.molstarFormat == "sdf",
             "defaultLayoutState": [
                 "left": "collapsed",
                 "right": "hidden",
@@ -256,6 +276,13 @@ private struct AppViewerRuntime {
           <style>
             :root { --buret-viewer-ui-scale: 0.86; }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
+            html.buret-transparent-background,
+            html.buret-transparent-background body,
+            html.buret-transparent-background #app,
+            html.buret-transparent-background .msp-plugin,
+            html.buret-transparent-background .msp-viewport,
+            html.buret-transparent-background .msp-layout-main,
+            html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
@@ -291,7 +318,6 @@ private struct AppViewerRuntime {
               max-width: min(880px, calc(100vw - 32px)); box-sizing: border-box;
               padding: 10px 12px; border-radius: 10px; color: rgba(255, 255, 255, 0.96);
               background: rgba(0, 0, 0, 0.76); font: 11px/1.35 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-              transform: scale(var(--buret-viewer-ui-scale)); transform-origin: top left;
               white-space: pre-wrap; pointer-events: auto;
             }
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
@@ -307,7 +333,6 @@ private struct AppViewerRuntime {
                 0 8px 22px rgba(0, 0, 0, 0.22),
                 inset 0 1px 0 rgba(255, 255, 255, 0.06);
               user-select: none; touch-action: none;
-              transform: scale(var(--buret-viewer-ui-scale)); transform-origin: top right;
             }
             .buret-button {
               min-width: 26px; height: 26px; border: 0; border-radius: 7px; padding: 0 7px;
@@ -346,7 +371,7 @@ private struct AppViewerRuntime {
             <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Move controls" title="Move controls">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
             </button>
-            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fullscreen" title="Fullscreen">
+            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fit window to screen" title="Fit window to screen">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
             </button>
             <button class="buret-button buret-panel-toggle active" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
@@ -374,6 +399,7 @@ private struct AppViewerRuntime {
 private struct AppViewerStructureFormat {
     let molstarFormat: String
     let isBinary: Bool
+    var prefersTransparentBackground: Bool { molstarFormat == "sdf" }
 
     init(url: URL, data: Data) {
         let ext = url.pathExtension.lowercased()

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -13,9 +13,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private let previewID = String(UUID().uuidString.prefix(8))
     private var hasRenderedTerminationError = false
     private var restoredWindowFrame: NSRect?
+    private var currentViewerPageZoom: CGFloat = 0.86
     private static let showDebugOverlay = false
     private static let verboseLogging = false
-    private static let maxStructureFileSize: Int64 = 75 * 1024 * 1024
+    private static let defaultViewerPageZoom: CGFloat = 0.86
+    private static let minViewerPageZoom: CGFloat = 0.72
+    private static let maxViewerPageZoom: CGFloat = 1.35
 
     deinit {
         renderTimeoutWorkItem?.cancel()
@@ -54,6 +57,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         }
         webView.navigationDelegate = self
         webView.uiDelegate = self
+        webView.pageZoom = Self.defaultViewerPageZoom
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.wantsLayer = true
         webView.setValue(false, forKey: "drawsBackground")
@@ -217,8 +221,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         try validateVendoredMolstarAssets(in: webDirectory, fileManager: fileManager, diagnostics: &diagnostics)
 
         let structureSize = try fileSize(for: url, fileManager: fileManager)
-        guard structureSize <= maxStructureFileSize else {
-            throw PreviewError.fileTooLarge(url.lastPathComponent, structureSize, maxStructureFileSize)
+        let sizeLimit = quickLookSizeLimit(for: url)
+        guard structureSize <= sizeLimit else {
+            throw PreviewError.fileTooLarge(url.lastPathComponent, structureSize, sizeLimit)
         }
         let structureData = try Data(contentsOf: url)
         guard !structureData.isEmpty else { throw PreviewError.emptyStructureFile(url.lastPathComponent) }
@@ -370,9 +375,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "quickLookBuild": "v10-product",
             "debug": showDebugOverlay,
             "uiScale": 0.86,
+            "transparentBackground": format.prefersTransparentBackground && preferences.transparentSDFBackground,
+            "sdfGrid": true,
             "showPanelControls": preferences.showPanelControls,
-            "transparentBackground": preferences.transparentBackground,
-            "sdfGrid": format.molstarFormat == "sdf",
             "defaultLayoutState": preferences.defaultLayoutState
         ]
         let jsonData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .withoutEscapingSlashes])
@@ -394,6 +399,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           <style>
             :root { --buret-viewer-ui-scale: 0.86; }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
+            html.buret-transparent-background,
+            html.buret-transparent-background body,
+            html.buret-transparent-background #app,
+            html.buret-transparent-background .msp-plugin,
+            html.buret-transparent-background .msp-viewport,
+            html.buret-transparent-background .msp-layout-main,
+            html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
@@ -431,7 +443,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               background: rgba(0, 0, 0, 0.76); -webkit-backdrop-filter: blur(12px); backdrop-filter: blur(12px);
               font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
               font-size: 11px; font-weight: 500; line-height: 1.35; white-space: pre-wrap; pointer-events: auto;
-              transform: scale(var(--buret-viewer-ui-scale)); transform-origin: top left;
             }
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
@@ -447,7 +458,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 0 8px 22px rgba(0, 0, 0, 0.22),
                 inset 0 1px 0 rgba(255, 255, 255, 0.06);
               user-select: none; touch-action: none;
-              transform: scale(var(--buret-viewer-ui-scale)); transform-origin: top right;
             }
             .buret-button {
               min-width: 26px; height: 26px; border: 0; border-radius: 7px; padding: 0 7px;
@@ -522,7 +532,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Move controls" title="Move controls">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
             </button>
-            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fullscreen" title="Fullscreen">
+            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fit window to screen" title="Fit window to screen">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
             </button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
@@ -599,11 +609,29 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         throw PreviewError.ubiquitousFileNotDownloaded(url.lastPathComponent)
     }
 
+    private static func quickLookSizeLimit(for url: URL) -> Int64 {
+        let mib: Int64 = 1024 * 1024
+        switch url.pathExtension.lowercased() {
+        case "pdb", "ent", "pdbqt", "pqr":
+            return 35 * mib
+        case "cif", "mmcif", "mcif":
+            return 40 * mib
+        case "bcif":
+            return 50 * mib
+        case "sdf", "sd", "mol", "mol2", "xyz", "gro":
+            return 25 * mib
+        default:
+            return 20 * mib
+        }
+    }
+
     private func scheduleRenderTimeout(for requestID: UUID) {
         renderTimeoutWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
-            self?.appendLog("render timeout waiting for JS ready")
-            self?.finishPreviewIfNeeded(PreviewError.webRenderTimedOut, requestID: requestID)
+            guard let self else { return }
+            self.appendLog("render timeout waiting for JS ready")
+            self.renderNativeError(PreviewError.webRenderTimedOut, fileURL: nil)
+            self.finishPreviewIfNeeded(nil, requestID: requestID)
         }
         renderTimeoutWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: workItem)
@@ -669,11 +697,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 handleJavaScriptAction(text)
                 return
             }
+            if type == "viewerZoom", let value = body["value"] as? NSNumber {
+                setViewerPageZoom(CGFloat(value.doubleValue))
+                return
+            }
             appendLog("JS message type=\(type): \(text.prefix(1600))")
             if type == "ready" {
                 finishPreviewIfNeeded(nil, requestID: activePreviewRequestID)
             } else if type == "error" {
-                finishPreviewIfNeeded(PreviewError.webRenderFailed(text), requestID: activePreviewRequestID)
+                finishPreviewIfNeeded(nil, requestID: activePreviewRequestID)
             }
             if Self.showDebugOverlay || type == "error" {
                 statusLabel.isHidden = false
@@ -691,6 +723,17 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             toggleFitToScreen()
         default:
             appendLog("unknown JS action=\(action)")
+        }
+    }
+
+    private func setViewerPageZoom(_ scale: CGFloat) {
+        let clamped = min(max(scale, Self.minViewerPageZoom), Self.maxViewerPageZoom)
+        guard abs(currentViewerPageZoom - clamped) > 0.001 else { return }
+        currentViewerPageZoom = clamped
+        webView.pageZoom = clamped
+        appendLog("viewer pageZoom=\(String(format: "%.2f", Double(clamped)))")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
         }
     }
 
@@ -932,6 +975,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 private struct StructureFormat {
     let molstarFormat: String
     let isBinary: Bool
+    var prefersTransparentBackground: Bool { molstarFormat == "sdf" }
 
     init(url: URL, data: Data) {
         let ext = url.pathExtension.lowercased()
@@ -1007,15 +1051,18 @@ private struct StructureFormat {
 private struct PreviewPreferences {
     let showPanelControls: Bool
     let transparentBackground: Bool
+    let transparentSDFBackground: Bool
     let defaultLayoutState: [String: String]
 
     static func load() -> PreviewPreferences {
         let appID = "com.local.BurreteV10" as CFString
         let showPanelControls = (CFPreferencesCopyAppValue("showPreviewPanelControls" as CFString, appID) as? Bool) ?? true
         let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? true
+        let transparentSDFBackground = (CFPreferencesCopyAppValue("transparentSDFBackground" as CFString, appID) as? Bool) ?? true
         return PreviewPreferences(
             showPanelControls: showPanelControls,
             transparentBackground: transparentBackground,
+            transparentSDFBackground: transparentSDFBackground,
             defaultLayoutState: [
                 "left": "collapsed",
                 "right": "hidden",
@@ -1049,9 +1096,9 @@ private enum PreviewError: LocalizedError {
         case .emptyStructureFile(let name):
             return "The structure file is empty or not downloaded locally: \(name)"
         case .fileTooLarge(let name, let size, let limit):
-            return "\(name) is too large for Quick Look preview (\(size) bytes; limit \(limit) bytes). Open it in a dedicated molecular viewer."
+            return "\(name) is too large for Quick Look preview (\(size) bytes; limit \(limit) bytes). Open it in the Burrete app viewer or use a smaller file."
         case .ubiquitousFileNotDownloaded(let name):
-            return "\(name) is not downloaded locally. Download the file first, then open Quick Look again."
+            return "\(name) is in iCloud and is not downloaded locally. Download it in Finder, then open Quick Look again."
         case .webRenderFailed(let message):
             return "Mol* web rendering failed: \(message)"
         case .webRenderTimedOut:

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -7,6 +7,13 @@
   <link rel="stylesheet" href="./molstar.css" />
   <style>
     html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
+    html.buret-transparent-background,
+    html.buret-transparent-background body,
+    html.buret-transparent-background #app,
+    html.buret-transparent-background .msp-plugin,
+    html.buret-transparent-background .msp-viewport,
+    html.buret-transparent-background .msp-layout-main,
+    html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
     body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
     body.burette-opaque-background,
     body.burette-opaque-background #app {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -11,9 +11,18 @@
   function post(type, message) {
     try {
       if (window.__mqlPost) window.__mqlPost(type, message || '');
-      else window.webkit?.messageHandlers?.burrete?.postMessage({ type, message: message || '' });
+      else postHostMessage({ type, message: message || '' });
     } catch (_) {
       // Browser-only testing, not WKWebView.
+    }
+  }
+
+  function postHostMessage(payload) {
+    try {
+      window.webkit?.messageHandlers?.burrete?.postMessage(payload);
+      return !!window.webkit?.messageHandlers?.burrete;
+    } catch (_) {
+      return false;
     }
   }
 
@@ -87,14 +96,15 @@
   const PICK_PIXEL_SCALE = 0.2;
 
   let panelControlsVisible = window.BurretePanelControlsVisible !== false;
-  let transparentBackground = true;
+  let transparentBackground = false;
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
   let activeViewer = null;
   let keyboardShortcutsInstalled = false;
 
   function applyConfigOptions(config) {
     panelControlsVisible = config.showPanelControls !== undefined ? !!config.showPanelControls : panelControlsVisible;
-    transparentBackground = config.transparentBackground !== undefined ? !!config.transparentBackground : transparentBackground;
+    transparentBackground = config.transparentBackground === true;
+    applyDocumentBackground();
     viewerUIScale = resolveInitialViewerScale(config);
     applyViewerUIScale();
     const nextLayoutState = config.defaultLayoutState;
@@ -125,7 +135,12 @@
   }
 
   function applyViewerUIScale(viewer = activeViewer) {
-    document.documentElement.style.setProperty('--buret-viewer-ui-scale', viewerUIScale.toFixed(2));
+    const scaleValue = viewerUIScale.toFixed(2);
+    const hostHandledScale = postHostMessage({ type: 'viewerZoom', value: viewerUIScale });
+    document.documentElement.style.setProperty('--buret-viewer-ui-scale', '1');
+    if (document.body) {
+      document.body.style.zoom = hostHandledScale ? '' : scaleValue;
+    }
 
     const pluginRoot = document.querySelector('.msp-plugin');
     if (pluginRoot) {
@@ -138,6 +153,25 @@
       try { viewer?.handleResize?.(); } catch (_) {}
       try { viewer?.plugin?.layout?.events?.updated?.next?.(); } catch (_) {}
     });
+  }
+
+  function applyDocumentBackground() {
+    document.documentElement.classList.toggle('buret-transparent-background', transparentBackground);
+    if (document.body) {
+      document.body.classList.toggle('buret-transparent-background', transparentBackground);
+    }
+  }
+
+  function applyViewerBackground(viewer = activeViewer) {
+    applyDocumentBackground();
+    const canvas3d = viewer?.plugin?.canvas3d;
+    if (!canvas3d) return;
+    try {
+      canvas3d.setProps({ transparentBackground });
+    } catch (error) {
+      debug('canvas3d transparentBackground failed: ' + (error && error.message || String(error)));
+    }
+    try { canvas3d.requestDraw?.(); } catch (_) {}
   }
 
   function setViewerUIScale(scale, viewer = activeViewer) {
@@ -399,7 +433,7 @@
       };
     }
     if (normalized === 'sdf') {
-      return prepareSdfStructure(rawStructureData({ ...config, binary: false }), config);
+      return prepareSdfStructure(rawStructureData(config), config);
     }
 
     return {
@@ -412,135 +446,168 @@
   function prepareSdfStructure(text, config) {
     const label = config.label || 'structure';
     const records = splitSdfRecords(text);
-    if (records.length <= 1 || config.sdfGrid !== true) {
-      return { data: text, format: 'sdf', label, loadPreset: records.length > 1 ? 'all-models' : 'default' };
+    if (records.length > 1 && config.sdfGrid !== false) {
+      const grid = buildSdfGrid(records, label);
+      if (grid) return grid;
     }
-
-    const grid = buildSdfGrid(records, label);
-    if (grid) return grid;
-    return { data: text, format: 'sdf', label: `${label} (${records.length} molecules)`, loadPreset: 'all-models' };
+    return {
+      data: text,
+      format: 'sdf',
+      label: records.length > 1 ? `${label} (${records.length} SDF records)` : label,
+      loadPreset: records.length > 1 ? 'all-models' : 'default'
+    };
   }
 
   function splitSdfRecords(text) {
-    return String(text || '')
-      .split(/\$\$\$\$\s*(?:\r?\n|$)/u)
-      .map(record => record.replace(/\s+$/u, ''))
-      .filter(record => record.trim().length > 0);
+    const lines = String(text || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    const records = [];
+    let current = [];
+    for (const line of lines) {
+      if (line.trim() === '$$$$') {
+        const record = current.join('\n').trimEnd();
+        if (record.trim()) records.push(record);
+        current = [];
+      } else {
+        current.push(line);
+      }
+    }
+    const tail = current.join('\n').trimEnd();
+    if (tail.trim()) records.push(tail);
+    return records;
   }
 
   function buildSdfGrid(records, label) {
     const molecules = [];
-    let atomTotal = 0;
-    let bondTotal = 0;
-
+    let totalAtoms = 0;
+    let totalBonds = 0;
     for (const record of records) {
       if (molecules.length >= MAX_SDF_GRID_MOLECULES) break;
       const molecule = parseV2000SdfRecord(record);
       if (!molecule) continue;
-      if (atomTotal + molecule.atoms.length > MAX_SDF_GRID_ATOMS || bondTotal + molecule.bonds.length > MAX_SDF_GRID_BONDS) break;
+      if (totalAtoms + molecule.atomCount > MAX_SDF_GRID_ATOMS ||
+          totalBonds + molecule.bondCount > MAX_SDF_GRID_BONDS) {
+        break;
+      }
       molecules.push(molecule);
-      atomTotal += molecule.atoms.length;
-      bondTotal += molecule.bonds.length;
+      totalAtoms += molecule.atomCount;
+      totalBonds += molecule.bondCount;
     }
-    if (molecules.length < 2 || atomTotal < 1) return null;
+    if (molecules.length <= 1 || totalAtoms > 999 || totalBonds > 999) return null;
 
-    const columns = Math.ceil(Math.sqrt(molecules.length));
+    const columns = Math.max(1, Math.ceil(Math.sqrt(molecules.length)));
+    const rows = Math.ceil(molecules.length / columns);
     const cellWidth = Math.max(2, ...molecules.map(m => Math.max(2, m.width))) + SDF_GRID_PADDING;
     const cellHeight = Math.max(2, ...molecules.map(m => Math.max(2, m.height))) + SDF_GRID_PADDING;
-    const output = [
-      label,
-      'Burrete SDF grid',
-      `${molecules.length} of ${records.length} molecules`
-    ];
-    output.push(formatSdfCountsLine(atomTotal, bondTotal));
+    const gridWidth = (columns - 1) * cellWidth;
+    const gridHeight = (rows - 1) * cellHeight;
 
-    const bondLines = [];
+    const atoms = [];
+    const bonds = [];
     let atomOffset = 0;
     molecules.forEach((molecule, index) => {
-      const col = index % columns;
+      const column = index % columns;
       const row = Math.floor(index / columns);
-      const centerX = col * cellWidth;
-      const centerY = -row * cellHeight;
+      const targetX = column * cellWidth - gridWidth / 2;
+      const targetY = gridHeight / 2 - row * cellHeight;
+      const dx = targetX - molecule.centerX;
+      const dy = targetY - molecule.centerY;
       for (const atom of molecule.atoms) {
-        output.push(formatSdfAtomLine(atom, atom.x - molecule.centerX + centerX, atom.y - molecule.centerY + centerY, atom.z));
+        atoms.push(formatSdfAtomLine(atom, atom.x + dx, atom.y + dy, atom.z));
       }
       for (const bond of molecule.bonds) {
-        bondLines.push(formatSdfBondLine(bond, atomOffset));
+        bonds.push(formatSdfBondLine(bond, atomOffset));
       }
-      atomOffset += molecule.atoms.length;
+      atomOffset += molecule.atomCount;
     });
 
-    output.push(...bondLines, 'M  END', '$$$$', '');
     return {
-      data: output.join('\n'),
+      data: [
+        'Burrete SDF Grid',
+        '  Burrete',
+        `${molecules.length} of ${records.length} SDF records`,
+        formatSdfCountsLine(totalAtoms, totalBonds),
+        ...atoms,
+        ...bonds,
+        'M  END',
+        '$$$$',
+        ''
+      ].join('\n'),
       format: 'sdf',
-      label: `${label} (grid: ${molecules.length} of ${records.length} molecules)`
+      label: `${label} (grid: ${molecules.length}${records.length > molecules.length ? ` of ${records.length}` : ''} molecules)`,
+      loadPreset: 'default'
     };
   }
 
   function parseV2000SdfRecord(record) {
-    const lines = String(record || '').replace(/\r\n?/gu, '\n').split('\n');
-    if (lines.length < 4 || !/V2000/u.test(lines[3])) return null;
+    const lines = String(record || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    if (lines.length < 4 || !lines[3].includes('V2000')) return null;
     const atomCount = parseInt(lines[3].slice(0, 3), 10);
     const bondCount = parseInt(lines[3].slice(3, 6), 10);
-    if (!Number.isFinite(atomCount) || !Number.isFinite(bondCount) || atomCount < 1 || bondCount < 0) return null;
-    if (lines.length < 4 + atomCount + bondCount) return null;
+    if (!Number.isFinite(atomCount) || !Number.isFinite(bondCount) || atomCount <= 0 ||
+        lines.length < 4 + atomCount + bondCount) {
+      return null;
+    }
 
     const atoms = [];
     for (let i = 0; i < atomCount; i++) {
-      const atom = parseSdfAtomLine(lines[4 + i]);
+      const line = lines[4 + i] || '';
+      const atom = parseSdfAtomLine(line);
       if (!atom) return null;
       atoms.push(atom);
     }
-
     const bonds = [];
     for (let i = 0; i < bondCount; i++) {
-      const bond = parseSdfBondLine(lines[4 + atomCount + i]);
+      const bond = parseSdfBondLine(lines[4 + atomCount + i] || '');
       if (!bond) return null;
       bonds.push(bond);
     }
 
     const xs = atoms.map(atom => atom.x);
     const ys = atoms.map(atom => atom.y);
-    const minX = Math.min(...xs), maxX = Math.max(...xs);
-    const minY = Math.min(...ys), maxY = Math.max(...ys);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
     return {
+      atomCount,
+      bondCount,
       atoms,
       bonds,
-      centerX: (minX + maxX) / 2,
-      centerY: (minY + maxY) / 2,
       width: maxX - minX,
-      height: maxY - minY
+      height: maxY - minY,
+      centerX: (minX + maxX) / 2,
+      centerY: (minY + maxY) / 2
     };
   }
 
   function parseSdfAtomLine(line) {
-    const fixed = {
-      x: Number(line.slice(0, 10)),
-      y: Number(line.slice(10, 20)),
-      z: Number(line.slice(20, 30)),
-      element: line.slice(31, 34).trim()
-    };
-    if (Number.isFinite(fixed.x) && Number.isFinite(fixed.y) && Number.isFinite(fixed.z) && fixed.element) return fixed;
-
-    const parts = line.trim().split(/\s+/u);
-    if (parts.length < 4) return null;
-    const atom = { x: Number(parts[0]), y: Number(parts[1]), z: Number(parts[2]), element: parts[3] };
-    return Number.isFinite(atom.x) && Number.isFinite(atom.y) && Number.isFinite(atom.z) && atom.element ? atom : null;
+    let x = Number(line.slice(0, 10));
+    let y = Number(line.slice(10, 20));
+    let z = Number(line.slice(20, 30));
+    let tail = line.length >= 30 ? line.slice(30) : '';
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      const parts = line.trim().split(/\s+/);
+      x = Number(parts[0]);
+      y = Number(parts[1]);
+      z = Number(parts[2]);
+      tail = ` ${parts[3] || 'C'}   0  0  0  0  0  0  0  0  0  0  0  0`;
+    }
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+    return { x, y, z, tail: tail || ' C   0  0  0  0  0  0  0  0  0  0  0  0' };
   }
 
   function parseSdfBondLine(line) {
-    const bond = {
-      a: parseInt(line.slice(0, 3), 10),
-      b: parseInt(line.slice(3, 6), 10),
-      order: parseInt(line.slice(6, 9), 10) || 1
-    };
-    if (Number.isFinite(bond.a) && Number.isFinite(bond.b) && bond.a > 0 && bond.b > 0) return bond;
-
-    const parts = line.trim().split(/\s+/u);
-    if (parts.length < 3) return null;
-    const fallback = { a: parseInt(parts[0], 10), b: parseInt(parts[1], 10), order: parseInt(parts[2], 10) || 1 };
-    return Number.isFinite(fallback.a) && Number.isFinite(fallback.b) && fallback.a > 0 && fallback.b > 0 ? fallback : null;
+    let a = parseInt(line.slice(0, 3), 10);
+    let b = parseInt(line.slice(3, 6), 10);
+    let tail = line.length >= 6 ? line.slice(6) : '';
+    if (!Number.isFinite(a) || !Number.isFinite(b)) {
+      const parts = line.trim().split(/\s+/);
+      a = parseInt(parts[0], 10);
+      b = parseInt(parts[1], 10);
+      tail = ` ${parts[2] || '1'}  0  0  0  0`;
+    }
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+    return { a, b, tail: tail || '  1  0  0  0  0' };
   }
 
   function formatSdfCountsLine(atomCount, bondCount) {
@@ -548,27 +615,27 @@
   }
 
   function formatSdfAtomLine(atom, x, y, z) {
-    const element = atom.element.padEnd(3, ' ').slice(0, 3);
-    return `${formatSdfCoord(x)}${formatSdfCoord(y)}${formatSdfCoord(z)} ${element} 0  0  0  0  0  0  0  0  0  0  0  0`;
+    return `${formatSdfCoord(x)}${formatSdfCoord(y)}${formatSdfCoord(z)}${atom.tail}`;
   }
 
   function formatSdfBondLine(bond, offset) {
-    return `${padSdfInt(bond.a + offset)}${padSdfInt(bond.b + offset)}${padSdfInt(bond.order)}  0  0  0`;
+    return `${padSdfInt(bond.a + offset)}${padSdfInt(bond.b + offset)}${bond.tail}`;
   }
 
   function formatSdfCoord(value) {
-    return Number(value).toFixed(4).padStart(10, ' ');
+    return value.toFixed(4).padStart(10, ' ');
   }
 
   function padSdfInt(value) {
-    return String(value).padStart(3, ' ').slice(-3);
+    return String(value).padStart(3, ' ');
   }
 
   async function loadPreparedStructure(viewer, prepared) {
     if (prepared.loadPreset === 'all-models') {
-      const data = await viewer.plugin.builders.data.rawData({ data: prepared.data, label: prepared.label });
-      const trajectory = await viewer.plugin.builders.structure.parseTrajectory(data, prepared.format);
-      await viewer.plugin.builders.structure.hierarchy.applyPreset(trajectory, 'all-models', { useDefaultIfSingleModel: true });
+      const plugin = viewer.plugin;
+      const data = await plugin.builders.data.rawData({ data: prepared.data, label: prepared.label });
+      const trajectory = await plugin.builders.structure.parseTrajectory(data, prepared.format);
+      await plugin.builders.structure.hierarchy.applyPreset(trajectory, 'all-models', { useDefaultIfSingleModel: true });
       return;
     }
     await viewer.loadStructureFromData(prepared.data, prepared.format, { dataLabel: prepared.label });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -6,7 +6,35 @@ cd "$ROOT"
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 export npm_config_cache="$ROOT/build/npm-cache"
 
-SAMPLE="${1:-samples/mini.pdb}"
+OPEN_PREVIEW=1
+OUT_DIR=""
+SAMPLE="samples/mini.pdb"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-open)
+      OPEN_PREVIEW=0
+      shift
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      if [[ -z "$OUT_DIR" ]]; then
+        echo "error: --out-dir requires a path" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      echo "usage: $0 [--no-open] [--out-dir DIR] [structure-file]" >&2
+      exit 0
+      ;;
+    *)
+      SAMPLE="$1"
+      shift
+      ;;
+  esac
+done
+
 if [[ ! -f "$SAMPLE" ]]; then
   echo "error: sample not found: $SAMPLE" >&2
   exit 1
@@ -18,7 +46,13 @@ if [[ ! -d node_modules/molstar ]]; then
 fi
 npm run vendor:molstar
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/burrete-web.XXXXXX")"
+if [[ -n "$OUT_DIR" ]]; then
+  TMP="$OUT_DIR"
+  rm -rf "$TMP"
+  mkdir -p "$TMP"
+else
+  TMP="$(mktemp -d "${TMPDIR:-/tmp}/burrete-web.XXXXXX")"
+fi
 cp -R PreviewExtension/Web "$TMP/Web"
 
 node - "$SAMPLE" "$TMP/Web/preview-config.js" "$TMP/Web/preview-data.js" <<'JS'
@@ -51,12 +85,84 @@ const config = {
   binary,
   byteCount: data.length,
   transparentBackground: format === 'sdf',
-  sdfGrid: format === 'sdf'
+  sdfGrid: true,
+  showPanelControls: true
 };
 fs.writeFileSync(configOut, 'window.BurreteConfig = ' + JSON.stringify(config, null, 2) + ';\n');
 fs.writeFileSync(dataOut, 'window.BurreteDataBase64 = "' + data.toString('base64') + '";\n');
 console.log(`Wrote preview config/data for ${file} as ${format}`);
 JS
 
-echo "Opening web-only preview in: $TMP/Web/index.html"
-open "$TMP/Web/index.html"
+node - "$SAMPLE" "$TMP/Web/index.html" "$TMP/Web/viewer.js" "$TMP/Web/preview-config.js" "$TMP/Web/preview-data.js" <<'JS'
+const fs = require('fs');
+const path = require('path');
+
+const sample = process.argv[2];
+const indexPath = process.argv[3];
+const viewerPath = process.argv[4];
+const configPath = process.argv[5];
+const dataPath = process.argv[6];
+
+const index = fs.readFileSync(indexPath, 'utf8');
+const viewer = fs.readFileSync(viewerPath, 'utf8');
+const configSource = fs.readFileSync(configPath, 'utf8');
+const dataSource = fs.readFileSync(dataPath, 'utf8');
+const config = JSON.parse(configSource.replace(/^window\.BurreteConfig = /, '').replace(/;\s*$/, ''));
+const ext = path.extname(sample).toLowerCase().slice(1);
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`error: ${message}`);
+    process.exit(1);
+  }
+}
+
+assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar role');
+assert(index.includes('aria-label="Fit window to screen"'), 'fit button must not be labelled Fullscreen');
+assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
+assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
+assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
+assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
+assert(config.label === path.basename(sample), 'config label should match sample basename');
+assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');
+assert(config.transparentBackground === (config.format === 'sdf'), 'transparent background should default to SDF only');
+assert(config.sdfGrid === true, 'SDF grid flag should be encoded');
+
+const expectedFormats = {
+  pdb: 'pdb',
+  ent: 'pdb',
+  pdbqt: 'pdb',
+  pqr: 'pdb',
+  mmcif: 'mmcif',
+  mcif: 'mmcif',
+  bcif: 'mmcif',
+  sdf: 'sdf',
+  sd: 'sdf',
+  mol: 'mol',
+  mol2: 'mol2',
+  xyz: 'xyz',
+  gro: 'gro'
+};
+if (expectedFormats[ext]) {
+  assert(config.format === expectedFormats[ext], `expected ${ext} to map to ${expectedFormats[ext]}, got ${config.format}`);
+}
+if (ext === 'bcif') {
+  assert(config.binary === true, 'BCIF should be marked binary');
+}
+console.log('Validated web preview contract');
+JS
+
+PREVIEW_URL="$(python3 - "$TMP/Web/index.html" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+
+if [[ "$OPEN_PREVIEW" == "1" ]]; then
+  echo "Opening web-only preview in: $PREVIEW_URL"
+  open "$PREVIEW_URL"
+else
+  echo "$PREVIEW_URL"
+fi


### PR DESCRIPTION
## Summary
- keep Burrete as an LSUIElement menu bar app without switching to regular activation policy
- make file default registration explicit and harden update checks/download validation
- improve Quick Look/native viewer error handling and extend web preview contract tests
- bump release version to 0.10.4 for the PR release flow

## Verification
- plutil -lint App/Info.plist PreviewExtension/Info.plist
- git diff --check
- GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main npm run check:release
- npm run test:web -- --no-open
- npm run test:web -- --no-open samples/mini.sdf
- ./scripts/build.sh
- pre-push npm run ci