### PR TITLE
Polish Molstar dark UI panels

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -762,7 +762,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.8")
+                Text("Version 0.10.9")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -38,8 +38,14 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         window.title = "Burrete - \(fileURL.lastPathComponent)"
         window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 660, height: 440)
-        window.isOpaque = !transparentBackground
-        window.backgroundColor = transparentBackground ? .clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.titlebarAppearsTransparent = true
+        if #available(macOS 11.0, *) {
+            window.toolbarStyle = .unifiedCompact
+        }
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
         window.contentView = BurreteAppViewerContainerView(contentView: webView, transparentBackground: transparentBackground)
 
         super.init(window: window)
@@ -274,6 +280,7 @@ private struct AppViewerRuntime {
               --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
               --buret-molstar-accent: #8fc7ff;
               --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
+              --buret-molstar-panel-radius: 10px;
             }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
@@ -358,6 +365,7 @@ private struct AppViewerRuntime {
             body .msp-plugin .msp-layout-bottom,
             body .msp-plugin .msp-layout-left,
             body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-sequence-select,
             body .msp-plugin .msp-control-row,
             body .msp-plugin .msp-log li,
             body .msp-plugin .msp-toast-container .msp-toast-entry,
@@ -381,6 +389,41 @@ private struct AppViewerRuntime {
               background: var(--buret-molstar-panel-background) !important;
               max-height: calc(100vh - 76px) !important;
               box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-hover-box-wrapper .msp-hover-box-body,
+            body .msp-plugin .msp-action-menu-options,
+            body .msp-plugin .msp-action-menu-options-no-header,
+            body .msp-plugin .msp-animation-viewport-controls-select,
+            body .msp-plugin .msp-selection-viewport-controls-actions,
+            body .msp-plugin .msp-panel-description-content,
+            body .msp-plugin .msp-simple-help-section,
+            body .msp-plugin .msp-help-text,
+            body .msp-plugin .msp-no-webgl,
+            body .msp-plugin .msp-log,
+            body .msp-plugin .msp-toast-container .msp-toast-entry {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: var(--buret-molstar-panel-radius);
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-action-menu-options .msp-control-group-children,
+            body .msp-plugin .msp-viewport-controls-panel .msp-viewport-controls-panel-controls {
+              border-radius: inherit;
+            }
+            body .msp-plugin .msp-sequence-select {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+              border-bottom: 1px solid var(--buret-molstar-border);
+              box-shadow: none;
+            }
+            body .msp-plugin .msp-sequence-select > span,
+            body .msp-plugin .msp-sequence-select > select {
+              color: var(--buret-molstar-text) !important;
+              background-color: var(--buret-molstar-field-background) !important;
+              border-right: 1px solid var(--buret-molstar-border);
             }
             body .msp-plugin .msp-control-row,
             body .msp-plugin .msp-control-current,
@@ -409,12 +452,17 @@ private struct AppViewerRuntime {
             body .msp-plugin .msp-control-row > div.msp-control-row-text,
             body .msp-plugin .msp-help-row > div,
             body .msp-plugin .msp-sequence-wrapper-non-empty,
+            body .msp-plugin .msp-sequence-wrapper,
             body .msp-plugin .msp-log .msp-log-entry,
             body .msp-plugin .msp-copy-image-wrapper div,
             body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
             body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
               color: var(--buret-molstar-text) !important;
               background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-sequence-wrapper-non-empty {
+              border-top: 1px solid var(--buret-molstar-border);
+              box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
             }
             body .msp-plugin .msp-form-control,
             body .msp-plugin .msp-control-row select,
@@ -465,9 +513,86 @@ private struct AppViewerRuntime {
             body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
               color: var(--buret-molstar-muted-text) !important;
             }
+            body .msp-plugin .msp-viewport-controls-panel {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: var(--buret-molstar-panel-radius);
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-wrapper {
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+              border-bottom: 1px solid var(--buret-molstar-border) !important;
+              font-weight: 700;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row {
+              border-top: 1px solid var(--buret-molstar-border) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div.msp-control-row-text,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-current {
+              background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: 10px;
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
+              border-left: 1px solid var(--buret-molstar-border) !important;
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
+              border-left: 0 !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls button,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn {
+              color: var(--buret-molstar-text) !important;
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls button:hover,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn-link-toggle-on {
+              color: var(--buret-molstar-accent) !important;
+              background: var(--buret-molstar-hover-background) !important;
+              outline: 0 !important;
+            }
             body .msp-plugin .msp-semi-transparent-background {
               background: var(--buret-molstar-panel-background) !important;
               opacity: 0.76 !important;
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper,
+            body .msp-plugin .msp-highlight-info {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              border: 1px solid var(--buret-molstar-border);
+              border-radius: 10px;
+              opacity: 1 !important;
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper *,
+            body .msp-plugin .msp-highlight-info * {
+              background: transparent !important;
+              color: inherit !important;
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper a,
+            body .msp-plugin .msp-highlight-info-additional {
+              color: var(--buret-molstar-accent) !important;
             }
             body .msp-plugin .msp-viewport-controls {
               top: 64px !important;
@@ -520,7 +645,7 @@ private struct AppViewerRuntime {
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
+              position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);
@@ -575,6 +700,7 @@ private struct AppViewerRuntime {
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
+            <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
           </div>
           <div id="status" class="hidden">Loading Burrete viewer...</div>
           <script>
@@ -682,6 +808,8 @@ private final class BurreteAppViewerContainerView: NSView {
         wantsLayer = true
         layer?.borderWidth = 1
         layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        layer?.cornerRadius = 16
+        layer?.masksToBounds = true
         layer?.backgroundColor = (transparentBackground ? NSColor.clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)).cgColor
 
         contentView.translatesAutoresizingMaskIntoConstraints = false

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.8;
+				MARKETING_VERSION = 0.10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.8;
+				MARKETING_VERSION = 0.10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.8;
+				MARKETING_VERSION = 0.10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.8;
+				MARKETING_VERSION = 0.10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -416,6 +416,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
               --buret-molstar-accent: #8fc7ff;
               --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
+              --buret-molstar-panel-radius: 10px;
             }
             html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
             html.buret-transparent-background,
@@ -500,6 +501,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body .msp-plugin .msp-layout-bottom,
             body .msp-plugin .msp-layout-left,
             body .msp-plugin .msp-layout-right,
+            body .msp-plugin .msp-sequence-select,
             body .msp-plugin .msp-control-row,
             body .msp-plugin .msp-log li,
             body .msp-plugin .msp-toast-container .msp-toast-entry,
@@ -523,6 +525,41 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
               background: var(--buret-molstar-panel-background) !important;
               max-height: calc(100vh - 76px) !important;
               box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-hover-box-wrapper .msp-hover-box-body,
+            body .msp-plugin .msp-action-menu-options,
+            body .msp-plugin .msp-action-menu-options-no-header,
+            body .msp-plugin .msp-animation-viewport-controls-select,
+            body .msp-plugin .msp-selection-viewport-controls-actions,
+            body .msp-plugin .msp-panel-description-content,
+            body .msp-plugin .msp-simple-help-section,
+            body .msp-plugin .msp-help-text,
+            body .msp-plugin .msp-no-webgl,
+            body .msp-plugin .msp-log,
+            body .msp-plugin .msp-toast-container .msp-toast-entry {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: var(--buret-molstar-panel-radius);
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-action-menu-options .msp-control-group-children,
+            body .msp-plugin .msp-viewport-controls-panel .msp-viewport-controls-panel-controls {
+              border-radius: inherit;
+            }
+            body .msp-plugin .msp-sequence-select {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+              border-bottom: 1px solid var(--buret-molstar-border);
+              box-shadow: none;
+            }
+            body .msp-plugin .msp-sequence-select > span,
+            body .msp-plugin .msp-sequence-select > select {
+              color: var(--buret-molstar-text) !important;
+              background-color: var(--buret-molstar-field-background) !important;
+              border-right: 1px solid var(--buret-molstar-border);
             }
             body .msp-plugin .msp-control-row,
             body .msp-plugin .msp-control-current,
@@ -551,12 +588,17 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body .msp-plugin .msp-control-row > div.msp-control-row-text,
             body .msp-plugin .msp-help-row > div,
             body .msp-plugin .msp-sequence-wrapper-non-empty,
+            body .msp-plugin .msp-sequence-wrapper,
             body .msp-plugin .msp-log .msp-log-entry,
             body .msp-plugin .msp-copy-image-wrapper div,
             body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
             body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
               color: var(--buret-molstar-text) !important;
               background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-sequence-wrapper-non-empty {
+              border-top: 1px solid var(--buret-molstar-border);
+              box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
             }
             body .msp-plugin .msp-form-control,
             body .msp-plugin .msp-control-row select,
@@ -607,9 +649,86 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
               color: var(--buret-molstar-muted-text) !important;
             }
+            body .msp-plugin .msp-viewport-controls-panel {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: var(--buret-molstar-panel-radius);
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-wrapper {
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+              border-bottom: 1px solid var(--buret-molstar-border) !important;
+              font-weight: 700;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row {
+              border-top: 1px solid var(--buret-molstar-border) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div.msp-control-row-text,
+            body .msp-plugin .msp-viewport-controls-panel .msp-control-current {
+              background: var(--buret-molstar-field-background) !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+              overflow: hidden;
+              border: 1px solid var(--buret-molstar-border) !important;
+              border-radius: 10px;
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
+              border-left: 1px solid var(--buret-molstar-border) !important;
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-row-background) !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
+              border-left: 0 !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls button,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn {
+              color: var(--buret-molstar-text) !important;
+              background: transparent !important;
+            }
+            body .msp-plugin .msp-selection-viewport-controls button:hover,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,
+            body .msp-plugin .msp-selection-viewport-controls .msp-btn-link-toggle-on {
+              color: var(--buret-molstar-accent) !important;
+              background: var(--buret-molstar-hover-background) !important;
+              outline: 0 !important;
+            }
             body .msp-plugin .msp-semi-transparent-background {
               background: var(--buret-molstar-panel-background) !important;
               opacity: 0.76 !important;
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper,
+            body .msp-plugin .msp-highlight-info {
+              color: var(--buret-molstar-text) !important;
+              background: var(--buret-molstar-panel-background) !important;
+              border: 1px solid var(--buret-molstar-border);
+              border-radius: 10px;
+              opacity: 1 !important;
+              -webkit-backdrop-filter: blur(12px);
+              backdrop-filter: blur(12px);
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper *,
+            body .msp-plugin .msp-highlight-info * {
+              background: transparent !important;
+              color: inherit !important;
+            }
+            body .msp-plugin .msp-snapshot-description-wrapper a,
+            body .msp-plugin .msp-highlight-info-additional {
+              color: var(--buret-molstar-accent) !important;
             }
             body .msp-plugin .msp-viewport-controls {
               top: 64px !important;
@@ -663,7 +782,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
+              position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);
@@ -755,6 +874,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
+            <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
           </div>
           <div id="status" class="hidden">[web] HTML body created. Waiting for embedded data and Mol* script…</div>
           <script>

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -23,6 +23,7 @@
       --buret-molstar-muted-text: rgba(190, 196, 204, 0.82);
       --buret-molstar-accent: #8fc7ff;
       --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
+      --buret-molstar-panel-radius: 10px;
     }
     html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
     html.buret-transparent-background,
@@ -107,6 +108,7 @@
     body .msp-plugin .msp-layout-bottom,
     body .msp-plugin .msp-layout-left,
     body .msp-plugin .msp-layout-right,
+    body .msp-plugin .msp-sequence-select,
     body .msp-plugin .msp-control-row,
     body .msp-plugin .msp-log li,
     body .msp-plugin .msp-toast-container .msp-toast-entry,
@@ -130,6 +132,41 @@
       background: var(--buret-molstar-panel-background) !important;
       max-height: calc(100vh - 76px) !important;
       box-shadow: 0 14px 34px var(--buret-molstar-shadow);
+    }
+    body .msp-plugin .msp-hover-box-wrapper .msp-hover-box-body,
+    body .msp-plugin .msp-action-menu-options,
+    body .msp-plugin .msp-action-menu-options-no-header,
+    body .msp-plugin .msp-animation-viewport-controls-select,
+    body .msp-plugin .msp-selection-viewport-controls-actions,
+    body .msp-plugin .msp-panel-description-content,
+    body .msp-plugin .msp-simple-help-section,
+    body .msp-plugin .msp-help-text,
+    body .msp-plugin .msp-no-webgl,
+    body .msp-plugin .msp-log,
+    body .msp-plugin .msp-toast-container .msp-toast-entry {
+      overflow: hidden;
+      border: 1px solid var(--buret-molstar-border) !important;
+      border-radius: var(--buret-molstar-panel-radius);
+      background: var(--buret-molstar-panel-background) !important;
+      box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+    }
+    body .msp-plugin .msp-action-menu-options .msp-control-group-children,
+    body .msp-plugin .msp-viewport-controls-panel .msp-viewport-controls-panel-controls {
+      border-radius: inherit;
+    }
+    body .msp-plugin .msp-sequence-select {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-row-background) !important;
+      border-bottom: 1px solid var(--buret-molstar-border);
+      box-shadow: none;
+    }
+    body .msp-plugin .msp-sequence-select > span,
+    body .msp-plugin .msp-sequence-select > select {
+      color: var(--buret-molstar-text) !important;
+      background-color: var(--buret-molstar-field-background) !important;
+      border-right: 1px solid var(--buret-molstar-border);
     }
     body .msp-plugin .msp-control-row,
     body .msp-plugin .msp-control-current,
@@ -158,12 +195,17 @@
     body .msp-plugin .msp-control-row > div.msp-control-row-text,
     body .msp-plugin .msp-help-row > div,
     body .msp-plugin .msp-sequence-wrapper-non-empty,
+    body .msp-plugin .msp-sequence-wrapper,
     body .msp-plugin .msp-log .msp-log-entry,
     body .msp-plugin .msp-copy-image-wrapper div,
     body .msp-plugin .msp-overlay-tasks .msp-task-state > div > div,
     body .msp-plugin .msp-background-tasks .msp-task-state > div > div {
       color: var(--buret-molstar-text) !important;
       background: var(--buret-molstar-field-background) !important;
+    }
+    body .msp-plugin .msp-sequence-wrapper-non-empty {
+      border-top: 1px solid var(--buret-molstar-border);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
     }
     body .msp-plugin .msp-form-control,
     body .msp-plugin .msp-control-row select,
@@ -213,6 +255,83 @@
     body .msp-plugin .msp-25-lower-contrast-text,
     body .msp-plugin .msp-sequence-wrapper .msp-sequence-missing {
       color: var(--buret-molstar-muted-text) !important;
+    }
+    body .msp-plugin .msp-viewport-controls-panel {
+      overflow: hidden;
+      border: 1px solid var(--buret-molstar-border) !important;
+      border-radius: var(--buret-molstar-panel-radius);
+      background: var(--buret-molstar-panel-background) !important;
+      box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+    }
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-group-wrapper {
+      background: transparent !important;
+    }
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header,
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button {
+      border-bottom: 1px solid var(--buret-molstar-border) !important;
+      font-weight: 700;
+    }
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-row {
+      border-top: 1px solid var(--buret-molstar-border) !important;
+      background: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div,
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div.msp-control-row-text,
+    body .msp-plugin .msp-viewport-controls-panel .msp-control-current {
+      background: var(--buret-molstar-field-background) !important;
+    }
+    body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+      overflow: hidden;
+      border: 1px solid var(--buret-molstar-border) !important;
+      border-radius: 10px;
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-panel-background) !important;
+      box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+    }
+    body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
+      border-left: 1px solid var(--buret-molstar-border) !important;
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-row-background) !important;
+    }
+    body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
+      border-left: 0 !important;
+    }
+    body .msp-plugin .msp-selection-viewport-controls button,
+    body .msp-plugin .msp-selection-viewport-controls .msp-btn {
+      color: var(--buret-molstar-text) !important;
+      background: transparent !important;
+    }
+    body .msp-plugin .msp-selection-viewport-controls button:hover,
+    body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,
+    body .msp-plugin .msp-selection-viewport-controls .msp-btn-link-toggle-on {
+      color: var(--buret-molstar-accent) !important;
+      background: var(--buret-molstar-hover-background) !important;
+      outline: 0 !important;
+    }
+    body .msp-plugin .msp-snapshot-description-wrapper,
+    body .msp-plugin .msp-highlight-info {
+      color: var(--buret-molstar-text) !important;
+      background: var(--buret-molstar-panel-background) !important;
+      border: 1px solid var(--buret-molstar-border);
+      border-radius: 10px;
+      opacity: 1 !important;
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+    }
+    body .msp-plugin .msp-snapshot-description-wrapper *,
+    body .msp-plugin .msp-highlight-info * {
+      background: transparent !important;
+      color: inherit !important;
+    }
+    body .msp-plugin .msp-snapshot-description-wrapper a,
+    body .msp-plugin .msp-highlight-info-additional {
+      color: var(--buret-molstar-accent) !important;
     }
     body .msp-plugin .msp-semi-transparent-background {
       background: var(--buret-molstar-panel-background) !important;
@@ -274,7 +393,7 @@
       font-size: 12px; font-weight: 500; pointer-events: auto;
     }
     #buret-toolbar {
-      position: absolute; top: 12px; left: 12px; right: auto; z-index: 2147483646;
+      position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
       display: flex; align-items: center; gap: 6px; padding: 6px;
       border: 1px solid var(--buret-toolbar-border);
       border-radius: 12px; color: var(--buret-toolbar-color);
@@ -338,6 +457,7 @@
     <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
     <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
     <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
+    <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
   </div>
   <div id="buret-window-outline" aria-hidden="true"></div>
   <div id="status">[web] Loading Mol* preview shell…</div>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6,8 +6,9 @@
   const MAX_SDF_GRID_ATOMS = 900;
   const MAX_SDF_GRID_BONDS = 900;
   const SDF_GRID_PADDING = 4.0;
-  const TOOLBAR_POSITION_VERSION = '3';
+  const TOOLBAR_POSITION_VERSION = '6';
   const TOOLBAR_MARGIN = 12;
+  const VIEWER_THEME_STORAGE_KEY = 'buret.viewer.theme';
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
   function post(type, message) {
@@ -55,7 +56,7 @@
   }
 
   const layoutState = {
-    left: 'hidden',
+    left: 'collapsed',
     right: 'hidden',
     top: 'hidden',
     bottom: 'hidden'
@@ -106,8 +107,10 @@
 
   function applyConfigOptions(config) {
     panelControlsVisible = config.showPanelControls !== undefined ? !!config.showPanelControls : panelControlsVisible;
-    viewerTheme = normalizeViewerTheme(config.theme);
+    viewerTheme = readStoredViewerTheme() || normalizeViewerTheme(config.theme);
     canvasBackground = normalizeCanvasBackground(config.canvasBackground);
+    if (viewerTheme === 'dark' && canvasBackground === 'white') canvasBackground = 'black';
+    if (viewerTheme === 'light' && canvasBackground === 'black') canvasBackground = 'white';
     transparentBackground = canvasBackground === 'transparent' || config.transparentBackground === true;
     applyDocumentBackground();
     viewerUIScale = resolveInitialViewerScale(config);
@@ -135,10 +138,20 @@
     document.body.classList.toggle('burette-transparent-background', transparentBackground);
     document.body.classList.toggle('burette-opaque-background', !transparentBackground);
     document.documentElement.style.setProperty('--buret-canvas-background', canvasBackgroundCSS());
+    updateThemeButton();
   }
 
   function normalizeViewerTheme(value) {
     return ['dark', 'light', 'auto'].includes(value) ? value : 'auto';
+  }
+
+  function readStoredViewerTheme() {
+    try {
+      const storedTheme = window.localStorage && window.localStorage.getItem(VIEWER_THEME_STORAGE_KEY);
+      return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+    } catch (_) {
+      return null;
+    }
   }
 
   function resolveViewerTheme() {
@@ -235,6 +248,30 @@
     try { canvas3d.requestDraw?.(); } catch (_) {}
   }
 
+  function setViewerTheme(theme, viewer = activeViewer, persist = true) {
+    viewerTheme = normalizeViewerTheme(theme);
+    if (viewerTheme === 'dark') {
+      canvasBackground = 'black';
+      transparentBackground = false;
+    } else if (viewerTheme === 'light') {
+      canvasBackground = 'white';
+      transparentBackground = false;
+    }
+    if (persist) {
+      try {
+        window.localStorage && window.localStorage.setItem(VIEWER_THEME_STORAGE_KEY, viewerTheme);
+      } catch (_) {}
+    }
+    applyBackgroundMode();
+    applyViewerBackground(viewer);
+    updateThemeButton();
+    scheduleViewerResize(viewer, 40);
+  }
+
+  function toggleViewerTheme(viewer = activeViewer) {
+    setViewerTheme(resolveViewerTheme() === 'dark' ? 'light' : 'dark', viewer);
+  }
+
   function setViewerUIScale(scale, viewer = activeViewer) {
     viewerUIScale = clampViewerScale(scale);
     applyViewerUIScale(viewer);
@@ -285,10 +322,14 @@
         toggleLayoutRegion(button.getAttribute('data-buret-toggle'), viewer);
       });
     });
+    toolbar.querySelector('[data-buret-action="theme"]')?.addEventListener('click', () => {
+      toggleViewerTheme(viewer);
+    });
 
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
     updateToolbarVisibility();
+    updateThemeButton();
     applyLayoutState(viewer);
   }
 
@@ -392,13 +433,14 @@
   function applyDefaultToolbarPosition(toolbar) {
     const main = document.querySelector('.msp-plugin .msp-layout-main');
     const rect = main && main.getBoundingClientRect();
-    const leftPanel = document.querySelector('.msp-plugin .msp-layout-left');
-    const leftPanelRect = leftPanel && leftPanel.getBoundingClientRect();
-    const leftPanelVisible = leftPanelRect &&
-      leftPanelRect.width > 0 &&
-      leftPanelRect.height > 0 &&
-      window.getComputedStyle(leftPanel).display !== 'none';
-    const left = leftPanelVisible ? leftPanelRect.right + TOOLBAR_MARGIN : (rect && rect.width > 0 ? rect.left + TOOLBAR_MARGIN : TOOLBAR_MARGIN);
+    const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
+    const controlsRect = viewportControls && viewportControls.getBoundingClientRect();
+    const controlsVisible = controlsRect &&
+      controlsRect.width > 0 &&
+      controlsRect.height > 0 &&
+      window.getComputedStyle(viewportControls).display !== 'none';
+    const right = controlsVisible ? controlsRect.left - TOOLBAR_MARGIN : window.innerWidth - TOOLBAR_MARGIN;
+    const left = right - toolbar.offsetWidth;
     const top = rect && rect.height > 0 ? rect.top + TOOLBAR_MARGIN : TOOLBAR_MARGIN;
     toolbar.dataset.defaultPosition = '1';
     moveToolbar(toolbar, left, top);
@@ -461,6 +503,16 @@
     toolbar.querySelector('[data-buret-toggle="right"]')?.classList.toggle('active', layoutState.right === 'full');
     toolbar.querySelector('[data-buret-toggle="sequence"]')?.classList.toggle('active', layoutState.top === 'full');
     toolbar.querySelector('[data-buret-toggle="log"]')?.classList.toggle('active', layoutState.bottom === 'full');
+  }
+
+  function updateThemeButton() {
+    const button = document.querySelector('#buret-toolbar [data-buret-action="theme"]');
+    if (!button) return;
+    const isDark = resolveViewerTheme() === 'dark';
+    button.textContent = isDark ? 'Light' : 'Dark';
+    button.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+    button.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+    button.classList.toggle('active', !isDark);
   }
 
   function loadScript(src, label, timeoutMs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -123,9 +123,17 @@ assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar rol
 assert(!index.includes('data-buret-action="fit"'), 'fit/fullscreen toolbar button should not be present');
 assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should collapse controls');
 assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
-assert(index.includes('top: 12px; left: 12px; right: auto'), 'toolbar should default to the upper-left corner');
+assert(index.includes('top: 12px; right: 12px; left: auto'), 'toolbar should default to the upper-right corner');
+assert(index.includes('data-buret-action="theme"'), 'toolbar should expose a separate theme toggle');
 assert(index.includes('--buret-molstar-panel-background'), 'preview HTML must define Mol* theme panel colors');
 assert(index.includes('.msp-viewport-controls-panel'), 'preview HTML must theme Mol* viewport panels');
+assert(index.includes('.msp-viewport-controls-panel .msp-control-group-header > button'), 'preview HTML must style Mol* floating settings panel headers');
+assert(index.includes('.msp-selection-viewport-controls > .msp-flex-row'), 'preview HTML must style Mol* selection viewport toolbar');
+assert(index.includes('--buret-molstar-panel-radius'), 'preview HTML must define a shared Mol* panel radius');
+assert(index.includes('.msp-hover-box-wrapper .msp-hover-box-body'), 'preview HTML must round Mol* hover panels');
+assert(index.includes('.msp-action-menu-options'), 'preview HTML must round Mol* action menu panels');
+assert(index.includes('.msp-snapshot-description-wrapper *'), 'preview HTML must theme Mol* snapshot description text');
+assert(index.includes('.msp-sequence-select > select'), 'preview HTML must theme Mol* sequence selectors');
 assert(index.includes('top: 64px !important'), 'Mol* viewport controls should clear the toolbar row');
 assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
@@ -133,6 +141,9 @@ assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConf
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
 assert(viewer.includes("mode: 'custom'"), 'viewer.js must distinguish custom toolbar positions from defaults');
+assert(!viewer.includes('initMolstarRightPanelToggle'), 'viewer.js must keep Mol* right-side buttons native');
+assert(viewer.includes('VIEWER_THEME_STORAGE_KEY'), 'viewer.js must persist the separate theme toggle');
+assert(!viewer.includes('initMolstarThemeToggle'), 'viewer.js must keep Mol* Illumination button native');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');


### PR DESCRIPTION
## Summary
- polish Molstar dark UI panels, sequence controls, selection toolbar, and floating menus
- keep native Molstar right-side controls behavior intact and add a separate preview theme toggle
- round and darken the app and preview window chrome

## Verification
- npm run check:js
- ./scripts/test-web-preview.sh --no-open /Users/nikolenko/Desktop/1HTB.pdb
- git diff --check
- ./scripts/build.sh
- pre-push npm run ci