### PR TITLE
Add viewer themes and compact toolbar

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @AppStorage("openSettingsAtLaunch") private var openSettingsAtLaunch = false
     @AppStorage("showPreviewPanelControls") private var showPreviewPanelControls = true
     @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = false
-    @AppStorage("viewerTheme") private var viewerTheme = "auto"
+    @AppStorage("viewerTheme") private var viewerTheme = "dark"
     @AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "black"
     @AppStorage("checkUpdatesAutomatically") private var checkUpdatesAutomatically = true
     @AppStorage("updateChannel") private var updateChannelRaw = BurreteUpdateChannel.stable.rawValue
@@ -699,7 +699,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 34, weight: .bold))
                     .foregroundColor(.white.opacity(0.92))
-                Text("Version 0.10.4")
+                Text("Version 0.10.6")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.white.opacity(0.42))
             }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -4,8 +4,9 @@ import SwiftUI
 struct ContentView: View {
     @AppStorage("openSettingsAtLaunch") private var openSettingsAtLaunch = false
     @AppStorage("showPreviewPanelControls") private var showPreviewPanelControls = true
-    @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = true
-    @AppStorage("transparentSDFBackground") private var transparentSDFBackground = true
+    @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = false
+    @AppStorage("viewerTheme") private var viewerTheme = "auto"
+    @AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "black"
     @AppStorage("checkUpdatesAutomatically") private var checkUpdatesAutomatically = true
     @AppStorage("updateChannel") private var updateChannelRaw = BurreteUpdateChannel.stable.rawValue
     @StateObject private var updater = BurreteUpdater.shared
@@ -70,9 +71,9 @@ struct ContentView: View {
                 )
                 SettingsDivider()
                 SettingsValueRow(
-                    icon: "arrow.up.left.and.arrow.down.right",
-                    title: "Fit to screen",
-                    subtitle: "Uses native window resizing so the macOS title bar stays reachable."
+                    icon: "arrow.up.left.and.arrow.down.right.circle",
+                    title: "Fullscreen",
+                    subtitle: "The green window button opens the full app viewer in native macOS fullscreen."
                 )
                 SettingsDivider()
                 SettingsActionRow(
@@ -93,12 +94,6 @@ struct ContentView: View {
                 SettingsDivider()
                 SettingsValueRow(icon: "doc.richtext", title: "Formats", subtitle: "PDB, PDBx/mmCIF, BinaryCIF, SDF, MOL, and MOL2")
                 SettingsDivider()
-                SettingsToggleRow(
-                    title: "Transparent SDF background",
-                    subtitle: "Use a transparent canvas by default for SDF molecule files.",
-                    isOn: $transparentSDFBackground
-                )
-                SettingsDivider()
                 SettingsValueRow(icon: "square.grid.3x3", title: "SDF molecule grid", subtitle: "Multi-record SDF files are laid out as a visible grid when possible.")
                 SettingsDivider()
                 SettingsValueRow(icon: "bolt.horizontal", title: "Performance", subtitle: "Bundled assets, cached runtime previews, and WebGL fallback.")
@@ -106,16 +101,35 @@ struct ContentView: View {
 
             SettingsSectionTitle("Appearance")
             SettingsCard {
-                SettingsToggleRow(
-                    title: "Transparent preview background",
-                    subtitle: "Use the native Quick Look glass behind the molecule instead of an opaque viewer surface.",
-                    isOn: $useTransparentPreviewBackground
+                SettingsStringPickerRow(
+                    icon: "circle.lefthalf.filled",
+                    title: "Theme",
+                    subtitle: "Use the system appearance, force dark, or force light.",
+                    selection: $viewerTheme,
+                    options: [
+                        ("auto", "Auto"),
+                        ("dark", "Dark"),
+                        ("light", "Light")
+                    ]
                 )
                 SettingsDivider()
-                SettingsValueRow(
-                    icon: "rectangle.fill",
-                    title: "Opaque mode",
-                    subtitle: "Turn transparency off to use the classic dark Mol* background."
+                SettingsStringPickerRow(
+                    icon: "circle.fill",
+                    title: "Canvas background",
+                    subtitle: "The molecule canvas uses black by default; choose another surface when needed.",
+                    selection: $viewerCanvasBackground,
+                    options: [
+                        ("black", "Black"),
+                        ("graphite", "Graphite"),
+                        ("white", "White"),
+                        ("transparent", "Transparent")
+                    ]
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    title: "Transparent preview background",
+                    subtitle: "Use native Quick Look glass around the canvas; the canvas background stays controlled above.",
+                    isOn: $useTransparentPreviewBackground
                 )
             }
 
@@ -128,9 +142,9 @@ struct ContentView: View {
                 )
                 SettingsDivider()
                 SettingsValueRow(
-                    icon: "arrow.up.left.and.arrow.down.right",
-                    title: "Fit control",
-                    subtitle: "The fit button resizes the viewer within the visible screen and can restore its previous size."
+                    icon: "rectangle.compress.vertical",
+                    title: "Compact controls",
+                    subtitle: "Click the dotted handle to collapse the toolbar to a miniature control, then click it again to restore it."
                 )
             }
 
@@ -304,9 +318,9 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
     var searchTerms: [String] {
         switch self {
         case .general:
-            return ["application", "launch", "startup", "menu bar", "icon", "dock", "preview window", "fit"]
+            return ["application", "launch", "startup", "menu bar", "icon", "dock", "preview window", "fullscreen"]
         case .viewer:
-            return ["molstar", "formats", "pdb", "cif", "sdf", "mol", "mol2", "xyz", "gro", "background", "transparent", "grid", "toolbar", "panels", "sequence", "log"]
+            return ["molstar", "formats", "pdb", "cif", "sdf", "mol", "mol2", "xyz", "gro", "background", "transparent", "black", "canvas", "theme", "dark", "light", "auto", "grid", "toolbar", "panels", "sequence", "log"]
         case .files:
             return ["finder", "default", "double-click", "open with", "quick look", "cache", "file", "extension"]
         case .logs:
@@ -459,7 +473,7 @@ private struct SettingsCard<Content: View>: View {
         }
         .padding(.vertical, 4)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(SettingsColors.card, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(SettingsColors.card, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 }
 
@@ -554,6 +568,47 @@ private struct SettingsPickerRow: View {
             Picker("", selection: $selection) {
                 ForEach(BurreteUpdateChannel.allCases) { channel in
                     Text(channel.title).tag(channel)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(width: 150)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+}
+
+private struct SettingsStringPickerRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    @Binding var selection: String
+    let options: [(value: String, title: String)]
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundColor(.white.opacity(0.82))
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.9))
+                Text(subtitle)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white.opacity(0.48))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Picker("", selection: $selection) {
+                ForEach(options, id: \.value) { option in
+                    Text(option.title).tag(option.value)
                 }
             }
             .labelsHidden()
@@ -689,10 +744,10 @@ private struct BurreteBadge: View {
 }
 
 private enum SettingsColors {
-    static let background = Color(red: 0.14, green: 0.15, blue: 0.14)
-    static let sidebar = Color(red: 0.10, green: 0.12, blue: 0.11).opacity(0.92)
-    static let card = Color.white.opacity(0.055)
-    static let search = Color.black.opacity(0.16)
+    static let background = Color(red: 0.055, green: 0.055, blue: 0.055)
+    static let sidebar = Color(red: 0.075, green: 0.075, blue: 0.075)
+    static let card = Color(red: 0.115, green: 0.115, blue: 0.115)
+    static let search = Color.white.opacity(0.055)
     static let selection = Color.accentColor
-    static let separator = Color.white.opacity(0.085)
+    static let separator = Color.white.opacity(0.075)
 }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -728,7 +728,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.6")
+                Text("Version 0.10.7")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -265,6 +265,15 @@ private struct AppViewerRuntime {
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+              --buret-molstar-border: rgba(255, 255, 255, 0.10);
+              --buret-molstar-text: rgba(246, 247, 249, 0.94);
+              --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+              --buret-molstar-accent: #8fc7ff;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
             }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
@@ -282,6 +291,15 @@ private struct AppViewerRuntime {
               --buret-toolbar-border: rgba(0, 0, 0, 0.12);
               --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
               --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+              --buret-molstar-panel-background: rgba(239, 239, 235, 0.94);
+              --buret-molstar-row-background: rgba(229, 228, 222, 0.96);
+              --buret-molstar-field-background: rgba(248, 247, 244, 0.98);
+              --buret-molstar-hover-background: rgba(218, 216, 209, 0.98);
+              --buret-molstar-border: rgba(0, 0, 0, 0.13);
+              --buret-molstar-text: rgba(32, 33, 35, 0.94);
+              --buret-molstar-muted-text: rgba(84, 78, 68, 0.82);
+              --buret-molstar-accent: #8a4b10;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
               color: #161719;
             }
             body.buret-theme-dark {
@@ -291,6 +309,15 @@ private struct AppViewerRuntime {
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+              --buret-molstar-border: rgba(255, 255, 255, 0.10);
+              --buret-molstar-text: rgba(246, 247, 249, 0.94);
+              --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+              --buret-molstar-accent: #8fc7ff;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
             }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
@@ -320,6 +347,148 @@ private struct AppViewerRuntime {
               background: var(--buret-panel-background) !important;
               -webkit-backdrop-filter: blur(14px);
               backdrop-filter: blur(14px);
+            }
+            body .msp-plugin,
+            body .msp-plugin .msp-plugin-content {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+            }
+            body .msp-plugin .msp-layout-standard,
+            body .msp-plugin .msp-layout-top,
+            body .msp-plugin .msp-layout-bottom,
+            body .msp-plugin .msp-layout-left,
+            body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-control-row,
+            body .msp-plugin .msp-log li,
+            body .msp-plugin .msp-toast-container .msp-toast-entry,
+            body .msp-plugin .msp-markdown table,
+            body .msp-plugin .msp-markdown th,
+            body .msp-plugin .msp-markdown td {
+              border-color: var(--buret-molstar-border) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel,
+            body .msp-plugin .msp-hover-box-body,
+            body .msp-plugin .msp-action-menu-options,
+            body .msp-plugin .msp-action-menu-options-no-header,
+            body .msp-plugin .msp-animation-viewport-controls-select,
+            body .msp-plugin .msp-selection-viewport-controls-actions,
+            body .msp-plugin .msp-snapshot-description-wrapper,
+            body .msp-plugin .msp-toast-container .msp-toast-entry,
+            body .msp-plugin .msp-no-webgl,
+            body .msp-plugin .msp-log,
+            body .msp-plugin .msp-sequence {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-control-row,
+            body .msp-plugin .msp-control-current,
+            body .msp-plugin .msp-control-group-header,
+            body .msp-plugin .msp-control-group-header > button,
+            body .msp-plugin .msp-control-group-header div,
+            body .msp-plugin .msp-control-group-header > span,
+            body .msp-plugin .msp-flex-row,
+            body .msp-plugin .msp-state-image-row,
+            body .msp-plugin .msp-row-text,
+            body .msp-plugin .msp-section-header,
+            body .msp-plugin .msp-current-header,
+            body .msp-plugin .msp-description,
+            body .msp-plugin .msp-help-text,
+            body .msp-plugin .msp-help-row,
+            body .msp-plugin .msp-image-preview,
+            body .msp-plugin .msp-simple-help-section,
+            body .msp-plugin .msp-left-panel-controls-buttons,
+            body .msp-plugin .msp-overlay-tasks .msp-task-state > div,
+            body .msp-plugin .msp-background-tasks .msp-task-state > div,
+            body .msp-plugin .msp-log li {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-control-row > div,
+            body .msp-plugin .msp-control-row > div.msp-control-row-text,
+            body .msp-plugin .msp-help-row > div,
+            body .msp-plugin .msp-sequence-wrapper-non-empty,
+            body .msp-plugin .msp-log .msp-log-entry,
+            body .msp-plugin .msp-copy-image-wrapper div,
+            body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
+            body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-form-control,
+            body .msp-plugin .msp-control-row select,
+            body .msp-plugin .msp-control-row button,
+            body .msp-plugin .msp-control-row input[type=text],
+            body .msp-plugin textarea,
+            body .msp-plugin .msp-btn {
+              color: var(--buret-molstar-text) !important;
+              background-color: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-form-control:hover,
+            body .msp-plugin .msp-control-row select:hover,
+            body .msp-plugin .msp-control-row button:hover,
+            body .msp-plugin .msp-control-row input[type=text]:hover,
+            body .msp-plugin .msp-btn:hover,
+            body .msp-plugin .msp-btn-icon:hover,
+            body .msp-plugin .msp-btn-icon-small:hover {
+              color: var(--buret-molstar-accent) !important;
+              background-color: var(--buret-molstar-hover-background) !important;
+              outline: 1px solid var(--buret-molstar-border) !important;
+            }
+            body .msp-plugin .msp-btn-link,
+            body .msp-plugin .msp-btn-link:active,
+            body .msp-plugin .msp-btn-link:focus,
+            body .msp-plugin .msp-btn-link-toggle-on,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-present,
+            body .msp-plugin .msp-svg-text {
+              color: var(--buret-molstar-text) !important;
+              fill: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-btn-link:hover,
+            body .msp-plugin .msp-highlight-info,
+            body .msp-plugin .msp-highlight-info-additional,
+            body .msp-plugin .msp-sequence-chain-label,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-label,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-number {
+              color: var(--buret-molstar-accent) !important;
+            }
+            body .msp-plugin .msp-control-row > span.msp-control-row-label,
+            body .msp-plugin .msp-control-row > button.msp-control-button-label,
+            body .msp-plugin .msp-control-group-header > button,
+            body .msp-plugin .msp-control-group-header div,
+            body .msp-plugin .msp-control-group-header > span,
+            body .msp-plugin .msp-log .msp-log-timestamp,
+            body .msp-plugin .msp-help-row > span,
+            body .msp-plugin .msp-row-text > div,
+            body .msp-plugin .msp-25-lower-contrast-text,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
+              color: var(--buret-molstar-muted-text) !important;
+            }
+            body .msp-plugin .msp-semi-transparent-background {
+              background: var(--buret-molstar-panel-background) !important;
+              opacity: 0.76 !important;
+            }
+            body .msp-plugin .msp-shape-filled,
+            body .msp-plugin .msp-transform-header-brand svg {
+              fill: var(--buret-molstar-text) !important;
+              stroke: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-shape-empty {
+              stroke: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-slider-base-rail {
+              background-color: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-slider-base-handle {
+              background-color: var(--buret-molstar-text) !important;
+              border-color: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin ::-webkit-scrollbar-track {
+              background-color: var(--buret-molstar-panel-background) !important;
+            }
+            body .msp-plugin ::-webkit-scrollbar-thumb {
+              background-color: var(--buret-molstar-hover-background) !important;
+              border-color: transparent !important;
             }
             #status {
               position: absolute; left: 12px; top: 12px; z-index: 2147483647;

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -4,7 +4,6 @@ import WebKit
 final class MoleculeViewerWindowController: NSWindowController, WKNavigationDelegate, WKScriptMessageHandler {
     private let fileURL: URL
     private let webView: WKWebView
-    private var restoredWindowFrame: NSRect?
     private var currentViewerPageZoom: CGFloat = 0.86
     private static let defaultViewerPageZoom: CGFloat = 0.86
     private static let minViewerPageZoom: CGFloat = 0.72
@@ -32,11 +31,12 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1040, height: 720),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullScreen],
             backing: .buffered,
             defer: false
         )
         window.title = "Burrete - \(fileURL.lastPathComponent)"
+        window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 660, height: 440)
         window.isOpaque = !transparentBackground
         window.backgroundColor = transparentBackground ? .clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)
@@ -82,10 +82,6 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
               let type = body["type"] as? String else {
             return
         }
-        if type == "action", (body["message"] as? String) == "fit" {
-            toggleFitToScreen()
-            return
-        }
         if type == "viewerZoom", let value = body["value"] as? NSNumber {
             setViewerPageZoom(CGFloat(value.doubleValue))
             return
@@ -104,24 +100,6 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         }
     }
 
-    private func toggleFitToScreen() {
-        guard let window, let screen = window.screen ?? NSScreen.main else { return }
-        if window.styleMask.contains(.fullScreen) {
-            window.toggleFullScreen(nil)
-            return
-        }
-        if let frame = restoredWindowFrame {
-            window.setFrame(frame, display: true, animate: false)
-            restoredWindowFrame = nil
-        } else {
-            restoredWindowFrame = window.frame
-            window.setFrame(screen.visibleFrame.insetBy(dx: 8, dy: 8), display: true, animate: false)
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
-        }
-    }
-
     private static func errorHTML(_ error: Error) -> String {
         """
         <!doctype html><html><head><meta charset="utf-8"><style>
@@ -133,7 +111,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     }
 
     private static var useTransparentPreviewBackground: Bool {
-        UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? true
+        UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
     }
 }
 
@@ -176,7 +154,10 @@ private struct AppViewerRuntime {
         try copyAssets(from: bundledWebDirectory, to: assetsDirectory)
 
         let format = AppViewerStructureFormat(url: fileURL, data: data)
-        let transparentBackground = UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? true
+        let transparentBackground = UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
+        let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto"
+        let canvasBackground = UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "black"
+        let canvasIsTransparent = canvasBackground == "transparent"
         let config: [String: Any] = [
             "format": format.molstarFormat,
             "binary": format.isBinary,
@@ -184,9 +165,10 @@ private struct AppViewerRuntime {
             "byteCount": data.count,
             "quickLookBuild": "burrete-app",
             "debug": false,
+            "theme": viewerTheme,
+            "canvasBackground": canvasBackground,
             "uiScale": 0.86,
-            "transparentBackground": format.prefersTransparentBackground &&
-                (UserDefaults.standard.object(forKey: "transparentSDFBackground") as? Bool ?? true),
+            "transparentBackground": canvasIsTransparent,
             "sdfGrid": true,
             "showPanelControls": UserDefaults.standard.object(forKey: "showPreviewPanelControls") as? Bool ?? true,
             "defaultLayoutState": [
@@ -274,7 +256,16 @@ private struct AppViewerRuntime {
           <title>Burrete - \(escapeHTML(title))</title>
           <link rel="stylesheet" href="../assets/molstar.css" />
           <style>
-            :root { --buret-viewer-ui-scale: 0.86; }
+            :root {
+              --buret-viewer-ui-scale: 0.86;
+              --buret-canvas-background: #000000;
+              --buret-shell-background: #000000;
+              --buret-panel-background: rgba(18, 20, 22, 0.82);
+              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+              --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+              --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+            }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
             html.buret-transparent-background body,
@@ -284,9 +275,26 @@ private struct AppViewerRuntime {
             html.buret-transparent-background .msp-layout-main,
             html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
+            body.buret-theme-light {
+              --buret-shell-background: #f7f7f2;
+              --buret-panel-background: rgba(247, 247, 242, 0.86);
+              --buret-toolbar-background: rgba(247, 247, 242, 0.90);
+              --buret-toolbar-border: rgba(0, 0, 0, 0.12);
+              --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
+              --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+              color: #161719;
+            }
+            body.buret-theme-dark {
+              --buret-shell-background: var(--buret-canvas-background);
+              --buret-panel-background: rgba(18, 20, 22, 0.82);
+              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+              --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+              --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+            }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
-              background: #111317;
+              background: var(--buret-shell-background);
             }
             #app { position: absolute; inset: 0; }
             body.burette-transparent-background .msp-plugin,
@@ -303,13 +311,13 @@ private struct AppViewerRuntime {
             body.burette-opaque-background .msp-plugin .msp-layout-viewport,
             body.burette-opaque-background .msp-plugin .msp-plugin-content,
             body.burette-opaque-background .msp-plugin canvas {
-              background: #111317 !important;
+              background: var(--buret-canvas-background) !important;
             }
-            body.burette-transparent-background .msp-plugin .msp-layout-left,
-            body.burette-transparent-background .msp-plugin .msp-layout-right,
-            body.burette-transparent-background .msp-plugin .msp-layout-top,
-            body.burette-transparent-background .msp-plugin .msp-layout-bottom {
-              background: rgba(238, 236, 231, 0.72) !important;
+            body .msp-plugin .msp-layout-left,
+            body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-layout-top,
+            body .msp-plugin .msp-layout-bottom {
+              background: var(--buret-panel-background) !important;
               -webkit-backdrop-filter: blur(14px);
               backdrop-filter: blur(14px);
             }
@@ -325,24 +333,27 @@ private struct AppViewerRuntime {
             #buret-toolbar {
               position: absolute; top: 12px; right: 12px; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
-              border: 1px solid rgba(255, 255, 255, 0.10);
-              border-radius: 12px; color: rgba(255, 255, 255, 0.94);
-              background: rgba(18, 20, 22, 0.86);
+              border: 1px solid var(--buret-toolbar-border);
+              border-radius: 12px; color: var(--buret-toolbar-color);
+              background: var(--buret-toolbar-background);
               -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
               box-shadow:
                 0 8px 22px rgba(0, 0, 0, 0.22),
                 inset 0 1px 0 rgba(255, 255, 255, 0.06);
               user-select: none; touch-action: none;
             }
+            #buret-toolbar.collapsed { gap: 0; }
+            #buret-toolbar.collapsed .buret-button:not(.buret-grip) { display: none; }
+            #buret-toolbar.collapsed .buret-grip { min-width: 26px; padding: 0; cursor: pointer; }
             .buret-button {
               min-width: 26px; height: 26px; border: 0; border-radius: 7px; padding: 0 7px;
               color: inherit; background: transparent; font: 600 11px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
               display: grid; place-items: center;
             }
-            .buret-button:hover, .buret-button.active { background: rgba(255, 255, 255, 0.14); }
+            .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
             .buret-button.hidden { display: none; }
             .buret-button svg { width: 15px; height: 15px; display: block; }
-            .buret-grip { cursor: move; color: rgba(255, 255, 255, 0.66); }
+            .buret-grip { cursor: grab; color: currentColor; opacity: 0.66; }
           </style>
           <script>
             (function () {
@@ -368,11 +379,8 @@ private struct AppViewerRuntime {
         <body class="\(backgroundClass)">
           <div id="app"></div>
           <div id="buret-toolbar" role="toolbar" aria-label="Burrete viewer controls">
-            <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Move controls" title="Move controls">
+            <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Collapse controls" aria-expanded="true" title="Collapse controls">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
-            </button>
-            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fit window to screen" title="Fit window to screen">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
             </button>
             <button class="buret-button buret-panel-toggle active" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -379,6 +379,7 @@ private struct AppViewerRuntime {
             body .msp-plugin .msp-sequence {
               color: var(--buret-molstar-text) !important;
               background: var(--buret-molstar-panel-background) !important;
+              max-height: calc(100vh - 76px) !important;
               box-shadow: 0 14px 34px var(--buret-molstar-shadow);
             }
             body .msp-plugin .msp-control-row,
@@ -469,6 +470,7 @@ private struct AppViewerRuntime {
               opacity: 0.76 !important;
             }
             body .msp-plugin .msp-viewport-controls {
+              top: 64px !important;
               z-index: 40;
             }
             body .msp-plugin .msp-viewport-controls-buttons > div {
@@ -518,7 +520,7 @@ private struct AppViewerRuntime {
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; right: 12px; z-index: 2147483646;
+              position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -155,7 +155,7 @@ private struct AppViewerRuntime {
 
         let format = AppViewerStructureFormat(url: fileURL, data: data)
         let transparentBackground = UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
-        let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto"
+        let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "dark"
         let canvasBackground = UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "black"
         let canvasIsTransparent = canvasBackground == "transparent"
         let config: [String: Any] = [
@@ -467,6 +467,24 @@ private struct AppViewerRuntime {
             body .msp-plugin .msp-semi-transparent-background {
               background: var(--buret-molstar-panel-background) !important;
               opacity: 0.76 !important;
+            }
+            body .msp-plugin .msp-viewport-controls {
+              z-index: 40;
+            }
+            body .msp-plugin .msp-viewport-controls-buttons > div {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border);
+              border-radius: 8px;
+              background: var(--buret-molstar-row-background) !important;
+              box-shadow: 0 8px 20px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-viewport-controls-buttons button {
+              color: var(--buret-molstar-text) !important;
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-viewport-controls-buttons button[disabled] {
+              color: var(--buret-molstar-muted-text) !important;
+              opacity: 0.55;
             }
             body .msp-plugin .msp-shape-filled,
             body .msp-plugin .msp-transform-header-brand svg {

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.4;
+				MARKETING_VERSION = 0.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.4;
+				MARKETING_VERSION = 0.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.4;
+				MARKETING_VERSION = 0.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.4;
+				MARKETING_VERSION = 0.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.6;
+				MARKETING_VERSION = 0.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.6;
+				MARKETING_VERSION = 0.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.6;
+				MARKETING_VERSION = 0.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.6;
+				MARKETING_VERSION = 0.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -521,6 +521,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body .msp-plugin .msp-sequence {
               color: var(--buret-molstar-text) !important;
               background: var(--buret-molstar-panel-background) !important;
+              max-height: calc(100vh - 76px) !important;
               box-shadow: 0 14px 34px var(--buret-molstar-shadow);
             }
             body .msp-plugin .msp-control-row,
@@ -611,6 +612,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               opacity: 0.76 !important;
             }
             body .msp-plugin .msp-viewport-controls {
+              top: 64px !important;
               z-index: 40;
             }
             body .msp-plugin .msp-viewport-controls-buttons > div {
@@ -661,7 +663,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; right: 12px; z-index: 2147483646;
+              position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -12,7 +12,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private var logLines: [String] = []
     private let previewID = String(UUID().uuidString.prefix(8))
     private var hasRenderedTerminationError = false
-    private var restoredWindowFrame: NSRect?
     private var currentViewerPageZoom: CGFloat = 0.86
     private static let showDebugOverlay = false
     private static let verboseLogging = false
@@ -374,8 +373,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "byteCount": byteCount,
             "quickLookBuild": "v10-product",
             "debug": showDebugOverlay,
+            "theme": preferences.viewerTheme,
+            "canvasBackground": preferences.canvasBackground,
             "uiScale": 0.86,
-            "transparentBackground": format.prefersTransparentBackground && preferences.transparentSDFBackground,
+            "transparentBackground": preferences.canvasBackground == "transparent",
             "sdfGrid": true,
             "showPanelControls": preferences.showPanelControls,
             "defaultLayoutState": preferences.defaultLayoutState
@@ -397,7 +398,16 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           <title>Burrete - \(safeTitle)</title>
           <link rel="stylesheet" href="../assets/molstar.css" />
           <style>
-            :root { --buret-viewer-ui-scale: 0.86; }
+            :root {
+              --buret-viewer-ui-scale: 0.86;
+              --buret-canvas-background: #000000;
+              --buret-shell-background: #000000;
+              --buret-panel-background: rgba(18, 20, 22, 0.82);
+              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+              --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+              --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+            }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
             html.buret-transparent-background body,
@@ -407,9 +417,26 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             html.buret-transparent-background .msp-layout-main,
             html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
+            body.buret-theme-light {
+              --buret-shell-background: #f7f7f2;
+              --buret-panel-background: rgba(247, 247, 242, 0.86);
+              --buret-toolbar-background: rgba(247, 247, 242, 0.90);
+              --buret-toolbar-border: rgba(0, 0, 0, 0.12);
+              --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
+              --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+              color: #161719;
+            }
+            body.buret-theme-dark {
+              --buret-shell-background: var(--buret-canvas-background);
+              --buret-panel-background: rgba(18, 20, 22, 0.82);
+              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+              --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+              --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+            }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
-              background: #111317;
+              background: var(--buret-shell-background);
             }
             #app { position: absolute; inset: 0; }
             body.burette-transparent-background .msp-plugin,
@@ -426,13 +453,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body.burette-opaque-background .msp-plugin .msp-layout-viewport,
             body.burette-opaque-background .msp-plugin .msp-plugin-content,
             body.burette-opaque-background .msp-plugin canvas {
-              background: #111317 !important;
+              background: var(--buret-canvas-background) !important;
             }
-            body.burette-transparent-background .msp-plugin .msp-layout-left,
-            body.burette-transparent-background .msp-plugin .msp-layout-right,
-            body.burette-transparent-background .msp-plugin .msp-layout-top,
-            body.burette-transparent-background .msp-plugin .msp-layout-bottom {
-              background: rgba(238, 236, 231, 0.72) !important;
+            body .msp-plugin .msp-layout-left,
+            body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-layout-top,
+            body .msp-plugin .msp-layout-bottom {
+              background: var(--buret-panel-background) !important;
               -webkit-backdrop-filter: blur(14px);
               backdrop-filter: blur(14px);
             }
@@ -449,9 +476,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             #buret-toolbar {
               position: absolute; top: 12px; right: 12px; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
-              border: 1px solid rgba(255, 255, 255, 0.10);
-              border-radius: 12px; color: rgba(255, 255, 255, 0.94);
-              background: rgba(18, 20, 22, 0.86);
+              border: 1px solid var(--buret-toolbar-border);
+              border-radius: 12px; color: var(--buret-toolbar-color);
+              background: var(--buret-toolbar-background);
               -webkit-backdrop-filter: blur(10px);
               backdrop-filter: blur(10px);
               box-shadow:
@@ -459,15 +486,18 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 inset 0 1px 0 rgba(255, 255, 255, 0.06);
               user-select: none; touch-action: none;
             }
+            #buret-toolbar.collapsed { gap: 0; }
+            #buret-toolbar.collapsed .buret-button:not(.buret-grip) { display: none; }
+            #buret-toolbar.collapsed .buret-grip { min-width: 26px; padding: 0; cursor: pointer; }
             .buret-button {
               min-width: 26px; height: 26px; border: 0; border-radius: 7px; padding: 0 7px;
               color: inherit; background: transparent; font: 600 11px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
               display: grid; place-items: center;
             }
-            .buret-button:hover, .buret-button.active { background: rgba(255, 255, 255, 0.14); }
+            .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
             .buret-button.hidden { display: none; }
             .buret-button svg { width: 15px; height: 15px; display: block; }
-            .buret-grip { cursor: move; color: rgba(255, 255, 255, 0.66); }
+            .buret-grip { cursor: grab; color: currentColor; opacity: 0.66; }
           </style>
           <script>
             (function () {
@@ -529,11 +559,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         <body class="\(backgroundClass)">
           <div id="app"></div>
           <div id="buret-toolbar" role="toolbar" aria-label="Burrete preview controls">
-            <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Move controls" title="Move controls">
+            <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Collapse controls" aria-expanded="true" title="Collapse controls">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
-            </button>
-            <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fit window to screen" title="Fit window to screen">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
             </button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
@@ -718,12 +745,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     private func handleJavaScriptAction(_ action: String) {
         appendLog("JS action=\(action)")
-        switch action {
-        case "fit":
-            toggleFitToScreen()
-        default:
-            appendLog("unknown JS action=\(action)")
-        }
+        appendLog("unknown JS action=\(action)")
     }
 
     private func setViewerPageZoom(_ scale: CGFloat) {
@@ -733,32 +755,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         webView.pageZoom = clamped
         appendLog("viewer pageZoom=\(String(format: "%.2f", Double(clamped)))")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-            self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
-        }
-    }
-
-    private func toggleFitToScreen() {
-        guard let window = view.window, let screen = window.screen ?? NSScreen.main else {
-            appendLog("fit action ignored: no preview window")
-            return
-        }
-        if window.styleMask.contains(.fullScreen) {
-            window.toggleFullScreen(nil)
-            return
-        }
-        if let frame = restoredWindowFrame {
-            window.setFrame(frame, display: true, animate: false)
-            restoredWindowFrame = nil
-        } else {
-            restoredWindowFrame = window.frame
-            let targetFrame = screen.visibleFrame.insetBy(dx: 8, dy: 8)
-            if window.styleMask.contains(.resizable) {
-                window.setFrame(targetFrame, display: true, animate: false)
-            } else {
-                window.toggleFullScreen(nil)
-            }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
             self?.webView.evaluateJavaScript("window.BurreteHandleResize && window.BurreteHandleResize();", completionHandler: nil)
         }
     }
@@ -1051,18 +1047,21 @@ private struct StructureFormat {
 private struct PreviewPreferences {
     let showPanelControls: Bool
     let transparentBackground: Bool
-    let transparentSDFBackground: Bool
+    let viewerTheme: String
+    let canvasBackground: String
     let defaultLayoutState: [String: String]
 
     static func load() -> PreviewPreferences {
         let appID = "com.local.BurreteV10" as CFString
         let showPanelControls = (CFPreferencesCopyAppValue("showPreviewPanelControls" as CFString, appID) as? Bool) ?? true
-        let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? true
-        let transparentSDFBackground = (CFPreferencesCopyAppValue("transparentSDFBackground" as CFString, appID) as? Bool) ?? true
+        let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? false
+        let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "auto"
+        let canvasBackground = (CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "black"
         return PreviewPreferences(
             showPanelControls: showPanelControls,
             transparentBackground: transparentBackground,
-            transparentSDFBackground: transparentSDFBackground,
+            viewerTheme: viewerTheme,
+            canvasBackground: canvasBackground,
             defaultLayoutState: [
                 "left": "collapsed",
                 "right": "hidden",

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -407,6 +407,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+              --buret-molstar-border: rgba(255, 255, 255, 0.10);
+              --buret-molstar-text: rgba(246, 247, 249, 0.94);
+              --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+              --buret-molstar-accent: #8fc7ff;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
             }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
@@ -424,6 +433,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               --buret-toolbar-border: rgba(0, 0, 0, 0.12);
               --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
               --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+              --buret-molstar-panel-background: rgba(239, 239, 235, 0.94);
+              --buret-molstar-row-background: rgba(229, 228, 222, 0.96);
+              --buret-molstar-field-background: rgba(248, 247, 244, 0.98);
+              --buret-molstar-hover-background: rgba(218, 216, 209, 0.98);
+              --buret-molstar-border: rgba(0, 0, 0, 0.13);
+              --buret-molstar-text: rgba(32, 33, 35, 0.94);
+              --buret-molstar-muted-text: rgba(84, 78, 68, 0.82);
+              --buret-molstar-accent: #8a4b10;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
               color: #161719;
             }
             body.buret-theme-dark {
@@ -433,6 +451,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+              --buret-molstar-border: rgba(255, 255, 255, 0.10);
+              --buret-molstar-text: rgba(246, 247, 249, 0.94);
+              --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+              --buret-molstar-accent: #8fc7ff;
+              --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
             }
             body.burette-opaque-background,
             body.burette-opaque-background #app {
@@ -462,6 +489,148 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               background: var(--buret-panel-background) !important;
               -webkit-backdrop-filter: blur(14px);
               backdrop-filter: blur(14px);
+            }
+            body .msp-plugin,
+            body .msp-plugin .msp-plugin-content {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+            }
+            body .msp-plugin .msp-layout-standard,
+            body .msp-plugin .msp-layout-top,
+            body .msp-plugin .msp-layout-bottom,
+            body .msp-plugin .msp-layout-left,
+            body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-control-row,
+            body .msp-plugin .msp-log li,
+            body .msp-plugin .msp-toast-container .msp-toast-entry,
+            body .msp-plugin .msp-markdown table,
+            body .msp-plugin .msp-markdown th,
+            body .msp-plugin .msp-markdown td {
+              border-color: var(--buret-molstar-border) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel,
+            body .msp-plugin .msp-hover-box-body,
+            body .msp-plugin .msp-action-menu-options,
+            body .msp-plugin .msp-action-menu-options-no-header,
+            body .msp-plugin .msp-animation-viewport-controls-select,
+            body .msp-plugin .msp-selection-viewport-controls-actions,
+            body .msp-plugin .msp-snapshot-description-wrapper,
+            body .msp-plugin .msp-toast-container .msp-toast-entry,
+            body .msp-plugin .msp-no-webgl,
+            body .msp-plugin .msp-log,
+            body .msp-plugin .msp-sequence {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-control-row,
+            body .msp-plugin .msp-control-current,
+            body .msp-plugin .msp-control-group-header,
+            body .msp-plugin .msp-control-group-header > button,
+            body .msp-plugin .msp-control-group-header div,
+            body .msp-plugin .msp-control-group-header > span,
+            body .msp-plugin .msp-flex-row,
+            body .msp-plugin .msp-state-image-row,
+            body .msp-plugin .msp-row-text,
+            body .msp-plugin .msp-section-header,
+            body .msp-plugin .msp-current-header,
+            body .msp-plugin .msp-description,
+            body .msp-plugin .msp-help-text,
+            body .msp-plugin .msp-help-row,
+            body .msp-plugin .msp-image-preview,
+            body .msp-plugin .msp-simple-help-section,
+            body .msp-plugin .msp-left-panel-controls-buttons,
+            body .msp-plugin .msp-overlay-tasks .msp-task-state > div,
+            body .msp-plugin .msp-background-tasks .msp-task-state > div,
+            body .msp-plugin .msp-log li {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-control-row > div,
+            body .msp-plugin .msp-control-row > div.msp-control-row-text,
+            body .msp-plugin .msp-help-row > div,
+            body .msp-plugin .msp-sequence-wrapper-non-empty,
+            body .msp-plugin .msp-log .msp-log-entry,
+            body .msp-plugin .msp-copy-image-wrapper div,
+            body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
+            body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-form-control,
+            body .msp-plugin .msp-control-row select,
+            body .msp-plugin .msp-control-row button,
+            body .msp-plugin .msp-control-row input[type=text],
+            body .msp-plugin textarea,
+            body .msp-plugin .msp-btn {
+              color: var(--buret-molstar-text) !important;
+              background-color: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-form-control:hover,
+            body .msp-plugin .msp-control-row select:hover,
+            body .msp-plugin .msp-control-row button:hover,
+            body .msp-plugin .msp-control-row input[type=text]:hover,
+            body .msp-plugin .msp-btn:hover,
+            body .msp-plugin .msp-btn-icon:hover,
+            body .msp-plugin .msp-btn-icon-small:hover {
+              color: var(--buret-molstar-accent) !important;
+              background-color: var(--buret-molstar-hover-background) !important;
+              outline: 1px solid var(--buret-molstar-border) !important;
+            }
+            body .msp-plugin .msp-btn-link,
+            body .msp-plugin .msp-btn-link:active,
+            body .msp-plugin .msp-btn-link:focus,
+            body .msp-plugin .msp-btn-link-toggle-on,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-present,
+            body .msp-plugin .msp-svg-text {
+              color: var(--buret-molstar-text) !important;
+              fill: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-btn-link:hover,
+            body .msp-plugin .msp-highlight-info,
+            body .msp-plugin .msp-highlight-info-additional,
+            body .msp-plugin .msp-sequence-chain-label,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-label,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-number {
+              color: var(--buret-molstar-accent) !important;
+            }
+            body .msp-plugin .msp-control-row > span.msp-control-row-label,
+            body .msp-plugin .msp-control-row > button.msp-control-button-label,
+            body .msp-plugin .msp-control-group-header > button,
+            body .msp-plugin .msp-control-group-header div,
+            body .msp-plugin .msp-control-group-header > span,
+            body .msp-plugin .msp-log .msp-log-timestamp,
+            body .msp-plugin .msp-help-row > span,
+            body .msp-plugin .msp-row-text > div,
+            body .msp-plugin .msp-25-lower-contrast-text,
+            body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
+              color: var(--buret-molstar-muted-text) !important;
+            }
+            body .msp-plugin .msp-semi-transparent-background {
+              background: var(--buret-molstar-panel-background) !important;
+              opacity: 0.76 !important;
+            }
+            body .msp-plugin .msp-shape-filled,
+            body .msp-plugin .msp-transform-header-brand svg {
+              fill: var(--buret-molstar-text) !important;
+              stroke: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-shape-empty {
+              stroke: var(--buret-molstar-text) !important;
+            }
+            body .msp-plugin .msp-slider-base-rail {
+              background-color: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-slider-base-handle {
+              background-color: var(--buret-molstar-text) !important;
+              border-color: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin ::-webkit-scrollbar-track {
+              background-color: var(--buret-molstar-panel-background) !important;
+            }
+            body .msp-plugin ::-webkit-scrollbar-thumb {
+              background-color: var(--buret-molstar-hover-background) !important;
+              border-color: transparent !important;
             }
             #status {
               position: absolute; left: 12px; top: 12px;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -610,6 +610,24 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               background: var(--buret-molstar-panel-background) !important;
               opacity: 0.76 !important;
             }
+            body .msp-plugin .msp-viewport-controls {
+              z-index: 40;
+            }
+            body .msp-plugin .msp-viewport-controls-buttons > div {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border);
+              border-radius: 8px;
+              background: var(--buret-molstar-row-background) !important;
+              box-shadow: 0 8px 20px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-viewport-controls-buttons button {
+              color: var(--buret-molstar-text) !important;
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-viewport-controls-buttons button[disabled] {
+              color: var(--buret-molstar-muted-text) !important;
+              opacity: 0.55;
+            }
             body .msp-plugin .msp-shape-filled,
             body .msp-plugin .msp-transform-header-brand svg {
               fill: var(--buret-molstar-text) !important;
@@ -1224,7 +1242,7 @@ private struct PreviewPreferences {
         let appID = "com.local.BurreteV10" as CFString
         let showPanelControls = (CFPreferencesCopyAppValue("showPreviewPanelControls" as CFString, appID) as? Bool) ?? true
         let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? false
-        let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "auto"
+        let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "dark"
         let canvasBackground = (CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "black"
         return PreviewPreferences(
             showPanelControls: showPanelControls,

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -217,6 +217,24 @@
       background: var(--buret-molstar-panel-background) !important;
       opacity: 0.76 !important;
     }
+    body .msp-plugin .msp-viewport-controls {
+      z-index: 40;
+    }
+    body .msp-plugin .msp-viewport-controls-buttons > div {
+      overflow: hidden;
+      border: 1px solid var(--buret-molstar-border);
+      border-radius: 8px;
+      background: var(--buret-molstar-row-background) !important;
+      box-shadow: 0 8px 20px var(--buret-molstar-shadow);
+    }
+    body .msp-plugin .msp-viewport-controls-buttons button {
+      color: var(--buret-molstar-text) !important;
+      background: transparent !important;
+    }
+    body .msp-plugin .msp-viewport-controls-buttons button[disabled] {
+      color: var(--buret-molstar-muted-text) !important;
+      opacity: 0.55;
+    }
     body .msp-plugin .msp-shape-filled,
     body .msp-plugin .msp-transform-header-brand svg {
       fill: var(--buret-molstar-text) !important;

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -14,6 +14,15 @@
       --buret-toolbar-border: rgba(255, 255, 255, 0.10);
       --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
       --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+      --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+      --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+      --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+      --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+      --buret-molstar-border: rgba(255, 255, 255, 0.10);
+      --buret-molstar-text: rgba(246, 247, 249, 0.94);
+      --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+      --buret-molstar-accent: #8fc7ff;
+      --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
     }
     html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
     html.buret-transparent-background,
@@ -31,6 +40,15 @@
       --buret-toolbar-border: rgba(0, 0, 0, 0.12);
       --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
       --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+      --buret-molstar-panel-background: rgba(239, 239, 235, 0.94);
+      --buret-molstar-row-background: rgba(229, 228, 222, 0.96);
+      --buret-molstar-field-background: rgba(248, 247, 244, 0.98);
+      --buret-molstar-hover-background: rgba(218, 216, 209, 0.98);
+      --buret-molstar-border: rgba(0, 0, 0, 0.13);
+      --buret-molstar-text: rgba(32, 33, 35, 0.94);
+      --buret-molstar-muted-text: rgba(84, 78, 68, 0.82);
+      --buret-molstar-accent: #8a4b10;
+      --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
       color: #161719;
     }
     body.buret-theme-dark {
@@ -40,6 +58,15 @@
       --buret-toolbar-border: rgba(255, 255, 255, 0.10);
       --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
       --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+      --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
+      --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
+      --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+      --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
+      --buret-molstar-border: rgba(255, 255, 255, 0.10);
+      --buret-molstar-text: rgba(246, 247, 249, 0.94);
+      --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
+      --buret-molstar-accent: #8fc7ff;
+      --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
     }
     body.burette-opaque-background,
     body.burette-opaque-background #app {
@@ -69,6 +96,148 @@
       background: var(--buret-panel-background) !important;
       -webkit-backdrop-filter: blur(14px);
       backdrop-filter: blur(14px);
+    }
+    body .msp-plugin,
+    body .msp-plugin .msp-plugin-content {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-panel-background) !important;
+    }
+    body .msp-plugin .msp-layout-standard,
+    body .msp-plugin .msp-layout-top,
+    body .msp-plugin .msp-layout-bottom,
+    body .msp-plugin .msp-layout-left,
+    body .msp-plugin .msp-layout-right,
+    body .msp-plugin .msp-control-row,
+    body .msp-plugin .msp-log li,
+    body .msp-plugin .msp-toast-container .msp-toast-entry,
+    body .msp-plugin .msp-markdown table,
+    body .msp-plugin .msp-markdown th,
+    body .msp-plugin .msp-markdown td {
+      border-color: var(--buret-molstar-border) !important;
+    }
+    body .msp-plugin .msp-viewport-controls-panel,
+    body .msp-plugin .msp-hover-box-body,
+    body .msp-plugin .msp-action-menu-options,
+    body .msp-plugin .msp-action-menu-options-no-header,
+    body .msp-plugin .msp-animation-viewport-controls-select,
+    body .msp-plugin .msp-selection-viewport-controls-actions,
+    body .msp-plugin .msp-snapshot-description-wrapper,
+    body .msp-plugin .msp-toast-container .msp-toast-entry,
+    body .msp-plugin .msp-no-webgl,
+    body .msp-plugin .msp-log,
+    body .msp-plugin .msp-sequence {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-panel-background) !important;
+      box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+    }
+    body .msp-plugin .msp-control-row,
+    body .msp-plugin .msp-control-current,
+    body .msp-plugin .msp-control-group-header,
+    body .msp-plugin .msp-control-group-header > button,
+    body .msp-plugin .msp-control-group-header div,
+    body .msp-plugin .msp-control-group-header > span,
+    body .msp-plugin .msp-flex-row,
+    body .msp-plugin .msp-state-image-row,
+    body .msp-plugin .msp-row-text,
+    body .msp-plugin .msp-section-header,
+    body .msp-plugin .msp-current-header,
+    body .msp-plugin .msp-description,
+    body .msp-plugin .msp-help-text,
+    body .msp-plugin .msp-help-row,
+    body .msp-plugin .msp-image-preview,
+    body .msp-plugin .msp-simple-help-section,
+    body .msp-plugin .msp-left-panel-controls-buttons,
+    body .msp-plugin .msp-overlay-tasks .msp-task-state > div,
+    body .msp-plugin .msp-background-tasks .msp-task-state > div,
+    body .msp-plugin .msp-log li {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin .msp-control-row > div,
+    body .msp-plugin .msp-control-row > div.msp-control-row-text,
+    body .msp-plugin .msp-help-row > div,
+    body .msp-plugin .msp-sequence-wrapper-non-empty,
+    body .msp-plugin .msp-log .msp-log-entry,
+    body .msp-plugin .msp-copy-image-wrapper div,
+    body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
+    body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-field-background) !important;
+    }
+    body .msp-plugin .msp-form-control,
+    body .msp-plugin .msp-control-row select,
+    body .msp-plugin .msp-control-row button,
+    body .msp-plugin .msp-control-row input[type=text],
+    body .msp-plugin textarea,
+    body .msp-plugin .msp-btn {
+      color: var(--buret-molstar-text) !important;
+      background-color: var(--buret-molstar-field-background) !important;
+    }
+    body .msp-plugin .msp-form-control:hover,
+    body .msp-plugin .msp-control-row select:hover,
+    body .msp-plugin .msp-control-row button:hover,
+    body .msp-plugin .msp-control-row input[type=text]:hover,
+    body .msp-plugin .msp-btn:hover,
+    body .msp-plugin .msp-btn-icon:hover,
+    body .msp-plugin .msp-btn-icon-small:hover {
+      color: var(--buret-molstar-accent) !important;
+      background-color: var(--buret-molstar-hover-background) !important;
+      outline: 1px solid var(--buret-molstar-border) !important;
+    }
+    body .msp-plugin .msp-btn-link,
+    body .msp-plugin .msp-btn-link:active,
+    body .msp-plugin .msp-btn-link:focus,
+    body .msp-plugin .msp-btn-link-toggle-on,
+    body .msp-plugin .msp-sequence-wrapper .msp-sequence-present,
+    body .msp-plugin .msp-svg-text {
+      color: var(--buret-molstar-text) !important;
+      fill: var(--buret-molstar-text) !important;
+    }
+    body .msp-plugin .msp-btn-link:hover,
+    body .msp-plugin .msp-highlight-info,
+    body .msp-plugin .msp-highlight-info-additional,
+    body .msp-plugin .msp-sequence-chain-label,
+    body .msp-plugin .msp-sequence-wrapper .msp-sequence-label,
+    body .msp-plugin .msp-sequence-wrapper .msp-sequence-number {
+      color: var(--buret-molstar-accent) !important;
+    }
+    body .msp-plugin .msp-control-row > span.msp-control-row-label,
+    body .msp-plugin .msp-control-row > button.msp-control-button-label,
+    body .msp-plugin .msp-control-group-header > button,
+    body .msp-plugin .msp-control-group-header div,
+    body .msp-plugin .msp-control-group-header > span,
+    body .msp-plugin .msp-log .msp-log-timestamp,
+    body .msp-plugin .msp-help-row > span,
+    body .msp-plugin .msp-row-text > div,
+    body .msp-plugin .msp-25-lower-contrast-text,
+    body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
+      color: var(--buret-molstar-muted-text) !important;
+    }
+    body .msp-plugin .msp-semi-transparent-background {
+      background: var(--buret-molstar-panel-background) !important;
+      opacity: 0.76 !important;
+    }
+    body .msp-plugin .msp-shape-filled,
+    body .msp-plugin .msp-transform-header-brand svg {
+      fill: var(--buret-molstar-text) !important;
+      stroke: var(--buret-molstar-text) !important;
+    }
+    body .msp-plugin .msp-shape-empty {
+      stroke: var(--buret-molstar-text) !important;
+    }
+    body .msp-plugin .msp-slider-base-rail {
+      background-color: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin .msp-slider-base-handle {
+      background-color: var(--buret-molstar-text) !important;
+      border-color: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin ::-webkit-scrollbar-track {
+      background-color: var(--buret-molstar-panel-background) !important;
+    }
+    body .msp-plugin ::-webkit-scrollbar-thumb {
+      background-color: var(--buret-molstar-hover-background) !important;
+      border-color: transparent !important;
     }
     #status {
       position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -128,6 +128,7 @@
     body .msp-plugin .msp-sequence {
       color: var(--buret-molstar-text) !important;
       background: var(--buret-molstar-panel-background) !important;
+      max-height: calc(100vh - 76px) !important;
       box-shadow: 0 14px 34px var(--buret-molstar-shadow);
     }
     body .msp-plugin .msp-control-row,
@@ -218,6 +219,7 @@
       opacity: 0.76 !important;
     }
     body .msp-plugin .msp-viewport-controls {
+      top: 64px !important;
       z-index: 40;
     }
     body .msp-plugin .msp-viewport-controls-buttons > div {
@@ -272,7 +274,7 @@
       font-size: 12px; font-weight: 500; pointer-events: auto;
     }
     #buret-toolbar {
-      position: absolute; top: 12px; right: 12px; z-index: 2147483646;
+      position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
       display: flex; align-items: center; gap: 6px; padding: 6px;
       border: 1px solid var(--buret-toolbar-border);
       border-radius: 12px; color: var(--buret-toolbar-color);

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -6,6 +6,15 @@
   <title>Burrete Preview</title>
   <link rel="stylesheet" href="./molstar.css" />
   <style>
+    :root {
+      --buret-canvas-background: #000000;
+      --buret-shell-background: #000000;
+      --buret-panel-background: rgba(18, 20, 22, 0.82);
+      --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+      --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+      --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+      --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+    }
     html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
     html.buret-transparent-background,
     html.buret-transparent-background body,
@@ -15,9 +24,26 @@
     html.buret-transparent-background .msp-layout-main,
     html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
     body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
+    body.buret-theme-light {
+      --buret-shell-background: #f7f7f2;
+      --buret-panel-background: rgba(247, 247, 242, 0.86);
+      --buret-toolbar-background: rgba(247, 247, 242, 0.90);
+      --buret-toolbar-border: rgba(0, 0, 0, 0.12);
+      --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
+      --buret-toolbar-color: rgba(20, 21, 23, 0.92);
+      color: #161719;
+    }
+    body.buret-theme-dark {
+      --buret-shell-background: var(--buret-canvas-background);
+      --buret-panel-background: rgba(18, 20, 22, 0.82);
+      --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+      --buret-toolbar-border: rgba(255, 255, 255, 0.10);
+      --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
+      --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+    }
     body.burette-opaque-background,
     body.burette-opaque-background #app {
-      background: #111317;
+      background: var(--buret-shell-background);
     }
     #app { position: absolute; inset: 0; }
     body.burette-transparent-background .msp-plugin,
@@ -34,13 +60,13 @@
     body.burette-opaque-background .msp-plugin .msp-layout-viewport,
     body.burette-opaque-background .msp-plugin .msp-plugin-content,
     body.burette-opaque-background .msp-plugin canvas {
-      background: #111317 !important;
+      background: var(--buret-canvas-background) !important;
     }
-    body.burette-transparent-background .msp-plugin .msp-layout-left,
-    body.burette-transparent-background .msp-plugin .msp-layout-right,
-    body.burette-transparent-background .msp-plugin .msp-layout-top,
-    body.burette-transparent-background .msp-plugin .msp-layout-bottom {
-      background: rgba(238, 236, 231, 0.72) !important;
+    body .msp-plugin .msp-layout-left,
+    body .msp-plugin .msp-layout-right,
+    body .msp-plugin .msp-layout-top,
+    body .msp-plugin .msp-layout-bottom {
+      background: var(--buret-panel-background) !important;
       -webkit-backdrop-filter: blur(14px);
       backdrop-filter: blur(14px);
     }
@@ -61,9 +87,9 @@
     #buret-toolbar {
       position: absolute; top: 12px; right: 12px; z-index: 2147483646;
       display: flex; align-items: center; gap: 6px; padding: 6px;
-      border: 1px solid rgba(255, 255, 255, 0.10);
-      border-radius: 12px; color: rgba(255, 255, 255, 0.94);
-      background: rgba(18, 20, 22, 0.86);
+      border: 1px solid var(--buret-toolbar-border);
+      border-radius: 12px; color: var(--buret-toolbar-color);
+      background: var(--buret-toolbar-background);
       -webkit-backdrop-filter: blur(10px);
       backdrop-filter: blur(10px);
       box-shadow:
@@ -71,14 +97,17 @@
         inset 0 1px 0 rgba(255, 255, 255, 0.06);
       user-select: none; touch-action: none;
     }
+    #buret-toolbar.collapsed { gap: 0; }
+    #buret-toolbar.collapsed .buret-button:not(.buret-grip) { display: none; }
+    #buret-toolbar.collapsed .buret-grip { min-width: 30px; padding: 0; cursor: pointer; }
     .buret-button {
       min-width: 30px; height: 30px; border: 0; border-radius: 8px; padding: 0 8px;
       color: inherit; background: transparent; font: 600 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
       display: grid; place-items: center;
     }
-    .buret-button:hover, .buret-button.active { background: rgba(255, 255, 255, 0.14); }
+    .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
     .buret-button svg { width: 17px; height: 17px; display: block; }
-    .buret-grip { cursor: move; color: rgba(255, 255, 255, 0.66); }
+    .buret-grip { cursor: grab; color: currentColor; opacity: 0.66; }
     #buret-window-outline {
       position: absolute; inset: 0; z-index: 2147483645;
       border: 1px solid rgba(255, 255, 255, 0.08);
@@ -113,16 +142,13 @@
 <body>
   <div id="app"></div>
   <div id="buret-toolbar" role="toolbar" aria-label="Burrete preview controls">
-    <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Move controls" title="Move controls">
+    <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Collapse controls" aria-expanded="true" title="Collapse controls">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
     </button>
-    <button class="buret-button" type="button" data-buret-action="fit" aria-label="Fit window to screen" title="Fit window to screen">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5v2H7.4l3.2 3.2-1.4 1.4L6 7.4V9H4Zm11-5h5v5h-2V7.4l-3.2 3.2-1.4-1.4L16.6 6H15V4ZM9.2 13.4l1.4 1.4L7.4 18H9v2H4v-5h2v1.6l3.2-3.2Zm5.6 0 3.2 3.2V15h2v5h-5v-2h1.6l-3.2-3.2 1.4-1.4Z" fill="currentColor"/></svg>
-    </button>
-    <button class="buret-button active" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
-    <button class="buret-button" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
-    <button class="buret-button" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
-    <button class="buret-button" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
+    <button class="buret-button buret-panel-toggle active" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
+    <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
+    <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
+    <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
   </div>
   <div id="buret-window-outline" aria-hidden="true"></div>
   <div id="status">[web] Loading Mol* preview shell…</div>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6,6 +6,8 @@
   const MAX_SDF_GRID_ATOMS = 900;
   const MAX_SDF_GRID_BONDS = 900;
   const SDF_GRID_PADDING = 4.0;
+  const TOOLBAR_POSITION_VERSION = '2';
+  const TOOLBAR_MARGIN = 12;
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
   function post(type, message) {
@@ -311,22 +313,29 @@
         window.localStorage && window.localStorage.setItem('buret.toolbar.collapsed', collapsed ? '1' : '0');
       } catch (_) {}
     }
-    moveToolbar(toolbar, toolbar.getBoundingClientRect().left, toolbar.getBoundingClientRect().top);
+    repositionToolbar(toolbar);
     scheduleViewerResize(viewer, 40);
   }
 
   function initToolbarDrag(toolbar) {
+    let hasSavedPosition = false;
     try {
       const raw = window.localStorage && window.localStorage.getItem('buret.toolbar.position');
-      if (raw) {
+      const version = window.localStorage && window.localStorage.getItem('buret.toolbar.position.version');
+      if (raw && version === TOOLBAR_POSITION_VERSION) {
         const saved = JSON.parse(raw);
         if (Number.isFinite(saved.left) && Number.isFinite(saved.top)) {
           toolbar.style.left = saved.left + 'px';
           toolbar.style.top = saved.top + 'px';
           toolbar.style.right = 'auto';
+          toolbar.dataset.defaultPosition = '0';
+          hasSavedPosition = true;
         }
+      } else if (raw) {
+        window.localStorage && window.localStorage.removeItem('buret.toolbar.position');
       }
     } catch (_) {}
+    if (!hasSavedPosition) applyDefaultToolbarPosition(toolbar);
 
     let drag = null;
     toolbar.addEventListener('pointerdown', event => {
@@ -359,15 +368,34 @@
       if (shouldToggle) {
         setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
       } else {
+        toolbar.dataset.defaultPosition = '0';
         saveToolbarPosition(toolbar);
       }
     });
     toolbar.addEventListener('pointercancel', () => { drag = null; });
     window.addEventListener('resize', () => {
-      const rect = toolbar.getBoundingClientRect();
-      moveToolbar(toolbar, rect.left, rect.top);
-      saveToolbarPosition(toolbar);
+      repositionToolbar(toolbar);
     });
+  }
+
+  function repositionToolbar(toolbar) {
+    if (toolbar.dataset.defaultPosition === '1') {
+      applyDefaultToolbarPosition(toolbar);
+      return;
+    }
+
+    const rect = toolbar.getBoundingClientRect();
+    moveToolbar(toolbar, rect.left, rect.top);
+    saveToolbarPosition(toolbar);
+  }
+
+  function applyDefaultToolbarPosition(toolbar) {
+    const main = document.querySelector('.msp-plugin .msp-layout-main');
+    const rect = main && main.getBoundingClientRect();
+    const left = rect && rect.width > 0 ? rect.left + TOOLBAR_MARGIN : TOOLBAR_MARGIN;
+    const top = rect && rect.height > 0 ? rect.top + TOOLBAR_MARGIN : TOOLBAR_MARGIN;
+    toolbar.dataset.defaultPosition = '1';
+    moveToolbar(toolbar, left, top);
   }
 
   function moveToolbar(toolbar, left, top) {
@@ -383,6 +411,7 @@
     try {
       const rect = toolbar.getBoundingClientRect();
       window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({ left: rect.left, top: rect.top }));
+      window.localStorage && window.localStorage.setItem('buret.toolbar.position.version', TOOLBAR_POSITION_VERSION);
     } catch (_) {}
   }
 
@@ -412,6 +441,10 @@
 
     updateToolbarButtons();
     scheduleViewerResize(viewer, 40);
+    const toolbar = document.getElementById('buret-toolbar');
+    if (toolbar?.dataset.defaultPosition === '1') {
+      requestAnimationFrame(() => applyDefaultToolbarPosition(toolbar));
+    }
   }
 
   function updateToolbarButtons() {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -450,6 +450,7 @@
     const toolbar = document.getElementById('buret-toolbar');
     if (toolbar?.dataset.defaultPosition === '1') {
       requestAnimationFrame(() => applyDefaultToolbarPosition(toolbar));
+      setTimeout(() => applyDefaultToolbarPosition(toolbar), 120);
     }
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -764,6 +764,7 @@
       emdbProvider: 'rcsb',
       preferWebgl1: true,
       disableAntialiasing: true,
+      viewportBackgroundColor: transparentBackground ? undefined : canvasBackgroundCSS(),
       powerPreference: 'high-performance'
     };
   }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -92,18 +92,21 @@
   const MIN_VIEWER_UI_SCALE = 0.72;
   const MAX_VIEWER_UI_SCALE = 1.35;
   const VIEWER_UI_SCALE_STEP = 0.08;
-  const RENDER_PIXEL_SCALE = 0.75;
-  const PICK_PIXEL_SCALE = 0.2;
 
   let panelControlsVisible = window.BurretePanelControlsVisible !== false;
   let transparentBackground = false;
+  let viewerTheme = 'auto';
+  let canvasBackground = 'black';
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
   let activeViewer = null;
   let keyboardShortcutsInstalled = false;
+  let themeListenerInstalled = false;
 
   function applyConfigOptions(config) {
     panelControlsVisible = config.showPanelControls !== undefined ? !!config.showPanelControls : panelControlsVisible;
-    transparentBackground = config.transparentBackground === true;
+    viewerTheme = normalizeViewerTheme(config.theme);
+    canvasBackground = normalizeCanvasBackground(config.canvasBackground);
+    transparentBackground = canvasBackground === 'transparent' || config.transparentBackground === true;
     applyDocumentBackground();
     viewerUIScale = resolveInitialViewerScale(config);
     applyViewerUIScale();
@@ -116,13 +119,65 @@
       }
     }
     applyBackgroundMode();
+    installThemeListener();
     updateToolbarVisibility();
   }
 
   function applyBackgroundMode() {
     if (!document.body) return;
+    const resolvedTheme = resolveViewerTheme();
+    document.documentElement.dataset.buretTheme = resolvedTheme;
+    document.body.dataset.buretTheme = resolvedTheme;
+    document.body.classList.toggle('buret-theme-dark', resolvedTheme === 'dark');
+    document.body.classList.toggle('buret-theme-light', resolvedTheme === 'light');
     document.body.classList.toggle('burette-transparent-background', transparentBackground);
     document.body.classList.toggle('burette-opaque-background', !transparentBackground);
+    document.documentElement.style.setProperty('--buret-canvas-background', canvasBackgroundCSS());
+  }
+
+  function normalizeViewerTheme(value) {
+    return ['dark', 'light', 'auto'].includes(value) ? value : 'auto';
+  }
+
+  function resolveViewerTheme() {
+    if (viewerTheme === 'dark' || viewerTheme === 'light') return viewerTheme;
+    try {
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    } catch (_) {
+      return 'dark';
+    }
+  }
+
+  function installThemeListener() {
+    if (themeListenerInstalled || !window.matchMedia) return;
+    themeListenerInstalled = true;
+    try {
+      const media = window.matchMedia('(prefers-color-scheme: light)');
+      const update = () => {
+        if (viewerTheme !== 'auto') return;
+        applyBackgroundMode();
+        applyViewerBackground();
+      };
+      if (typeof media.addEventListener === 'function') media.addEventListener('change', update);
+      else if (typeof media.addListener === 'function') media.addListener(update);
+    } catch (_) {}
+  }
+
+  function normalizeCanvasBackground(value) {
+    return ['black', 'graphite', 'white', 'transparent'].includes(value) ? value : 'black';
+  }
+
+  function canvasBackgroundCSS() {
+    if (canvasBackground === 'white') return '#f7f7f2';
+    if (canvasBackground === 'graphite') return '#111317';
+    if (canvasBackground === 'transparent') return 'transparent';
+    return '#000000';
+  }
+
+  function canvasBackgroundColor() {
+    if (canvasBackground === 'white') return 0xf7f7f2;
+    if (canvasBackground === 'graphite') return 0x111317;
+    return 0x000000;
   }
 
   function resolveInitialViewerScale(config) {
@@ -167,9 +222,13 @@
     const canvas3d = viewer?.plugin?.canvas3d;
     if (!canvas3d) return;
     try {
-      canvas3d.setProps({ transparentBackground });
+      if (transparentBackground) {
+        canvas3d.setProps({ transparentBackground: true });
+      } else {
+        canvas3d.setProps({ transparentBackground: false, renderer: { backgroundColor: canvasBackgroundColor() } });
+      }
     } catch (error) {
-      debug('canvas3d transparentBackground failed: ' + (error && error.message || String(error)));
+      debug('canvas3d background mode failed: ' + (error && error.message || String(error)));
     }
     try { canvas3d.requestDraw?.(); } catch (_) {}
   }
@@ -219,15 +278,6 @@
     const toolbar = document.getElementById('buret-toolbar');
     if (!toolbar) return;
 
-    toolbar.querySelectorAll('[data-buret-action]').forEach(button => {
-      button.addEventListener('click', () => {
-        const action = button.getAttribute('data-buret-action');
-        if (action === 'fit') {
-          post('action', 'fit');
-        }
-      });
-    });
-
     toolbar.querySelectorAll('[data-buret-toggle]').forEach(button => {
       button.addEventListener('click', () => {
         toggleLayoutRegion(button.getAttribute('data-buret-toggle'), viewer);
@@ -235,8 +285,34 @@
     });
 
     initToolbarDrag(toolbar);
+    restoreToolbarCollapsed(toolbar, viewer);
     updateToolbarVisibility();
     applyLayoutState(viewer);
+  }
+
+  function restoreToolbarCollapsed(toolbar, viewer) {
+    let collapsed = false;
+    try {
+      collapsed = window.localStorage && window.localStorage.getItem('buret.toolbar.collapsed') === '1';
+    } catch (_) {}
+    setToolbarCollapsed(toolbar, collapsed, viewer, false);
+  }
+
+  function setToolbarCollapsed(toolbar, collapsed, viewer, persist = true) {
+    toolbar.classList.toggle('collapsed', collapsed);
+    const grip = toolbar.querySelector('[data-drag-handle]');
+    if (grip) {
+      grip.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      grip.setAttribute('aria-label', collapsed ? 'Expand controls' : 'Collapse controls');
+      grip.setAttribute('title', collapsed ? 'Expand controls' : 'Collapse controls');
+    }
+    if (persist) {
+      try {
+        window.localStorage && window.localStorage.setItem('buret.toolbar.collapsed', collapsed ? '1' : '0');
+      } catch (_) {}
+    }
+    moveToolbar(toolbar, toolbar.getBoundingClientRect().left, toolbar.getBoundingClientRect().top);
+    scheduleViewerResize(viewer, 40);
   }
 
   function initToolbarDrag(toolbar) {
@@ -259,19 +335,32 @@
       drag = {
         dx: event.clientX - rect.left,
         dy: event.clientY - rect.top,
-        pointerId: event.pointerId
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false
       };
       toolbar.setPointerCapture(event.pointerId);
       event.preventDefault();
     });
     toolbar.addEventListener('pointermove', event => {
       if (!drag || event.pointerId !== drag.pointerId) return;
-      moveToolbar(toolbar, event.clientX - drag.dx, event.clientY - drag.dy);
+      if (!drag.moved) {
+        drag.moved = Math.abs(event.clientX - drag.startX) > 4 || Math.abs(event.clientY - drag.startY) > 4;
+      }
+      if (drag.moved) {
+        moveToolbar(toolbar, event.clientX - drag.dx, event.clientY - drag.dy);
+      }
     });
     toolbar.addEventListener('pointerup', event => {
       if (!drag || event.pointerId !== drag.pointerId) return;
+      const shouldToggle = !drag.moved;
       drag = null;
-      saveToolbarPosition(toolbar);
+      if (shouldToggle) {
+        setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
+      } else {
+        saveToolbarPosition(toolbar);
+      }
     });
     toolbar.addEventListener('pointercancel', () => { drag = null; });
     window.addEventListener('resize', () => {
@@ -675,9 +764,6 @@
       emdbProvider: 'rcsb',
       preferWebgl1: true,
       disableAntialiasing: true,
-      resolutionMode: 'scaled',
-      pixelScale: RENDER_PIXEL_SCALE,
-      pickScale: PICK_PIXEL_SCALE,
       powerPreference: 'high-performance'
     };
   }
@@ -695,18 +781,6 @@
     }
 
     return new window.molstar.Viewer('app', createViewerOptions());
-  }
-
-  function applyViewerBackground(viewer) {
-    try {
-      viewer?.plugin?.canvas3d?.setProps?.(
-        transparentBackground
-          ? { transparentBackground: true }
-          : { transparentBackground: false, renderer: { backgroundColor: 0x111317 } }
-      );
-    } catch (error) {
-      debug('canvas3d background mode failed: ' + (error && error.message || String(error)));
-    }
   }
 
   async function start() {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6,7 +6,7 @@
   const MAX_SDF_GRID_ATOMS = 900;
   const MAX_SDF_GRID_BONDS = 900;
   const SDF_GRID_PADDING = 4.0;
-  const TOOLBAR_POSITION_VERSION = '2';
+  const TOOLBAR_POSITION_VERSION = '3';
   const TOOLBAR_MARGIN = 12;
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
@@ -324,15 +324,12 @@
       const version = window.localStorage && window.localStorage.getItem('buret.toolbar.position.version');
       if (raw && version === TOOLBAR_POSITION_VERSION) {
         const saved = JSON.parse(raw);
-        if (Number.isFinite(saved.left) && Number.isFinite(saved.top)) {
-          const savedDefaultCorner = saved.left <= TOOLBAR_MARGIN + 4 && saved.top <= TOOLBAR_MARGIN + 4;
-          if (!savedDefaultCorner) {
-            toolbar.style.left = saved.left + 'px';
-            toolbar.style.top = saved.top + 'px';
-            toolbar.style.right = 'auto';
-            toolbar.dataset.defaultPosition = '0';
-            hasSavedPosition = true;
-          }
+        if (saved.mode === 'custom' && Number.isFinite(saved.left) && Number.isFinite(saved.top)) {
+          toolbar.style.left = saved.left + 'px';
+          toolbar.style.top = saved.top + 'px';
+          toolbar.style.right = 'auto';
+          toolbar.dataset.defaultPosition = '0';
+          hasSavedPosition = true;
         }
       } else if (raw) {
         window.localStorage && window.localStorage.removeItem('buret.toolbar.position');
@@ -419,7 +416,7 @@
   function saveToolbarPosition(toolbar) {
     try {
       const rect = toolbar.getBoundingClientRect();
-      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({ left: rect.left, top: rect.top }));
+      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({ left: rect.left, top: rect.top, mode: 'custom' }));
       window.localStorage && window.localStorage.setItem('buret.toolbar.position.version', TOOLBAR_POSITION_VERSION);
     } catch (_) {}
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.4",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.4",
+      "version": "0.10.6",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.4",
+  "version": "0.10.6",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -84,7 +84,7 @@ const config = {
   format,
   binary,
   byteCount: data.length,
-  theme: 'auto',
+  theme: 'dark',
   canvasBackground: 'black',
   transparentBackground: false,
   sdfGrid: true,
@@ -135,7 +135,7 @@ assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* wit
 assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
 assert(config.label === path.basename(sample), 'config label should match sample basename');
 assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');
-assert(config.theme === 'auto', 'theme should default to auto');
+assert(config.theme === 'dark', 'theme should default to dark');
 assert(config.canvasBackground === 'black', 'canvas background should default to black');
 assert(config.transparentBackground === false, 'transparent background should be opt-in');
 assert(config.sdfGrid === true, 'SDF grid flag should be encoded');

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -84,7 +84,9 @@ const config = {
   format,
   binary,
   byteCount: data.length,
-  transparentBackground: format === 'sdf',
+  theme: 'auto',
+  canvasBackground: 'black',
+  transparentBackground: false,
   sdfGrid: true,
   showPanelControls: true
 };
@@ -118,14 +120,21 @@ function assert(condition, message) {
 }
 
 assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar role');
-assert(index.includes('aria-label="Fit window to screen"'), 'fit button must not be labelled Fullscreen');
+assert(!index.includes('data-buret-action="fit"'), 'fit/fullscreen toolbar button should not be present');
+assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should collapse controls');
+assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
 assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
+assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
+assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
+assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
 assert(config.label === path.basename(sample), 'config label should match sample basename');
 assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');
-assert(config.transparentBackground === (config.format === 'sdf'), 'transparent background should default to SDF only');
+assert(config.theme === 'auto', 'theme should default to auto');
+assert(config.canvasBackground === 'black', 'canvas background should default to black');
+assert(config.transparentBackground === false, 'transparent background should be opt-in');
 assert(config.sdfGrid === true, 'SDF grid flag should be encoded');
 
 const expectedFormats = {

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -123,12 +123,15 @@ assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar rol
 assert(!index.includes('data-buret-action="fit"'), 'fit/fullscreen toolbar button should not be present');
 assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should collapse controls');
 assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
+assert(index.includes('top: 12px; left: 12px; right: auto'), 'toolbar should default to the upper-left corner');
 assert(index.includes('--buret-molstar-panel-background'), 'preview HTML must define Mol* theme panel colors');
 assert(index.includes('.msp-viewport-controls-panel'), 'preview HTML must theme Mol* viewport panels');
+assert(index.includes('top: 64px !important'), 'Mol* viewport controls should clear the toolbar row');
 assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
+assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -123,12 +123,15 @@ assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar rol
 assert(!index.includes('data-buret-action="fit"'), 'fit/fullscreen toolbar button should not be present');
 assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should collapse controls');
 assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
+assert(index.includes('--buret-molstar-panel-background'), 'preview HTML must define Mol* theme panel colors');
+assert(index.includes('.msp-viewport-controls-panel'), 'preview HTML must theme Mol* viewport panels');
 assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
+assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');
 assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
 assert(config.label === path.basename(sample), 'config label should match sample basename');
 assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -132,6 +132,7 @@ assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
+assert(viewer.includes("mode: 'custom'"), 'viewer.js must distinguish custom toolbar positions from defaults');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');


### PR DESCRIPTION
## Summary
- add Auto/Dark/Light viewer theme settings and configurable canvas backgrounds
- default the molecule canvas to black and keep transparent canvas explicit
- remove the floating fullscreen button, make the dotted handle collapse/expand the toolbar, and use native macOS fullscreen for the app window
- restore render quality by removing the forced scaled pixel settings

## Validation
- node --check PreviewExtension/Web/viewer.js
- npm run test:web -- --no-open
- npm run test:web -- --no-open samples/mini.sdf
- ./scripts/build.sh
- pre-push npm run ci