### PR TITLE
Add browser agent bridge for previews

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -762,7 +762,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.10")
+                Text("Version 0.10.11")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -201,7 +201,7 @@ private struct AppViewerRuntime {
     }
 
     private static func copyAssets(from sourceDirectory: URL, to assetsDirectory: URL) throws {
-        for name in ["molstar.js", "molstar.css", "viewer.js"] {
+        for name in ["molstar.js", "molstar.css", "burette-agent.js", "viewer.js"] {
             let source = sourceDirectory.appendingPathComponent(name)
             let destination = assetsDirectory.appendingPathComponent(name)
             try copyAssetAtomically(from: source, to: destination)
@@ -712,6 +712,7 @@ private struct AppViewerRuntime {
           <script src="../assets/molstar.js"></script>
           <script src="preview-config.js"></script>
           <script src="preview-data.js"></script>
+          <script src="../assets/burette-agent.js"></script>
           <script src="../assets/viewer.js"></script>
         </body>
         </html>

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.10;
+				MARKETING_VERSION = 0.10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -417,7 +417,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.10;
+				MARKETING_VERSION = 0.10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -441,7 +441,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.10;
+				MARKETING_VERSION = 0.10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -466,7 +466,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.10;
+				MARKETING_VERSION = 0.10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 				inputPaths = (
 					"$(SRCROOT)/PreviewExtension/Web/molstar.js",
 					"$(SRCROOT)/PreviewExtension/Web/molstar.css",
+					"$(SRCROOT)/PreviewExtension/Web/burette-agent.js",
 					"$(SRCROOT)/PreviewExtension/Web/viewer.js",
 				);
 				name = "Validate Mol* assets";
@@ -248,7 +249,7 @@
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 				shellPath = /bin/sh;
-				shellScript = "set -euo pipefail\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"\ncd \"${SRCROOT}\"\n\nif ! command -v node >/dev/null 2>&1; then\n  echo \"error: Node.js is required to validate Burrete web assets. Install it with: brew install node\"\n  exit 1\nfi\nfor asset in PreviewExtension/Web/molstar.js PreviewExtension/Web/molstar.css PreviewExtension/Web/viewer.js; do\n  if [ ! -s \"$asset\" ]; then\n    echo \"error: missing vendored web asset: $asset\"\n    echo \"Run: npm ci --ignore-scripts && npm run vendor:molstar\"\n    exit 1\n  fi\ndone\nnode --check PreviewExtension/Web/viewer.js\n\n# Downloaded archives and unzipped bundles can carry com.apple.quarantine, FinderInfo,\n# or AppleDouble files. If Xcode copies those into the .appex, codesign fails with:\n# \"resource fork, Finder information, or similar detritus not allowed\".\nif command -v xattr >/dev/null 2>&1; then\n  xattr -cr \"${SRCROOT}/PreviewExtension/Web\" || true\nfi\nif command -v dot_clean >/dev/null 2>&1; then\n  dot_clean -m \"${SRCROOT}/PreviewExtension/Web\" || true\nfi\nfind \"${SRCROOT}/PreviewExtension/Web\" \\( -name \"._*\" -o -name \".DS_Store\" \\) -delete || true\nmkdir -p \"${DERIVED_FILE_DIR}\"\ntouch \"${DERIVED_FILE_DIR}/BurreteWebAssetsValidated.stamp\"\n";
+				shellScript = "set -euo pipefail\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"\ncd \"${SRCROOT}\"\n\nif ! command -v node >/dev/null 2>&1; then\n  echo \"error: Node.js is required to validate Burrete web assets. Install it with: brew install node\"\n  exit 1\nfi\nfor asset in PreviewExtension/Web/molstar.js PreviewExtension/Web/molstar.css PreviewExtension/Web/burette-agent.js PreviewExtension/Web/viewer.js; do\n  if [ ! -s \"$asset\" ]; then\n    echo \"error: missing vendored web asset: $asset\"\n    echo \"Run: npm ci --ignore-scripts && npm run vendor:molstar\"\n    exit 1\n  fi\ndone\nnode --check PreviewExtension/Web/viewer.js\nnode --check PreviewExtension/Web/burette-agent.js\n\n# Downloaded archives and unzipped bundles can carry com.apple.quarantine, FinderInfo,\n# or AppleDouble files. If Xcode copies those into the .appex, codesign fails with:\n# \"resource fork, Finder information, or similar detritus not allowed\".\nif command -v xattr >/dev/null 2>&1; then\n  xattr -cr \"${SRCROOT}/PreviewExtension/Web\" || true\nfi\nif command -v dot_clean >/dev/null 2>&1; then\n  dot_clean -m \"${SRCROOT}/PreviewExtension/Web\" || true\nfi\nfind \"${SRCROOT}/PreviewExtension/Web\" \\( -name \"._*\" -o -name \".DS_Store\" \\) -delete || true\nmkdir -p \"${DERIVED_FILE_DIR}\"\ntouch \"${DERIVED_FILE_DIR}/BurreteWebAssetsValidated.stamp\"\n";
 			};
 
 		7E7F01C829F8540000010001 /* Clean bundle detritus before codesign */ = {

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -337,7 +337,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     ) throws {
         let assetsDirectory = previewsDirectory.appendingPathComponent("assets", isDirectory: true)
         try fileManager.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
-        for assetName in ["molstar.js", "molstar.css", "viewer.js"] {
+        for assetName in ["molstar.js", "molstar.css", "burette-agent.js", "viewer.js"] {
             let source = bundledWebDirectory.appendingPathComponent(assetName)
             let destination = assetsDirectory.appendingPathComponent(assetName)
             try copyAssetAtomically(from: source, to: destination, fileManager: fileManager)
@@ -893,6 +893,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           <script>
             window.__mqlStatus && window.__mqlStatus('[web] About to load viewer.js from bundled resource…');
           </script>
+          <script src="../assets/burette-agent.js"></script>
           <script src="../assets/viewer.js"></script>
           <script>
             window.__mqlDebug && window.__mqlDebug('[web] viewer.js script tag parsed. async startup may still be running.');
@@ -918,7 +919,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static func validateVendoredMolstarAssets(in webDirectory: URL, fileManager: FileManager, diagnostics: inout [String]) throws {
-        let required = ["viewer.js", "molstar.js", "molstar.css"]
+        let required = ["viewer.js", "burette-agent.js", "molstar.js", "molstar.css"]
         for name in required {
             let url = webDirectory.appendingPathComponent(name)
             let exists = fileManager.fileExists(atPath: url.path)

--- a/PreviewExtension/Web/burette-agent.js
+++ b/PreviewExtension/Web/burette-agent.js
@@ -1,0 +1,1156 @@
+(() => {
+  'use strict';
+
+  const API_VERSION = 'burette-agent/v1';
+  const AGENT_VERSION = '0.1.0';
+  const DEFAULT_READY_TIMEOUT_MS = 30000;
+  const DEFAULT_CONTACT_RADIUS_A = 4.0;
+  const MAX_SCHEMA_RESIDUES = 256;
+  const MAX_CONTACT_SOURCE_ATOMS = 5000;
+  const MAX_CONTACT_TARGET_ATOMS = 250000;
+
+  const STANDARD_AA = new Set([
+    'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
+    'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+    'SEC', 'PYL', 'ASX', 'GLX', 'UNK'
+  ]);
+  const NUCLEIC = new Set([
+    'A', 'C', 'G', 'T', 'U', 'DA', 'DC', 'DG', 'DT', 'DU', 'I', 'DI',
+    'PSU', '5MC', 'OMC', 'OMG', '1MA', '2MG', 'M2G', '7MG'
+  ]);
+  const WATER = new Set(['HOH', 'WAT', 'H2O', 'DOD']);
+  const COMMON_IONS = new Set([
+    'NA', 'K', 'CL', 'CA', 'MG', 'ZN', 'FE', 'MN', 'CU', 'CO', 'NI', 'CD',
+    'HG', 'BR', 'IOD', 'I', 'F', 'LI', 'CS', 'RB', 'SR', 'BA', 'AL', 'AG',
+    'AU', 'PT', 'PB', 'SE', 'SO4', 'PO4', 'NO3'
+  ]);
+
+  const SCHEMA_FIELDS = [
+    'label_entity_id', 'label_asym_id', 'auth_asym_id', 'label_seq_id', 'auth_seq_id',
+    'pdbx_PDB_ins_code', 'beg_label_seq_id', 'end_label_seq_id', 'beg_auth_seq_id',
+    'end_auth_seq_id', 'label_comp_id', 'auth_comp_id', 'label_atom_id', 'auth_atom_id',
+    'type_symbol', 'atom_id', 'atom_index', 'instance_id'
+  ];
+
+  const state = {
+    viewer: null,
+    plugin: null,
+    config: null,
+    prepared: null,
+    structureReady: false,
+    sceneVersion: 0,
+    selectionCounter: 0,
+    lastSelectionId: null,
+    selections: new Map(),
+    commandLog: [],
+    readyResolve: null,
+    readyReject: null,
+    readyPromise: null
+  };
+
+  resetReadyPromise();
+
+  function resetReadyPromise() {
+    state.readyPromise = new Promise((resolve, reject) => {
+      state.readyResolve = resolve;
+      state.readyReject = reject;
+    });
+  }
+
+  function now() {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now();
+    return Date.now();
+  }
+
+  function cloneJson(value) {
+    if (value == null) return value;
+    try { return JSON.parse(JSON.stringify(value)); } catch (_) { return value; }
+  }
+
+  function durationSince(start) {
+    return Math.max(0, Math.round(now() - start));
+  }
+
+  function success(command, result, start, warnings = [], requestId) {
+    return {
+      ok: true,
+      requestId,
+      command,
+      result,
+      warnings: warnings.length ? warnings : undefined,
+      sceneVersion: state.sceneVersion,
+      molstarVersion: getMolstarVersion(),
+      durationMs: durationSince(start)
+    };
+  }
+
+  function failure(command, code, message, start, details, warnings = [], requestId) {
+    return {
+      ok: false,
+      requestId,
+      command,
+      error: { code, message, details },
+      warnings: warnings.length ? warnings : undefined,
+      sceneVersion: state.sceneVersion,
+      durationMs: durationSince(start)
+    };
+  }
+
+  function normalizeRequest(input, args) {
+    if (typeof input === 'string') return { command: input, args: args || {} };
+    const req = input && typeof input === 'object' ? input : {};
+    return {
+      apiVersion: req.apiVersion,
+      requestId: req.requestId,
+      command: req.command,
+      args: req.args || {}
+    };
+  }
+
+  function attach({ viewer, plugin, config } = {}) {
+    const nextViewer = viewer || state.viewer || window.BurreteViewer || window.BuretteViewer || null;
+    const nextPlugin = plugin || nextViewer?.plugin || state.plugin || null;
+    const nextConfig = config || state.config || window.BurreteConfig || null;
+    const changed = nextViewer !== state.viewer || nextPlugin !== state.plugin || nextConfig !== state.config;
+    state.viewer = nextViewer;
+    state.plugin = nextPlugin;
+    state.config = nextConfig;
+    if (changed) state.sceneVersion++;
+    return state.viewer && state.plugin;
+  }
+
+  function notifyStructureLoaded({ viewer, plugin, prepared, config } = {}) {
+    attach({ viewer, plugin, config });
+    state.prepared = prepared || state.prepared || null;
+    state.config = config || state.config || window.BurreteConfig || null;
+    state.structureReady = true;
+    state.sceneVersion++;
+    try { state.readyResolve?.({ viewer: state.viewer, plugin: state.plugin }); } catch (_) {}
+    dispatchAgentEvent('burette-agent-ready', { sceneVersion: state.sceneVersion });
+  }
+
+  function dispatchAgentEvent(name, detail) {
+    try {
+      if (typeof window.CustomEvent === 'function') {
+        window.dispatchEvent(new window.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+  }
+
+  function getMolstarVersion() {
+    return window.molstar?.version || window.molstar?.Viewer?.version || undefined;
+  }
+
+  function commands() {
+    return [
+      'capabilities', 'summary', 'select', 'selectResidues', 'focusSelection', 'colorSelection',
+      'showLigands', 'focusLigand', 'contacts', 'resetCamera', 'screenshot', 'loadMVS', 'exportMVS'
+    ];
+  }
+
+  function capabilities() {
+    attach();
+    const plugin = state.plugin;
+    const viewer = state.viewer;
+    return {
+      apiVersion: API_VERSION,
+      version: AGENT_VERSION,
+      molstarVersion: getMolstarVersion(),
+      commands: commands(),
+      aliases: ['window.BurreteAgent', 'window.BuretteAgent'],
+      ready: state.structureReady,
+      hasViewer: !!viewer,
+      hasPlugin: !!plugin,
+      hasStructureInteractivity: typeof viewer?.structureInteractivity === 'function',
+      hasViewportScreenshot: typeof plugin?.helpers?.viewportScreenshot?.getImageDataUri === 'function',
+      hasLoadMvsData: typeof viewer?.loadMvsData === 'function',
+      hasCameraManager: !!plugin?.managers?.camera,
+      hasHierarchy: !!plugin?.managers?.structure?.hierarchy,
+      notes: [
+        'Selections use Mol* Viewer.structureInteractivity with StructureElement.Schema when available.',
+        'colorSelection is implemented as a stable selection/highlight fallback unless an overpaint bridge is added later.',
+        'contacts is a lightweight distance-neighborhood calculation, not full interaction chemistry.'
+      ]
+    };
+  }
+
+  function ensureViewer() {
+    attach();
+    if (!state.viewer || !state.plugin) {
+      const error = new Error('Burrete Mol* viewer is not attached yet.');
+      error.code = 'NO_VIEWER';
+      throw error;
+    }
+  }
+
+  async function waitUntilReady(timeoutMs = DEFAULT_READY_TIMEOUT_MS) {
+    ensureViewer();
+    if (state.structureReady) return;
+    await withTimeout(state.readyPromise, timeoutMs, 'Timed out waiting for Burette structure load.');
+  }
+
+  function withTimeout(promise, timeoutMs, message) {
+    if (!timeoutMs || timeoutMs <= 0) return promise;
+    let timer;
+    return Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(Object.assign(new Error(message), { code: 'NO_STRUCTURE' })), timeoutMs);
+      })
+    ]).finally(() => clearTimeout(timer));
+  }
+
+  async function run(input, maybeArgs) {
+    const req = normalizeRequest(input, maybeArgs);
+    const command = req.command;
+    const start = now();
+    const warnings = [];
+
+    if (!command || typeof command !== 'string') {
+      return failure('unknown', 'INVALID_ARGS', 'Request is missing a string command.', start, req, warnings, req.requestId);
+    }
+
+    if (req.apiVersion && req.apiVersion !== API_VERSION) {
+      warnings.push(`Requested apiVersion ${req.apiVersion}; responding with ${API_VERSION}.`);
+    }
+
+    try {
+      let result;
+      if (command === 'capabilities') {
+        result = capabilities();
+      } else {
+        await waitUntilReady(Number(req.args?.readyTimeoutMs) || DEFAULT_READY_TIMEOUT_MS);
+        result = await executeCommand(command, req.args || {}, warnings);
+        logCommand(command, req.args || {}, result, warnings);
+      }
+      return success(command, result, start, warnings, req.requestId);
+    } catch (error) {
+      const code = error?.code || inferErrorCode(error);
+      const message = error?.message || String(error);
+      return failure(command, code, message, start, error?.details, warnings, req.requestId);
+    }
+  }
+
+  async function batch(requests, opts = {}) {
+    if (!Array.isArray(requests)) {
+      return [await run({ command: 'capabilities', args: {} })];
+    }
+    const out = [];
+    for (const req of requests) {
+      const res = await run(req);
+      out.push(res);
+      if (opts.stopOnError && !res.ok) break;
+    }
+    return out;
+  }
+
+  function inferErrorCode(error) {
+    const msg = String(error?.message || error || '');
+    if (msg.includes('empty') || msg.includes('matched no atoms')) return 'SELECTION_EMPTY';
+    if (msg.includes('not attached')) return 'NO_VIEWER';
+    if (msg.includes('No structure')) return 'NO_STRUCTURE';
+    if (msg.includes('Unsupported') || msg.includes('not implemented')) return 'NOT_IMPLEMENTED';
+    return 'MOLSTAR_ERROR';
+  }
+
+  async function executeCommand(command, args, warnings) {
+    if (command === 'summary') return commandSummary(args);
+    if (command === 'select' || command === 'selectResidues') return commandSelect(args, command, warnings);
+    if (command === 'focusSelection') return commandFocus(args, warnings);
+    if (command === 'colorSelection') return commandColor(args, warnings);
+    if (command === 'showLigands') return commandShowLigands(args, warnings);
+    if (command === 'focusLigand') return commandFocusLigand(args, warnings);
+    if (command === 'contacts') return commandContacts(args, warnings);
+    if (command === 'resetCamera') return commandResetCamera(args, warnings);
+    if (command === 'screenshot') return commandScreenshot(args, warnings);
+    if (command === 'loadMVS') return commandLoadMVS(args, warnings);
+    if (command === 'exportMVS') return commandExportMVS(args, warnings);
+    const error = new Error(`Unsupported BuretteAgent command: ${command}`);
+    error.code = 'NOT_IMPLEMENTED';
+    throw error;
+  }
+
+  function logCommand(command, args, result, warnings) {
+    state.commandLog.push({
+      at: new Date().toISOString(),
+      command,
+      args: cloneJson(args),
+      resultSummary: summarizeResultForLog(result),
+      warnings: warnings.length ? [...warnings] : undefined,
+      sceneVersion: state.sceneVersion
+    });
+    if (state.commandLog.length > 250) state.commandLog.splice(0, state.commandLog.length - 250);
+  }
+
+  function summarizeResultForLog(result) {
+    if (!result || typeof result !== 'object') return result;
+    if (result.selectionId) return { selectionId: result.selectionId, counts: result.counts };
+    if (result.structures) return { structureCount: result.structures.length, format: result.format };
+    if (result.dataUri) return { dataUri: '[png data uri]', width: result.width, height: result.height };
+    return cloneJson(result);
+  }
+
+  function commandSummary(args = {}) {
+    const structures = getStructures();
+    if (!structures.length) throw coded('NO_STRUCTURE', 'No Mol* structure objects are available yet.');
+    const summaries = structures.map((entry, index) => summarizeStructure(entry, index, args));
+    const atomCount = summaries.reduce((sum, s) => sum + s.atomCount, 0);
+    const residueCount = summaries.reduce((sum, s) => sum + s.residueCount, 0);
+    const ligandCount = summaries.reduce((sum, s) => sum + s.ligands.length, 0);
+    return {
+      format: state.prepared?.format || state.config?.format || undefined,
+      label: state.prepared?.label || state.config?.label || undefined,
+      structures: summaries,
+      counts: {
+        structures: summaries.length,
+        models: summaries.reduce((sum, s) => sum + s.models, 0),
+        chains: summaries.reduce((sum, s) => sum + s.chains.length, 0),
+        atoms: atomCount,
+        residues: residueCount,
+        ligands: ligandCount
+      }
+    };
+  }
+
+  function commandSelect(args = {}, command, warnings) {
+    const selector = normalizeSelector(args.selector || args, command === 'selectResidues');
+    const counts = countSelectorMatches(selector, Number(args.maxPreviewResidues) || 24);
+    if (!counts.atoms) throw coded('SELECTION_EMPTY', 'Selector matched no atoms.', { selector });
+    const selectionId = rememberSelection(selector, counts, args.label);
+    if (args.applyToViewer !== false) {
+      applyMolstarInteractivity(selector, 'select', {
+        mode: args.mode || 'replace',
+        granularity: args.granularity || 'residue',
+        warnings
+      });
+      state.sceneVersion++;
+    }
+    return {
+      selectionId,
+      selectorEcho: selector,
+      counts: counts.counts,
+      residuesPreview: counts.residuesPreview
+    };
+  }
+
+  function commandFocus(args = {}, warnings) {
+    const selection = resolveSelection(args.selection || args.selector || 'last');
+    const counts = countSelectorMatches(selection.selector, Number(args.maxPreviewResidues) || 24);
+    if (!counts.atoms) throw coded('SELECTION_EMPTY', 'Focus selector matched no atoms.', { selector: selection.selector });
+    applyMolstarInteractivity(selection.selector, 'focus', {
+      durationMs: args.durationMs,
+      extraRadius: args.extraRadius,
+      warnings
+    });
+    state.sceneVersion++;
+    return {
+      selectionId: selection.id,
+      selectorEcho: selection.selector,
+      counts: counts.counts,
+      residuesPreview: counts.residuesPreview
+    };
+  }
+
+  function commandColor(args = {}, warnings) {
+    const selection = resolveSelection(args.selection || args.selector || 'last');
+    const color = normalizeColor(args.color || args.hex || '#ffcc00');
+    const counts = countSelectorMatches(selection.selector, Number(args.maxPreviewResidues) || 24);
+    if (!counts.atoms) throw coded('SELECTION_EMPTY', 'Color selector matched no atoms.', { selector: selection.selector });
+    applyMolstarInteractivity(selection.selector, args.highlight === false ? 'select' : 'highlight', {
+      mode: args.mode || 'replace',
+      granularity: args.granularity || 'residue',
+      warnings
+    });
+    warnings.push('Persistent Mol* overpaint is not wired in this no-build MVP; colorSelection records the requested color and applies a viewer highlight/select fallback. Add a bundled overpaint bridge for durable representation coloring.');
+    state.sceneVersion++;
+    return {
+      selectionId: selection.id,
+      color,
+      persistent: false,
+      fallback: args.highlight === false ? 'select' : 'highlight',
+      selectorEcho: selection.selector,
+      counts: counts.counts,
+      residuesPreview: counts.residuesPreview
+    };
+  }
+
+  function commandShowLigands(args = {}, warnings) {
+    const ligands = listLigands();
+    if (!ligands.length) throw coded('SELECTION_EMPTY', 'No ligands were detected by the MVP ligand policy.');
+    const selector = { kind: 'ligand' };
+    const counts = countSelectorMatches(selector, Number(args.maxPreviewResidues) || 48);
+    const selectionId = rememberSelection(selector, counts, args.label || 'ligands');
+    if (args.applyToViewer !== false) {
+      applyMolstarInteractivity(selector, args.highlight ? 'highlight' : 'select', {
+        mode: args.mode || 'replace',
+        granularity: 'residue',
+        warnings
+      });
+      state.sceneVersion++;
+    }
+    return { selectionId, ligands, counts: counts.counts, residuesPreview: counts.residuesPreview };
+  }
+
+  function commandFocusLigand(args = {}, warnings) {
+    const ligands = listLigands();
+    if (!ligands.length) throw coded('SELECTION_EMPTY', 'No ligands were detected by the MVP ligand policy.');
+    const selector = normalizeSelector(args.selector || args, false);
+    const matches = ligands.filter(ligand => matchesLigand(ligand, selector));
+    if (!matches.length) throw coded('SELECTION_EMPTY', 'Ligand selector matched no ligands.', { selector, available: ligands });
+    const index = Number.isInteger(args.index) ? args.index : 0;
+    if (matches.length > 1 && !args.allowAmbiguous && args.index == null) {
+      throw coded('INVALID_ARGS', 'Ligand selector is ambiguous; pass chain/residue/index or allowAmbiguous: true.', { selector, matches });
+    }
+    const ligand = matches[Math.max(0, Math.min(index, matches.length - 1))];
+    const ligandSelector = ligandToSelector(ligand);
+    const counts = countSelectorMatches(ligandSelector, Number(args.maxPreviewResidues) || 24);
+    const selectionId = rememberSelection(ligandSelector, counts, args.label || `ligand:${ligand.label_comp_id}`);
+    applyMolstarInteractivity(ligandSelector, 'select', { mode: 'replace', granularity: 'residue', warnings });
+    applyMolstarInteractivity(ligandSelector, 'focus', { durationMs: args.durationMs, extraRadius: args.extraRadius, warnings });
+    state.sceneVersion++;
+    const result = { selectionId, ligand, counts: counts.counts, residuesPreview: counts.residuesPreview };
+    if (args.showNeighborhood || args.contacts) {
+      result.neighborhood = computeContacts({
+        source: ligandSelector,
+        target: args.target || { kind: 'protein' },
+        radiusA: Number(args.radiusA) || DEFAULT_CONTACT_RADIUS_A,
+        maxSourceAtoms: args.maxSourceAtoms,
+        maxTargetAtoms: args.maxTargetAtoms
+      }, warnings);
+    }
+    return result;
+  }
+
+  function commandContacts(args = {}, warnings) {
+    return computeContacts(args, warnings);
+  }
+
+  function commandResetCamera(args = {}, warnings) {
+    const camera = state.plugin?.managers?.camera;
+    let handled = false;
+    try {
+      if (typeof camera?.reset === 'function') {
+        camera.reset(Number(args.durationMs) || 250);
+        handled = true;
+      }
+    } catch (error) {
+      warnings.push(`camera.reset failed: ${error?.message || String(error)}`);
+    }
+    try {
+      if (!handled && typeof state.plugin?.canvas3d?.requestCameraReset === 'function') {
+        state.plugin.canvas3d.requestCameraReset();
+        handled = true;
+      }
+    } catch (error) {
+      warnings.push(`canvas3d.requestCameraReset failed: ${error?.message || String(error)}`);
+    }
+    if (!handled) warnings.push('No Mol* camera reset API was found on this runtime.');
+    state.sceneVersion++;
+    return { handled };
+  }
+
+  async function commandScreenshot(args = {}, warnings) {
+    const helper = state.plugin?.helpers?.viewportScreenshot;
+    let dataUri = null;
+    if (typeof helper?.getImageDataUri === 'function') {
+      dataUri = await helper.getImageDataUri();
+    }
+    if (!dataUri) {
+      try {
+        const canvas = document.querySelector('#app canvas, canvas');
+        if (canvas && typeof canvas.toDataURL === 'function') dataUri = canvas.toDataURL('image/png');
+      } catch (error) {
+        warnings.push(`canvas.toDataURL fallback failed: ${error?.message || String(error)}`);
+      }
+    }
+    if (!dataUri) throw coded('NOT_IMPLEMENTED', 'No screenshot API is available in this runtime.');
+    return {
+      dataUri,
+      mimeType: 'image/png',
+      width: Number(args.width) || undefined,
+      height: Number(args.height) || undefined,
+      note: 'Native/MCP bridge should decode this data URI and write it to an allowlisted local path when a file path is required.'
+    };
+  }
+
+  async function commandLoadMVS(args = {}, warnings) {
+    if (typeof state.viewer?.loadMvsData !== 'function') {
+      throw coded('NOT_IMPLEMENTED', 'viewer.loadMvsData is not available in this Mol* viewer build.');
+    }
+    const format = args.format || (String(args.data || '').trim().startsWith('{') ? 'mvsj' : 'mvsx');
+    if (!args.data) throw coded('INVALID_ARGS', 'loadMVS requires args.data.');
+    await state.viewer.loadMvsData(args.data, format, args.options || {});
+    state.sceneVersion++;
+    warnings.push('MVS loading is delegated directly to Mol* viewer.loadMvsData; validate with a real mvsj/mvsx fixture.');
+    return { format, loaded: true };
+  }
+
+  function commandExportMVS(args = {}, warnings) {
+    warnings.push('This MVP exports the BuretteAgent command log, not an arbitrary Mol* state-tree-to-MVS conversion.');
+    return {
+      kind: 'burette-agent-command-log',
+      apiVersion: API_VERSION,
+      version: AGENT_VERSION,
+      label: state.prepared?.label || state.config?.label || undefined,
+      format: state.prepared?.format || state.config?.format || undefined,
+      sceneVersion: state.sceneVersion,
+      commands: cloneJson(state.commandLog),
+      asJson: args.pretty === false ? undefined : JSON.stringify({
+        kind: 'burette-agent-command-log',
+        apiVersion: API_VERSION,
+        version: AGENT_VERSION,
+        commands: state.commandLog
+      }, null, 2)
+    };
+  }
+
+  function coded(code, message, details) {
+    const error = new Error(message);
+    error.code = code;
+    error.details = details;
+    return error;
+  }
+
+  function getStructures() {
+    attach();
+    const out = [];
+    const seen = new Set();
+    const hierarchyStructures = state.plugin?.managers?.structure?.hierarchy?.current?.structures || [];
+    for (let i = 0; i < hierarchyStructures.length; i++) {
+      const entry = hierarchyStructures[i];
+      const data = entry?.cell?.obj?.data || entry?.obj?.data || entry?.data;
+      if (!data || seen.has(data)) continue;
+      seen.add(data);
+      out.push({ data, entry, ref: entry?.cell?.transform?.ref || entry?.cell?.ref || entry?.ref || `structure-${i}` });
+    }
+    // Very small fallback for test stubs or alternate Mol* state shapes.
+    const roots = state.plugin?.state?.data?.tree?.children || state.plugin?.state?.data?.cells;
+    if (!out.length && roots && typeof roots.forEach === 'function') {
+      roots.forEach((cell, key) => {
+        const data = cell?.obj?.data;
+        if (data?.units && !seen.has(data)) {
+          seen.add(data);
+          out.push({ data, entry: cell, ref: cell?.transform?.ref || cell?.ref || key });
+        }
+      });
+    }
+    return out;
+  }
+
+  function summarizeStructure(entry, index, args = {}) {
+    const atoms = collectAtoms(null, { includePositions: false, maxAtoms: Infinity, structureEntry: entry });
+    const chainMap = new Map();
+    const residueMap = new Map();
+    const ligandMap = new Map();
+    const modelSet = new Set();
+
+    for (const atom of atoms) {
+      modelSet.add(atom.modelIndex ?? 0);
+      const chainKey = [atom.label_entity_id, atom.label_asym_id, atom.auth_asym_id].join('|');
+      let chain = chainMap.get(chainKey);
+      if (!chain) {
+        chain = {
+          label_entity_id: atom.label_entity_id,
+          label_asym_id: atom.label_asym_id,
+          auth_asym_id: atom.auth_asym_id,
+          entityType: atom.entityType || atom.kind,
+          atomCount: 0,
+          residueCount: 0,
+          authSeqRange: [null, null],
+          labelSeqRange: [null, null],
+          _residues: new Set()
+        };
+        chainMap.set(chainKey, chain);
+      }
+      chain.atomCount++;
+      const residueKey = residueIdentity(atom);
+      if (!chain._residues.has(residueKey)) {
+        chain._residues.add(residueKey);
+        chain.residueCount++;
+        updateRange(chain.authSeqRange, atom.auth_seq_id);
+        updateRange(chain.labelSeqRange, atom.label_seq_id);
+      }
+      if (!residueMap.has(residueKey)) {
+        residueMap.set(residueKey, residueSummary(atom));
+      }
+      if (atom.kind === 'ligand') {
+        let ligand = ligandMap.get(residueKey);
+        if (!ligand) {
+          ligand = { ...residueSummary(atom), atomCount: 0 };
+          ligandMap.set(residueKey, ligand);
+        }
+        ligand.atomCount++;
+      }
+    }
+
+    const chains = Array.from(chainMap.values()).map(chain => {
+      const clean = { ...chain };
+      delete clean._residues;
+      clean.authSeqRange = clean.authSeqRange[0] == null ? undefined : clean.authSeqRange;
+      clean.labelSeqRange = clean.labelSeqRange[0] == null ? undefined : clean.labelSeqRange;
+      return clean;
+    }).sort(sortChain);
+
+    const ligands = Array.from(ligandMap.values()).sort(sortResidueLike);
+    const summary = {
+      id: String(entry.ref || `structure-${index}`),
+      label: entry.entry?.cell?.obj?.label || state.prepared?.label || state.config?.label || undefined,
+      models: Math.max(1, modelSet.size),
+      atomCount: atoms.length,
+      residueCount: residueMap.size,
+      chains,
+      ligands
+    };
+    if (args.includeResidues) {
+      summary.residues = Array.from(residueMap.values()).sort(sortResidueLike);
+    }
+    return summary;
+  }
+
+  function updateRange(range, value) {
+    if (!Number.isFinite(value)) return;
+    if (range[0] == null || value < range[0]) range[0] = value;
+    if (range[1] == null || value > range[1]) range[1] = value;
+  }
+
+  function sortChain(a, b) {
+    return String(a.auth_asym_id || a.label_asym_id || '').localeCompare(String(b.auth_asym_id || b.label_asym_id || ''), undefined, { numeric: true });
+  }
+
+  function sortResidueLike(a, b) {
+    const c = String(a.auth_asym_id || a.label_asym_id || '').localeCompare(String(b.auth_asym_id || b.label_asym_id || ''), undefined, { numeric: true });
+    if (c) return c;
+    return (a.auth_seq_id ?? a.label_seq_id ?? 0) - (b.auth_seq_id ?? b.label_seq_id ?? 0);
+  }
+
+  function residueSummary(atom) {
+    return {
+      label_entity_id: atom.label_entity_id,
+      label_asym_id: atom.label_asym_id,
+      auth_asym_id: atom.auth_asym_id,
+      label_seq_id: atom.label_seq_id,
+      auth_seq_id: atom.auth_seq_id,
+      pdbx_PDB_ins_code: atom.pdbx_PDB_ins_code,
+      label_comp_id: atom.label_comp_id,
+      auth_comp_id: atom.auth_comp_id,
+      kind: atom.kind
+    };
+  }
+
+  function collectAtoms(selector, options = {}) {
+    const structures = options.structureEntry ? [options.structureEntry] : getStructures();
+    const atoms = [];
+    const includePositions = options.includePositions !== false;
+    const maxAtoms = options.maxAtoms == null ? Infinity : Number(options.maxAtoms);
+    for (let structureIndex = 0; structureIndex < structures.length; structureIndex++) {
+      const entry = structures[structureIndex];
+      const structure = entry.data || entry;
+      const units = Array.isArray(structure?.units) ? structure.units : [];
+      for (let unitIndex = 0; unitIndex < units.length; unitIndex++) {
+        const unit = units[unitIndex];
+        const elements = unit?.elements || [];
+        for (let i = 0; i < elements.length; i++) {
+          const atomIndex = elements[i];
+          const atom = atomRecord(entry, structureIndex, unit, unitIndex, atomIndex, includePositions);
+          if (!atom) continue;
+          if (selector && !matchesSelector(atom, selector)) continue;
+          atoms.push(atom);
+          if (atoms.length >= maxAtoms) return atoms;
+        }
+      }
+    }
+    return atoms;
+  }
+
+  function atomRecord(entry, structureIndex, unit, unitIndex, atomIndex, includePosition) {
+    const model = unit?.model;
+    const ah = model?.atomicHierarchy;
+    if (!ah) return null;
+    const residueIndex = segmentIndex(ah.residueAtomSegments, atomIndex);
+    const chainIndex = segmentIndex(ah.chainAtomSegments, atomIndex);
+    const atoms = ah.atoms || {};
+    const residues = ah.residues || {};
+    const chains = ah.chains || {};
+    const labelEntity = valueAt(chains.label_entity_id, chainIndex);
+    const labelComp = valueAt(residues.label_comp_id, residueIndex);
+    const authComp = valueAt(residues.auth_comp_id, residueIndex) || labelComp;
+    const entityType = entityTypeFor(model, labelEntity);
+    const rec = {
+      structureId: String(entry.ref || `structure-${structureIndex}`),
+      structureIndex,
+      modelIndex: Number(model?.modelNum || model?.trajectoryInfo?.index || 0),
+      unitIndex,
+      unitId: unit?.id,
+      atom_index: atomIndex,
+      atom_id: numberOrUndefined(valueAt(atoms.id, atomIndex)),
+      label_atom_id: valueAt(atoms.label_atom_id, atomIndex),
+      auth_atom_id: valueAt(atoms.auth_atom_id, atomIndex),
+      type_symbol: valueAt(atoms.type_symbol, atomIndex),
+      label_entity_id: labelEntity,
+      label_asym_id: valueAt(chains.label_asym_id, chainIndex),
+      auth_asym_id: valueAt(chains.auth_asym_id, chainIndex),
+      label_seq_id: numberOrUndefined(valueAt(residues.label_seq_id, residueIndex)),
+      auth_seq_id: numberOrUndefined(valueAt(residues.auth_seq_id, residueIndex)),
+      pdbx_PDB_ins_code: normalizeMissing(valueAt(residues.pdbx_PDB_ins_code, residueIndex)),
+      label_comp_id: labelComp,
+      auth_comp_id: authComp,
+      entityType,
+      residueIndex,
+      chainIndex
+    };
+    rec.kind = classify(rec);
+    if (includePosition) rec.position = atomPosition(unit, atomIndex);
+    return rec;
+  }
+
+  function valueAt(column, index) {
+    if (index == null || index < 0 || !column) return undefined;
+    try {
+      if (typeof column.value === 'function') return normalizeMissing(column.value(index));
+      if (Array.isArray(column)) return normalizeMissing(column[index]);
+      if (column.array) return normalizeMissing(column.array[index]);
+      if (column.data) return normalizeMissing(column.data[index]);
+      return normalizeMissing(column[index]);
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  function normalizeMissing(value) {
+    if (value == null || value === '?' || value === '.') return undefined;
+    return value;
+  }
+
+  function numberOrUndefined(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
+  function segmentIndex(segment, atomIndex) {
+    const idx = segment?.index;
+    const value = valueAt(idx, atomIndex);
+    return Number.isInteger(value) ? value : numberOrUndefined(value);
+  }
+
+  function entityTypeFor(model, labelEntityId) {
+    if (!model || labelEntityId == null) return undefined;
+    try {
+      const entities = model.entities;
+      let index = undefined;
+      if (typeof entities?.getEntityIndex === 'function') index = entities.getEntityIndex(labelEntityId);
+      if (index == null && entities?.data?.id) {
+        const rowCount = entities.data._rowCount || entities.data.rowCount || 0;
+        for (let i = 0; i < rowCount; i++) {
+          if (String(valueAt(entities.data.id, i)) === String(labelEntityId)) { index = i; break; }
+        }
+      }
+      return valueAt(entities?.data?.type, index);
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  function atomPosition(unit, atomIndex) {
+    const c = unit?.conformation;
+    try {
+      if (typeof c?.position === 'function') {
+        const v = [0, 0, 0];
+        c.position(atomIndex, v);
+        return [Number(v[0]), Number(v[1]), Number(v[2])];
+      }
+    } catch (_) {}
+    try {
+      const x = typeof c?.x === 'function' ? c.x(atomIndex) : valueAt(c?.x, atomIndex);
+      const y = typeof c?.y === 'function' ? c.y(atomIndex) : valueAt(c?.y, atomIndex);
+      const z = typeof c?.z === 'function' ? c.z(atomIndex) : valueAt(c?.z, atomIndex);
+      if ([x, y, z].every(Number.isFinite)) return [Number(x), Number(y), Number(z)];
+    } catch (_) {}
+    return [NaN, NaN, NaN];
+  }
+
+  function classify(atom) {
+    const comp = String(atom.label_comp_id || atom.auth_comp_id || '').toUpperCase();
+    const entityType = String(atom.entityType || '').toLowerCase();
+    if (WATER.has(comp) || entityType === 'water') return 'water';
+    if (STANDARD_AA.has(comp)) return 'protein';
+    if (NUCLEIC.has(comp)) return 'nucleic';
+    if (entityType === 'polymer') return 'polymer';
+    if (COMMON_IONS.has(comp)) return 'ion';
+    return 'ligand';
+  }
+
+  function normalizeSelector(input, residueDefaults) {
+    if (input === 'last') return resolveSelection('last').selector;
+    if (typeof input === 'string') return { kind: input };
+    const selector = { ...(input || {}) };
+    delete selector.readyTimeoutMs;
+    delete selector.applyToViewer;
+    delete selector.mode;
+    delete selector.granularity;
+    delete selector.maxPreviewResidues;
+    delete selector.label;
+    if (selector.chain && !selector.auth_asym_id && !selector.label_asym_id) {
+      selector.auth_asym_id = selector.chain;
+      delete selector.chain;
+    }
+    if (selector.start != null && selector.end != null && !selector.beg_auth_seq_id && !selector.beg_label_seq_id) {
+      selector.beg_auth_seq_id = Number(selector.start);
+      selector.end_auth_seq_id = Number(selector.end);
+      delete selector.start;
+      delete selector.end;
+    }
+    if (selector.range && Array.isArray(selector.range) && !selector.beg_auth_seq_id && !selector.beg_label_seq_id) {
+      selector.beg_auth_seq_id = Number(selector.range[0]);
+      selector.end_auth_seq_id = Number(selector.range[1]);
+      delete selector.range;
+    }
+    if (residueDefaults && selector.auth_seq_id == null && selector.label_seq_id == null && selector.beg_auth_seq_id == null && selector.beg_label_seq_id == null) {
+      // Nothing to add; selecting a whole chain is allowed.
+    }
+    for (const key of ['label_seq_id', 'auth_seq_id', 'beg_label_seq_id', 'end_label_seq_id', 'beg_auth_seq_id', 'end_auth_seq_id', 'atom_id', 'atom_index']) {
+      if (selector[key] != null && !Array.isArray(selector[key])) selector[key] = Number(selector[key]);
+    }
+    return selector;
+  }
+
+  function matchesSelector(atom, selector = {}) {
+    if (!selector || selector.kind === 'all') return true;
+    if (selector.structure && selector.structure !== 'primary' && selector.structure !== atom.structureId && Number(selector.structure) !== atom.structureIndex) return false;
+    if (selector.modelIndex != null && Number(selector.modelIndex) !== atom.modelIndex) return false;
+    if (selector.kind && !matchesKind(atom, selector.kind)) return false;
+    for (const key of ['label_entity_id', 'label_asym_id', 'auth_asym_id', 'pdbx_PDB_ins_code', 'label_comp_id', 'auth_comp_id', 'label_atom_id', 'auth_atom_id', 'type_symbol', 'atom_id', 'atom_index', 'instance_id']) {
+      if (selector[key] != null && !fieldMatches(atom[key], selector[key])) return false;
+    }
+    for (const key of ['label_seq_id', 'auth_seq_id']) {
+      if (selector[key] != null && !fieldMatches(atom[key], selector[key])) return false;
+    }
+    if (!rangeMatches(atom.label_seq_id, selector.beg_label_seq_id, selector.end_label_seq_id)) return false;
+    if (!rangeMatches(atom.auth_seq_id, selector.beg_auth_seq_id, selector.end_auth_seq_id)) return false;
+    return true;
+  }
+
+  function matchesKind(atom, kind) {
+    const k = String(kind || '').toLowerCase();
+    if (k === 'all') return true;
+    if (k === 'polymer') return atom.kind === 'protein' || atom.kind === 'nucleic' || atom.kind === 'polymer';
+    if (k === 'protein') return atom.kind === 'protein';
+    if (k === 'nucleic') return atom.kind === 'nucleic';
+    if (k === 'ligand') return atom.kind === 'ligand';
+    if (k === 'ion') return atom.kind === 'ion';
+    if (k === 'water') return atom.kind === 'water';
+    return atom.kind === k;
+  }
+
+  function fieldMatches(value, expected) {
+    if (Array.isArray(expected)) return expected.some(x => fieldMatches(value, x));
+    if (expected == null) return true;
+    if (value == null) return false;
+    return String(value) === String(expected);
+  }
+
+  function rangeMatches(value, beg, end) {
+    if (beg == null && end == null) return true;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return false;
+    if (beg != null && n < Number(beg)) return false;
+    if (end != null && n > Number(end)) return false;
+    return true;
+  }
+
+  function countSelectorMatches(selector, maxPreviewResidues = 24) {
+    const atoms = collectAtoms(selector, { includePositions: false });
+    const residueMap = new Map();
+    const chainSet = new Set();
+    for (const atom of atoms) {
+      residueMap.set(residueIdentity(atom), residueSummary(atom));
+      chainSet.add([atom.label_entity_id, atom.label_asym_id, atom.auth_asym_id].join('|'));
+    }
+    return {
+      atoms: atoms.length,
+      residues: residueMap.size,
+      counts: { atoms: atoms.length, residues: residueMap.size, chains: chainSet.size },
+      residuesPreview: Array.from(residueMap.values()).sort(sortResidueLike).slice(0, maxPreviewResidues)
+    };
+  }
+
+  function residueIdentity(atom) {
+    return [
+      atom.structureId,
+      atom.modelIndex,
+      atom.label_entity_id,
+      atom.label_asym_id,
+      atom.auth_asym_id,
+      atom.label_seq_id,
+      atom.auth_seq_id,
+      atom.pdbx_PDB_ins_code || '',
+      atom.label_comp_id
+    ].join('|');
+  }
+
+  function rememberSelection(selector, counts, label) {
+    state.selectionCounter++;
+    const id = `sel-${String(state.selectionCounter).padStart(6, '0')}`;
+    state.selections.set(id, {
+      id,
+      label,
+      selector: cloneJson(selector),
+      counts: counts.counts,
+      createdAt: new Date().toISOString()
+    });
+    state.lastSelectionId = id;
+    return id;
+  }
+
+  function resolveSelection(selection) {
+    if (!selection || selection === 'last') {
+      if (!state.lastSelectionId) throw coded('INVALID_ARGS', 'No previous selection exists.');
+      return state.selections.get(state.lastSelectionId);
+    }
+    if (typeof selection === 'string') {
+      const saved = state.selections.get(selection);
+      if (!saved) throw coded('INVALID_ARGS', `Unknown selection id: ${selection}`);
+      return saved;
+    }
+    const selector = normalizeSelector(selection, false);
+    const counts = countSelectorMatches(selector, 0);
+    const id = rememberSelection(selector, counts, selection.label);
+    return state.selections.get(id);
+  }
+
+  function applyMolstarInteractivity(selector, action, options = {}) {
+    const viewer = state.viewer;
+    if (typeof viewer?.structureInteractivity !== 'function') {
+      options.warnings?.push('viewer.structureInteractivity is not available; JSON result was computed without visual Mol* selection/focus.');
+      return;
+    }
+    const atoms = collectAtoms(selector, { includePositions: false, maxAtoms: 200000 });
+    const schemas = schemasForSelector(selector, atoms, options.warnings);
+    if (action === 'select' && options.mode !== 'add') {
+      try { viewer.structureInteractivity({ action: 'select' }); } catch (_) {}
+    }
+    if (action === 'highlight' && options.mode !== 'add') {
+      try { viewer.structureInteractivity({ action: 'highlight' }); } catch (_) {}
+    }
+    const focusOptions = {
+      durationMs: Number(options.durationMs) || 250,
+      extraRadius: Number(options.extraRadius) || undefined
+    };
+    for (const schema of schemas) {
+      try {
+        viewer.structureInteractivity({
+          elements: schema,
+          action,
+          applyGranularity: options.granularity !== 'atom',
+          focusOptions: action === 'focus' ? focusOptions : undefined
+        });
+        if (action === 'focus') break;
+      } catch (error) {
+        options.warnings?.push(`viewer.structureInteractivity(${action}) failed: ${error?.message || String(error)}`);
+      }
+    }
+  }
+
+  function schemasForSelector(selector, atoms, warnings) {
+    const direct = directSchema(selector);
+    if (direct) return [direct];
+    const residueMap = new Map();
+    for (const atom of atoms) {
+      residueMap.set(residueIdentity(atom), ligandToSelector(residueSummary(atom)));
+      if (residueMap.size > MAX_SCHEMA_RESIDUES) break;
+    }
+    if (residueMap.size > MAX_SCHEMA_RESIDUES) {
+      warnings?.push(`Selector expands to more than ${MAX_SCHEMA_RESIDUES} residues; Mol* visual application is capped.`);
+    }
+    return Array.from(residueMap.values()).slice(0, MAX_SCHEMA_RESIDUES).map(directSchema).filter(Boolean);
+  }
+
+  function directSchema(selector = {}) {
+    if (selector.kind && !hasAnySchemaField(selector)) return null;
+    const schema = {};
+    for (const field of SCHEMA_FIELDS) {
+      if (selector[field] != null) schema[field] = selector[field];
+    }
+    return Object.keys(schema).length ? schema : null;
+  }
+
+  function hasAnySchemaField(selector) {
+    return SCHEMA_FIELDS.some(field => selector[field] != null);
+  }
+
+  function listLigands() {
+    const ligands = new Map();
+    for (const atom of collectAtoms({ kind: 'ligand' }, { includePositions: false })) {
+      const key = residueIdentity(atom);
+      let ligand = ligands.get(key);
+      if (!ligand) {
+        ligand = { ...residueSummary(atom), atomCount: 0 };
+        ligands.set(key, ligand);
+      }
+      ligand.atomCount++;
+    }
+    return Array.from(ligands.values()).sort(sortResidueLike);
+  }
+
+  function matchesLigand(ligand, selector) {
+    const cleaned = { ...selector };
+    delete cleaned.kind;
+    if (!Object.keys(cleaned).length) return true;
+    return matchesSelector({ ...ligand, kind: 'ligand' }, cleaned);
+  }
+
+  function ligandToSelector(ligand) {
+    const selector = { kind: 'ligand' };
+    for (const key of ['label_entity_id', 'label_asym_id', 'auth_asym_id', 'label_seq_id', 'auth_seq_id', 'pdbx_PDB_ins_code', 'label_comp_id', 'auth_comp_id']) {
+      if (ligand[key] != null) selector[key] = ligand[key];
+    }
+    return selector;
+  }
+
+  function normalizeColor(value) {
+    const text = String(value || '').trim();
+    if (/^#[0-9a-f]{6}$/iu.test(text)) return text.toLowerCase();
+    if (/^0x[0-9a-f]{6}$/iu.test(text)) return `#${text.slice(2).toLowerCase()}`;
+    if (/^[0-9a-f]{6}$/iu.test(text)) return `#${text.toLowerCase()}`;
+    return '#ffcc00';
+  }
+
+  function computeContacts(args = {}, warnings = []) {
+    const radiusA = Number(args.radiusA || args.radius || DEFAULT_CONTACT_RADIUS_A);
+    if (!Number.isFinite(radiusA) || radiusA <= 0 || radiusA > 20) {
+      throw coded('INVALID_ARGS', 'contacts radiusA must be in (0, 20].', { radiusA });
+    }
+    const sourceInput = args.source || args.selection || args.selector || 'last';
+    const sourceSelector = normalizeSelector(
+      typeof sourceInput === 'string' && (sourceInput === 'last' || state.selections.has(sourceInput))
+        ? resolveSelection(sourceInput).selector
+        : sourceInput,
+      false
+    );
+    const targetSelector = normalizeSelector(args.target || { kind: 'protein' }, false);
+    const maxSourceAtoms = Number(args.maxSourceAtoms) || MAX_CONTACT_SOURCE_ATOMS;
+    const maxTargetAtoms = Number(args.maxTargetAtoms) || MAX_CONTACT_TARGET_ATOMS;
+    const sourceAtoms = collectAtoms(sourceSelector, { includePositions: true, maxAtoms: maxSourceAtoms + 1 });
+    const targetAtoms = collectAtoms(targetSelector, { includePositions: true, maxAtoms: maxTargetAtoms + 1 });
+    if (!sourceAtoms.length) throw coded('SELECTION_EMPTY', 'contacts source selector matched no atoms.', { sourceSelector });
+    if (!targetAtoms.length) throw coded('SELECTION_EMPTY', 'contacts target selector matched no atoms.', { targetSelector });
+    if (sourceAtoms.length > maxSourceAtoms) warnings.push(`contacts source atoms capped at ${maxSourceAtoms}.`);
+    if (targetAtoms.length > maxTargetAtoms) warnings.push(`contacts target atoms capped at ${maxTargetAtoms}.`);
+
+    const grid = buildSpatialGrid(targetAtoms.slice(0, maxTargetAtoms), radiusA);
+    const residues = new Map();
+    const radius2 = radiusA * radiusA;
+    let pairCount = 0;
+    for (const sourceAtom of sourceAtoms.slice(0, maxSourceAtoms)) {
+      if (!finitePosition(sourceAtom.position)) continue;
+      for (const targetAtom of nearbyAtoms(grid, sourceAtom.position, radiusA)) {
+        if (!finitePosition(targetAtom.position)) continue;
+        if (residueIdentity(sourceAtom) === residueIdentity(targetAtom)) continue;
+        const d2 = squaredDistance(sourceAtom.position, targetAtom.position);
+        if (d2 > radius2) continue;
+        pairCount++;
+        const key = residueIdentity(targetAtom);
+        let residue = residues.get(key);
+        const distance = Math.sqrt(d2);
+        if (!residue) {
+          residue = { ...residueSummary(targetAtom), minDistanceA: distance, contactAtomCount: 0, examples: [] };
+          residues.set(key, residue);
+        }
+        residue.minDistanceA = Math.min(residue.minDistanceA, distance);
+        residue.contactAtomCount++;
+        if (residue.examples.length < 3) {
+          residue.examples.push({
+            source: atomLabel(sourceAtom),
+            target: atomLabel(targetAtom),
+            distanceA: Number(distance.toFixed(3))
+          });
+        }
+      }
+    }
+    const residueList = Array.from(residues.values())
+      .map(r => ({ ...r, minDistanceA: Number(r.minDistanceA.toFixed(3)) }))
+      .sort((a, b) => a.minDistanceA - b.minDistanceA || sortResidueLike(a, b));
+    return {
+      method: 'distance-neighborhood',
+      classified: false,
+      radiusA,
+      sourceSelector,
+      targetSelector,
+      sourceAtomCount: Math.min(sourceAtoms.length, maxSourceAtoms),
+      targetAtomCount: Math.min(targetAtoms.length, maxTargetAtoms),
+      pairCount,
+      residues: residueList
+    };
+  }
+
+  function atomLabel(atom) {
+    return {
+      auth_asym_id: atom.auth_asym_id,
+      auth_seq_id: atom.auth_seq_id,
+      label_comp_id: atom.label_comp_id,
+      atom: atom.auth_atom_id || atom.label_atom_id,
+      type_symbol: atom.type_symbol
+    };
+  }
+
+  function finitePosition(pos) {
+    return Array.isArray(pos) && pos.length >= 3 && pos.every(Number.isFinite);
+  }
+
+  function buildSpatialGrid(atoms, cellSize) {
+    const cells = new Map();
+    for (const atom of atoms) {
+      if (!finitePosition(atom.position)) continue;
+      const key = gridKey(atom.position, cellSize);
+      let bucket = cells.get(key);
+      if (!bucket) cells.set(key, bucket = []);
+      bucket.push(atom);
+    }
+    return { cells, cellSize };
+  }
+
+  function gridKey(pos, cellSize) {
+    return `${Math.floor(pos[0] / cellSize)},${Math.floor(pos[1] / cellSize)},${Math.floor(pos[2] / cellSize)}`;
+  }
+
+  function nearbyAtoms(grid, pos) {
+    const ix = Math.floor(pos[0] / grid.cellSize);
+    const iy = Math.floor(pos[1] / grid.cellSize);
+    const iz = Math.floor(pos[2] / grid.cellSize);
+    const out = [];
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dz = -1; dz <= 1; dz++) {
+          const bucket = grid.cells.get(`${ix + dx},${iy + dy},${iz + dz}`);
+          if (bucket) out.push(...bucket);
+        }
+      }
+    }
+    return out;
+  }
+
+  function squaredDistance(a, b) {
+    const dx = a[0] - b[0];
+    const dy = a[1] - b[1];
+    const dz = a[2] - b[2];
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  const agent = {
+    version: AGENT_VERSION,
+    apiVersion: API_VERSION,
+    get ready() { return state.readyPromise; },
+    attach,
+    notifyStructureLoaded,
+    capabilities: () => run({ command: 'capabilities' }),
+    run,
+    batch,
+    _state: state
+  };
+
+  window.BurreteAgent = agent;
+  window.BuretteAgent = agent;
+
+  if (window.BurreteViewer || window.BuretteViewer) {
+    attach({ viewer: window.BurreteViewer || window.BuretteViewer });
+  }
+})();

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -462,6 +462,7 @@
   <div id="buret-window-outline" aria-hidden="true"></div>
   <div id="status">[web] Loading Mol* preview shell…</div>
   <script>window.BurreteCacheBuster = String(Date.now());</script>
+  <script src="./burette-agent.js"></script>
   <script src="./viewer.js"></script>
 </body>
 </html>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -912,6 +912,12 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
 ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     applyViewerBackground(viewer);
     window.BurreteViewer = viewer;
+    window.BuretteViewer = viewer;
+    try {
+      window.BurreteAgent?.attach?.({ viewer, plugin: viewer.plugin, config });
+    } catch (error) {
+      debug('BurreteAgent attach failed: ' + (error && error.message || String(error)));
+    }
     activeViewer = viewer;
     window.BurreteHandleResize = () => scheduleViewerResize(viewer, 60);
     applyViewerUIScale(viewer);
@@ -932,6 +938,12 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
       45000,
       `Mol* timed out while parsing/rendering ${prepared.label} as ${prepared.format}.`
     );
+
+    try {
+      window.BurreteAgent?.notifyStructureLoaded?.({ viewer, plugin: viewer.plugin, config, prepared });
+    } catch (error) {
+      debug('BurreteAgent notifyStructureLoaded failed: ' + (error && error.message || String(error)));
+    }
 
     window.addEventListener('resize', () => scheduleViewerResize(viewer, 100));
     await waitForAnimationFrame();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.10",
+      "version": "0.10.11",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "vendor:molstar": "node scripts/vendor-molstar.mjs",
     "build:macos": "bash scripts/build.sh",
     "test:web": "bash scripts/test-web-preview.sh",
-    "check:js": "node --check PreviewExtension/Web/viewer.js && node --check scripts/vendor-molstar.mjs && node --check scripts/check-release-version.mjs",
+    "agent:preview": "node scripts/agent-preview.mjs",
+    "test:agent": "node tests/test-burette-agent.mjs && node tests/test-agent-preview-server.mjs",
+    "check:js": "node --check PreviewExtension/Web/viewer.js && node --check PreviewExtension/Web/burette-agent.js && node --check scripts/vendor-molstar.mjs && node --check scripts/agent-preview.mjs && node --check scripts/check-release-version.mjs",
     "check:release": "node scripts/check-release-version.mjs",
     "ci": "bash scripts/ci.sh",
     "prepare": "lefthook install"

--- a/scripts/agent-preview.mjs
+++ b/scripts/agent-preview.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { basename, extname, join, resolve, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const webRoot = resolve(repoRoot, 'PreviewExtension', 'Web');
+
+function usage() {
+  console.error(`Usage: node scripts/agent-preview.mjs <structure-file> [--port 5177] [--host 127.0.0.1]
+
+Starts a tiny localhost-only Burette agent viewer for browser-use/manual QA.
+It serves PreviewExtension/Web assets and generates preview-config.js/preview-data.js in-memory.`);
+}
+
+function parseArgs(argv) {
+  const args = { host: '127.0.0.1', port: 5177, structure: null };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') { args.help = true; continue; }
+    if (arg === '--port') { args.port = Number(argv[++i]); continue; }
+    if (arg === '--host') { args.host = String(argv[++i] || '127.0.0.1'); continue; }
+    if (!args.structure) args.structure = arg;
+    else throw new Error(`Unexpected argument: ${arg}`);
+  }
+  return args;
+}
+
+function inferFormat(file) {
+  const ext = extname(file).toLowerCase().replace(/^\./, '');
+  if (ext === 'cif' || ext === 'mmcif' || ext === 'mcif' || ext === 'bcif') return 'mmcif';
+  if (ext === 'pdb' || ext === 'pdbqt') return 'pdb';
+  if (ext === 'sdf' || ext === 'sd') return 'sdf';
+  if (ext === 'mol') return 'mol';
+  if (ext === 'mol2') return 'mol2';
+  if (ext === 'xyz') return 'xyz';
+  if (ext === 'gro') return 'gro';
+  return 'auto';
+}
+
+function isBinaryFormat(file) {
+  return extname(file).toLowerCase() === '.bcif';
+}
+
+function js(name, value) {
+  return `window.${name} = ${JSON.stringify(value)};\n`;
+}
+
+function cookieValue(cookieHeader, name) {
+  const prefix = `${name}=`;
+  for (const part of String(cookieHeader || '').split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) return decodeURIComponent(trimmed.slice(prefix.length));
+  }
+  return '';
+}
+
+function contentType(pathname) {
+  if (pathname.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (pathname.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (pathname.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (pathname.endsWith('.png')) return 'image/png';
+  if (pathname.endsWith('.svg')) return 'image/svg+xml';
+  if (pathname.endsWith('.wasm')) return 'application/wasm';
+  return 'application/octet-stream';
+}
+
+function safeWebPath(urlPath) {
+  const stripped = decodeURIComponent(urlPath.split('?')[0]).replace(/^\/+/, '') || 'index.html';
+  const normal = normalize(stripped);
+  if (normal.startsWith('..') || normal.includes('/../') || normal.includes('\\')) return null;
+  return resolve(webRoot, normal);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.structure || !Number.isInteger(args.port) || args.port <= 0) {
+    usage();
+    process.exit(args.help ? 0 : 2);
+  }
+
+  const structurePath = resolve(args.structure);
+  const bytes = await readFile(structurePath);
+  const st = await stat(structurePath);
+  const config = {
+    label: basename(structurePath),
+    format: inferFormat(structurePath),
+    binary: isBinaryFormat(structurePath),
+    byteCount: st.size,
+    showPanelControls: true,
+    defaultLayoutState: { left: 'hidden', right: 'hidden', top: 'hidden', bottom: 'hidden' },
+    theme: 'auto',
+    canvasBackground: 'black'
+  };
+  const dataBase64 = bytes.toString('base64');
+  const token = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  const tokenCookieName = 'BurreteAgentPreviewToken';
+
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || '/', `http://${args.host}:${args.port}`);
+      const hasValidToken = url.searchParams.get('token') === token || cookieValue(req.headers.cookie, tokenCookieName) === token;
+      if (url.pathname === '/healthz') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, tokenRequired: true }));
+        return;
+      }
+      if ((url.pathname === '/' || url.pathname.endsWith('.html')) && !hasValidToken) {
+        res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Missing or invalid token.');
+        return;
+      }
+      if ((url.pathname === '/preview-config.js' || url.pathname === '/preview-data.js') && !hasValidToken) {
+        res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Missing or invalid token.');
+        return;
+      }
+      if (url.pathname === '/preview-config.js') {
+        res.writeHead(200, { 'Content-Type': 'text/javascript; charset=utf-8' });
+        res.end(js('BurreteConfig', config));
+        return;
+      }
+      if (url.pathname === '/preview-data.js') {
+        res.writeHead(200, { 'Content-Type': 'text/javascript; charset=utf-8' });
+        res.end(js('BurreteDataBase64', dataBase64));
+        return;
+      }
+      const file = safeWebPath(url.pathname);
+      if (!file || !file.startsWith(webRoot)) {
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Bad path.');
+        return;
+      }
+      await stat(file);
+      const headers = { 'Content-Type': contentType(file) };
+      if (url.pathname === '/' || url.pathname.endsWith('.html')) {
+        headers['Set-Cookie'] = `${tokenCookieName}=${encodeURIComponent(token)}; Path=/; SameSite=Strict`;
+      }
+      res.writeHead(200, headers);
+      createReadStream(file).pipe(res);
+    } catch (error) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end(error?.message || 'Not found');
+    }
+  });
+
+  server.listen(args.port, args.host, () => {
+    const url = `http://${args.host}:${args.port}/index.html?token=${encodeURIComponent(token)}`;
+    console.log(JSON.stringify({ ok: true, url, token, structurePath, config }, null, 2));
+  });
+}
+
+main().catch(error => {
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,8 +61,10 @@ grep -q 'com.local.burrete10.pdb' scripts/force-preview.sh || { echo "error: for
 
 require_asset PreviewExtension/Web/molstar.js
 require_asset PreviewExtension/Web/molstar.css
+require_asset PreviewExtension/Web/burette-agent.js
 require_asset PreviewExtension/Web/viewer.js
 node --check PreviewExtension/Web/viewer.js >/dev/null
+node --check PreviewExtension/Web/burette-agent.js >/dev/null
 clean_detritus "$ROOT"
 rm -f /tmp/Burrete.log "${TMPDIR:-/tmp}/Burrete.log" 2>/dev/null || true
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,5 +10,6 @@ export npm_config_cache="$ROOT/build/npm-cache"
 npm ci --ignore-scripts
 npm run check:release
 npm run check:js
+npm run test:agent
 plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
 ./scripts/build.sh samples/mini.sdf

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,8 +26,10 @@ require_tool ditto "ditto is normally present on macOS."
 
 require_asset PreviewExtension/Web/molstar.js
 require_asset PreviewExtension/Web/molstar.css
+require_asset PreviewExtension/Web/burette-agent.js
 require_asset PreviewExtension/Web/viewer.js
 node --check PreviewExtension/Web/viewer.js >/dev/null
+node --check PreviewExtension/Web/burette-agent.js >/dev/null
 
 if [[ ! -f "$EXPORT_OPTIONS" ]]; then
   cat >&2 <<MSG

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -95,20 +95,27 @@ fs.writeFileSync(dataOut, 'window.BurreteDataBase64 = "' + data.toString('base64
 console.log(`Wrote preview config/data for ${file} as ${format}`);
 JS
 
-node - "$SAMPLE" "$TMP/Web/index.html" "$TMP/Web/viewer.js" "$TMP/Web/preview-config.js" "$TMP/Web/preview-data.js" <<'JS'
+node - "$SAMPLE" "$TMP/Web/index.html" "$TMP/Web/viewer.js" "$TMP/Web/burette-agent.js" "$TMP/Web/preview-config.js" "$TMP/Web/preview-data.js" <<'JS'
 const fs = require('fs');
 const path = require('path');
 
 const sample = process.argv[2];
 const indexPath = process.argv[3];
 const viewerPath = process.argv[4];
-const configPath = process.argv[5];
-const dataPath = process.argv[6];
+const agentPath = process.argv[5];
+const configPath = process.argv[6];
+const dataPath = process.argv[7];
 
 const index = fs.readFileSync(indexPath, 'utf8');
 const viewer = fs.readFileSync(viewerPath, 'utf8');
+const agent = fs.readFileSync(agentPath, 'utf8');
 const configSource = fs.readFileSync(configPath, 'utf8');
 const dataSource = fs.readFileSync(dataPath, 'utf8');
+const appViewer = fs.readFileSync('App/MoleculeViewerWindowController.swift', 'utf8');
+const quickLookViewer = fs.readFileSync('PreviewExtension/PreviewViewController.swift', 'utf8');
+const buildScript = fs.readFileSync('scripts/build.sh', 'utf8');
+const releaseScript = fs.readFileSync('scripts/release.sh', 'utf8');
+const xcodeProject = fs.readFileSync('Burrete.xcodeproj/project.pbxproj', 'utf8');
 const config = JSON.parse(configSource.replace(/^window\.BurreteConfig = /, '').replace(/;\s*$/, ''));
 const ext = path.extname(sample).toLowerCase().slice(1);
 
@@ -137,7 +144,16 @@ assert(index.includes('.msp-sequence-select > select'), 'preview HTML must theme
 assert(index.includes('top: 64px !important'), 'Mol* viewport controls should clear the toolbar row');
 assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label found');
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
+assert(index.includes('./burette-agent.js'), 'preview HTML must load the Burette agent bridge before viewer.js');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
+assert(viewer.includes('BurreteAgent?.attach'), 'viewer.js must attach the Burette agent bridge');
+assert(agent.includes('window.BurreteAgent'), 'burette-agent.js must expose the BurreteAgent alias');
+assert(agent.includes('window.BuretteAgent'), 'burette-agent.js must expose the BuretteAgent alias');
+assert(appViewer.includes('burette-agent.js'), 'app viewer runtime must copy and load burette-agent.js');
+assert(quickLookViewer.includes('burette-agent.js'), 'Quick Look runtime must copy and load burette-agent.js');
+assert(buildScript.includes('PreviewExtension/Web/burette-agent.js'), 'build script must require and syntax-check burette-agent.js');
+assert(releaseScript.includes('PreviewExtension/Web/burette-agent.js'), 'release script must require and syntax-check burette-agent.js');
+assert(xcodeProject.includes('PreviewExtension/Web/burette-agent.js'), 'Xcode validation phase must track burette-agent.js');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
 assert(viewer.includes("mode: 'custom'"), 'viewer.js must distinguish custom toolbar positions from defaults');

--- a/tests/test-agent-preview-server.mjs
+++ b/tests/test-agent-preview-server.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer, request } from 'node:http';
+
+async function freePort() {
+  const server = createServer();
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  await new Promise(resolve => server.close(resolve));
+  return port;
+}
+
+function get(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = request(url, { headers }, res => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolve({
+        statusCode: res.statusCode,
+        headers: res.headers,
+        body: Buffer.concat(chunks).toString('utf8')
+      }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function waitForReady(child) {
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', chunk => { stdout += chunk.toString('utf8'); });
+  child.stderr.on('data', chunk => { stderr += chunk.toString('utf8'); });
+
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const start = stdout.indexOf('{');
+    const end = stdout.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      return JSON.parse(stdout.slice(start, end + 1));
+    }
+    if (child.exitCode != null) break;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error(`agent-preview did not become ready. stdout=${stdout} stderr=${stderr}`);
+}
+
+const port = await freePort();
+const child = spawn(process.execPath, ['scripts/agent-preview.mjs', 'samples/mini.pdb', '--port', String(port)], {
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+try {
+  const ready = await waitForReady(child);
+  assert.equal(ready.ok, true);
+  assert.match(ready.url, new RegExp(`^http://127\\.0\\.0\\.1:${port}/index\\.html\\?token=`));
+
+  const base = `http://127.0.0.1:${port}`;
+  const htmlWithoutToken = await get(`${base}/index.html`);
+  assert.equal(htmlWithoutToken.statusCode, 403);
+
+  const dataWithoutToken = await get(`${base}/preview-data.js`);
+  assert.equal(dataWithoutToken.statusCode, 403);
+
+  const configWithoutToken = await get(`${base}/preview-config.js`);
+  assert.equal(configWithoutToken.statusCode, 403);
+
+  const staticAgent = await get(`${base}/burette-agent.js`);
+  assert.equal(staticAgent.statusCode, 200);
+  assert.match(staticAgent.body, /window\.BurreteAgent/);
+
+  const htmlWithToken = await get(ready.url);
+  assert.equal(htmlWithToken.statusCode, 200);
+  const cookie = htmlWithToken.headers['set-cookie']?.find(value => value.startsWith('BurreteAgentPreviewToken='));
+  assert.ok(cookie, 'authorized HTML response should set the preview token cookie');
+
+  const cookieHeader = cookie.split(';')[0];
+  const dataWithCookie = await get(`${base}/preview-data.js`, { Cookie: cookieHeader });
+  assert.equal(dataWithCookie.statusCode, 200);
+  assert.match(dataWithCookie.body, /^window\.BurreteDataBase64 = "/);
+
+  const configWithCookie = await get(`${base}/preview-config.js`, { Cookie: cookieHeader });
+  assert.equal(configWithCookie.statusCode, 200);
+  assert.match(configWithCookie.body, /^window\.BurreteConfig = /);
+
+  console.log('agent-preview server tests passed');
+} finally {
+  child.kill('SIGTERM');
+}

--- a/tests/test-burette-agent.mjs
+++ b/tests/test-burette-agent.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { resolve } from 'node:path';
+
+function col(values) {
+  return { value: i => values[i], array: values, rowCount: values.length };
+}
+
+function fakeStructure() {
+  const elements = [0, 1, 2, 3, 4, 5];
+  const residueIndex = [0, 0, 1, 1, 2, 2];
+  const chainIndex = [0, 0, 0, 0, 1, 1];
+  const positions = [
+    [0, 0, 0], [1, 0, 0], [8, 0, 0], [9, 0, 0], [2.5, 0, 0], [2.8, 0, 0]
+  ];
+  const model = {
+    modelNum: 0,
+    atomicHierarchy: {
+      atoms: {
+        id: col([1, 2, 3, 4, 5, 6]),
+        label_atom_id: col(['N', 'CA', 'N', 'CA', 'C1', 'N1']),
+        auth_atom_id: col(['N', 'CA', 'N', 'CA', 'C1', 'N1']),
+        type_symbol: col(['N', 'C', 'N', 'C', 'C', 'N'])
+      },
+      residues: {
+        label_comp_id: col(['GLY', 'ALA', 'HEM']),
+        auth_comp_id: col(['GLY', 'ALA', 'HEM']),
+        label_seq_id: col([1, 2, 100]),
+        auth_seq_id: col([1, 2, 100]),
+        pdbx_PDB_ins_code: col([undefined, undefined, undefined])
+      },
+      chains: {
+        label_entity_id: col(['1', '2']),
+        label_asym_id: col(['A', 'B']),
+        auth_asym_id: col(['A', 'B'])
+      },
+      residueAtomSegments: { index: col(residueIndex) },
+      chainAtomSegments: { index: col(chainIndex) }
+    },
+    entities: {
+      getEntityIndex: id => id === '1' ? 0 : 1,
+      data: { type: col(['polymer', 'non-polymer']), id: col(['1', '2']), rowCount: 2 }
+    }
+  };
+  return {
+    units: [{ id: 1, elements, model, conformation: { position: (i, out) => { out[0] = positions[i][0]; out[1] = positions[i][1]; out[2] = positions[i][2]; } } }]
+  };
+}
+
+const agentSource = await readFile(resolve('PreviewExtension/Web/burette-agent.js'), 'utf8');
+const interactions = [];
+const context = {
+  console,
+  setTimeout,
+  clearTimeout,
+  Date,
+  performance: { now: () => Date.now() },
+  window: {
+    molstar: { version: '5.7.0-test' },
+    dispatchEvent() {},
+    CustomEvent: class CustomEvent { constructor(name, init) { this.name = name; this.detail = init?.detail; } }
+  },
+  document: {
+    querySelector() {
+      return { toDataURL: () => 'data:image/png;base64,stub' };
+    }
+  }
+};
+context.window.window = context.window;
+context.window.document = context.document;
+vm.createContext(context);
+vm.runInContext(agentSource, context, { filename: 'burette-agent.js' });
+
+const viewer = {
+  plugin: {
+    managers: {
+      structure: { hierarchy: { current: { structures: [{ cell: { transform: { ref: 's0' }, obj: { data: fakeStructure(), label: 'fake.pdb' } } }] } } },
+      camera: { reset: () => { interactions.push({ action: 'reset' }); } }
+    },
+    helpers: { viewportScreenshot: { getImageDataUri: async () => 'data:image/png;base64,from-helper' } }
+  },
+  structureInteractivity(payload) { interactions.push(payload); },
+  loadMvsData: async () => {}
+};
+
+context.window.BurreteAgent.attach({ viewer, plugin: viewer.plugin, config: { label: 'fake.pdb', format: 'pdb' } });
+context.window.BurreteAgent.notifyStructureLoaded({ prepared: { label: 'fake.pdb', format: 'pdb' } });
+
+const capabilities = await context.window.BurreteAgent.run({ command: 'capabilities' });
+assert.equal(capabilities.ok, true);
+assert.equal(capabilities.result.hasViewer, true);
+assert.equal(capabilities.result.hasStructureInteractivity, true);
+
+const summary = await context.window.BurreteAgent.run({ command: 'summary', args: { includeLigands: true } });
+assert.equal(summary.ok, true);
+assert.equal(summary.result.counts.atoms, 6);
+assert.equal(summary.result.counts.ligands, 1);
+assert.equal(summary.result.structures[0].chains.length, 2);
+
+const selected = await context.window.BurreteAgent.run({ command: 'selectResidues', args: { selector: { auth_asym_id: 'A', beg_auth_seq_id: 1, end_auth_seq_id: 2 } } });
+assert.equal(selected.ok, true);
+assert.equal(selected.result.counts.residues, 2);
+assert.ok(selected.result.selectionId.startsWith('sel-'));
+assert.ok(interactions.some(x => x.action === 'select'));
+
+const focus = await context.window.BurreteAgent.run({ command: 'focusSelection', args: { selection: 'last' } });
+assert.equal(focus.ok, true);
+assert.ok(interactions.some(x => x.action === 'focus'));
+
+const lig = await context.window.BurreteAgent.run({ command: 'focusLigand', args: { selector: { label_comp_id: 'HEM' }, showNeighborhood: true, radiusA: 4 } });
+assert.equal(lig.ok, true);
+assert.equal(lig.result.ligand.label_comp_id, 'HEM');
+assert.ok(lig.result.neighborhood.residues.some(r => r.auth_asym_id === 'A'));
+
+const shot = await context.window.BurreteAgent.run({ command: 'screenshot' });
+assert.equal(shot.ok, true);
+assert.equal(shot.result.dataUri, 'data:image/png;base64,from-helper');
+
+const bad = await context.window.BurreteAgent.run({ command: 'selectResidues', args: { selector: { auth_asym_id: 'Z' } } });
+assert.equal(bad.ok, false);
+assert.equal(bad.error.code, 'SELECTION_EMPTY');
+
+console.log('burette-agent tests passed');


### PR DESCRIPTION
## Summary

- Add a browser-controllable `BurreteAgent`/`BuretteAgent` bridge for Mol* preview sessions.
- Load and package the bridge in standalone web preview, app viewer, and Quick Look generated runtimes.
- Add a local `agent-preview` server for browser-use workflows with token-protected generated structure/config endpoints.
- Add regression coverage for agent commands, preview token protection, and runtime asset wiring.

## Why

The original patch only loaded the agent script from the standalone web HTML, while the real Burrete app and Quick Look HTML are generated from Swift and copied only the existing Mol* assets. This meant `window.BurreteAgent` would not exist in actual app/Quick Look previews. The preview server also exposed `/preview-data.js` and `/preview-config.js` without token validation, which leaked structure data to any local browser page.

## Validation

- `npm run check:js`
- `npm run test:agent`
- `./scripts/test-web-preview.sh --no-open`
- `./scripts/build.sh`
- `npm run ci`
- Verified the built `.app` contains `burette-agent.js` in both app resources and `BurretePreview.appex` resources.