### PR TITLE
Improve viewer renderer and grid behavior

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -143,6 +143,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let existing = viewerWindows[fileURL] {
             existing.showWindow(nil)
             presentWindow(existing.window, activate: true)
+            existing.enterFullScreen()
             return
         }
 
@@ -162,6 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller.showWindow(nil)
         controller.window?.center()
         presentWindow(controller.window, activate: true)
+        controller.enterFullScreen()
     }
 
     private func presentWindow(_ window: NSWindow?, activate: Bool) {
@@ -268,6 +270,7 @@ enum BurreteFileAssociations {
         "com.local.molstarquicklook10.mmcif",
         "com.local.molstarquicklook10.bcif",
         "com.local.molstarquicklook10.sdf",
+        "com.local.molstarquicklook10.smiles",
         "com.local.molstarquicklook10.mol",
         "com.local.molstarquicklook10.mol2",
         "org.wwpdb.pdb",

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -930,7 +930,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.15")
+                Text("Version 0.10.16")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @AppStorage("openSettingsAtLaunch") private var openSettingsAtLaunch = false
     @AppStorage("showPreviewPanelControls") private var showPreviewPanelControls = true
     @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = false
-    @AppStorage("viewerTheme") private var viewerTheme = "dark"
+    @AppStorage("viewerTheme") private var viewerTheme = "auto"
     @AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "black"
     @AppStorage("structureRendererMode") private var structureRendererMode = "auto"
     @AppStorage("xyzFastStyle") private var xyzFastStyle = "default"
@@ -18,6 +18,7 @@ struct ContentView: View {
     @StateObject private var updater = BurreteUpdater.shared
     @State private var section: SettingsSection = .general
     @State private var defaultOpenStatus = BurreteFileAssociations.defaultHandlerSummary
+    @State private var showExternalXyzrenderSettings = false
 
     var body: some View {
         ZStack {
@@ -98,12 +99,33 @@ struct ContentView: View {
             }
 
         case .viewer:
-            SettingsSectionTitle("Viewer")
+            SettingsSectionTitle("File Type Behavior")
+            SettingsCard {
+                SettingsValueRow(
+                    icon: "cube.transparent",
+                    title: "PDB / mmCIF / BinaryCIF / GRO",
+                    subtitle: "Opened with Mol* Interactive for rotation, chains, residues, sequence, and structure panels."
+                )
+                SettingsDivider()
+                SettingsValueRow(
+                    icon: "square.grid.3x3",
+                    title: "SDF / SMILES / MOL / MOL2",
+                    subtitle: "SMILES and multi-record SDF files show a molecule grid when possible; single structure files stay in Mol*."
+                )
+                SettingsDivider()
+                SettingsValueRow(
+                    icon: "sparkles",
+                    title: "XYZ",
+                    subtitle: "Auto uses Fast XYZ SVG for Quick Look speed. In the full app toolbar, .xyz can switch to Mol* or external xyzrender."
+                )
+            }
+
+            SettingsSectionTitle("Renderer")
             SettingsCard {
                 SettingsStringPickerRow(
                     icon: "atom",
-                    title: "Renderer",
-                    subtitle: "Auto uses Fast XYZ SVG for .xyz and Mol* for the rest. Choose Mol* Interactive when you want live rotation and the full app controls.",
+                    title: "Default renderer policy",
+                    subtitle: "Recommended: Auto. It chooses Fast XYZ for .xyz and Mol* for PDB, mmCIF, SDF, MOL, MOL2, and GRO.",
                     selection: $structureRendererMode,
                     options: [
                         ("auto", "Auto"),
@@ -116,7 +138,7 @@ struct ContentView: View {
                 SettingsStringPickerRow(
                     icon: "sparkles",
                     title: "Fast XYZ style",
-                    subtitle: "Static SVG style for Quick Look and app .xyz previews.",
+                    subtitle: "Only affects .xyz files when the renderer resolves to Fast XYZ SVG.",
                     selection: $xyzFastStyle,
                     options: [
                         ("default", "Default"),
@@ -125,46 +147,63 @@ struct ContentView: View {
                         ("spacefill", "Spacefill")
                     ]
                 )
+            }
+
+            SettingsSectionTitle("External xyzrender")
+            SettingsCard {
+                DisclosureGroup(isExpanded: $showExternalXyzrenderSettings) {
+                    VStack(spacing: 0) {
+                        SettingsDivider()
+                        SettingsStringPickerRow(
+                            icon: "terminal",
+                            title: "Preset",
+                            subtitle: "Used only by the standalone app for .xyz files when external xyzrender is selected.",
+                            selection: $xyzrenderPreset,
+                            options: AppViewerXyzrenderPreset.pickerOptions
+                        )
+                        SettingsDivider()
+                        SettingsTextFieldRow(
+                            icon: "doc.badge.gearshape",
+                            title: "Custom config path",
+                            subtitle: "Used when the preset is Custom JSON. Point this to a local xyzrender config file.",
+                            text: $xyzrenderCustomConfigPath,
+                            placeholder: "/Users/me/styles/my_style.json"
+                        )
+                        SettingsDivider()
+                        SettingsTextFieldRow(
+                            icon: "point.3.connected.trianglepath.dotted",
+                            title: "Executable path",
+                            subtitle: "Leave empty to run xyzrender from PATH. Set an absolute path for a custom venv, uv tool, or signed helper.",
+                            text: $xyzrenderExecutablePath,
+                            placeholder: "/opt/homebrew/bin/xyzrender"
+                        )
+                        SettingsDivider()
+                        SettingsTextFieldRow(
+                            icon: "curlybraces",
+                            title: "Extra flags",
+                            subtitle: "Optional app-only CLI flags such as --cell --idx sn --no-hy. Output flags are ignored.",
+                            text: $xyzrenderExtraArguments,
+                            placeholder: "--cell --idx sn"
+                        )
+                    }
+                } label: {
+                    SettingsDisclosureHeader(
+                        icon: "terminal",
+                        title: "External xyzrender (optional)",
+                        subtitle: "Advanced .xyz SVG rendering. Leave closed unless you installed xyzrender and want Burrete to call it."
+                    )
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+            }
+
+            SettingsSectionTitle("What The Modes Mean")
+            SettingsCard {
+                SettingsValueRow(icon: "bolt.horizontal", title: "Fast XYZ SVG", subtitle: "Fast static SVG for .xyz previews. Best for Quick Look and large simple XYZ files.")
                 SettingsDivider()
-                SettingsStringPickerRow(
-                    icon: "terminal",
-                    title: "External xyzrender preset",
-                    subtitle: "Used only by the standalone app when xyzrender is available on PATH or configured via defaults.",
-                    selection: $xyzrenderPreset,
-                    options: AppViewerXyzrenderPreset.pickerOptions
-                )
+                SettingsValueRow(icon: "rotate.3d", title: "Mol* Interactive", subtitle: "Full interactive viewer for rotation, measurement, panels, sequence, logs, and structure inspection.")
                 SettingsDivider()
-                SettingsTextFieldRow(
-                    icon: "doc.badge.gearshape",
-                    title: "External xyzrender custom config",
-                    subtitle: "Used when the preset is Custom JSON. Point this to a local xyzrender config file.",
-                    text: $xyzrenderCustomConfigPath,
-                    placeholder: "/Users/me/styles/my_style.json"
-                )
-                SettingsDivider()
-                SettingsTextFieldRow(
-                    icon: "point.3.connected.trianglepath.dotted",
-                    title: "External xyzrender executable",
-                    subtitle: "Leave empty to run `xyzrender` from PATH. Set an absolute path when using a custom venv, uv tool, or signed helper.",
-                    text: $xyzrenderExecutablePath,
-                    placeholder: "/opt/homebrew/bin/xyzrender"
-                )
-                SettingsDivider()
-                SettingsTextFieldRow(
-                    icon: "curlybraces",
-                    title: "External xyzrender extra flags",
-                    subtitle: "Optional app-only CLI flags such as `--cell --idx sn --no-hy`. Output flags are ignored so Burrete can keep displaying the generated SVG.",
-                    text: $xyzrenderExtraArguments,
-                    placeholder: "--cell --idx sn"
-                )
-                SettingsDivider()
-                SettingsValueRow(icon: "doc.richtext", title: "Formats", subtitle: "PDB, PDBx/mmCIF, BinaryCIF, SDF, MOL, MOL2, XYZ, and GRO")
-                SettingsDivider()
-                SettingsValueRow(icon: "rotate.3d", title: "Interactive XYZ", subtitle: "Open .xyz in the standalone app and switch to Mol* Interactive from the toolbar to rotate, inspect, and use Mol* panels.")
-                SettingsDivider()
-                SettingsValueRow(icon: "square.grid.3x3", title: "SDF molecule grid", subtitle: "Multi-record SDF files are laid out as a visible grid when possible.")
-                SettingsDivider()
-                SettingsValueRow(icon: "bolt.horizontal", title: "Performance", subtitle: "Fast SVG for .xyz; bundled Mol* assets and WebGL fallback for interactive formats.")
+                SettingsValueRow(icon: "terminal", title: "External xyzrender SVG", subtitle: "Optional app-only renderer for .xyz when xyzrender is installed. Quick Look still uses bundled renderers.")
             }
 
             SettingsSectionTitle("Appearance")
@@ -754,32 +793,60 @@ private struct SettingsTextFieldRow: View {
     let placeholder: String
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: 10) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 13, weight: .medium))
                 .symbolRenderingMode(.hierarchical)
-                .foregroundColor(.white.opacity(0.82))
-                .frame(width: 24)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(0.9))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
                 Text(subtitle)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.48))
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: 10)
 
             TextField(placeholder, text: $text)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 12, weight: .regular, design: .monospaced))
                 .frame(width: 220)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+    }
+}
+
+private struct SettingsDisclosureHeader: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .medium))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
     }
 }
 

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -49,6 +49,7 @@
 				<string>com.local.molstarquicklook10.mmcif</string>
 				<string>com.local.molstarquicklook10.bcif</string>
 				<string>com.local.molstarquicklook10.sdf</string>
+				<string>com.local.molstarquicklook10.smiles</string>
 				<string>com.local.molstarquicklook10.mol</string>
 				<string>com.local.molstarquicklook10.mol2</string>
 				<string>org.wwpdb.pdb</string>

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -46,6 +46,8 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     private var currentViewerPageZoom: CGFloat = 0.86
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
+    private var isInNativeFullScreen = false
+    private var isEnteringNativeFullScreen = false
     private static let defaultViewerPageZoom: CGFloat = 0.86
     private static let minViewerPageZoom: CGFloat = 0.72
     private static let maxViewerPageZoom: CGFloat = 1.35
@@ -79,7 +81,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         window.title = "Burrete - \(fileURL.lastPathComponent)"
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = false
-        window.isMovableByWindowBackground = true
+        window.isMovableByWindowBackground = false
         window.styleMask.remove(.fullSizeContentView)
         window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 660, height: 440)
@@ -87,13 +89,25 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         if #available(macOS 11.0, *) {
             window.toolbarStyle = .unifiedCompact
         }
-        window.isOpaque = false
-        window.backgroundColor = .clear
+        window.isOpaque = true
+        window.backgroundColor = .windowBackgroundColor
         window.hasShadow = true
-        window.contentView = BurreteAppViewerContainerView(contentView: webView, transparentBackground: transparentBackground)
+        window.contentView = webView
 
         super.init(window: window)
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidEnterFullScreen),
+            name: NSWindow.didEnterFullScreenNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidExitFullScreen),
+            name: NSWindow.didExitFullScreenNotification,
+            object: window
+        )
         userContentController.add(self, name: "burrete")
         webView.navigationDelegate = self
         webView.wantsLayer = true
@@ -114,6 +128,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     }
 
     deinit {
+        NotificationCenter.default.removeObserver(self)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "burrete")
     }
 
@@ -128,6 +143,25 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         } catch {
             webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
         }
+    }
+
+    func enterFullScreen() {
+        guard window != nil, !isInNativeFullScreen, !isEnteringNativeFullScreen else { return }
+        isEnteringNativeFullScreen = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let window = self.window else { return }
+            window.toggleFullScreen(nil)
+        }
+    }
+
+    @objc private func windowDidEnterFullScreen(_ notification: Notification) {
+        isInNativeFullScreen = true
+        isEnteringNativeFullScreen = false
+    }
+
+    @objc private func windowDidExitFullScreen(_ notification: Notification) {
+        isInNativeFullScreen = false
+        isEnteringNativeFullScreen = false
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -272,11 +306,17 @@ private struct AppViewerRuntime {
         try copyAssets(from: bundledWebDirectory, to: assetsDirectory)
 
         let transparentBackground = UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
-        let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "dark"
+        let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto"
         let canvasBackground = UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "black"
         let canvasIsTransparent = canvasBackground == "transparent"
 
-        if let gridPreview = try MoleculeGridPreviewBuilder.makePreview(
+        let rendererOverride = rendererModeOverride.map(AppViewerRendererMode.normalize)
+        let bypassGridForRendererSwitch = ["sdf", "sd"].contains(fileURL.pathExtension.lowercased()) &&
+            rendererOverride != nil &&
+            rendererOverride != "auto"
+
+        if !bypassGridForRendererSwitch,
+           let gridPreview = try MoleculeGridPreviewBuilder.makePreview(
             fileURL: fileURL,
             data: data,
             host: .app,
@@ -286,7 +326,7 @@ private struct AppViewerRuntime {
             debug: false,
             allowSelection: true,
             allowExport: true,
-            maxRecords: 5000
+            maxRecords: 10000
         ) {
             try requireGridRuntimeAssets(in: assetsDirectory)
             try Data(gridHTML(title: fileURL.lastPathComponent, transparentBackground: transparentBackground).utf8)
@@ -297,6 +337,11 @@ private struct AppViewerRuntime {
                 .write(to: runtimeDirectory.appendingPathComponent("preview-data.js"), options: [.atomic])
             try Data(gridPreview.recordsScript.utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-grid-records.js"), options: [.atomic])
+            let rdkitWasmURL = assetsDirectory
+                .appendingPathComponent("rdkit", isDirectory: true)
+                .appendingPathComponent("RDKit_minimal.wasm")
+            try Data(rdkitWasmInlineScript(from: rdkitWasmURL).utf8)
+                .write(to: runtimeDirectory.appendingPathComponent("preview-rdkit-wasm.js"), options: [.atomic])
             return AppViewerRuntime(
                 indexURL: runtimeDirectory.appendingPathComponent("index.html"),
                 readAccessURL: baseDirectory
@@ -424,6 +469,23 @@ private struct AppViewerRuntime {
         }
     }
 
+    private static func rdkitWasmInlineScript(from url: URL) throws -> String {
+        let base64 = try Data(contentsOf: url).base64EncodedString(options: [])
+        let chunkSize = 32_768
+        var chunks: [String] = []
+        var start = base64.startIndex
+        while start < base64.endIndex {
+            let end = base64.index(start, offsetBy: chunkSize, limitedBy: base64.endIndex) ?? base64.endIndex
+            chunks.append(String(base64[start..<end]))
+            start = end
+        }
+        let jsonData = try JSONSerialization.data(withJSONObject: chunks, options: [.withoutEscapingSlashes])
+        guard let json = String(data: jsonData, encoding: .utf8) else {
+            throw AppViewerError.missingWebResources
+        }
+        return "window.BurreteRDKitWasmBase64Chunks = \(json);\n"
+    }
+
     private static func copyAssetAtomically(from source: URL, to destination: URL) throws {
         let fileManager = FileManager.default
         let temporaryURL = destination
@@ -478,13 +540,14 @@ private struct AppViewerRuntime {
 
     private static func resolveRenderer(for format: AppViewerStructureFormat, rendererMode: String) -> String {
         let isXYZ = format.molstarFormat == "xyz" && !format.isBinary
+        let isSDF = format.molstarFormat == "sdf" && !format.isBinary
         switch AppViewerRendererMode.normalize(rendererMode) {
         case "molstar":
             return "molstar"
         case "xyz-fast":
             return isXYZ ? "xyz-fast" : "molstar"
         case "xyzrender-external":
-            return isXYZ ? "xyzrender-external" : "molstar"
+            return (isXYZ || isSDF) ? "xyzrender-external" : "molstar"
         default:
             return isXYZ ? "xyz-fast" : "molstar"
         }
@@ -569,6 +632,7 @@ private struct AppViewerRuntime {
           </script>
           <script src="preview-config.js"></script>
           <script src="preview-grid-records.js"></script>
+          <script src="preview-rdkit-wasm.js"></script>
           <script src="../assets/rdkit/RDKit_minimal.js"></script>
           <script src="../assets/grid-viewer.js"></script>
         </body>
@@ -1323,45 +1387,6 @@ private enum AppViewerError: LocalizedError {
         case .missingCacheDirectory:
             return "Could not locate the app cache directory."
         }
-    }
-}
-
-private final class BurreteAppViewerContainerView: NSView {
-    private static let contentInset: CGFloat = 7
-    private static let cornerRadius: CGFloat = 14
-
-    init(contentView: NSView, transparentBackground: Bool) {
-        super.init(frame: .zero)
-        wantsLayer = true
-        layer?.borderWidth = 1
-        layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
-        layer?.cornerRadius = 16
-        layer?.masksToBounds = true
-        layer?.backgroundColor = (transparentBackground ? NSColor.clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)).cgColor
-        layer?.cornerRadius = Self.cornerRadius
-        if #available(macOS 10.15, *) {
-            layer?.cornerCurve = .continuous
-        }
-        layer?.masksToBounds = true
-
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(contentView)
-        contentView.wantsLayer = true
-        contentView.layer?.cornerRadius = Self.cornerRadius - Self.contentInset
-        if #available(macOS 10.15, *) {
-            contentView.layer?.cornerCurve = .continuous
-        }
-        contentView.layer?.masksToBounds = true
-        NSLayoutConstraint.activate([
-            contentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.contentInset),
-            contentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.contentInset),
-            contentView.topAnchor.constraint(equalTo: topAnchor, constant: Self.contentInset),
-            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.contentInset)
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }
 

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.15;
+				MARKETING_VERSION = 0.10.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -427,7 +427,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.15;
+				MARKETING_VERSION = 0.10.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -451,7 +451,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.15;
+				MARKETING_VERSION = 0.10.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.15;
+				MARKETING_VERSION = 0.10.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -51,6 +51,30 @@
 				<string>public.data</string>
 			</array>
 			<key>UTTypeDescription</key>
+			<string>SMILES molecular structure list</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.smiles</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>smi</string>
+					<string>smiles</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>chemical/x-daylight-smiles</string>
+					<string>chemical/x-smiles</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
 			<string>GROMACS structure file</string>
 			<key>UTTypeIdentifier</key>
 			<string>com.local.burrete10.gro</string>
@@ -82,6 +106,7 @@
 				<string>com.local.molstarquicklook10.mmcif</string>
 				<string>com.local.molstarquicklook10.bcif</string>
 				<string>com.local.molstarquicklook10.sdf</string>
+				<string>com.local.molstarquicklook10.smiles</string>
 				<string>com.local.molstarquicklook10.mol</string>
 				<string>com.local.molstarquicklook10.mol2</string>
 				<string>org.wwpdb.pdb</string>

--- a/PreviewExtension/MoleculeGridPreview.swift
+++ b/PreviewExtension/MoleculeGridPreview.swift
@@ -62,6 +62,7 @@ enum MoleculeGridPreviewBuilder {
             "host": host.rawValue,
             "quickLookBuild": host == .quickLook ? "burrete-grid2d-quicklook" : "burrete-grid2d-app",
             "debug": debug,
+            "appViewer": host == .app,
             "theme": theme,
             "canvasBackground": canvasBackground,
             "transparentBackground": transparentBackground,
@@ -72,7 +73,8 @@ enum MoleculeGridPreviewBuilder {
             "capabilities": [
                 "selection": allowSelection,
                 "export": allowExport,
-                "substructureSearch": false
+                "substructureSearch": true,
+                "rendererSwitch": host == .app && collection.format == "sdf"
             ]
         ]
 

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -205,7 +205,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static let supportedStructureExtensions: Set<String> = [
-        "bcif", "cif", "ent", "gro", "mcif", "mmcif", "mol", "mol2", "pdb", "pdbqt", "pqr", "sd", "sdf", "xyz"
+        "bcif", "cif", "ent", "gro", "mcif", "mmcif", "mol", "mol2", "pdb", "pdbqt", "pqr", "sd", "sdf", "smi", "smiles", "xyz"
     ]
 
     private static func buildInlinePreviewHTML(for url: URL) throws -> BuildResult {
@@ -248,7 +248,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             debug: showDebugOverlay,
             allowSelection: false,
             allowExport: false,
-            maxRecords: 750
+            maxRecords: 3000
         ) {
             diag("detected.previewMode=grid2d format=\(gridPreview.format) records=\(gridPreview.recordsIncluded)/\(gridPreview.recordsTotal)")
             try validateVendoredMoleculeGridAssets(in: webDirectory, fileManager: fileManager, diagnostics: &diagnostics)
@@ -350,8 +350,32 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         if let gridRecordsScript {
             try Data(gridRecordsScript.utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-grid-records.js"), options: [.atomic])
+            let rdkitWasmURL = bundledWebDirectory
+                .appendingPathComponent("rdkit", isDirectory: true)
+                .appendingPathComponent("RDKit_minimal.wasm")
+            let rdkitWasmScript = try rdkitWasmInlineScript(from: rdkitWasmURL)
+            try Data(rdkitWasmScript.utf8)
+                .write(to: runtimeDirectory.appendingPathComponent("preview-rdkit-wasm.js"), options: [.atomic])
+            diagnostics.append("[build] preview-rdkit-wasm.script.bytes=\(rdkitWasmScript.utf8.count)")
         }
         return RuntimePreview(runtimeDirectory: runtimeDirectory, indexURL: indexURL, readAccessURL: previewsDirectory)
+    }
+
+    private static func rdkitWasmInlineScript(from url: URL) throws -> String {
+        let base64 = try Data(contentsOf: url).base64EncodedString(options: [])
+        let chunkSize = 32_768
+        var chunks: [String] = []
+        var start = base64.startIndex
+        while start < base64.endIndex {
+            let end = base64.index(start, offsetBy: chunkSize, limitedBy: base64.endIndex) ?? base64.endIndex
+            chunks.append(String(base64[start..<end]))
+            start = end
+        }
+        let jsonData = try JSONSerialization.data(withJSONObject: chunks, options: [.withoutEscapingSlashes])
+        guard let json = String(data: jsonData, encoding: .utf8) else {
+            throw PreviewError.couldNotCreateRuntimePreview("Could not encode RDKit WASM chunks")
+        }
+        return "window.BurreteRDKitWasmBase64Chunks = \(json);\n"
     }
 
     private static func pruneRuntimePreviews(
@@ -515,6 +539,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           </script>
           <script src="preview-config.js"></script>
           <script src="preview-grid-records.js"></script>
+          <script src="preview-rdkit-wasm.js"></script>
           <script src="../assets/rdkit/RDKit_minimal.js"></script>
           <script src="../assets/grid-viewer.js"></script>
         </body>
@@ -1612,7 +1637,7 @@ private struct PreviewPreferences {
         let appID = "com.local.BurreteV10" as CFString
         let showPanelControls = (CFPreferencesCopyAppValue("showPreviewPanelControls" as CFString, appID) as? Bool) ?? true
         let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? false
-        let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "dark"
+        let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "auto"
         let canvasBackground = (CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "black"
         let rendererMode = (CFPreferencesCopyAppValue("structureRendererMode" as CFString, appID) as? String) ?? "auto"
         let xyzFastStyle = (CFPreferencesCopyAppValue("xyzFastStyle" as CFString, appID) as? String) ?? "default"

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -7,19 +7,30 @@
     rdkit: null,
     all: Array.isArray(window.BurreteGridRecords) ? window.BurreteGridRecords : [],
     rows: [],
-    page: 0,
+    visibleCount: 0,
+    batchSize: 0,
     query: '',
+    smarts: '',
+    smartsError: '',
+    smartsMatches: new Map(),
     sort: 'index',
     selected: new Set(),
     svgCache: new Map(),
-    token: 0
+    token: 0,
+    autoLoadScheduled: false
   };
 
   function post(type, message, payload = {}) {
     try {
-      if (window.__mqlPost) window.__mqlPost(type, message || '', payload);
-      else window.webkit?.messageHandlers?.burrete?.postMessage({ type, message: String(message || ''), ...payload });
+      if (window.__mqlPost) {
+        window.__mqlPost(type, message || '', payload);
+        return true;
+      }
+      const handler = window.webkit?.messageHandlers?.burrete;
+      handler?.postMessage({ type, message: String(message || ''), ...payload });
+      return !!handler;
     } catch (_) {}
+    return false;
   }
 
   function setStatus(message, kind = 'info') {
@@ -40,7 +51,11 @@
 
   function capabilities(cfg) {
     const caps = cfg.capabilities || {};
-    return { selection: !!caps.selection, export: !!caps.export };
+    return {
+      selection: !!caps.selection,
+      export: !!caps.export,
+      rendererSwitch: cfg.appViewer === true && !!caps.rendererSwitch
+    };
   }
 
   async function initRDKit() {
@@ -49,13 +64,44 @@
       throw new Error('RDKit_minimal.js is missing. Run npm run vendor:rdkit and rebuild.');
     }
     setStatus('[grid] Loading RDKit.js...');
-    state.rdkit = await window.initRDKitModule({ locateFile: file => `../assets/rdkit/${file}` });
+    state.rdkit = await window.initRDKitModule(rdkitModuleOptions());
     return state.rdkit;
   }
 
-  function pageSize(cfg) {
-    const value = Number(cfg.pageSize || 72);
-    return Number.isFinite(value) ? Math.max(12, Math.min(180, Math.floor(value))) : 72;
+  function rdkitModuleOptions() {
+    const options = {
+      locateFile: file => new URL(`../assets/rdkit/${file}`, document.baseURI).href,
+      printErr: message => post('error', `[grid] RDKit stderr: ${String(message || '')}`),
+      onAbort: reason => post('error', `[grid] RDKit aborted: ${String(reason || '')}`)
+    };
+    const wasmBinary = embeddedRDKitWasmBinary();
+    if (wasmBinary) options.wasmBinary = wasmBinary;
+    return options;
+  }
+
+  function embeddedRDKitWasmBinary() {
+    const chunks = window.BurreteRDKitWasmBase64Chunks;
+    if (!Array.isArray(chunks) || chunks.length === 0) return null;
+    const binary = window.atob(chunks.join(''));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+
+  function defaultBatchSize(cfg) {
+    const value = Number(cfg.pageSize || 96);
+    return Number.isFinite(value) ? Math.max(24, Math.min(480, Math.floor(value))) : 96;
+  }
+
+  function batchSize(cfg) {
+    return state.batchSize || defaultBatchSize(cfg);
+  }
+
+  function batchOptions(cfg) {
+    return [...new Set([24, 60, 96, 120, 240, 480, defaultBatchSize(cfg)])]
+      .sort((a, b) => a - b)
+      .map(value => `<option value="${value}">${value} at a time</option>`)
+      .join('');
   }
 
   function applyTheme(cfg) {
@@ -89,36 +135,49 @@
         </header>
         <div class="buret-grid-toolbar">
           <label>Search <input id="search" type="search" placeholder="name, SMILES, metadata" /></label>
+          <label>SMARTS <input id="smarts" type="search" spellcheck="false" autocapitalize="off" placeholder="[#6]=O" /></label>
           <label>Sort <select id="sort"><option value="index">File order</option><option value="name">Name</option><option value="smiles">SMILES</option>${propertyOptions()}</select></label>
-          <div class="buret-pager"><button id="prev" type="button" aria-label="Previous page">&lsaquo;</button><span id="page-label"></span><button id="next" type="button" aria-label="Next page">&rsaquo;</button></div>
+          <label>Show <select id="display-count">${batchOptions(cfg)}</select></label>
+          <button id="clear-smarts" class="buret-clear-smarts" type="button" hidden>Clear SMARTS</button>
+          ${caps.rendererSwitch ? rendererSwitchHTML() : ''}
+          <div class="buret-load-controls"><span id="shown-label"></span><button id="load-more" type="button">Show more</button></div>
         </div>
         <main id="grid" class="buret-grid"></main>
         <footer id="footer" class="buret-grid-footer"></footer>
       </section>`;
+    state.batchSize = defaultBatchSize(cfg);
+    document.getElementById('display-count').value = String(state.batchSize);
     document.getElementById('search').addEventListener('input', event => {
       state.query = event.target.value || '';
-      state.page = 0;
+      refresh(cfg);
+    });
+    document.getElementById('smarts').addEventListener('input', event => {
+      state.smarts = event.target.value || '';
       refresh(cfg);
     });
     document.getElementById('sort').addEventListener('change', event => {
       state.sort = event.target.value || 'index';
       refresh(cfg);
     });
-    document.getElementById('prev').addEventListener('click', () => {
-      if (state.page > 0) {
-        state.page--;
-        render(cfg);
-      }
+    document.getElementById('display-count').addEventListener('change', event => {
+      state.batchSize = Math.max(24, Math.min(480, Number(event.target.value) || defaultBatchSize(cfg)));
+      refresh(cfg);
     });
-    document.getElementById('next').addEventListener('click', () => {
-      if (state.page + 1 < pages(cfg)) {
-        state.page++;
-        render(cfg);
-      }
+    document.getElementById('load-more').addEventListener('click', () => loadMore(cfg));
+    root.querySelectorAll('[data-buret-grid-renderer]').forEach(button => {
+      button.addEventListener('click', () => requestRendererSwitch(button.getAttribute('data-buret-grid-renderer')));
     });
     document.getElementById('copy-selected')?.addEventListener('click', copySelected);
     document.getElementById('export-smi')?.addEventListener('click', () => exportSmiles(cfg));
     document.getElementById('export-csv')?.addEventListener('click', () => exportCSV(cfg));
+    document.getElementById('clear-smarts')?.addEventListener('click', () => {
+      state.smarts = '';
+      const input = document.getElementById('smarts');
+      if (input) input.value = '';
+      refresh(cfg);
+      input?.focus();
+    });
+    window.addEventListener('scroll', () => scheduleAutoLoad(cfg), { passive: true });
   }
 
   function propertyOptions() {
@@ -132,14 +191,81 @@
     return [...keys].sort().map(key => `<option value="prop:${escapeAttr(key)}">${escapeHTML(key)}</option>`).join('');
   }
 
+  function rendererSwitchHTML() {
+    return `
+      <div class="buret-grid-renderer-switch" aria-label="3D renderer">
+        <button type="button" data-buret-grid-renderer="molstar">Mol*</button>
+        <button type="button" data-buret-grid-renderer="xyzrender-external">xyzrender</button>
+      </div>`;
+  }
+
+  function requestRendererSwitch(renderer) {
+    const value = normalizeRenderer(renderer);
+    const sent = post('setRenderer', `[grid] Switch renderer to ${value}.`, { value });
+    if (!sent) setStatus('Renderer switching is available only in the standalone app viewer.', 'error');
+  }
+
+  function normalizeRenderer(renderer) {
+    const value = String(renderer || 'molstar').toLowerCase();
+    return value === 'xyzrender-external' || value === 'xyzrender' ? 'xyzrender-external' : 'molstar';
+  }
+
   function refresh(cfg) {
     const query = normalize(state.query);
-    state.rows = query
+    const textRows = query
       ? state.all.filter(row => normalize([row.name, row.smiles, ...Object.entries(row.props || {}).flat()].join('\n')).includes(query))
       : state.all.slice();
+    state.rows = filterBySMARTS(textRows);
     state.rows.sort((a, b) => compare(a, b, state.sort));
-    if (state.page >= pages(cfg)) state.page = Math.max(0, pages(cfg) - 1);
+    resetVisibleCount(cfg);
     render(cfg);
+  }
+
+  function filterBySMARTS(rows) {
+    state.smartsError = '';
+    state.smartsMatches = new Map();
+    const pattern = state.smarts.trim();
+    if (!pattern) return rows;
+    if (!state.rdkit || typeof state.rdkit.get_qmol !== 'function') {
+      state.smartsError = 'This RDKit build does not support SMARTS queries.';
+      return rows;
+    }
+
+    let qmol = null;
+    try {
+      qmol = state.rdkit.get_qmol(pattern);
+      if (!qmol || (typeof qmol.is_valid === 'function' && !qmol.is_valid())) throw new Error('invalid SMARTS');
+      const matches = [];
+      for (const row of rows) {
+        const match = substructureMatch(row, qmol);
+        if (!match) continue;
+        state.smartsMatches.set(Number(row.index), match);
+        matches.push(row);
+      }
+      return matches;
+    } catch (error) {
+      state.smartsError = error?.message || String(error);
+      return rows;
+    } finally {
+      try { qmol?.delete?.(); } catch (_) {}
+    }
+  }
+
+  function substructureMatch(row, qmol) {
+    let mol = null;
+    try {
+      mol = state.rdkit.get_mol(row.molblock || row.smiles || '');
+      if (!mol || (typeof mol.is_valid === 'function' && !mol.is_valid())) return null;
+      const raw = mol.get_substruct_match(qmol);
+      const parsed = typeof raw === 'string' ? JSON.parse(raw || '{}') : raw;
+      const atoms = Array.isArray(parsed?.atoms) ? parsed.atoms.filter(Number.isInteger) : [];
+      const bonds = Array.isArray(parsed?.bonds) ? parsed.bonds.filter(Number.isInteger) : [];
+      return atoms.length ? { atoms, bonds } : null;
+    } catch (_) {
+      return null;
+    } finally {
+      try { mol?.delete?.(); } catch (_) {}
+    }
   }
 
   function compare(a, b, key) {
@@ -151,15 +277,31 @@
     }) || Number(a.index) - Number(b.index);
   }
 
-  function pages(cfg) {
-    return Math.max(1, Math.ceil(state.rows.length / pageSize(cfg)));
+  function resetVisibleCount(cfg) {
+    state.visibleCount = Math.min(state.rows.length, batchSize(cfg));
+  }
+
+  function loadMore(cfg) {
+    if (state.visibleCount >= state.rows.length) return;
+    state.visibleCount = Math.min(state.rows.length, state.visibleCount + batchSize(cfg));
+    render(cfg);
+  }
+
+  function scheduleAutoLoad(cfg) {
+    if (state.autoLoadScheduled || state.visibleCount >= state.rows.length) return;
+    state.autoLoadScheduled = true;
+    window.requestAnimationFrame(() => {
+      state.autoLoadScheduled = false;
+      const scrollBottom = window.scrollY + window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
+      if (scrollBottom >= documentHeight - 720) loadMore(cfg);
+    });
   }
 
   async function render(cfg) {
     const token = ++state.token;
     const grid = document.getElementById('grid');
-    const start = state.page * pageSize(cfg);
-    const rows = state.rows.slice(start, start + pageSize(cfg));
+    const rows = state.rows.slice(0, state.visibleCount);
     grid.innerHTML = '';
     if (!rows.length) grid.innerHTML = '<div class="buret-empty">No molecules match this search.</div>';
     for (const row of rows) {
@@ -177,16 +319,27 @@
     const included = Number(cfg.recordsIncluded || state.all.length);
     document.getElementById('summary').textContent = [
       `${state.rows.length.toLocaleString()} visible`,
+      `${Math.min(state.visibleCount, state.rows.length).toLocaleString()} shown`,
       `${included.toLocaleString()} loaded`,
       `${total.toLocaleString()} in file`,
       state.selected.size ? `${state.selected.size.toLocaleString()} selected` : ''
     ].filter(Boolean).join(' · ');
-    document.getElementById('page-label').textContent = `Page ${state.page + 1} / ${pages(cfg)}`;
-    document.getElementById('prev').disabled = state.page <= 0;
-    document.getElementById('next').disabled = state.page + 1 >= pages(cfg);
-    document.getElementById('footer').textContent = total > included
-      ? `Showing first ${included.toLocaleString()} of ${total.toLocaleString()} records.`
-      : 'Offline RDKit.js rendering. No network access required.';
+    if (state.smarts.trim() && !state.smartsError) {
+      document.getElementById('summary').textContent += ` · SMARTS matches ${state.smartsMatches.size.toLocaleString()}`;
+    }
+    const shownLabel = document.getElementById('shown-label');
+    if (shownLabel) shownLabel.textContent = `${Math.min(state.visibleCount, state.rows.length).toLocaleString()} / ${state.rows.length.toLocaleString()}`;
+    const loadMoreButton = document.getElementById('load-more');
+    if (loadMoreButton) loadMoreButton.disabled = state.visibleCount >= state.rows.length;
+    const clearSMARTS = document.getElementById('clear-smarts');
+    if (clearSMARTS) clearSMARTS.hidden = !state.smarts.trim();
+    const smartsInput = document.getElementById('smarts');
+    if (smartsInput) smartsInput.classList.toggle('invalid', !!state.smartsError);
+    document.getElementById('footer').textContent = state.smartsError
+      ? `SMARTS error: ${state.smartsError}`
+      : (total > included
+          ? `Showing first ${included.toLocaleString()} of ${total.toLocaleString()} records.`
+          : 'Offline RDKit.js rendering. No network access required.');
   }
 
   function card(row, cfg) {
@@ -195,9 +348,11 @@
     el.className = 'buret-card';
     el.dataset.index = String(row.index);
     if (state.selected.has(Number(row.index))) el.classList.add('selected');
+    if (state.smartsMatches.has(Number(row.index))) el.classList.add('smarts-match');
     el.innerHTML = `
       <div class="buret-molecule-picture">${draw(row)}</div>
       <div class="buret-card-body">
+        ${state.smartsMatches.has(Number(row.index)) ? '<div class="buret-match-badge">SMARTS match</div>' : ''}
         <h2>${escapeHTML(row.name || `Molecule ${Number(row.index) + 1}`)}</h2>
         ${row.smiles ? `<div class="buret-smiles">${escapeHTML(row.smiles)}</div>` : ''}
         ${metadata(row)}
@@ -224,7 +379,8 @@
   }
 
   function draw(row) {
-    const key = `${row.index}|${row.smiles || ''}|${hash(row.molblock || '')}`;
+    const match = state.smartsMatches.get(Number(row.index));
+    const key = `${row.index}|${row.smiles || ''}|${hash(row.molblock || '')}|${state.smarts}|${match ? `${match.atoms.join(',')}:${match.bonds.join(',')}` : ''}`;
     if (state.svgCache.has(key)) return state.svgCache.get(key);
     let mol = null;
     let html = '';
@@ -232,7 +388,14 @@
       mol = state.rdkit.get_mol(row.molblock || row.smiles || '');
       if (!mol || (typeof mol.is_valid === 'function' && !mol.is_valid())) throw new Error('invalid molecule');
       try {
-        html = mol.get_svg(260, 190);
+        html = match && typeof mol.get_svg_with_highlights === 'function'
+          ? mol.get_svg_with_highlights(JSON.stringify({
+              atoms: match.atoms,
+              bonds: match.bonds,
+              width: 172,
+              height: 124
+            }))
+          : mol.get_svg(172, 124);
       } catch (_) {
         html = mol.get_svg();
       }
@@ -249,7 +412,7 @@
   }
 
   function metadata(row) {
-    const entries = Object.entries(row.props || {}).filter(([, value]) => String(value || '').length).slice(0, 6);
+    const entries = Object.entries(row.props || {}).filter(([, value]) => String(value || '').length).slice(0, 3);
     if (!entries.length) return '<div class="buret-no-metadata">No metadata</div>';
     return `<dl class="buret-metadata">${entries.map(([key, value]) => `<dt>${escapeHTML(key)}</dt><dd>${escapeHTML(value)}</dd>`).join('')}</dl>`;
   }

--- a/PreviewExtension/Web/grid.css
+++ b/PreviewExtension/Web/grid.css
@@ -69,7 +69,7 @@ button:disabled {
 .buret-grid-shell {
   box-sizing: border-box;
   min-height: 100vh;
-  padding: 18px;
+  padding: 12px;
 }
 
 .buret-grid-header {
@@ -77,7 +77,7 @@ button:disabled {
   justify-content: space-between;
   align-items: flex-start;
   gap: 16px;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
 }
 
 .buret-grid-header h1 {
@@ -100,7 +100,7 @@ button:disabled {
 }
 
 .buret-actions,
-.buret-pager {
+.buret-load-controls {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -114,9 +114,9 @@ button:disabled {
   flex-wrap: wrap;
   align-items: end;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 10px;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 8px;
   border: 1px solid var(--buret-border);
   border-radius: 8px;
   background: var(--buret-surface);
@@ -135,11 +135,19 @@ button:disabled {
 }
 
 .buret-grid-toolbar label:first-child {
-  flex: 1 1 320px;
+  flex: 1 1 280px;
 }
 
 .buret-grid-toolbar label:nth-child(2) {
   flex: 0 1 220px;
+}
+
+.buret-grid-toolbar label:nth-child(3) {
+  flex: 0 1 220px;
+}
+
+.buret-grid-toolbar label:nth-child(4) {
+  flex: 0 0 132px;
 }
 
 .buret-grid-toolbar input,
@@ -162,22 +170,42 @@ button:disabled {
   box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.20);
 }
 
-.buret-pager {
+.buret-grid-toolbar input.invalid {
+  border-color: #ff8f8f;
+  box-shadow: 0 0 0 3px rgba(255, 143, 143, 0.18);
+}
+
+.buret-clear-smarts {
+  min-height: 34px;
+}
+
+.buret-grid-renderer-switch {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 34px;
+  padding-left: 6px;
+  border-left: 1px solid var(--buret-border);
+}
+
+.buret-grid-renderer-switch button {
+  min-height: 34px;
+}
+
+.buret-load-controls {
   color: var(--buret-muted);
   font-size: 12px;
 }
 
-.buret-pager button {
-  min-width: 34px;
+.buret-load-controls button {
   min-height: 34px;
   padding: 4px 8px;
-  font-size: 18px;
 }
 
 .buret-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fill, minmax(164px, 1fr));
+  gap: 8px;
 }
 
 .buret-card {
@@ -186,9 +214,9 @@ button:disabled {
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--buret-border);
-  border-radius: 8px;
+  border-radius: 7px;
   background: var(--buret-surface);
-  box-shadow: 0 10px 22px var(--buret-shadow);
+  box-shadow: 0 6px 14px var(--buret-shadow);
   transition: transform 120ms ease, border-color 120ms ease;
 }
 
@@ -205,23 +233,27 @@ button:disabled {
 
 .buret-card.selected {
   border-color: var(--buret-accent);
-  box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.22), 0 10px 22px var(--buret-shadow);
+  box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.22), 0 6px 14px var(--buret-shadow);
+}
+
+.buret-card.smarts-match {
+  border-color: rgba(255, 188, 92, 0.72);
 }
 
 .buret-molecule-picture {
   display: grid;
   place-items: center;
-  min-height: 192px;
-  padding: 8px;
+  min-height: 128px;
+  padding: 4px;
   background: #fff;
 }
 
 .buret-molecule-picture svg {
   display: block;
   width: 100%;
-  max-width: 260px;
+  max-width: 172px;
   height: auto;
-  max-height: 190px;
+  max-height: 124px;
 }
 
 .buret-molecule-error {
@@ -230,8 +262,8 @@ button:disabled {
   gap: 6px;
   box-sizing: border-box;
   width: 100%;
-  min-height: 170px;
-  padding: 12px;
+  min-height: 116px;
+  padding: 8px;
   color: #4a2b2b;
   text-align: center;
   background: #fff8f8;
@@ -249,11 +281,26 @@ button:disabled {
 
 .buret-card-body {
   min-width: 0;
-  padding: 12px;
+  padding: 8px;
+}
+
+.buret-match-badge {
+  display: inline-flex;
+  max-width: 100%;
+  margin-bottom: 6px;
+  padding: 3px 7px;
+  border: 1px solid rgba(255, 188, 92, 0.42);
+  border-radius: 999px;
+  color: #2d2210;
+  background: #ffd98d;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 .buret-card h2 {
-  margin: 0 0 6px;
+  margin: 0 0 4px;
   overflow: hidden;
   color: var(--buret-text);
   font-size: 14px;
@@ -264,7 +311,7 @@ button:disabled {
 
 .buret-smiles {
   overflow: hidden;
-  margin-bottom: 9px;
+  margin-bottom: 6px;
   color: var(--buret-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
@@ -276,7 +323,7 @@ button:disabled {
 .buret-metadata {
   display: grid;
   grid-template-columns: minmax(64px, 0.45fr) minmax(0, 1fr);
-  gap: 5px 8px;
+  gap: 3px 6px;
   margin: 0;
   color: var(--buret-muted);
   font-size: 11px;
@@ -313,7 +360,7 @@ button:disabled {
 }
 
 .buret-grid-footer {
-  padding: 16px 2px 4px;
+  padding: 10px 2px 4px;
 }
 
 #status {
@@ -355,6 +402,6 @@ button:disabled {
   }
 
   .buret-grid {
-    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   }
 }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -334,13 +334,16 @@
   function configureRendererControls(config) {
     const control = document.querySelector('[data-buret-renderer-control]');
     if (!control) return;
-    const isXYZ = config.appViewer === true && normalizeFormat(config.molstarFormat || config.format) === 'xyz';
-    control.classList.toggle('visible', isXYZ);
-    if (!isXYZ) return;
+    const format = normalizeFormat(config.molstarFormat || config.format);
+    const canSwitchRenderer = config.appViewer === true && (format === 'xyz' || format === 'sdf');
+    control.classList.toggle('visible', canSwitchRenderer);
+    if (!canSwitchRenderer) return;
 
     const renderer = normalizeRenderer(config.renderer);
     control.querySelectorAll('[data-buret-renderer]').forEach(button => {
       const value = button.getAttribute('data-buret-renderer');
+      const isFastXYZOnly = value === 'xyz-fast';
+      button.classList.toggle('hidden', isFastXYZOnly && format !== 'xyz');
       button.classList.toggle('active', value === renderer);
       if (control.dataset.rendererBound !== '1') {
         button.addEventListener('click', () => requestRendererSwitch(value));
@@ -411,6 +414,40 @@
     applyLayoutState(viewer);
   }
 
+  function initFastViewportReset(viewer) {
+    if (document.documentElement.dataset.buretFastViewportReset === '1') return;
+    document.documentElement.dataset.buretFastViewportReset = '1';
+    document.addEventListener('click', event => {
+      const button = event.target.closest('.msp-viewport-controls button[title="Reset Zoom"]');
+      if (!button) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      resetCameraInstantly(viewer);
+    }, true);
+  }
+
+  function resetCameraInstantly(viewer) {
+    let handled = false;
+    try {
+      if (typeof viewer?.plugin?.managers?.camera?.reset === 'function') {
+        viewer.plugin.managers.camera.reset(0);
+        handled = true;
+      }
+    } catch (error) {
+      debug('fast viewport reset via camera manager failed: ' + (error && error.message || String(error)));
+    }
+    try {
+      if (!handled && typeof viewer?.plugin?.canvas3d?.requestCameraReset === 'function') {
+        viewer.plugin.canvas3d.requestCameraReset(0);
+        handled = true;
+      }
+    } catch (error) {
+      debug('fast viewport reset via canvas3d failed: ' + (error && error.message || String(error)));
+    }
+    try { viewer?.plugin?.canvas3d?.requestDraw?.(); } catch (_) {}
+  }
+
   function restoreToolbarCollapsed(toolbar, viewer) {
     let collapsed = false;
     try {
@@ -467,6 +504,7 @@
         pointerId: event.pointerId,
         startX: event.clientX,
         startY: event.clientY,
+        startedOnHandle: !!event.target.closest('[data-drag-handle]'),
         moved: false
       };
       toolbar.setPointerCapture(event.pointerId);
@@ -483,7 +521,7 @@
     });
     toolbar.addEventListener('pointerup', event => {
       if (!drag || event.pointerId !== drag.pointerId) return;
-      const shouldToggle = !drag.moved && event.target.closest('[data-drag-handle]');
+      const shouldToggle = !drag.moved && drag.startedOnHandle;
       try { toolbar.releasePointerCapture(event.pointerId); } catch (_) {}
       drag = null;
       if (shouldToggle) {
@@ -1112,6 +1150,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     applyViewerUIScale(viewer);
     initViewerKeyboardShortcuts(viewer);
     initBuretToolbar(viewer);
+    initFastViewportReset(viewer);
 
     await waitForAnimationFrame();
     applyLayoutState(viewer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.15",
+      "version": "0.10.16",
       "dependencies": {
         "@rdkit/rdkit": "2025.3.4-1.0.0",
         "molstar": "5.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/force-preview.sh
+++ b/scripts/force-preview.sh
@@ -11,6 +11,7 @@ case "${FILE##*.}" in
   mmcif|MMCIF|mcif|MCIF) TYPE="com.local.burrete10.mmcif" ;;
   bcif|BCIF) TYPE="com.local.burrete10.bcif" ;;
   sdf|SDF|sd|SD) TYPE="com.local.burrete10.sdf" ;;
+  smi|SMI|smiles|SMILES) TYPE="com.local.burrete10.smiles" ;;
   mol|MOL) TYPE="com.local.burrete10.mol" ;;
   mol2|MOL2) TYPE="com.local.burrete10.mol2" ;;
   xyz|XYZ) TYPE="com.local.burrete10.xyz" ;;

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -74,6 +74,7 @@ else if (ext === 'cif') {
 else if (['mmcif', 'mcif'].includes(ext)) format = 'mmcif';
 else if (ext === 'bcif') { format = 'mmcif'; binary = true; }
 else if (['sdf', 'sd'].includes(ext)) format = 'sdf';
+else if (['smi', 'smiles'].includes(ext)) format = 'smiles';
 else if (ext === 'mol') format = 'mol';
 else if (ext === 'mol2') format = 'mol2';
 else if (ext === 'xyz') format = 'xyz';
@@ -89,7 +90,7 @@ const config = {
   binary,
   byteCount: data.length,
   previewByteCount: data.length,
-  theme: 'dark',
+  theme: 'auto',
   canvasBackground: 'black',
   transparentBackground: false,
   sdfGrid: true,
@@ -127,8 +128,10 @@ const xyzFastPath = path.join(path.dirname(indexPath), 'xyz-fast.js');
 const xyzFast = fs.readFileSync(xyzFastPath, 'utf8');
 const configSource = fs.readFileSync(configPath, 'utf8');
 const dataSource = fs.readFileSync(dataPath, 'utf8');
+const contentView = fs.readFileSync('App/ContentView.swift', 'utf8');
 const appViewer = fs.readFileSync('App/MoleculeViewerWindowController.swift', 'utf8');
 const quickLookViewer = fs.readFileSync('PreviewExtension/PreviewViewController.swift', 'utf8');
+const quickLookInfo = fs.readFileSync('PreviewExtension/Info.plist', 'utf8');
 const buildScript = fs.readFileSync('scripts/build.sh', 'utf8');
 const releaseScript = fs.readFileSync('scripts/release.sh', 'utf8');
 const xcodeProject = fs.readFileSync('Burrete.xcodeproj/project.pbxproj', 'utf8');
@@ -168,6 +171,15 @@ assert(agent.includes('window.BurreteAgent'), 'burette-agent.js must expose the 
 assert(agent.includes('window.BuretteAgent'), 'burette-agent.js must expose the BuretteAgent alias');
 assert(appViewer.includes('burette-agent.js'), 'app viewer runtime must copy and load burette-agent.js');
 assert(quickLookViewer.includes('burette-agent.js'), 'Quick Look runtime must copy and load burette-agent.js');
+assert(appViewer.includes('window.contentView = webView'), 'app viewer should use the native NSWindow resize border directly');
+assert(!appViewer.includes('BurreteAppViewerContainerView'), 'app viewer must not wrap WKWebView in a custom rounded border');
+assert(appViewer.includes('window.isOpaque = true'), 'app viewer window should keep normal opaque AppKit chrome');
+assert(appViewer.includes('window.backgroundColor = .windowBackgroundColor'), 'app viewer window should use a system window background');
+assert(contentView.includes('File Type Behavior'), 'settings should explain renderer behavior by file type');
+assert(contentView.includes('PDB / mmCIF / BinaryCIF / GRO'), 'settings should document protein-like formats');
+assert(contentView.includes('SDF / SMILES / MOL / MOL2'), 'settings should document small-molecule formats');
+assert(contentView.includes('External xyzrender (optional)'), 'settings should hide external xyzrender behind an optional advanced section');
+assert(!contentView.includes('foregroundColor(.white'), 'settings rows should not hard-code white text on light cards');
 assert(buildScript.includes('PreviewExtension/Web/burette-agent.js'), 'build script must require and syntax-check burette-agent.js');
 assert(releaseScript.includes('PreviewExtension/Web/burette-agent.js'), 'release script must require and syntax-check burette-agent.js');
 assert(xcodeProject.includes('PreviewExtension/Web/burette-agent.js'), 'Xcode validation phase must track burette-agent.js');
@@ -182,14 +194,52 @@ assert(!viewer.includes('initMolstarRightPanelToggle'), 'viewer.js must keep Mol
 assert(viewer.includes('VIEWER_THEME_STORAGE_KEY'), 'viewer.js must persist the separate theme toggle');
 assert(!viewer.includes('initMolstarThemeToggle'), 'viewer.js must keep Mol* Illumination button native');
 assert(viewer.includes("event.target.closest('[data-buret-toggle]')"), 'toolbar drag should not capture panel toggle buttons');
+assert(viewer.includes('startedOnHandle'), 'toolbar handle clicks should survive pointer capture retargeting');
+assert(viewer.includes('const shouldToggle = !drag.moved && drag.startedOnHandle'), 'toolbar handle click should collapse without checking the retargeted pointerup target');
+assert(viewer.includes('initFastViewportReset(viewer)'), 'viewer.js must install the instant Mol* reset-zoom handler');
+assert(viewer.includes('.msp-viewport-controls button[title="Reset Zoom"]'), 'instant reset must target only the Mol* Reset Zoom viewport button');
+assert(viewer.includes('viewer.plugin.managers.camera.reset(0)'), 'Mol* Reset Zoom should skip the slow default animation');
 assert(viewer.includes('toolbarSafeTop'), 'toolbar drag should clamp to the safe top inset');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');
+const gridViewer = fs.readFileSync('PreviewExtension/Web/grid-viewer.js', 'utf8');
+const gridCSS = fs.readFileSync('PreviewExtension/Web/grid.css', 'utf8');
+assert(gridViewer.includes('new URL(`../assets/rdkit/${file}`, document.baseURI).href'), 'grid viewer must resolve RDKit WASM to an absolute file URL from the preview document');
+assert(gridViewer.includes('embeddedRDKitWasmBinary'), 'grid viewer must use the embedded Quick Look RDKit WASM payload when available');
+assert(gridViewer.includes('options.wasmBinary = wasmBinary'), 'grid viewer must pass embedded RDKit WASM bytes into initRDKitModule');
+assert(gridViewer.includes('get_qmol'), 'grid viewer must compile SMARTS with RDKit get_qmol');
+assert(gridViewer.includes('get_substruct_match'), 'grid viewer must filter molecules by SMARTS substructure matches');
+assert(gridViewer.includes('get_svg_with_highlights'), 'grid viewer must highlight SMARTS matches in molecule drawings');
+assert(gridViewer.includes('SMARTS match'), 'grid viewer must mark cards that match the SMARTS query');
+assert(gridViewer.includes('id="display-count"'), 'grid viewer must let the user choose the visible batch size');
+assert(gridViewer.includes('function loadMore(cfg)'), 'grid viewer must dynamically append more molecules without rerunning the filters');
+assert(gridViewer.includes('function scheduleAutoLoad(cfg)'), 'grid viewer must auto-load the next molecule batch while scrolling');
+assert(gridViewer.includes('state.rows.slice(0, state.visibleCount)'), 'grid viewer must render only the current visible molecule batch');
+assert(gridViewer.includes('data-buret-grid-renderer="molstar"'), 'app grid should expose a Mol* renderer switch for SDF collections');
+assert(gridViewer.includes('data-buret-grid-renderer="xyzrender-external"'), 'app grid should expose an xyzrender switch for SDF collections');
+assert(gridViewer.includes("post('setRenderer'"), 'app grid renderer switch must call the native host');
+assert(gridCSS.includes('repeat(auto-fill, minmax(164px, 1fr))'), 'grid cards should use a compact desktop column width');
+assert(gridCSS.includes('min-height: 128px'), 'grid molecule drawings should use a compact picture area');
+assert(quickLookViewer.includes('preview-rdkit-wasm.js'), 'Quick Look grid previews must write and load embedded RDKit WASM bytes');
+assert(quickLookViewer.includes('BurreteRDKitWasmBase64Chunks'), 'Quick Look grid previews must encode RDKit WASM as chunked base64');
+assert(appViewer.includes('preview-rdkit-wasm.js'), 'app grid previews must write and load embedded RDKit WASM bytes');
+assert(appViewer.includes('BurreteRDKitWasmBase64Chunks'), 'app grid previews must encode RDKit WASM as chunked base64');
+assert(quickLookViewer.includes('maxRecords: 3000'), 'Quick Look grid previews should load enough records for large collection browsing');
+assert(appViewer.includes('maxRecords: 10000'), 'app grid previews should load a larger record window for large collection browsing');
+assert(appViewer.includes('bypassGridForRendererSwitch'), 'app viewer should let SDF grid switch into renderer mode');
+assert(appViewer.includes('(isXYZ || isSDF) ? "xyzrender-external" : "molstar"'), 'app viewer should allow external xyzrender for SDF and XYZ');
+assert(viewer.includes("format === 'xyz' || format === 'sdf'"), 'viewer toolbar should expose renderer switching for XYZ and SDF');
+assert(viewer.includes("button.classList.toggle('hidden', isFastXYZOnly && format !== 'xyz')"), 'viewer toolbar should hide the Fast XYZ button outside XYZ files');
+assert(fs.readFileSync('scripts/force-preview.sh', 'utf8').includes('com.local.burrete10.smiles'), 'force-preview should support .smi/.smiles Quick Look previews');
+assert(quickLookInfo.includes('com.local.burrete10.smiles') && quickLookInfo.includes('<string>smi</string>') && quickLookInfo.includes('<string>smiles</string>'), 'Quick Look extension must export the SMILES UTI for .smi/.smiles previews');
+assert(quickLookInfo.includes('com.local.molstarquicklook10.smiles'), 'Quick Look extension must accept legacy SMILES UTI registrations');
+assert(quickLookViewer.includes('"smi", "smiles"'), 'Quick Look native extension gate must allow .smi/.smiles files');
+assert(!gridViewer.includes("locateFile: file => `../assets/rdkit/${file}`"), 'grid viewer must not use a relative RDKit WASM path in file:// Quick Look previews');
 assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
 assert(config.label === path.basename(sample), 'config label should match sample basename');
 assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');
-assert(config.theme === 'dark', 'theme should default to dark');
+assert(config.theme === 'auto', 'theme should default to auto');
 assert(config.canvasBackground === 'black', 'canvas background should default to black');
 assert(config.transparentBackground === false, 'transparent background should be opt-in');
 assert(config.sdfGrid === true, 'SDF grid flag should be encoded');
@@ -211,6 +261,8 @@ const expectedFormats = {
   bcif: 'mmcif',
   sdf: 'sdf',
   sd: 'sdf',
+  smi: 'smiles',
+  smiles: 'smiles',
   mol: 'mol',
   mol2: 'mol2',
   xyz: 'xyz',


### PR DESCRIPTION
## Summary
- open standalone viewer windows in native fullscreen and remove the custom rounded wrapper so AppKit resize borders work normally
- default viewer theme to Auto and clarify file-type renderer behavior in settings
- add SMILES grid registration, compact grid cards, SMARTS filtering/highlighting, batch loading, and app-side SDF renderer switching between Mol* and xyzrender
- allow external xyzrender for SDF as well as XYZ in the standalone app

## Verification
- git diff --check
- npm run check:js
- npm run test:web -- --no-open /Users/nikolenko/Desktop/BurettePreviewSamples/sdf/single.sdf
- pre-commit hook: plist, release-version, js-syntax
- pre-push hook: npm run ci, including Xcode build
- manual app runtime checks for single.sdf and single.xyz with renderer=xyzrender-external