### PR TITLE
Fix desktop viewer chrome

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -762,7 +762,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.12")
+                Text("Version 0.10.13")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -36,10 +36,13 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
             defer: false
         )
         window.title = "Burrete - \(fileURL.lastPathComponent)"
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.styleMask.remove(.fullSizeContentView)
         window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 660, height: 440)
         window.appearance = NSAppearance(named: .darkAqua)
-        window.titlebarAppearsTransparent = true
         if #available(macOS 11.0, *) {
             window.toolbarStyle = .unifiedCompact
         }
@@ -264,6 +267,7 @@ private struct AppViewerRuntime {
           <style>
             :root {
               --buret-viewer-ui-scale: 0.86;
+              --buret-toolbar-safe-top: 18px;
               --buret-canvas-background: #000000;
               --buret-shell-background: #000000;
               --buret-panel-background: rgba(18, 20, 22, 0.82);
@@ -645,7 +649,7 @@ private struct AppViewerRuntime {
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
+              position: absolute; top: var(--buret-toolbar-safe-top); right: 12px; left: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);
@@ -804,22 +808,34 @@ private enum AppViewerError: LocalizedError {
 }
 
 private final class BurreteAppViewerContainerView: NSView {
+    private static let contentInset: CGFloat = 7
+    private static let cornerRadius: CGFloat = 14
+
     init(contentView: NSView, transparentBackground: Bool) {
         super.init(frame: .zero)
         wantsLayer = true
         layer?.borderWidth = 1
         layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
-        layer?.cornerRadius = 16
-        layer?.masksToBounds = true
         layer?.backgroundColor = (transparentBackground ? NSColor.clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)).cgColor
+        layer?.cornerRadius = Self.cornerRadius
+        if #available(macOS 10.15, *) {
+            layer?.cornerCurve = .continuous
+        }
+        layer?.masksToBounds = true
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentView)
+        contentView.wantsLayer = true
+        contentView.layer?.cornerRadius = Self.cornerRadius - Self.contentInset
+        if #available(macOS 10.15, *) {
+            contentView.layer?.cornerCurve = .continuous
+        }
+        contentView.layer?.masksToBounds = true
         NSLayoutConstraint.activate([
-            contentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 1),
-            contentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1),
-            contentView.topAnchor.constraint(equalTo: topAnchor, constant: 1),
-            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1)
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.contentInset),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.contentInset),
+            contentView.topAnchor.constraint(equalTo: topAnchor, constant: Self.contentInset),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.contentInset)
         ])
     }
 

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.12;
+				MARKETING_VERSION = 0.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -417,7 +417,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.12;
+				MARKETING_VERSION = 0.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -441,7 +441,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.12;
+				MARKETING_VERSION = 0.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -466,7 +466,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.12;
+				MARKETING_VERSION = 0.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -400,6 +400,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           <style>
             :root {
               --buret-viewer-ui-scale: 0.86;
+              --buret-toolbar-safe-top: 12px;
               --buret-canvas-background: #000000;
               --buret-shell-background: #000000;
               --buret-panel-background: rgba(18, 20, 22, 0.82);
@@ -782,7 +783,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             #status.error { color: #ffd4d4; background: rgba(70, 0, 0, 0.82); }
             #status.hidden { display: none; }
             #buret-toolbar {
-              position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
+              position: absolute; top: var(--buret-toolbar-safe-top); right: 12px; left: auto; z-index: 2147483646;
               display: flex; align-items: center; gap: 6px; padding: 6px;
               border: 1px solid var(--buret-toolbar-border);
               border-radius: 12px; color: var(--buret-toolbar-color);

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="./molstar.css" />
   <style>
     :root {
+      --buret-toolbar-safe-top: 12px;
       --buret-canvas-background: #000000;
       --buret-shell-background: #000000;
       --buret-panel-background: rgba(18, 20, 22, 0.82);
@@ -393,7 +394,7 @@
       font-size: 12px; font-weight: 500; pointer-events: auto;
     }
     #buret-toolbar {
-      position: absolute; top: 12px; right: 12px; left: auto; z-index: 2147483646;
+      position: absolute; top: var(--buret-toolbar-safe-top); right: 12px; left: auto; z-index: 2147483646;
       display: flex; align-items: center; gap: 6px; padding: 6px;
       border: 1px solid var(--buret-toolbar-border);
       border-radius: 12px; color: var(--buret-toolbar-color);

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6,7 +6,7 @@
   const MAX_SDF_GRID_ATOMS = 900;
   const MAX_SDF_GRID_BONDS = 900;
   const SDF_GRID_PADDING = 4.0;
-  const TOOLBAR_POSITION_VERSION = '6';
+  const TOOLBAR_POSITION_VERSION = '7';
   const TOOLBAR_MARGIN = 12;
   const VIEWER_THEME_STORAGE_KEY = 'buret.viewer.theme';
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
@@ -380,7 +380,8 @@
 
     let drag = null;
     toolbar.addEventListener('pointerdown', event => {
-      if (!event.target.closest('[data-drag-handle]')) return;
+      if (event.target.closest('[data-buret-toggle]')) return;
+      if (!event.target.closest('[data-drag-handle]') && event.target.closest('.buret-button')) return;
       const rect = toolbar.getBoundingClientRect();
       drag = {
         dx: event.clientX - rect.left,
@@ -404,7 +405,8 @@
     });
     toolbar.addEventListener('pointerup', event => {
       if (!drag || event.pointerId !== drag.pointerId) return;
-      const shouldToggle = !drag.moved;
+      const shouldToggle = !drag.moved && event.target.closest('[data-drag-handle]');
+      try { toolbar.releasePointerCapture(event.pointerId); } catch (_) {}
       drag = null;
       if (shouldToggle) {
         setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
@@ -441,18 +443,25 @@
       window.getComputedStyle(viewportControls).display !== 'none';
     const right = controlsVisible ? controlsRect.left - TOOLBAR_MARGIN : window.innerWidth - TOOLBAR_MARGIN;
     const left = right - toolbar.offsetWidth;
-    const top = rect && rect.height > 0 ? rect.top + TOOLBAR_MARGIN : TOOLBAR_MARGIN;
+    const top = Math.max(toolbarSafeTop(), rect && rect.height > 0 ? rect.top + TOOLBAR_MARGIN : TOOLBAR_MARGIN);
     toolbar.dataset.defaultPosition = '1';
     moveToolbar(toolbar, left, top);
   }
 
   function moveToolbar(toolbar, left, top) {
-    const margin = 8;
+    const margin = TOOLBAR_MARGIN;
+    const safeTop = toolbarSafeTop();
     const maxLeft = Math.max(margin, window.innerWidth - toolbar.offsetWidth - margin);
-    const maxTop = Math.max(margin, window.innerHeight - toolbar.offsetHeight - margin);
+    const maxTop = Math.max(safeTop, window.innerHeight - toolbar.offsetHeight - margin);
     toolbar.style.left = Math.min(Math.max(margin, left), maxLeft) + 'px';
-    toolbar.style.top = Math.min(Math.max(margin, top), maxTop) + 'px';
+    toolbar.style.top = Math.min(Math.max(safeTop, top), maxTop) + 'px';
     toolbar.style.right = 'auto';
+  }
+
+  function toolbarSafeTop() {
+    const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--buret-toolbar-safe-top');
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? Math.max(TOOLBAR_MARGIN, parsed) : TOOLBAR_MARGIN;
   }
 
   function saveToolbarPosition(toolbar) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.12",
+      "version": "0.10.13",
       "dependencies": {
         "molstar": "5.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -130,7 +130,7 @@ assert(index.includes('role="toolbar"'), 'preview HTML must expose a toolbar rol
 assert(!index.includes('data-buret-action="fit"'), 'fit/fullscreen toolbar button should not be present');
 assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should collapse controls');
 assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
-assert(index.includes('top: 12px; right: 12px; left: auto'), 'toolbar should default to the upper-right corner');
+assert(index.includes('top: var(--buret-toolbar-safe-top); right: 12px; left: auto'), 'toolbar should honor the safe top inset');
 assert(index.includes('data-buret-action="theme"'), 'toolbar should expose a separate theme toggle');
 assert(index.includes('--buret-molstar-panel-background'), 'preview HTML must define Mol* theme panel colors');
 assert(index.includes('.msp-viewport-controls-panel'), 'preview HTML must theme Mol* viewport panels');
@@ -156,10 +156,13 @@ assert(releaseScript.includes('PreviewExtension/Web/burette-agent.js'), 'release
 assert(xcodeProject.includes('PreviewExtension/Web/burette-agent.js'), 'Xcode validation phase must track burette-agent.js');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
+assert(viewer.includes("TOOLBAR_POSITION_VERSION = '7'"), 'toolbar position cache should invalidate pre-safe-area positions');
 assert(viewer.includes("mode: 'custom'"), 'viewer.js must distinguish custom toolbar positions from defaults');
 assert(!viewer.includes('initMolstarRightPanelToggle'), 'viewer.js must keep Mol* right-side buttons native');
 assert(viewer.includes('VIEWER_THEME_STORAGE_KEY'), 'viewer.js must persist the separate theme toggle');
 assert(!viewer.includes('initMolstarThemeToggle'), 'viewer.js must keep Mol* Illumination button native');
+assert(viewer.includes("event.target.closest('[data-buret-toggle]')"), 'toolbar drag should not capture panel toggle buttons');
+assert(viewer.includes('toolbarSafeTop'), 'toolbar drag should clamp to the safe top inset');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');


### PR DESCRIPTION
Summary:
- port the desktop viewer chrome fix onto main without pulling beta-only RDKit/grid changes
- keep the main branch toolbar on the right while adding the safe top inset and drag clamp
- preserve the Burette agent bridge and existing main viewer controls
- bump release metadata to 0.10.13 because main already owns v0.10.12

Testing:
- node --check PreviewExtension/Web/viewer.js
- ./scripts/test-web-preview.sh --no-open samples/mini.pdb
- npm run check:release
- pre-commit: plist, release-version, js-syntax
- git push pre-push hook: npm run ci