### PR TITLE
Make menu bar item icon-only

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -69,10 +69,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func installStatusItem() {
-        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = item.button {
             button.image = BurreteIcon.statusImage()
-            button.title = " Burrete"
+            button.imagePosition = .imageOnly
             button.toolTip = "Burrete - molecular Quick Look previews. Open Settings from this menu."
         }
 

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -762,7 +762,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.9")
+                Text("Version 0.10.10")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -392,7 +392,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.9;
+				MARKETING_VERSION = 0.10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -416,7 +416,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.9;
+				MARKETING_VERSION = 0.10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -440,7 +440,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.9;
+				MARKETING_VERSION = 0.10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -465,7 +465,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.9;
+				MARKETING_VERSION = 0.10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.9",
+      "version": "0.10.10",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -40,6 +40,17 @@ if (!contentView.includes(`Text("Version ${packageVersion}")`)) {
   fail(`App/ContentView.swift About panel does not show Version ${packageVersion}`);
 }
 
+const appDelegate = readFileSync('App/BurreteApp.swift', 'utf8');
+if (!appDelegate.includes('statusItem(withLength: NSStatusItem.squareLength)')) {
+  fail('menu bar status item must use squareLength so it stays icon-only');
+}
+if (!appDelegate.includes('button.imagePosition = .imageOnly')) {
+  fail('menu bar status item must use imageOnly so it does not show a text label');
+}
+if (/button\.title\s*=\s*"[^"]*\S[^"]*"/.test(appDelegate)) {
+  fail('menu bar status item must not set a visible button title');
+}
+
 if (process.env.GITHUB_EVENT_NAME === 'pull_request' && process.env.GITHUB_BASE_REF) {
   const base = process.env.GITHUB_BASE_REF;
   try {


### PR DESCRIPTION
## Summary
- Make the macOS status item square and image-only so the menu bar shows only the Burrete icon.
- Add a release-check guard against reintroducing a visible status item title.
- Bump the release version to 0.10.10 across package, Xcode, and About metadata as required for mergeable PRs.

## Root Cause
The menu bar status item was created with `NSStatusItem.variableLength` and explicitly set `button.title = " Burrete"`, so macOS rendered text next to the icon.

## Validation
- `npm run check:release`
- `npm run check:js`
- `plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements`
- `./scripts/build.sh`
- pre-push `npm run ci` hook passed