### PR TITLE
Compact native settings UI

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
             SettingsColors.background.ignoresSafeArea()
             HStack(spacing: 0) {
                 Sidebar(selection: $section)
-                    .frame(width: 236)
+                    .frame(width: 198)
                     .background(SettingsColors.sidebar)
 
                 Rectangle()
@@ -27,19 +27,23 @@ struct ContentView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
                         Text(section.title)
-                            .font(.system(size: 23, weight: .bold))
-                            .padding(.bottom, 8)
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(.primary)
+                            .padding(.bottom, 2)
 
                         content
                     }
-                    .frame(maxWidth: 720, alignment: .leading)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 22)
+                    .id(section)
+                    .frame(maxWidth: 620, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 18)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .animation(.easeInOut(duration: 0.16), value: section)
+                .animation(.easeInOut(duration: 0.12), value: useTransparentPreviewBackground)
             }
         }
-        .frame(minWidth: 740, minHeight: 500)
+        .frame(minWidth: 660, minHeight: 440)
     }
 
     @ViewBuilder
@@ -106,9 +110,9 @@ struct ContentView: View {
                 )
                 SettingsDivider()
                 SettingsValueRow(
-                    icon: "rectangle.fill",
-                    title: "Opaque mode",
-                    subtitle: "Turn transparency off to use the classic dark Mol* background."
+                    icon: previewBackgroundIcon,
+                    title: previewBackgroundModeTitle,
+                    subtitle: previewBackgroundModeSubtitle
                 )
             }
 
@@ -243,6 +247,21 @@ struct ContentView: View {
         )
     }
 
+    private var previewBackgroundIcon: String {
+        useTransparentPreviewBackground ? "square.stack.3d.down.forward" : "rectangle.fill"
+    }
+
+    private var previewBackgroundModeTitle: String {
+        useTransparentPreviewBackground ? "Transparent background" : "Opaque background"
+    }
+
+    private var previewBackgroundModeSubtitle: String {
+        if useTransparentPreviewBackground {
+            return "Quick Look glass is visible behind the molecule."
+        }
+        return "Mol* uses its classic opaque viewer surface."
+    }
+
     private func run(_ executable: String, arguments: [String]) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -310,24 +329,24 @@ private struct Sidebar: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Spacer().frame(height: 28)
+            Spacer().frame(height: 18)
 
             SearchField(text: $searchText)
-                .padding(.horizontal, 14)
-                .padding(.bottom, 14)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 10)
 
             Rectangle()
                 .fill(SettingsColors.separator)
                 .frame(height: 1)
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 10) {
                 ForEach(groupedSections, id: \.0) { group, sections in
-                    VStack(alignment: .leading, spacing: 5) {
+                    VStack(alignment: .leading, spacing: 3) {
                         if let group {
                             Text(group)
-                                .font(.system(size: 11, weight: .bold))
-                                .foregroundColor(.white.opacity(0.28))
-                                .padding(.horizontal, 14)
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                                .padding(.horizontal, 10)
                                 .padding(.top, 4)
                         }
 
@@ -339,8 +358,8 @@ private struct Sidebar: View {
                     }
                 }
             }
-            .padding(.horizontal, 10)
-            .padding(.top, 18)
+            .padding(.horizontal, 8)
+            .padding(.top, 12)
 
             Spacer()
         }
@@ -354,21 +373,21 @@ private struct SidebarRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 11) {
+            HStack(spacing: 8) {
                 Image(systemName: section.icon)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 13, weight: .medium))
                     .symbolRenderingMode(.hierarchical)
-                    .frame(width: 20)
+                    .frame(width: 18)
 
                 Text(section.title)
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: 13, weight: .medium))
 
                 Spacer(minLength: 0)
             }
-            .foregroundColor(.white)
-            .padding(.horizontal, 10)
-            .frame(height: 36)
-            .background(isSelected ? SettingsColors.selection : Color.clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .foregroundStyle(isSelected ? .primary : .secondary)
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(isSelected ? SettingsColors.selection : Color.clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
         .buttonStyle(.plain)
     }
@@ -380,17 +399,17 @@ private struct SearchField: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(.white.opacity(0.38))
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(.tertiary)
 
             TextField("Search settings...", text: $text)
                 .textFieldStyle(.plain)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white.opacity(0.82))
+                .font(.system(size: 12, weight: .regular))
+                .foregroundStyle(.primary)
         }
-        .padding(.horizontal, 10)
-        .frame(height: 30)
-        .background(SettingsColors.search, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .padding(.horizontal, 8)
+        .frame(height: 24)
+        .background(SettingsColors.search, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 }
 
@@ -403,9 +422,9 @@ private struct SettingsSectionTitle: View {
 
     var body: some View {
         Text(title.uppercased())
-            .font(.system(size: 11, weight: .bold))
-            .foregroundColor(.white.opacity(0.42))
-            .padding(.top, 4)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.top, 2)
     }
 }
 
@@ -420,9 +439,13 @@ private struct SettingsCard<Content: View>: View {
         VStack(spacing: 0) {
             content
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 2)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(SettingsColors.card, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(SettingsColors.card, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(SettingsColors.separator, lineWidth: 1)
+        )
     }
 }
 
@@ -433,27 +456,27 @@ private struct SettingsToggleRow: View {
     var isDisabled = false
 
     var body: some View {
-        HStack(alignment: .center, spacing: 14) {
-            VStack(alignment: .leading, spacing: 3) {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(isDisabled ? 0.52 : 0.9))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(isDisabled ? .tertiary : .primary)
                 Text(subtitle)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.46))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: 10)
 
             Toggle("", isOn: $isOn)
                 .labelsHidden()
                 .toggleStyle(.switch)
-                .controlSize(.regular)
+                .controlSize(.small)
                 .disabled(isDisabled)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
     }
 }
 
@@ -463,28 +486,28 @@ private struct SettingsValueRow: View {
     let subtitle: String
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: 10) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 13, weight: .medium))
                 .symbolRenderingMode(.hierarchical)
-                .foregroundColor(.white.opacity(0.82))
-                .frame(width: 24)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.9))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
                 Text(subtitle)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.48))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
                     .lineLimit(3)
                     .textSelection(.enabled)
             }
 
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
     }
 }
 
@@ -495,24 +518,24 @@ private struct SettingsPickerRow: View {
     @Binding var selection: BurreteUpdateChannel
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: 10) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 13, weight: .medium))
                 .symbolRenderingMode(.hierarchical)
-                .foregroundColor(.white.opacity(0.82))
-                .frame(width: 24)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.9))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
                 Text(subtitle)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.48))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: 10)
 
             Picker("", selection: $selection) {
                 ForEach(BurreteUpdateChannel.allCases) { channel in
@@ -521,10 +544,11 @@ private struct SettingsPickerRow: View {
             }
             .labelsHidden()
             .pickerStyle(.menu)
-            .frame(width: 150)
+            .controlSize(.small)
+            .frame(width: 128)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
     }
 }
 
@@ -537,32 +561,32 @@ private struct SettingsActionRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(alignment: .center, spacing: 12) {
+            HStack(alignment: .center, spacing: 10) {
                 Image(systemName: icon)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 13, weight: .medium))
                     .symbolRenderingMode(.hierarchical)
-                    .foregroundColor(.white.opacity(0.86))
-                    .frame(width: 24)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18)
 
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.9))
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.primary)
                     Text(subtitle)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.white.opacity(0.48))
+                        .font(.system(size: 11, weight: .regular))
+                        .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Spacer(minLength: 12)
+                Spacer(minLength: 10)
 
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.white.opacity(0.24))
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
             }
             .opacity(isDisabled ? 0.55 : 1)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -575,7 +599,7 @@ private struct SettingsDivider: View {
         Rectangle()
             .fill(SettingsColors.separator)
             .frame(height: 1)
-            .padding(.leading, 50)
+            .padding(.leading, 40)
     }
 }
 
@@ -588,8 +612,8 @@ private struct SettingsFootnote: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundColor(.white.opacity(0.42))
+            .font(.system(size: 11, weight: .regular))
+            .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 4)
     }
@@ -597,19 +621,19 @@ private struct SettingsFootnote: View {
 
 private struct AboutPanel: View {
     var body: some View {
-        VStack(spacing: 18) {
-            Spacer(minLength: 34)
+        VStack(spacing: 14) {
+            Spacer(minLength: 22)
 
             BurreteBadge()
-                .frame(width: 104, height: 104)
+                .frame(width: 82, height: 82)
 
             VStack(spacing: 4) {
                 Text("Burrete")
-                    .font(.system(size: 34, weight: .bold))
-                    .foregroundColor(.white.opacity(0.92))
-                Text("Version 0.10.3")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.42))
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text("Version 0.10.4")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(.secondary)
             }
 
             HStack(spacing: 12) {
@@ -617,45 +641,44 @@ private struct AboutPanel: View {
                 Button("Clear Cache") { AppDelegate.clearPreviewCache() }
             }
             .buttonStyle(.bordered)
-            .controlSize(.large)
-            .padding(.top, 16)
+            .controlSize(.regular)
+            .padding(.top, 8)
 
-            Spacer(minLength: 44)
+            Spacer(minLength: 24)
 
             SettingsCard {
                 SettingsValueRow(icon: "sparkles", title: "Release Notes", subtitle: "First Burrete release with native settings, hidden logs, and movable Quick Look controls.")
                 SettingsDivider()
                 SettingsValueRow(icon: "envelope", title: "Contact", subtitle: "Local build for molecular Quick Look previews.")
             }
-            .frame(maxWidth: 560)
+            .frame(maxWidth: 500)
 
             Spacer()
         }
-        .frame(maxWidth: .infinity, minHeight: 430)
+        .frame(maxWidth: .infinity, minHeight: 360)
     }
 }
 
 private struct BurreteBadge: View {
     var body: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(LinearGradient(colors: [Color.black.opacity(0.96), Color.black.opacity(0.82)], startPoint: .top, endPoint: .bottom))
-                .overlay(RoundedRectangle(cornerRadius: 24, style: .continuous).stroke(Color.white.opacity(0.14), lineWidth: 1))
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(SettingsColors.card)
+                .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(SettingsColors.separator, lineWidth: 1))
 
             Image(systemName: "atom")
-                .font(.system(size: 48, weight: .regular))
+                .font(.system(size: 38, weight: .regular))
                 .symbolRenderingMode(.hierarchical)
-                .foregroundColor(.white.opacity(0.9))
+                .foregroundStyle(.primary)
         }
-        .shadow(color: .black.opacity(0.34), radius: 12, y: 6)
     }
 }
 
 private enum SettingsColors {
-    static let background = Color(red: 0.14, green: 0.15, blue: 0.14)
-    static let sidebar = Color(red: 0.10, green: 0.12, blue: 0.11).opacity(0.92)
-    static let card = Color.white.opacity(0.055)
-    static let search = Color.black.opacity(0.16)
-    static let selection = Color.accentColor
-    static let separator = Color.white.opacity(0.085)
+    static let background = Color(nsColor: .windowBackgroundColor)
+    static let sidebar = Color(nsColor: .underPageBackgroundColor)
+    static let card = Color(nsColor: .controlBackgroundColor)
+    static let search = Color(nsColor: .textBackgroundColor)
+    static let selection = Color.accentColor.opacity(0.18)
+    static let separator = Color(nsColor: .separatorColor).opacity(0.55)
 }

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.10.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">Finder-native molecular structure previews for macOS, powered by Mol*.</p>
 
 <p align="center">
-  <img alt="Version 0.10.3" src="https://img.shields.io/badge/version-0.10.3-0f8f72.svg?style=flat-square" />
+  <img alt="Version 0.10.4" src="https://img.shields.io/badge/version-0.10.4-0f8f72.svg?style=flat-square" />
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square" /></a>
   <img alt="macOS 12+" src="https://img.shields.io/badge/macOS-12%2B-blue.svg?style=flat-square" />
   <img alt="Quick Look" src="https://img.shields.io/badge/Quick%20Look-extension-57606a.svg?style=flat-square" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {


### PR DESCRIPTION
## Summary
- make the settings window more compact and native-looking with smaller fonts, tighter spacing, and system-adaptive colors
- reduce sidebar/window sizing and use small controls for dense macOS settings
- make the preview background status row update dynamically when transparency is toggled
- bump version to 0.10.4 for the release workflow

## Checks
- npm run ci