### PR TITLE
Improve viewer settings and molecule grid previews

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -17,6 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var settingsWindow: NSWindow?
     private var viewerWindows: [URL: MoleculeViewerWindowController] = [:]
+    private var viewerRuntimePreferences = ViewerRuntimePreferences.load()
     private var openedDocumentAtLaunch = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -28,6 +29,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if UserDefaults.standard.object(forKey: "openSettingsAtLaunch") == nil {
             UserDefaults.standard.set(false, forKey: "openSettingsAtLaunch")
+        }
+        if UserDefaults.standard.object(forKey: "showPreviewPanelControls") == nil {
+            UserDefaults.standard.set(true, forKey: "showPreviewPanelControls")
+        }
+        if UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") == nil {
+            UserDefaults.standard.set(false, forKey: "useTransparentPreviewBackground")
+        }
+        if UserDefaults.standard.object(forKey: "viewerTheme") == nil {
+            UserDefaults.standard.set("auto", forKey: "viewerTheme")
+        }
+        if UserDefaults.standard.object(forKey: "viewerCanvasBackground") == nil {
+            UserDefaults.standard.set("auto", forKey: "viewerCanvasBackground")
         }
         if UserDefaults.standard.object(forKey: "structureRendererMode") == nil {
             UserDefaults.standard.set("auto", forKey: "structureRendererMode")
@@ -47,6 +60,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if UserDefaults.standard.object(forKey: "xyzrenderExtraArguments") == nil {
             UserDefaults.standard.set("", forKey: "xyzrenderExtraArguments")
         }
+        if UserDefaults.standard.object(forKey: "viewerWindowOpacity") == nil {
+            UserDefaults.standard.set(0.82, forKey: "viewerWindowOpacity")
+        }
+        if UserDefaults.standard.object(forKey: "viewerOverlayOpacity") == nil {
+            UserDefaults.standard.set(0.90, forKey: "viewerOverlayOpacity")
+        }
+        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.sdfKey) == nil {
+            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.sdfKey)
+        }
+        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.smilesKey) == nil {
+            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.smilesKey)
+        }
+        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.csvKey) == nil {
+            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.csvKey)
+        }
+        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.tsvKey) == nil {
+            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.tsvKey)
+        }
+        viewerRuntimePreferences = ViewerRuntimePreferences.load()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(viewerRuntimePreferencesDidChange),
+            name: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard
+        )
         if UserDefaults.standard.bool(forKey: "openSettingsAtLaunch") {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
                 if self?.openedDocumentAtLaunch == false {
@@ -128,6 +166,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         settingsWindow?.center()
         presentWindow(settingsWindow, activate: true)
+    }
+
+    @objc private func viewerRuntimePreferencesDidChange(_ notification: Notification) {
+        let previous = viewerRuntimePreferences
+        let next = ViewerRuntimePreferences.load()
+        guard next != previous else { return }
+        viewerRuntimePreferences = next
+        for controller in viewerWindows.values {
+            if next.rendererSettingsDiffer(from: previous) {
+                controller.reloadSettingsPreferences()
+            } else {
+                controller.reloadDisplayPreferences()
+            }
+        }
     }
 
     @objc private func checkForUpdates() {
@@ -248,18 +300,64 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
+private struct ViewerRuntimePreferences: Equatable {
+    let transparentPreviewBackground: Bool
+    let viewerTheme: String
+    let canvasBackground: String
+    let windowOpacity: Double
+    let overlayOpacity: Double
+    let showPanelControls: Bool
+    let structureRendererMode: String
+    let xyzFastStyle: String
+    let xyzrenderPreset: String
+    let xyzrenderCustomConfigPath: String
+    let xyzrenderExecutablePath: String
+    let xyzrenderExtraArguments: String
+    let gridFileSupport: MoleculeGridFileSupport
+
+    static func load() -> ViewerRuntimePreferences {
+        ViewerRuntimePreferences(
+            transparentPreviewBackground: UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false,
+            viewerTheme: UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto",
+            canvasBackground: UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "auto",
+            windowOpacity: UserDefaults.standard.object(forKey: "viewerWindowOpacity") as? Double ?? 0.82,
+            overlayOpacity: UserDefaults.standard.object(forKey: "viewerOverlayOpacity") as? Double ?? 0.90,
+            showPanelControls: UserDefaults.standard.object(forKey: "showPreviewPanelControls") as? Bool ?? true,
+            structureRendererMode: UserDefaults.standard.string(forKey: "structureRendererMode") ?? "auto",
+            xyzFastStyle: UserDefaults.standard.string(forKey: "xyzFastStyle") ?? "default",
+            xyzrenderPreset: UserDefaults.standard.string(forKey: "xyzrenderPreset") ?? "default",
+            xyzrenderCustomConfigPath: UserDefaults.standard.string(forKey: "xyzrenderCustomConfigPath") ?? "",
+            xyzrenderExecutablePath: UserDefaults.standard.string(forKey: "xyzrenderExecutablePath") ?? "",
+            xyzrenderExtraArguments: UserDefaults.standard.string(forKey: "xyzrenderExtraArguments") ?? "",
+            gridFileSupport: MoleculeGridFileSupport.load()
+        )
+    }
+
+    func rendererSettingsDiffer(from other: ViewerRuntimePreferences) -> Bool {
+        structureRendererMode != other.structureRendererMode ||
+            xyzFastStyle != other.xyzFastStyle ||
+            xyzrenderPreset != other.xyzrenderPreset ||
+            xyzrenderCustomConfigPath != other.xyzrenderCustomConfigPath ||
+            xyzrenderExecutablePath != other.xyzrenderExecutablePath ||
+            xyzrenderExtraArguments != other.xyzrenderExtraArguments
+    }
+}
+
 enum BurreteFileAssociations {
     static let bundleIdentifier = "com.local.BurreteV10"
-    static let contentTypes = [
+    static var contentTypes: [String] {
+        contentTypes(for: MoleculeGridFileSupport.load())
+    }
+
+    private static let structureContentTypes = [
         "com.local.burrete10.pdb",
         "com.local.burrete10.cif",
         "com.local.burrete10.mmcif",
         "com.local.burrete10.bcif",
-        "com.local.burrete10.sdf",
-        "com.local.burrete10.smiles",
         "com.local.burrete10.mol",
         "com.local.burrete10.mol2",
         "com.local.burrete10.xyz",
+        "net.sourceforge.openbabel.xyz",
         // LaunchServices resolves bare .xyz files to this dynamic UTI on current macOS.
         "dyn.ah62d4rv4ge81u8p4",
         "com.local.burrete10.gro",
@@ -280,13 +378,44 @@ enum BurreteFileAssociations {
         "org.iucr.cif",
         "org.iucr.mmcif",
         "com.schrodinger.pdb",
-        "org.openscience.sdf",
         "org.openscience.molfile",
         "org.openscience.mol2",
         "public.pdb",
         "public.cif",
         "public.mmcif"
     ]
+
+    private static let sdfContentTypes = [
+        "com.local.burrete10.sdf",
+        "com.local.molstarquicklook10.sdf",
+        "org.openscience.sdf",
+        "com.schrodinger.sdf",
+        "com.mdli.sdf",
+        "com.mdl.sdf"
+    ]
+
+    private static let smilesContentTypes = [
+        "com.local.burrete10.smiles",
+        "com.local.burettexyzrender.smiles",
+        "com.local.molstarquicklook10.smiles"
+    ]
+
+    private static let csvContentTypes = [
+        "public.comma-separated-values-text",
+    ]
+
+    private static let tsvContentTypes = [
+        "public.tab-separated-values-text"
+    ]
+
+    private static func contentTypes(for fileSupport: MoleculeGridFileSupport) -> [String] {
+        var types = structureContentTypes
+        if fileSupport.sdf { types.append(contentsOf: sdfContentTypes) }
+        if fileSupport.smiles { types.append(contentsOf: smilesContentTypes) }
+        if fileSupport.csv { types.append(contentsOf: csvContentTypes) }
+        if fileSupport.tsv { types.append(contentsOf: tsvContentTypes) }
+        return types
+    }
 
     static var defaultHandlerSummary: String {
         let current = contentTypes.filter { defaultHandler(for: $0) == bundleIdentifier }.count

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -6,19 +6,24 @@ struct ContentView: View {
     @AppStorage("showPreviewPanelControls") private var showPreviewPanelControls = true
     @AppStorage("useTransparentPreviewBackground") private var useTransparentPreviewBackground = false
     @AppStorage("viewerTheme") private var viewerTheme = "auto"
-    @AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "black"
+    @AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "auto"
+    @AppStorage("viewerWindowOpacity") private var viewerWindowOpacity = 0.82
+    @AppStorage("viewerOverlayOpacity") private var viewerOverlayOpacity = 0.90
     @AppStorage("structureRendererMode") private var structureRendererMode = "auto"
     @AppStorage("xyzFastStyle") private var xyzFastStyle = "default"
     @AppStorage("xyzrenderPreset") private var xyzrenderPreset = "default"
     @AppStorage("xyzrenderCustomConfigPath") private var xyzrenderCustomConfigPath = ""
     @AppStorage("xyzrenderExecutablePath") private var xyzrenderExecutablePath = ""
     @AppStorage("xyzrenderExtraArguments") private var xyzrenderExtraArguments = ""
+    @AppStorage(MoleculeGridFileSupport.sdfKey) private var gridPreviewSupportsSDF = true
+    @AppStorage(MoleculeGridFileSupport.smilesKey) private var gridPreviewSupportsSMILES = true
+    @AppStorage(MoleculeGridFileSupport.csvKey) private var gridPreviewSupportsCSV = true
+    @AppStorage(MoleculeGridFileSupport.tsvKey) private var gridPreviewSupportsTSV = true
     @AppStorage("checkUpdatesAutomatically") private var checkUpdatesAutomatically = true
     @AppStorage("updateChannel") private var updateChannelRaw = BurreteUpdateChannel.stable.rawValue
     @StateObject private var updater = BurreteUpdater.shared
     @State private var section: SettingsSection = .general
     @State private var defaultOpenStatus = BurreteFileAssociations.defaultHandlerSummary
-    @State private var showExternalXyzrenderSettings = false
 
     var body: some View {
         ZStack {
@@ -52,6 +57,10 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 660, minHeight: 440)
+        .onChange(of: gridPreviewSupportsSDF) { _ in refreshDefaultOpenStatus() }
+        .onChange(of: gridPreviewSupportsSMILES) { _ in refreshDefaultOpenStatus() }
+        .onChange(of: gridPreviewSupportsCSV) { _ in refreshDefaultOpenStatus() }
+        .onChange(of: gridPreviewSupportsTSV) { _ in refreshDefaultOpenStatus() }
     }
 
     @ViewBuilder
@@ -99,33 +108,12 @@ struct ContentView: View {
             }
 
         case .viewer:
-            SettingsSectionTitle("File Type Behavior")
-            SettingsCard {
-                SettingsValueRow(
-                    icon: "cube.transparent",
-                    title: "PDB / mmCIF / BinaryCIF / GRO",
-                    subtitle: "Opened with Mol* Interactive for rotation, chains, residues, sequence, and structure panels."
-                )
-                SettingsDivider()
-                SettingsValueRow(
-                    icon: "square.grid.3x3",
-                    title: "SDF / SMILES / MOL / MOL2",
-                    subtitle: "SMILES and multi-record SDF files show a molecule grid when possible; single structure files stay in Mol*."
-                )
-                SettingsDivider()
-                SettingsValueRow(
-                    icon: "sparkles",
-                    title: "XYZ",
-                    subtitle: "Auto uses Fast XYZ SVG for Quick Look speed. In the full app toolbar, .xyz can switch to Mol* or external xyzrender."
-                )
-            }
-
-            SettingsSectionTitle("Renderer")
+            SettingsSectionTitle("Viewer")
             SettingsCard {
                 SettingsStringPickerRow(
                     icon: "atom",
-                    title: "Default renderer policy",
-                    subtitle: "Recommended: Auto. It chooses Fast XYZ for .xyz and Mol* for PDB, mmCIF, SDF, MOL, MOL2, and GRO.",
+                    title: "Renderer",
+                    subtitle: "Auto uses Fast XYZ SVG for .xyz and Mol* for the rest. Choose Mol* Interactive when you want live rotation and the full app controls.",
                     selection: $structureRendererMode,
                     options: [
                         ("auto", "Auto"),
@@ -138,7 +126,7 @@ struct ContentView: View {
                 SettingsStringPickerRow(
                     icon: "sparkles",
                     title: "Fast XYZ style",
-                    subtitle: "Only affects .xyz files when the renderer resolves to Fast XYZ SVG.",
+                    subtitle: "Static SVG style for Quick Look and app .xyz previews.",
                     selection: $xyzFastStyle,
                     options: [
                         ("default", "Default"),
@@ -147,63 +135,46 @@ struct ContentView: View {
                         ("spacefill", "Spacefill")
                     ]
                 )
-            }
-
-            SettingsSectionTitle("External xyzrender")
-            SettingsCard {
-                DisclosureGroup(isExpanded: $showExternalXyzrenderSettings) {
-                    VStack(spacing: 0) {
-                        SettingsDivider()
-                        SettingsStringPickerRow(
-                            icon: "terminal",
-                            title: "Preset",
-                            subtitle: "Used only by the standalone app for .xyz files when external xyzrender is selected.",
-                            selection: $xyzrenderPreset,
-                            options: AppViewerXyzrenderPreset.pickerOptions
-                        )
-                        SettingsDivider()
-                        SettingsTextFieldRow(
-                            icon: "doc.badge.gearshape",
-                            title: "Custom config path",
-                            subtitle: "Used when the preset is Custom JSON. Point this to a local xyzrender config file.",
-                            text: $xyzrenderCustomConfigPath,
-                            placeholder: "/Users/me/styles/my_style.json"
-                        )
-                        SettingsDivider()
-                        SettingsTextFieldRow(
-                            icon: "point.3.connected.trianglepath.dotted",
-                            title: "Executable path",
-                            subtitle: "Leave empty to run xyzrender from PATH. Set an absolute path for a custom venv, uv tool, or signed helper.",
-                            text: $xyzrenderExecutablePath,
-                            placeholder: "/opt/homebrew/bin/xyzrender"
-                        )
-                        SettingsDivider()
-                        SettingsTextFieldRow(
-                            icon: "curlybraces",
-                            title: "Extra flags",
-                            subtitle: "Optional app-only CLI flags such as --cell --idx sn --no-hy. Output flags are ignored.",
-                            text: $xyzrenderExtraArguments,
-                            placeholder: "--cell --idx sn"
-                        )
-                    }
-                } label: {
-                    SettingsDisclosureHeader(
-                        icon: "terminal",
-                        title: "External xyzrender (optional)",
-                        subtitle: "Advanced .xyz SVG rendering. Leave closed unless you installed xyzrender and want Burrete to call it."
-                    )
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 7)
-            }
-
-            SettingsSectionTitle("What The Modes Mean")
-            SettingsCard {
-                SettingsValueRow(icon: "bolt.horizontal", title: "Fast XYZ SVG", subtitle: "Fast static SVG for .xyz previews. Best for Quick Look and large simple XYZ files.")
                 SettingsDivider()
-                SettingsValueRow(icon: "rotate.3d", title: "Mol* Interactive", subtitle: "Full interactive viewer for rotation, measurement, panels, sequence, logs, and structure inspection.")
+                SettingsStringPickerRow(
+                    icon: "terminal",
+                    title: "External xyzrender preset",
+                    subtitle: "Used only by the standalone app when xyzrender is available on PATH or configured via defaults.",
+                    selection: $xyzrenderPreset,
+                    options: AppViewerXyzrenderPreset.pickerOptions
+                )
                 SettingsDivider()
-                SettingsValueRow(icon: "terminal", title: "External xyzrender SVG", subtitle: "Optional app-only renderer for .xyz when xyzrender is installed. Quick Look still uses bundled renderers.")
+                SettingsTextFieldRow(
+                    icon: "doc.badge.gearshape",
+                    title: "External xyzrender custom config",
+                    subtitle: "Used when the preset is Custom JSON. Point this to a local xyzrender config file.",
+                    text: $xyzrenderCustomConfigPath,
+                    placeholder: "/Users/me/styles/my_style.json"
+                )
+                SettingsDivider()
+                SettingsTextFieldRow(
+                    icon: "point.3.connected.trianglepath.dotted",
+                    title: "External xyzrender executable",
+                    subtitle: "Leave empty to run `xyzrender` from PATH. Set an absolute path when using a custom venv, uv tool, or signed helper.",
+                    text: $xyzrenderExecutablePath,
+                    placeholder: "/opt/homebrew/bin/xyzrender"
+                )
+                SettingsDivider()
+                SettingsTextFieldRow(
+                    icon: "curlybraces",
+                    title: "External xyzrender extra flags",
+                    subtitle: "Optional app-only CLI flags such as `--cell --idx sn --no-hy`. Output flags are ignored so Burrete can keep displaying the generated SVG.",
+                    text: $xyzrenderExtraArguments,
+                    placeholder: "--cell --idx sn"
+                )
+                SettingsDivider()
+                SettingsValueRow(icon: "doc.richtext", title: "Formats", subtitle: "PDB, PDBx/mmCIF, BinaryCIF, SDF, MOL, MOL2, XYZ, and GRO")
+                SettingsDivider()
+                SettingsValueRow(icon: "rotate.3d", title: "Interactive XYZ", subtitle: "Open .xyz in the standalone app and switch to Mol* Interactive from the toolbar to rotate, inspect, and use Mol* panels.")
+                SettingsDivider()
+                SettingsValueRow(icon: "square.grid.3x3", title: "SDF molecule grid", subtitle: "Multi-record SDF files are laid out as a visible grid when possible.")
+                SettingsDivider()
+                SettingsValueRow(icon: "bolt.horizontal", title: "Performance", subtitle: "Fast SVG for .xyz; bundled Mol* assets and WebGL fallback for interactive formats.")
             }
 
             SettingsSectionTitle("Appearance")
@@ -223,9 +194,10 @@ struct ContentView: View {
                 SettingsStringPickerRow(
                     icon: "circle.fill",
                     title: "Canvas background",
-                    subtitle: "The molecule canvas uses black by default; choose another surface when needed.",
+                    subtitle: "Auto follows the viewer theme: white in light mode and black in dark mode.",
                     selection: $viewerCanvasBackground,
                     options: [
+                        ("auto", "Auto"),
                         ("black", "Black"),
                         ("graphite", "Graphite"),
                         ("white", "White"),
@@ -235,8 +207,24 @@ struct ContentView: View {
                 SettingsDivider()
                 SettingsToggleRow(
                     title: "Transparent preview background",
-                    subtitle: "Use native Quick Look glass around the canvas; the canvas background stays controlled above.",
+                    subtitle: "Use native macOS material behind transparent canvas areas instead of a fully clear window.",
                     isOn: $useTransparentPreviewBackground
+                )
+                SettingsDivider()
+                SettingsSliderRow(
+                    icon: "square.stack.3d.down.forward",
+                    title: "Window material opacity",
+                    subtitle: "Controls how solid the viewer surface is when transparency is enabled.",
+                    value: $viewerWindowOpacity,
+                    range: 0.35...0.95
+                )
+                SettingsDivider()
+                SettingsSliderRow(
+                    icon: "rectangle.3.group.bubble",
+                    title: "Panel readability",
+                    subtitle: "Controls toolbar and Mol* panel opacity so controls stay readable over transparent content.",
+                    value: $viewerOverlayOpacity,
+                    range: 0.72...0.98
                 )
                 SettingsDivider()
                 SettingsValueRow(
@@ -269,6 +257,33 @@ struct ContentView: View {
             }
 
         case .files:
+            SettingsSectionTitle("Molecule Grid File Types")
+            SettingsCard {
+                SettingsToggleRow(
+                    title: "SDF / SD",
+                    subtitle: "Show multi-record SDF files as a molecule grid in Quick Look and the app.",
+                    isOn: $gridPreviewSupportsSDF
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    title: "SMILES / SMI",
+                    subtitle: "Open plain SMILES collections as a 2D molecule grid.",
+                    isOn: $gridPreviewSupportsSMILES
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    title: "CSV tables",
+                    subtitle: "Open CSV files that contain a SMILES, canonical_smiles, isomeric_smiles, cxsmiles, or smiles_string column.",
+                    isOn: $gridPreviewSupportsCSV
+                )
+                SettingsDivider()
+                SettingsToggleRow(
+                    title: "TSV tables",
+                    subtitle: "Open tab-separated molecule tables with a recognized SMILES column.",
+                    isOn: $gridPreviewSupportsTSV
+                )
+            }
+
             SettingsSectionTitle("Open In Finder")
             SettingsCard {
                 SettingsValueRow(
@@ -280,7 +295,7 @@ struct ContentView: View {
                 SettingsActionRow(
                     icon: "checkmark.seal",
                     title: "Make Burrete Default",
-                    subtitle: defaultOpenStatus
+                    subtitle: "\(defaultOpenStatus) Uses the enabled file types above."
                 ) {
                     defaultOpenStatus = BurreteFileAssociations.registerAsDefaultHandler()
                 }
@@ -390,9 +405,9 @@ struct ContentView: View {
 
     private var previewBackgroundModeSubtitle: String {
         if useTransparentPreviewBackground {
-            return "Quick Look glass is visible behind the molecule."
+            return "The standalone viewer uses a native material surface; transparent canvas areas no longer remove the window edge."
         }
-        return "Mol* uses its classic opaque viewer surface."
+        return "The viewer uses a regular opaque macOS window surface."
     }
 
     private func run(_ executable: String, arguments: [String]) {
@@ -400,6 +415,10 @@ struct ContentView: View {
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
         try? process.run()
+    }
+
+    private func refreshDefaultOpenStatus() {
+        defaultOpenStatus = BurreteFileAssociations.defaultHandlerSummary
     }
 }
 
@@ -450,7 +469,7 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .viewer:
             return ["renderer", "fast xyz", "xyzrender", "external", "molstar", "formats", "pdb", "cif", "sdf", "mol", "mol2", "xyz", "gro", "background", "transparent", "black", "canvas", "theme", "dark", "light", "auto", "grid", "toolbar", "panels", "sequence", "log"]
         case .files:
-            return ["finder", "default", "double-click", "open with", "quick look", "cache", "file", "extension"]
+            return ["finder", "default", "double-click", "open with", "quick look", "cache", "file", "extension", "sdf", "smiles", "smi", "csv", "tsv", "table", "grid"]
         case .logs:
             return ["diagnostics", "log", "logs", "folder", "clipboard", "path", "troubleshooting"]
         case .updates:
@@ -793,39 +812,41 @@ private struct SettingsTextFieldRow: View {
     let placeholder: String
 
     var body: some View {
-        HStack(alignment: .center, spacing: 10) {
+        HStack(alignment: .center, spacing: 12) {
             Image(systemName: icon)
-                .font(.system(size: 13, weight: .medium))
+                .font(.system(size: 15, weight: .semibold))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(.secondary)
-                .frame(width: 18)
+                .frame(width: 24)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(title)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.primary)
                 Text(subtitle)
-                    .font(.system(size: 11, weight: .regular))
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 10)
+            Spacer(minLength: 12)
 
             TextField(placeholder, text: $text)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 12, weight: .regular, design: .monospaced))
                 .frame(width: 220)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 7)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
     }
 }
 
-private struct SettingsDisclosureHeader: View {
+private struct SettingsSliderRow: View {
     let icon: String
     let title: String
     let subtitle: String
+    @Binding var value: Double
+    let range: ClosedRange<Double>
 
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -845,8 +866,19 @@ private struct SettingsDisclosureHeader: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 0)
+            Spacer(minLength: 12)
+
+            HStack(spacing: 8) {
+                Slider(value: $value, in: range)
+                    .frame(width: 150)
+                Text("\(Int((value * 100).rounded()))%")
+                    .font(.system(size: 12, weight: .regular, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 42, alignment: .trailing)
+            }
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
     }
 }
 
@@ -930,7 +962,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.16")
+                Text("Version 0.10.17")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -13,6 +13,7 @@
 			<array>
 				<string>bcif</string>
 				<string>cif</string>
+				<string>csv</string>
 				<string>ent</string>
 				<string>mcif</string>
 				<string>mmcif</string>
@@ -25,6 +26,7 @@
 				<string>sdf</string>
 				<string>smi</string>
 				<string>smiles</string>
+				<string>tsv</string>
 				<string>xyz</string>
 				<string>gro</string>
 			</array>
@@ -42,6 +44,7 @@
 				<string>com.local.burrete10.bcif</string>
 				<string>com.local.burrete10.sdf</string>
 				<string>com.local.burrete10.smiles</string>
+				<string>com.local.burettexyzrender.smiles</string>
 				<string>com.local.burrete10.mol</string>
 				<string>com.local.burrete10.mol2</string>
 				<string>com.local.molstarquicklook10.pdb</string>
@@ -92,7 +95,10 @@
 				<string>public.pdb</string>
 				<string>public.mmcif</string>
 					<string>public.cif</string>
+					<string>public.comma-separated-values-text</string>
+					<string>public.tab-separated-values-text</string>
 					<string>com.local.burrete10.xyz</string>
+					<string>net.sourceforge.openbabel.xyz</string>
 					<string>dyn.ah62d4rv4ge81u8p4</string>
 					<string>com.local.burrete10.gro</string>
 					<string>dyn.ah62d4rv4ge80s6xt</string>

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -43,18 +43,18 @@ enum AppViewerXyzrenderPreset {
 final class MoleculeViewerWindowController: NSWindowController, WKNavigationDelegate, WKScriptMessageHandler {
     private let fileURL: URL
     private let webView: WKWebView
-    private var currentViewerPageZoom: CGFloat = 0.86
+    private var currentViewerPageZoom: CGFloat = 1.0
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
     private var isInNativeFullScreen = false
     private var isEnteringNativeFullScreen = false
-    private static let defaultViewerPageZoom: CGFloat = 0.86
-    private static let minViewerPageZoom: CGFloat = 0.72
-    private static let maxViewerPageZoom: CGFloat = 1.35
+    private static let defaultViewerPageZoom: CGFloat = 1.0
+    private static let minViewerPageZoom: CGFloat = 1.0
+    private static let maxViewerPageZoom: CGFloat = 1.0
 
     init(fileURL: URL) {
         self.fileURL = fileURL
-        let transparentBackground = Self.useTransparentPreviewBackground
+        let displayPreferences = Self.currentDisplayPreferences
 
         let userContentController = WKUserContentController()
         let configuration = WKWebViewConfiguration()
@@ -81,18 +81,14 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         window.title = "Burrete - \(fileURL.lastPathComponent)"
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = false
-        window.isMovableByWindowBackground = false
-        window.styleMask.remove(.fullSizeContentView)
+        window.isMovableByWindowBackground = true
         window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 660, height: 440)
-        window.appearance = NSAppearance(named: .darkAqua)
         if #available(macOS 11.0, *) {
             window.toolbarStyle = .unifiedCompact
         }
-        window.isOpaque = true
-        window.backgroundColor = .windowBackgroundColor
         window.hasShadow = true
-        window.contentView = webView
+        window.contentView = BurreteAppViewerContainerView(contentView: webView, preferences: displayPreferences)
 
         super.init(window: window)
 
@@ -111,11 +107,8 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         userContentController.add(self, name: "burrete")
         webView.navigationDelegate = self
         webView.wantsLayer = true
-        webView.layer?.backgroundColor = (transparentBackground ? NSColor.clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)).cgColor
+        applyWindowDisplayPreferences(displayPreferences)
         webView.setValue(false, forKey: "drawsBackground")
-        if #available(macOS 11.0, *) {
-            webView.underPageBackgroundColor = transparentBackground ? .clear : NSColor(calibratedWhite: 0.055, alpha: 1.0)
-        }
         #if DEBUG
         if #available(macOS 13.3, *) {
             webView.isInspectable = true
@@ -143,6 +136,17 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         } catch {
             webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
         }
+    }
+
+    func reloadDisplayPreferences() {
+        applyWindowDisplayPreferences(Self.currentDisplayPreferences)
+        load()
+    }
+
+    func reloadSettingsPreferences() {
+        rendererOverride = nil
+        xyzrenderPresetOverride = nil
+        reloadDisplayPreferences()
     }
 
     func enterFullScreen() {
@@ -194,6 +198,18 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         }
         let text = (body["message"] as? String) ?? ""
         NSLog("[BurreteAppViewer] %@: %@ %@", fileURL.lastPathComponent, type, text)
+    }
+
+    private func applyWindowDisplayPreferences(_ preferences: AppViewerDisplayPreferences) {
+        let backgroundColor = preferences.isWindowTransparent ? NSColor.clear : NSColor.windowBackgroundColor
+        window?.appearance = preferences.windowAppearance
+        window?.isOpaque = !preferences.isWindowTransparent
+        window?.backgroundColor = backgroundColor
+        (window?.contentView as? BurreteAppViewerContainerView)?.apply(preferences)
+        webView.layer?.backgroundColor = backgroundColor.cgColor
+        if #available(macOS 11.0, *) {
+            webView.underPageBackgroundColor = backgroundColor
+        }
     }
 
     private func setViewerPageZoom(_ scale: CGFloat) {
@@ -258,8 +274,50 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         """
     }
 
-    private static var useTransparentPreviewBackground: Bool {
-        UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
+    private static var currentDisplayPreferences: AppViewerDisplayPreferences {
+        AppViewerDisplayPreferences(
+            transparentWindow: UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false,
+            theme: UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto",
+            windowOpacity: UserDefaults.standard.object(forKey: "viewerWindowOpacity") as? Double ?? 0.82,
+            overlayOpacity: UserDefaults.standard.object(forKey: "viewerOverlayOpacity") as? Double ?? 0.90
+        )
+    }
+}
+
+private struct AppViewerDisplayPreferences {
+    let transparentWindow: Bool
+    let theme: String
+    let windowOpacity: Double
+    let overlayOpacity: Double
+
+    var isWindowTransparent: Bool {
+        transparentWindow
+    }
+
+    var clampedWindowOpacity: CGFloat {
+        CGFloat(min(max(windowOpacity, 0.35), 0.95))
+    }
+
+    var clampedOverlayOpacity: Double {
+        min(max(overlayOpacity, 0.72), 0.98)
+    }
+
+    var resolvedTheme: String {
+        if theme == "dark" || theme == "light" { return theme }
+        if let appearance = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]), appearance == .darkAqua {
+            return "dark"
+        }
+        return "light"
+    }
+
+    var windowAppearance: NSAppearance? {
+        if theme == "dark" { return NSAppearance(named: .darkAqua) }
+        if theme == "light" { return NSAppearance(named: .aqua) }
+        return nil
+    }
+
+    var baseColor: NSColor {
+        resolvedTheme == "dark" ? NSColor(calibratedWhite: 0.08, alpha: 1.0) : NSColor.windowBackgroundColor
     }
 }
 
@@ -307,45 +365,52 @@ private struct AppViewerRuntime {
 
         let transparentBackground = UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") as? Bool ?? false
         let viewerTheme = UserDefaults.standard.string(forKey: "viewerTheme") ?? "auto"
-        let canvasBackground = UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "black"
+        let canvasBackground = UserDefaults.standard.string(forKey: "viewerCanvasBackground") ?? "auto"
         let canvasIsTransparent = canvasBackground == "transparent"
+        let overlayOpacity = AppViewerDisplayPreferences(
+            transparentWindow: transparentBackground,
+            theme: viewerTheme,
+            windowOpacity: UserDefaults.standard.object(forKey: "viewerWindowOpacity") as? Double ?? 0.82,
+            overlayOpacity: UserDefaults.standard.object(forKey: "viewerOverlayOpacity") as? Double ?? 0.90
+        ).clampedOverlayOpacity
 
-        let rendererOverride = rendererModeOverride.map(AppViewerRendererMode.normalize)
-        let bypassGridForRendererSwitch = ["sdf", "sd"].contains(fileURL.pathExtension.lowercased()) &&
-            rendererOverride != nil &&
-            rendererOverride != "auto"
-
-        if !bypassGridForRendererSwitch,
-           let gridPreview = try MoleculeGridPreviewBuilder.makePreview(
+        if let gridPreview = try MoleculeGridPreviewBuilder.makePreview(
             fileURL: fileURL,
             data: data,
             host: .app,
             theme: viewerTheme,
             canvasBackground: canvasBackground,
             transparentBackground: canvasIsTransparent,
+            overlayOpacity: overlayOpacity,
             debug: false,
             allowSelection: true,
             allowExport: true,
-            maxRecords: 10000
+            maxRecords: 5000,
+            fileSupport: MoleculeGridFileSupport.load()
         ) {
             try requireGridRuntimeAssets(in: assetsDirectory)
+            let gridRecordsScript = try gridRecordsScriptWithRDKitWasm(
+                gridPreview.recordsScript,
+                bundledWebDirectory: bundledWebDirectory
+            )
             try Data(gridHTML(title: fileURL.lastPathComponent, transparentBackground: transparentBackground).utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("index.html"), options: [.atomic])
             try Data("window.BurreteConfig = \(gridPreview.configJSON);\n".utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-config.js"), options: [.atomic])
             try Data("window.BurreteDataBase64 = null;\n".utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-data.js"), options: [.atomic])
-            try Data(gridPreview.recordsScript.utf8)
+            try Data(gridRecordsScript.utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-grid-records.js"), options: [.atomic])
-            let rdkitWasmURL = assetsDirectory
-                .appendingPathComponent("rdkit", isDirectory: true)
-                .appendingPathComponent("RDKit_minimal.wasm")
-            try Data(rdkitWasmInlineScript(from: rdkitWasmURL).utf8)
-                .write(to: runtimeDirectory.appendingPathComponent("preview-rdkit-wasm.js"), options: [.atomic])
             return AppViewerRuntime(
                 indexURL: runtimeDirectory.appendingPathComponent("index.html"),
                 readAccessURL: baseDirectory
             )
+        }
+        if MoleculeGridFileSupport.requiresGridPreview(fileExtension: fileURL.pathExtension) {
+            if !MoleculeGridFileSupport.load().supports(fileExtension: fileURL.pathExtension) {
+                throw AppViewerError.gridFileTypeDisabled(fileURL.pathExtension)
+            }
+            throw AppViewerError.unsupportedFile(fileURL.lastPathComponent)
         }
 
         let format = AppViewerStructureFormat(url: fileURL, data: data)
@@ -393,7 +458,8 @@ private struct AppViewerRuntime {
             "debug": false,
             "theme": viewerTheme,
             "canvasBackground": canvasBackground,
-            "uiScale": 0.86,
+            "uiScale": 1.0,
+            "overlayOpacity": overlayOpacity,
             "transparentBackground": canvasIsTransparent,
             "sdfGrid": true,
             "appViewer": true,
@@ -469,21 +535,12 @@ private struct AppViewerRuntime {
         }
     }
 
-    private static func rdkitWasmInlineScript(from url: URL) throws -> String {
-        let base64 = try Data(contentsOf: url).base64EncodedString(options: [])
-        let chunkSize = 32_768
-        var chunks: [String] = []
-        var start = base64.startIndex
-        while start < base64.endIndex {
-            let end = base64.index(start, offsetBy: chunkSize, limitedBy: base64.endIndex) ?? base64.endIndex
-            chunks.append(String(base64[start..<end]))
-            start = end
-        }
-        let jsonData = try JSONSerialization.data(withJSONObject: chunks, options: [.withoutEscapingSlashes])
-        guard let json = String(data: jsonData, encoding: .utf8) else {
-            throw AppViewerError.missingWebResources
-        }
-        return "window.BurreteRDKitWasmBase64Chunks = \(json);\n"
+    private static func gridRecordsScriptWithRDKitWasm(_ recordsScript: String, bundledWebDirectory: URL) throws -> String {
+        let wasmURL = bundledWebDirectory
+            .appendingPathComponent("rdkit", isDirectory: true)
+            .appendingPathComponent("RDKit_minimal.wasm")
+        let wasmBase64 = try Data(contentsOf: wasmURL).base64EncodedString()
+        return recordsScript + "window.BurreteRDKitWasmBase64 = \"\(wasmBase64)\";\n"
     }
 
     private static func copyAssetAtomically(from source: URL, to destination: URL) throws {
@@ -540,14 +597,13 @@ private struct AppViewerRuntime {
 
     private static func resolveRenderer(for format: AppViewerStructureFormat, rendererMode: String) -> String {
         let isXYZ = format.molstarFormat == "xyz" && !format.isBinary
-        let isSDF = format.molstarFormat == "sdf" && !format.isBinary
         switch AppViewerRendererMode.normalize(rendererMode) {
         case "molstar":
             return "molstar"
         case "xyz-fast":
             return isXYZ ? "xyz-fast" : "molstar"
         case "xyzrender-external":
-            return (isXYZ || isSDF) ? "xyzrender-external" : "molstar"
+            return isXYZ ? "xyzrender-external" : "molstar"
         default:
             return isXYZ ? "xyz-fast" : "molstar"
         }
@@ -632,7 +688,6 @@ private struct AppViewerRuntime {
           </script>
           <script src="preview-config.js"></script>
           <script src="preview-grid-records.js"></script>
-          <script src="preview-rdkit-wasm.js"></script>
           <script src="../assets/rdkit/RDKit_minimal.js"></script>
           <script src="../assets/grid-viewer.js"></script>
         </body>
@@ -671,16 +726,18 @@ private struct AppViewerRuntime {
             :root {
               --buret-viewer-ui-scale: 0.86;
               --buret-toolbar-safe-top: 18px;
+              --buret-overlay-opacity: 0.90;
+              --buret-overlay-strong-opacity: 0.96;
               --buret-canvas-background: #000000;
               --buret-shell-background: #000000;
-              --buret-panel-background: rgba(18, 20, 22, 0.82);
-              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-panel-background: rgba(18, 20, 22, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(12, 13, 14, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
-              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
-              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(32, 35, 39, var(--buret-overlay-strong-opacity));
               --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
               --buret-molstar-border: rgba(255, 255, 255, 0.10);
               --buret-molstar-text: rgba(246, 247, 249, 0.94);
@@ -699,33 +756,33 @@ private struct AppViewerRuntime {
             html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
             body.buret-theme-light {
-              --buret-shell-background: #f7f7f2;
-              --buret-panel-background: rgba(247, 247, 242, 0.86);
-              --buret-toolbar-background: rgba(247, 247, 242, 0.90);
+              --buret-shell-background: #ffffff;
+              --buret-panel-background: rgba(248, 248, 248, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(248, 248, 248, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(0, 0, 0, 0.12);
               --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
               --buret-toolbar-color: rgba(20, 21, 23, 0.92);
-              --buret-molstar-panel-background: rgba(239, 239, 235, 0.94);
-              --buret-molstar-row-background: rgba(229, 228, 222, 0.96);
-              --buret-molstar-field-background: rgba(248, 247, 244, 0.98);
-              --buret-molstar-hover-background: rgba(218, 216, 209, 0.98);
+              --buret-molstar-panel-background: rgba(248, 248, 248, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(238, 238, 238, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(255, 255, 255, var(--buret-overlay-strong-opacity));
+              --buret-molstar-hover-background: rgba(228, 228, 228, 0.98);
               --buret-molstar-border: rgba(0, 0, 0, 0.13);
               --buret-molstar-text: rgba(32, 33, 35, 0.94);
-              --buret-molstar-muted-text: rgba(84, 78, 68, 0.82);
-              --buret-molstar-accent: #8a4b10;
+              --buret-molstar-muted-text: rgba(86, 88, 92, 0.82);
+              --buret-molstar-accent: #006bd6;
               --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
               color: #161719;
             }
             body.buret-theme-dark {
               --buret-shell-background: var(--buret-canvas-background);
-              --buret-panel-background: rgba(18, 20, 22, 0.82);
-              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-panel-background: rgba(18, 20, 22, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(12, 13, 14, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
-              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
-              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(32, 35, 39, var(--buret-overlay-strong-opacity));
               --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
               --buret-molstar-border: rgba(255, 255, 255, 0.10);
               --buret-molstar-text: rgba(246, 247, 249, 0.94);
@@ -765,7 +822,7 @@ private struct AppViewerRuntime {
             body .msp-plugin,
             body .msp-plugin .msp-plugin-content {
               color: var(--buret-molstar-text) !important;
-              background: var(--buret-molstar-panel-background) !important;
+              background: transparent !important;
             }
             body .msp-plugin .msp-layout-standard,
             body .msp-plugin .msp-layout-top,
@@ -1373,6 +1430,8 @@ private struct AppViewerStructureFormat {
 private enum AppViewerError: LocalizedError {
     case missingWebResources
     case emptyFile(String)
+    case unsupportedFile(String)
+    case gridFileTypeDisabled(String)
     case fileTooLarge(String, Int64, Int64)
     case missingCacheDirectory
 
@@ -1382,11 +1441,69 @@ private enum AppViewerError: LocalizedError {
             return "Bundled Mol* web resources are missing from Burrete.app."
         case .emptyFile(let name):
             return "The structure file is empty: \(name)"
+        case .unsupportedFile(let name):
+            return "Unsupported molecule grid file: \(name)"
+        case .gridFileTypeDisabled(let ext):
+            return ".\(ext) molecule grid previews are disabled in Burrete Settings."
         case .fileTooLarge(let name, let size, let limit):
             return "\(name) is too large for the Burrete app viewer (\(size) bytes; limit \(limit) bytes). Open it in a dedicated molecular viewer."
         case .missingCacheDirectory:
             return "Could not locate the app cache directory."
         }
+    }
+}
+
+private final class BurreteAppViewerContainerView: NSView {
+    private let materialView = NSVisualEffectView()
+    private let backgroundFillView = NSView()
+
+    init(contentView: NSView, preferences: AppViewerDisplayPreferences) {
+        super.init(frame: .zero)
+        wantsLayer = true
+
+        materialView.translatesAutoresizingMaskIntoConstraints = false
+        materialView.blendingMode = .behindWindow
+        materialView.state = .active
+        materialView.material = .underWindowBackground
+        addSubview(materialView)
+
+        backgroundFillView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundFillView.wantsLayer = true
+        addSubview(backgroundFillView)
+
+        contentView.wantsLayer = true
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentView)
+        NSLayoutConstraint.activate([
+            materialView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            materialView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            materialView.topAnchor.constraint(equalTo: topAnchor),
+            materialView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            backgroundFillView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundFillView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundFillView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundFillView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        apply(preferences)
+    }
+
+    override var mouseDownCanMoveWindow: Bool {
+        true
+    }
+
+    func apply(_ preferences: AppViewerDisplayPreferences) {
+        materialView.isHidden = !preferences.isWindowTransparent
+        let fillColor = preferences.baseColor.withAlphaComponent(preferences.isWindowTransparent ? preferences.clampedWindowOpacity : 1.0)
+        layer?.backgroundColor = fillColor.cgColor
+        backgroundFillView.layer?.backgroundColor = fillColor.cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.16;
+				MARKETING_VERSION = 0.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -427,7 +427,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.16;
+				MARKETING_VERSION = 0.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -451,7 +451,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.16;
+				MARKETING_VERSION = 0.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.16;
+				MARKETING_VERSION = 0.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -99,6 +99,7 @@
 				<string>com.local.burrete10.bcif</string>
 				<string>com.local.burrete10.sdf</string>
 				<string>com.local.burrete10.smiles</string>
+				<string>com.local.burettexyzrender.smiles</string>
 				<string>com.local.burrete10.mol</string>
 				<string>com.local.burrete10.mol2</string>
 				<string>com.local.molstarquicklook10.pdb</string>
@@ -144,12 +145,14 @@
 				<string>uk.ac.ebi.pdbe.pdb</string>
 				<string>uk.ac.ebi.pdbe.cif</string>
 				<string>uk.ac.ebi.pdbe.mmcif</string>
-					<string>public.pdb</string>
-					<string>public.mmcif</string>
+				<string>public.pdb</string>
+				<string>public.mmcif</string>
 					<string>public.cif</string>
-					<string>public.data</string>
+					<string>public.comma-separated-values-text</string>
+					<string>public.tab-separated-values-text</string>
 						<string>com.schrodinger.sdf</string>
 						<string>com.local.burrete10.xyz</string>
+						<string>net.sourceforge.openbabel.xyz</string>
 						<string>dyn.ah62d4rv4ge81u8p4</string>
 						<string>com.local.burrete10.gro</string>
 						<string>dyn.ah62d4rv4ge80s6xt</string>

--- a/PreviewExtension/MoleculeGridPreview.swift
+++ b/PreviewExtension/MoleculeGridPreview.swift
@@ -13,6 +13,65 @@ enum MoleculeGridPreviewHost: String {
     case app
 }
 
+struct MoleculeGridFileSupport: Equatable {
+    static let sdfKey = "gridPreviewSupportsSDF"
+    static let smilesKey = "gridPreviewSupportsSMILES"
+    static let csvKey = "gridPreviewSupportsCSV"
+    static let tsvKey = "gridPreviewSupportsTSV"
+
+    let sdf: Bool
+    let smiles: Bool
+    let csv: Bool
+    let tsv: Bool
+
+    static let all = MoleculeGridFileSupport(sdf: true, smiles: true, csv: true, tsv: true)
+
+    static func load(from defaults: UserDefaults = .standard) -> MoleculeGridFileSupport {
+        MoleculeGridFileSupport(
+            sdf: boolValue(defaults.object(forKey: sdfKey), defaultValue: true),
+            smiles: boolValue(defaults.object(forKey: smilesKey), defaultValue: true),
+            csv: boolValue(defaults.object(forKey: csvKey), defaultValue: true),
+            tsv: boolValue(defaults.object(forKey: tsvKey), defaultValue: true)
+        )
+    }
+
+    static func loadFromAppPreferences(appID: CFString) -> MoleculeGridFileSupport {
+        MoleculeGridFileSupport(
+            sdf: boolValue(CFPreferencesCopyAppValue(sdfKey as CFString, appID), defaultValue: true),
+            smiles: boolValue(CFPreferencesCopyAppValue(smilesKey as CFString, appID), defaultValue: true),
+            csv: boolValue(CFPreferencesCopyAppValue(csvKey as CFString, appID), defaultValue: true),
+            tsv: boolValue(CFPreferencesCopyAppValue(tsvKey as CFString, appID), defaultValue: true)
+        )
+    }
+
+    func supports(fileExtension ext: String) -> Bool {
+        switch ext.lowercased() {
+        case "sdf", "sd":
+            return sdf
+        case "smi", "smiles":
+            return smiles
+        case "csv":
+            return csv
+        case "tsv":
+            return tsv
+        default:
+            return false
+        }
+    }
+
+    static func canPreview(fileExtension ext: String) -> Bool {
+        ["csv", "sd", "sdf", "smi", "smiles", "tsv"].contains(ext.lowercased())
+    }
+
+    static func requiresGridPreview(fileExtension ext: String) -> Bool {
+        ["csv", "smi", "smiles", "tsv"].contains(ext.lowercased())
+    }
+
+    private static func boolValue(_ value: Any?, defaultValue: Bool) -> Bool {
+        (value as? Bool) ?? defaultValue
+    }
+}
+
 enum MoleculeGridPreviewBuilder {
     static func makePreview(
         fileURL: URL,
@@ -21,23 +80,32 @@ enum MoleculeGridPreviewBuilder {
         theme: String,
         canvasBackground: String,
         transparentBackground: Bool,
+        overlayOpacity: Double = 0.90,
         debug: Bool,
         allowSelection: Bool,
         allowExport: Bool,
-        maxRecords: Int
+        maxRecords: Int,
+        fileSupport: MoleculeGridFileSupport = .all
     ) throws -> MoleculeGridPreview? {
         let ext = fileURL.pathExtension.lowercased()
+        guard fileSupport.supports(fileExtension: ext) else { return nil }
         let text = decodeText(data)
         let recordLimit = max(1, maxRecords)
         let collection: MoleculeGridCollection
 
         switch ext {
+        case "csv":
+            collection = try parseDelimitedTable(text, separator: ",", format: "csv", maxRecords: recordLimit)
+            guard collection.recordsTotal > 0 else { return nil }
         case "smi", "smiles":
             collection = parseSmiles(text, maxRecords: recordLimit)
             guard collection.recordsTotal > 0 else { return nil }
         case "sdf", "sd":
             collection = parseSDF(text, maxRecords: recordLimit)
             guard collection.recordsTotal > 1 else { return nil }
+        case "tsv":
+            collection = try parseDelimitedTable(text, separator: "\t", format: "tsv", maxRecords: recordLimit)
+            guard collection.recordsTotal > 0 else { return nil }
         default:
             return nil
         }
@@ -65,6 +133,7 @@ enum MoleculeGridPreviewBuilder {
             "appViewer": host == .app,
             "theme": theme,
             "canvasBackground": canvasBackground,
+            "overlayOpacity": min(max(overlayOpacity, 0.72), 0.98),
             "transparentBackground": transparentBackground,
             "recordsTotal": collection.recordsTotal,
             "recordsIncluded": includedRecords.count,
@@ -153,6 +222,87 @@ enum MoleculeGridPreviewBuilder {
         }
         finishRecord()
         return MoleculeGridCollection(format: "sdf", records: records, recordsTotal: recordsTotal)
+    }
+
+    private static func parseDelimitedTable(
+        _ text: String,
+        separator: Character,
+        format: String,
+        maxRecords: Int
+    ) throws -> MoleculeGridCollection {
+        let rows = normalizedLines(text).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard let headerLine = rows.first else {
+            return MoleculeGridCollection(format: format, records: [], recordsTotal: 0)
+        }
+        let headers = parseDelimitedLine(headerLine, separator: separator).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let normalizedHeaders = headers.map { $0.lowercased().replacingOccurrences(of: " ", with: "_") }
+        guard let smilesIndex = normalizedHeaders.firstIndex(where: { isSmilesColumn($0) }) else {
+            throw MoleculeGridPreviewError.missingMoleculeColumn(format.uppercased())
+        }
+        let nameIndex = normalizedHeaders.firstIndex(where: { ["compound_id", "id", "name", "title", "compound"].contains($0) && $0 != normalizedHeaders[smilesIndex] })
+
+        var records: [MoleculeGridRecord] = []
+        var recordsTotal = 0
+        for line in rows.dropFirst() {
+            let cells = parseDelimitedLine(line, separator: separator)
+            guard smilesIndex < cells.count else { continue }
+            let smiles = cells[smilesIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !smiles.isEmpty else { continue }
+            defer { recordsTotal += 1 }
+            guard records.count < maxRecords else { continue }
+
+            let rawName = nameIndex.flatMap { $0 < cells.count ? cells[$0].trimmingCharacters(in: .whitespacesAndNewlines) : nil } ?? ""
+            let name = rawName.isEmpty ? "Molecule \(recordsTotal + 1)" : rawName
+            var props: [String: String] = [:]
+            for (index, header) in headers.enumerated() where index != smilesIndex && index != nameIndex {
+                guard index < cells.count else { continue }
+                let value = cells[index].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !header.isEmpty, !value.isEmpty, props.count < 64 {
+                    props[clipped(header, limit: 80)] = clipped(value, limit: 500)
+                }
+            }
+            records.append(MoleculeGridRecord(
+                index: recordsTotal,
+                name: clipped(name, limit: 160),
+                smiles: clipped(smiles, limit: 2048),
+                molblock: nil,
+                props: props
+            ))
+        }
+        return MoleculeGridCollection(format: format, records: records, recordsTotal: recordsTotal)
+    }
+
+    private static func parseDelimitedLine(_ line: String, separator: Character) -> [String] {
+        let chars = Array(line)
+        var fields: [String] = []
+        var field = ""
+        var index = 0
+        var inQuotes = false
+        while index < chars.count {
+            let char = chars[index]
+            if char == "\"" {
+                if inQuotes, index + 1 < chars.count, chars[index + 1] == "\"" {
+                    field.append(char)
+                    index += 1
+                } else {
+                    inQuotes.toggle()
+                }
+            } else if char == separator, !inQuotes {
+                fields.append(field)
+                field = ""
+            } else {
+                field.append(char)
+            }
+            index += 1
+        }
+        fields.append(field)
+        return fields
+    }
+
+    private static func isSmilesColumn(_ value: String) -> Bool {
+        ["smiles", "canonical_smiles", "isomeric_smiles", "cxsmiles", "smiles_string"].contains(value)
     }
 
     private static func normalizedLines(_ text: String) -> [String] {
@@ -245,8 +395,14 @@ private struct MoleculeGridRecord {
 
 private enum MoleculeGridPreviewError: LocalizedError {
     case couldNotEncodeJSON
+    case missingMoleculeColumn(String)
 
     var errorDescription: String? {
-        "Could not encode molecule grid preview JSON."
+        switch self {
+        case .couldNotEncodeJSON:
+            return "Could not encode molecule grid preview JSON."
+        case .missingMoleculeColumn(let format):
+            return "\(format) table needs a SMILES, canonical_smiles, isomeric_smiles, cxsmiles, or smiles_string column."
+        }
     }
 }

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -12,12 +12,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private var logLines: [String] = []
     private let previewID = String(UUID().uuidString.prefix(8))
     private var hasRenderedTerminationError = false
-    private var currentViewerPageZoom: CGFloat = 0.86
+    private var currentViewerPageZoom: CGFloat = 1.0
     private static let showDebugOverlay = false
     private static let verboseLogging = false
-    private static let defaultViewerPageZoom: CGFloat = 0.86
-    private static let minViewerPageZoom: CGFloat = 0.72
-    private static let maxViewerPageZoom: CGFloat = 1.35
+    private static let defaultViewerPageZoom: CGFloat = 1.0
+    private static let minViewerPageZoom: CGFloat = 1.0
+    private static let maxViewerPageZoom: CGFloat = 1.0
 
     deinit {
         renderTimeoutWorkItem?.cancel()
@@ -205,7 +205,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static let supportedStructureExtensions: Set<String> = [
-        "bcif", "cif", "ent", "gro", "mcif", "mmcif", "mol", "mol2", "pdb", "pdbqt", "pqr", "sd", "sdf", "smi", "smiles", "xyz"
+        "bcif", "cif", "csv", "ent", "gro", "mcif", "mmcif", "mol", "mol2", "pdb", "pdbqt", "pqr", "sd", "sdf", "smi", "smiles", "tsv", "xyz"
     ]
 
     private static func buildInlinePreviewHTML(for url: URL) throws -> BuildResult {
@@ -238,6 +238,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         diag("structureData.bytes=\(structureData.count)")
 
         let preferences = PreviewPreferences.load()
+        let gridFileSupport = preferences.gridFileSupport
         if let gridPreview = try MoleculeGridPreviewBuilder.makePreview(
             fileURL: url,
             data: structureData,
@@ -245,21 +246,29 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             theme: preferences.viewerTheme,
             canvasBackground: preferences.canvasBackground,
             transparentBackground: preferences.canvasBackground == "transparent",
+            overlayOpacity: preferences.overlayOpacity,
             debug: showDebugOverlay,
             allowSelection: false,
             allowExport: false,
-            maxRecords: 3000
+            maxRecords: 750,
+            fileSupport: gridFileSupport
         ) {
             diag("detected.previewMode=grid2d format=\(gridPreview.format) records=\(gridPreview.recordsIncluded)/\(gridPreview.recordsTotal)")
             try validateVendoredMoleculeGridAssets(in: webDirectory, fileManager: fileManager, diagnostics: &diagnostics)
             let html = gridInlineHTML(title: url.lastPathComponent, preferences: preferences)
             diag("gridInlineHTML.bytes=\(html.utf8.count)")
+            let gridRecordsScript = try gridRecordsScriptWithRDKitWasm(
+                gridPreview.recordsScript,
+                bundledWebDirectory: webDirectory
+            )
             let runtimePreview = try createRuntimePreview(
                 bundledWebDirectory: webDirectory,
                 html: html,
                 configJSON: gridPreview.configJSON,
                 structureBase64: nil,
-                gridRecordsScript: gridPreview.recordsScript,
+                gridRecordsScript: gridRecordsScript,
+                requiredAssets: ["grid-viewer.js", "grid.css"],
+                requiresRDKit: true,
                 fileManager: fileManager,
                 diagnostics: &diagnostics
             )
@@ -267,6 +276,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             diag("runtimeDirectory=\(runtimePreview.runtimeDirectory.path)")
             diag("runtime.index.exists=\(fileManager.fileExists(atPath: indexURL.path))")
             return BuildResult(html: html, indexURL: indexURL, readAccessURL: runtimePreview.readAccessURL, diagnostics: diagnostics)
+        }
+        if MoleculeGridFileSupport.requiresGridPreview(fileExtension: pathExtension) {
+            if !gridFileSupport.supports(fileExtension: pathExtension) {
+                throw PreviewError.gridFileTypeDisabled(pathExtension)
+            }
+            throw PreviewError.unsupportedStructureFile(url.lastPathComponent)
         }
 
         let format = StructureFormat(url: url, data: structureData)
@@ -298,6 +313,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             configJSON: configJSON,
             structureBase64: base64,
             gridRecordsScript: nil,
+            requiredAssets: runtimeAssets(for: renderer),
+            requiresRDKit: false,
             fileManager: fileManager,
             diagnostics: &diagnostics
         )
@@ -319,6 +336,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         configJSON: String,
         structureBase64: String?,
         gridRecordsScript: String?,
+        requiredAssets: [String],
+        requiresRDKit: Bool,
         fileManager: FileManager,
         diagnostics: inout [String]
     ) throws -> RuntimePreview {
@@ -333,6 +352,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         try ensureRuntimeAssets(
             bundledWebDirectory: bundledWebDirectory,
             previewsDirectory: previewsDirectory,
+            requiredAssets: requiredAssets,
+            requiresRDKit: requiresRDKit,
             fileManager: fileManager,
             diagnostics: &diagnostics
         )
@@ -350,32 +371,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         if let gridRecordsScript {
             try Data(gridRecordsScript.utf8)
                 .write(to: runtimeDirectory.appendingPathComponent("preview-grid-records.js"), options: [.atomic])
-            let rdkitWasmURL = bundledWebDirectory
-                .appendingPathComponent("rdkit", isDirectory: true)
-                .appendingPathComponent("RDKit_minimal.wasm")
-            let rdkitWasmScript = try rdkitWasmInlineScript(from: rdkitWasmURL)
-            try Data(rdkitWasmScript.utf8)
-                .write(to: runtimeDirectory.appendingPathComponent("preview-rdkit-wasm.js"), options: [.atomic])
-            diagnostics.append("[build] preview-rdkit-wasm.script.bytes=\(rdkitWasmScript.utf8.count)")
         }
         return RuntimePreview(runtimeDirectory: runtimeDirectory, indexURL: indexURL, readAccessURL: previewsDirectory)
-    }
-
-    private static func rdkitWasmInlineScript(from url: URL) throws -> String {
-        let base64 = try Data(contentsOf: url).base64EncodedString(options: [])
-        let chunkSize = 32_768
-        var chunks: [String] = []
-        var start = base64.startIndex
-        while start < base64.endIndex {
-            let end = base64.index(start, offsetBy: chunkSize, limitedBy: base64.endIndex) ?? base64.endIndex
-            chunks.append(String(base64[start..<end]))
-            start = end
-        }
-        let jsonData = try JSONSerialization.data(withJSONObject: chunks, options: [.withoutEscapingSlashes])
-        guard let json = String(data: jsonData, encoding: .utf8) else {
-            throw PreviewError.couldNotCreateRuntimePreview("Could not encode RDKit WASM chunks")
-        }
-        return "window.BurreteRDKitWasmBase64Chunks = \(json);\n"
     }
 
     private static func pruneRuntimePreviews(
@@ -412,26 +409,48 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private static func ensureRuntimeAssets(
         bundledWebDirectory: URL,
         previewsDirectory: URL,
+        requiredAssets: [String],
+        requiresRDKit: Bool,
         fileManager: FileManager,
         diagnostics: inout [String]
     ) throws {
         let assetsDirectory = previewsDirectory.appendingPathComponent("assets", isDirectory: true)
         try fileManager.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
-        for assetName in ["molstar.js", "molstar.css", "burette-agent.js", "viewer.js", "xyz-fast.js", "grid-viewer.js", "grid.css"] {
+        for assetName in requiredAssets {
             let source = bundledWebDirectory.appendingPathComponent(assetName)
             let destination = assetsDirectory.appendingPathComponent(assetName)
-            try copyAssetAtomically(from: source, to: destination, fileManager: fileManager)
+            let copied = try copyAssetIfNeeded(from: source, to: destination, fileManager: fileManager)
             let size = ((try? fileManager.attributesOfItem(atPath: destination.path)[.size]) as? NSNumber)?.intValue ?? -1
-            diagnostics.append("[build] runtime.asset.\(assetName).exists=\(fileManager.fileExists(atPath: destination.path)) size=\(size) copied=true")
+            diagnostics.append("[build] runtime.asset.\(assetName).exists=\(fileManager.fileExists(atPath: destination.path)) size=\(size) copied=\(copied)")
         }
-        let rdkitSource = bundledWebDirectory.appendingPathComponent("rdkit", isDirectory: true)
-        if fileManager.fileExists(atPath: rdkitSource.path) {
-            try copyDirectoryAtomically(from: rdkitSource, to: assetsDirectory.appendingPathComponent("rdkit", isDirectory: true), fileManager: fileManager)
-            diagnostics.append("[build] runtime.asset.rdkit.exists=true copied=true")
+        if requiresRDKit {
+            let rdkitSource = bundledWebDirectory.appendingPathComponent("rdkit", isDirectory: true)
+            if fileManager.fileExists(atPath: rdkitSource.path) {
+                let copied = try copyDirectoryIfNeeded(from: rdkitSource, to: assetsDirectory.appendingPathComponent("rdkit", isDirectory: true), fileManager: fileManager)
+                diagnostics.append("[build] runtime.asset.rdkit.exists=true copied=\(copied)")
+            }
         }
     }
 
-    private static func copyAssetAtomically(from source: URL, to destination: URL, fileManager: FileManager) throws {
+    private static func runtimeAssets(for renderer: String) -> [String] {
+        if renderer == "xyz-fast" {
+            return ["xyz-fast.js", "burette-agent.js", "viewer.js"]
+        }
+        return ["molstar.js", "molstar.css", "burette-agent.js", "viewer.js"]
+    }
+
+    private static func gridRecordsScriptWithRDKitWasm(_ recordsScript: String, bundledWebDirectory: URL) throws -> String {
+        let wasmURL = bundledWebDirectory
+            .appendingPathComponent("rdkit", isDirectory: true)
+            .appendingPathComponent("RDKit_minimal.wasm")
+        let wasmBase64 = try Data(contentsOf: wasmURL).base64EncodedString()
+        return recordsScript + "window.BurreteRDKitWasmBase64 = \"\(wasmBase64)\";\n"
+    }
+
+    private static func copyAssetIfNeeded(from source: URL, to destination: URL, fileManager: FileManager) throws -> Bool {
+        if try fileExistsAndMatches(source: source, destination: destination, fileManager: fileManager) {
+            return false
+        }
         let temporaryURL = destination
             .deletingLastPathComponent()
             .appendingPathComponent(".\(destination.lastPathComponent).\(UUID().uuidString).tmp")
@@ -443,9 +462,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         } else {
             try fileManager.moveItem(at: temporaryURL, to: destination)
         }
+        return true
     }
 
-    private static func copyDirectoryAtomically(from source: URL, to destination: URL, fileManager: FileManager) throws {
+    private static func copyDirectoryIfNeeded(from source: URL, to destination: URL, fileManager: FileManager) throws -> Bool {
+        if try directoryExistsAndMatches(source: source, destination: destination, fileManager: fileManager) {
+            return false
+        }
         let temporaryURL = destination
             .deletingLastPathComponent()
             .appendingPathComponent(".\(destination.lastPathComponent).\(UUID().uuidString).tmp", isDirectory: true)
@@ -456,6 +479,27 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             try fileManager.removeItem(at: destination)
         }
         try fileManager.moveItem(at: temporaryURL, to: destination)
+        return true
+    }
+
+    private static func fileExistsAndMatches(source: URL, destination: URL, fileManager: FileManager) throws -> Bool {
+        guard fileManager.fileExists(atPath: destination.path) else { return false }
+        let sourceAttributes = try fileManager.attributesOfItem(atPath: source.path)
+        let destinationAttributes = try fileManager.attributesOfItem(atPath: destination.path)
+        return (sourceAttributes[.size] as? NSNumber)?.int64Value == (destinationAttributes[.size] as? NSNumber)?.int64Value &&
+            sourceAttributes[.modificationDate] as? Date == destinationAttributes[.modificationDate] as? Date
+    }
+
+    private static func directoryExistsAndMatches(source: URL, destination: URL, fileManager: FileManager) throws -> Bool {
+        guard fileManager.fileExists(atPath: destination.path) else { return false }
+        for name in ["RDKit_minimal.js", "RDKit_minimal.wasm"] {
+            let sourceFile = source.appendingPathComponent(name)
+            let destinationFile = destination.appendingPathComponent(name)
+            if !(try fileExistsAndMatches(source: sourceFile, destination: destinationFile, fileManager: fileManager)) {
+                return false
+            }
+        }
+        return true
     }
 
     private static func fileSize(for url: URL, fileManager: FileManager) throws -> Int64 {
@@ -485,7 +529,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "debug": showDebugOverlay,
             "theme": preferences.viewerTheme,
             "canvasBackground": preferences.canvasBackground,
-            "uiScale": 0.86,
+            "uiScale": 1.0,
+            "overlayOpacity": preferences.overlayOpacity,
             "transparentBackground": preferences.canvasBackground == "transparent",
             "sdfGrid": true,
             "showPanelControls": preferences.showPanelControls,
@@ -539,7 +584,6 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           </script>
           <script src="preview-config.js"></script>
           <script src="preview-grid-records.js"></script>
-          <script src="preview-rdkit-wasm.js"></script>
           <script src="../assets/rdkit/RDKit_minimal.js"></script>
           <script src="../assets/grid-viewer.js"></script>
         </body>
@@ -578,16 +622,18 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             :root {
               --buret-viewer-ui-scale: 0.86;
               --buret-toolbar-safe-top: 12px;
+              --buret-overlay-opacity: 0.90;
+              --buret-overlay-strong-opacity: 0.96;
               --buret-canvas-background: #000000;
               --buret-shell-background: #000000;
-              --buret-panel-background: rgba(18, 20, 22, 0.82);
-              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-panel-background: rgba(18, 20, 22, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(12, 13, 14, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
-              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
-              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(32, 35, 39, var(--buret-overlay-strong-opacity));
               --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
               --buret-molstar-border: rgba(255, 255, 255, 0.10);
               --buret-molstar-text: rgba(246, 247, 249, 0.94);
@@ -606,33 +652,33 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             html.buret-transparent-background canvas { background: transparent !important; background-color: transparent !important; }
             body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: #f2f2f2; }
             body.buret-theme-light {
-              --buret-shell-background: #f7f7f2;
-              --buret-panel-background: rgba(247, 247, 242, 0.86);
-              --buret-toolbar-background: rgba(247, 247, 242, 0.90);
+              --buret-shell-background: #ffffff;
+              --buret-panel-background: rgba(248, 248, 248, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(248, 248, 248, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(0, 0, 0, 0.12);
               --buret-toolbar-hover: rgba(0, 0, 0, 0.08);
               --buret-toolbar-color: rgba(20, 21, 23, 0.92);
-              --buret-molstar-panel-background: rgba(239, 239, 235, 0.94);
-              --buret-molstar-row-background: rgba(229, 228, 222, 0.96);
-              --buret-molstar-field-background: rgba(248, 247, 244, 0.98);
-              --buret-molstar-hover-background: rgba(218, 216, 209, 0.98);
+              --buret-molstar-panel-background: rgba(248, 248, 248, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(238, 238, 238, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(255, 255, 255, var(--buret-overlay-strong-opacity));
+              --buret-molstar-hover-background: rgba(228, 228, 228, 0.98);
               --buret-molstar-border: rgba(0, 0, 0, 0.13);
               --buret-molstar-text: rgba(32, 33, 35, 0.94);
-              --buret-molstar-muted-text: rgba(84, 78, 68, 0.82);
-              --buret-molstar-accent: #8a4b10;
+              --buret-molstar-muted-text: rgba(86, 88, 92, 0.82);
+              --buret-molstar-accent: #006bd6;
               --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
               color: #161719;
             }
             body.buret-theme-dark {
               --buret-shell-background: var(--buret-canvas-background);
-              --buret-panel-background: rgba(18, 20, 22, 0.82);
-              --buret-toolbar-background: rgba(12, 13, 14, 0.90);
+              --buret-panel-background: rgba(18, 20, 22, var(--buret-overlay-opacity));
+              --buret-toolbar-background: rgba(12, 13, 14, var(--buret-overlay-opacity));
               --buret-toolbar-border: rgba(255, 255, 255, 0.10);
               --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
               --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-              --buret-molstar-panel-background: rgba(14, 15, 17, 0.94);
-              --buret-molstar-row-background: rgba(24, 26, 29, 0.96);
-              --buret-molstar-field-background: rgba(32, 35, 39, 0.98);
+              --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
+              --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
+              --buret-molstar-field-background: rgba(32, 35, 39, var(--buret-overlay-strong-opacity));
               --buret-molstar-hover-background: rgba(48, 52, 58, 0.98);
               --buret-molstar-border: rgba(255, 255, 255, 0.10);
               --buret-molstar-text: rgba(246, 247, 249, 0.94);
@@ -672,7 +718,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             body .msp-plugin,
             body .msp-plugin .msp-plugin-content {
               color: var(--buret-molstar-text) !important;
-              background: var(--buret-molstar-panel-background) !important;
+              background: transparent !important;
             }
             body .msp-plugin .msp-layout-standard,
             body .msp-plugin .msp-layout-top,
@@ -1225,7 +1271,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             return 40 * mib
         case "bcif":
             return 50 * mib
-        case "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles":
+        case "csv", "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles", "tsv":
             return 25 * mib
         default:
             return 20 * mib
@@ -1629,8 +1675,10 @@ private struct PreviewPreferences {
     let transparentBackground: Bool
     let viewerTheme: String
     let canvasBackground: String
+    let overlayOpacity: Double
     let rendererMode: String
     let xyzFastStyle: String
+    let gridFileSupport: MoleculeGridFileSupport
     let defaultLayoutState: [String: String]
 
     static func load() -> PreviewPreferences {
@@ -1638,16 +1686,20 @@ private struct PreviewPreferences {
         let showPanelControls = (CFPreferencesCopyAppValue("showPreviewPanelControls" as CFString, appID) as? Bool) ?? true
         let transparentBackground = (CFPreferencesCopyAppValue("useTransparentPreviewBackground" as CFString, appID) as? Bool) ?? false
         let viewerTheme = (CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "auto"
-        let canvasBackground = (CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "black"
+        let canvasBackground = (CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "auto"
+        let overlayOpacity = (CFPreferencesCopyAppValue("viewerOverlayOpacity" as CFString, appID) as? Double) ?? 0.90
         let rendererMode = (CFPreferencesCopyAppValue("structureRendererMode" as CFString, appID) as? String) ?? "auto"
         let xyzFastStyle = (CFPreferencesCopyAppValue("xyzFastStyle" as CFString, appID) as? String) ?? "default"
+        let gridFileSupport = MoleculeGridFileSupport.loadFromAppPreferences(appID: appID)
         return PreviewPreferences(
             showPanelControls: showPanelControls,
             transparentBackground: transparentBackground,
             viewerTheme: viewerTheme,
             canvasBackground: canvasBackground,
+            overlayOpacity: min(max(overlayOpacity, 0.72), 0.98),
             rendererMode: rendererMode,
             xyzFastStyle: xyzFastStyle,
+            gridFileSupport: gridFileSupport,
             defaultLayoutState: [
                 "left": "collapsed",
                 "right": "hidden",
@@ -1664,6 +1716,7 @@ private enum PreviewError: LocalizedError {
     case molstarAssetsNotVendored(Int)
     case emptyStructureFile(String)
     case unsupportedStructureFile(String)
+    case gridFileTypeDisabled(String)
     case fileTooLarge(String, Int64, Int64)
     case ubiquitousFileNotDownloaded(String)
     case webRenderFailed(String)
@@ -1683,6 +1736,8 @@ private enum PreviewError: LocalizedError {
             return "The structure file is empty or not downloaded locally: \(name)"
         case .unsupportedStructureFile(let name):
             return "Unsupported structure file type: \(name)"
+        case .gridFileTypeDisabled(let ext):
+            return ".\(ext) molecule grid previews are disabled in Burrete Settings."
         case .fileTooLarge(let name, let size, let limit):
             return "\(name) is too large for Quick Look preview (\(size) bytes; limit \(limit) bytes). Open it in the Burrete app viewer or use a smaller file."
         case .ubiquitousFileNotDownloaded(let name):

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -3,34 +3,41 @@
 
   const root = document.getElementById('app');
   const status = document.getElementById('status');
+  const GRID_SIZE_STORAGE_KEY = 'buret.grid.cardSize';
+  const MOLECULE_SCALE_STORAGE_KEY = 'buret.grid.moleculeScale';
+  const LOAD_BATCH_STORAGE_KEY = 'buret.grid.loadBatch';
+  const SHOW_PROPERTIES_STORAGE_KEY = 'buret.grid.showProperties';
+  const GRID_SIZES = ['compact', 'medium', 'large'];
+  const LOAD_BATCH_OPTIONS = ['auto', '24', '60', '120', '240'];
   const state = {
     rdkit: null,
     all: Array.isArray(window.BurreteGridRecords) ? window.BurreteGridRecords : [],
     rows: [],
     visibleCount: 0,
-    batchSize: 0,
+    renderedCount: 0,
     query: '',
     smarts: '',
     smartsError: '',
     smartsMatches: new Map(),
     sort: 'index',
+    gridSize: storedChoice(GRID_SIZE_STORAGE_KEY, GRID_SIZES, 'medium'),
+    moleculeScale: storedNumber(MOLECULE_SCALE_STORAGE_KEY, 100, 80, 140),
+    loadBatchChoice: storedChoice(LOAD_BATCH_STORAGE_KEY, LOAD_BATCH_OPTIONS, 'auto'),
+    showProperties: storedBoolean(SHOW_PROPERTIES_STORAGE_KEY, true),
     selected: new Set(),
     svgCache: new Map(),
     token: 0,
-    autoLoadScheduled: false
+    rendering: false,
+    pendingLoad: false,
+    loadObserver: null,
+    scrollHandler: null
   };
 
   function post(type, message, payload = {}) {
     try {
-      if (window.__mqlPost) {
-        window.__mqlPost(type, message || '', payload);
-        return true;
-      }
-      const handler = window.webkit?.messageHandlers?.burrete;
-      handler?.postMessage({ type, message: String(message || ''), ...payload });
-      return !!handler;
+      if (window.__mqlPost) window.__mqlPost(type, message || '', payload);
+      else window.webkit?.messageHandlers?.burrete?.postMessage({ type, message: String(message || ''), ...payload });
     } catch (_) {}
-    return false;
   }
 
   function setStatus(message, kind = 'info') {
@@ -64,44 +71,56 @@
       throw new Error('RDKit_minimal.js is missing. Run npm run vendor:rdkit and rebuild.');
     }
     setStatus('[grid] Loading RDKit.js...');
-    state.rdkit = await window.initRDKitModule(rdkitModuleOptions());
+    const options = { locateFile: file => `../assets/rdkit/${file}` };
+    if (window.BurreteRDKitWasmBase64) {
+      options.wasmBinary = base64ToBytes(window.BurreteRDKitWasmBase64);
+      window.BurreteRDKitWasmBase64 = '';
+    }
+    state.rdkit = await window.initRDKitModule(options);
     return state.rdkit;
   }
 
-  function rdkitModuleOptions() {
-    const options = {
-      locateFile: file => new URL(`../assets/rdkit/${file}`, document.baseURI).href,
-      printErr: message => post('error', `[grid] RDKit stderr: ${String(message || '')}`),
-      onAbort: reason => post('error', `[grid] RDKit aborted: ${String(reason || '')}`)
-    };
-    const wasmBinary = embeddedRDKitWasmBinary();
-    if (wasmBinary) options.wasmBinary = wasmBinary;
-    return options;
-  }
-
-  function embeddedRDKitWasmBinary() {
-    const chunks = window.BurreteRDKitWasmBase64Chunks;
-    if (!Array.isArray(chunks) || chunks.length === 0) return null;
-    const binary = window.atob(chunks.join(''));
+  function base64ToBytes(value) {
+    const binary = atob(String(value || ''));
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
     return bytes;
   }
 
-  function defaultBatchSize(cfg) {
-    const value = Number(cfg.pageSize || 96);
-    return Number.isFinite(value) ? Math.max(24, Math.min(480, Math.floor(value))) : 96;
+  function loadBatchSize(cfg) {
+    if (state.loadBatchChoice !== 'auto') return Number(state.loadBatchChoice);
+    const value = Number(cfg.pageSize || 72);
+    return Number.isFinite(value) ? Math.max(12, Math.min(180, Math.floor(value))) : 72;
   }
 
-  function batchSize(cfg) {
-    return state.batchSize || defaultBatchSize(cfg);
+  function storedChoice(key, options, fallback) {
+    try {
+      const value = window.localStorage?.getItem(key);
+      return options.includes(value) ? value : fallback;
+    } catch (_) {
+      return fallback;
+    }
   }
 
-  function batchOptions(cfg) {
-    return [...new Set([24, 60, 96, 120, 240, 480, defaultBatchSize(cfg)])]
-      .sort((a, b) => a - b)
-      .map(value => `<option value="${value}">${value} at a time</option>`)
-      .join('');
+  function storedBoolean(key, fallback) {
+    try {
+      const value = window.localStorage?.getItem(key);
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+    } catch (_) {}
+    return fallback;
+  }
+
+  function storedNumber(key, fallback, min, max) {
+    try {
+      const value = Number(window.localStorage?.getItem(key));
+      if (Number.isFinite(value)) return Math.max(min, Math.min(max, Math.round(value)));
+    } catch (_) {}
+    return fallback;
+  }
+
+  function store(key, value) {
+    try { window.localStorage?.setItem(key, String(value)); } catch (_) {}
   }
 
   function applyTheme(cfg) {
@@ -134,19 +153,32 @@
           </div>
         </header>
         <div class="buret-grid-toolbar">
-          <label>Search <input id="search" type="search" placeholder="name, SMILES, metadata" /></label>
-          <label>SMARTS <input id="smarts" type="search" spellcheck="false" autocapitalize="off" placeholder="[#6]=O" /></label>
-          <label>Sort <select id="sort"><option value="index">File order</option><option value="name">Name</option><option value="smiles">SMILES</option>${propertyOptions()}</select></label>
-          <label>Show <select id="display-count">${batchOptions(cfg)}</select></label>
-          <button id="clear-smarts" class="buret-clear-smarts" type="button" hidden>Clear SMARTS</button>
-          ${caps.rendererSwitch ? rendererSwitchHTML() : ''}
-          <div class="buret-load-controls"><span id="shown-label"></span><button id="load-more" type="button">Show more</button></div>
+          <div class="buret-toolbar-row buret-toolbar-row-main">
+            <label class="buret-search-control">Search <input id="search" type="search" placeholder="name, SMILES, metadata" /></label>
+            <label class="buret-smarts-control">SMARTS <input id="smarts" type="search" spellcheck="false" autocapitalize="off" placeholder="[#6]=O" /></label>
+            <label class="buret-sort-control">Sort <select id="sort"><option value="index">File order</option><option value="name">Name</option><option value="smiles">SMILES</option>${propertyOptions()}</select></label>
+            <label class="buret-load-control">Load batch <select id="load-batch"><option value="auto">Auto</option><option value="24">24</option><option value="60">60</option><option value="120">120</option><option value="240">240</option></select></label>
+            <div id="load-status" class="buret-load-status"></div>
+          </div>
+          <div class="buret-toolbar-row buret-toolbar-row-view">
+            <fieldset class="buret-segmented-control">
+              <legend>Card size</legend>
+              <div>
+                <button type="button" data-grid-size="compact">Compact</button>
+                <button type="button" data-grid-size="medium">Regular</button>
+                <button type="button" data-grid-size="large">Large</button>
+              </div>
+            </fieldset>
+            <label class="buret-scale-control">Molecule zoom <span><input id="molecule-scale" type="range" min="80" max="140" step="5" /><output id="molecule-scale-label"></output></span></label>
+            <button id="show-properties" class="buret-toggle-button" type="button" aria-pressed="true">Properties</button>
+            <button id="clear-smarts" class="buret-toggle-button buret-clear-smarts" type="button" hidden>Clear SMARTS</button>
+            ${caps.rendererSwitch ? rendererSwitchHTML() : ''}
+          </div>
         </div>
         <main id="grid" class="buret-grid"></main>
+        <div id="load-sentinel" class="buret-load-sentinel" aria-hidden="true"></div>
         <footer id="footer" class="buret-grid-footer"></footer>
       </section>`;
-    state.batchSize = defaultBatchSize(cfg);
-    document.getElementById('display-count').value = String(state.batchSize);
     document.getElementById('search').addEventListener('input', event => {
       state.query = event.target.value || '';
       refresh(cfg);
@@ -159,13 +191,25 @@
       state.sort = event.target.value || 'index';
       refresh(cfg);
     });
-    document.getElementById('display-count').addEventListener('change', event => {
-      state.batchSize = Math.max(24, Math.min(480, Number(event.target.value) || defaultBatchSize(cfg)));
-      refresh(cfg);
+    document.getElementById('load-batch').addEventListener('change', event => {
+      state.loadBatchChoice = LOAD_BATCH_OPTIONS.includes(event.target.value) ? event.target.value : 'auto';
+      store(LOAD_BATCH_STORAGE_KEY, state.loadBatchChoice);
+      render(cfg);
     });
-    document.getElementById('load-more').addEventListener('click', () => loadMore(cfg));
-    root.querySelectorAll('[data-buret-grid-renderer]').forEach(button => {
-      button.addEventListener('click', () => requestRendererSwitch(button.getAttribute('data-buret-grid-renderer')));
+    document.querySelectorAll('[data-grid-size]').forEach(button => button.addEventListener('click', event => {
+      state.gridSize = event.currentTarget.dataset.gridSize || 'medium';
+      store(GRID_SIZE_STORAGE_KEY, state.gridSize);
+      applyGridPreferences();
+    }));
+    document.getElementById('molecule-scale').addEventListener('input', event => {
+      state.moleculeScale = storedNumberFromValue(event.target.value, 100, 80, 140);
+      store(MOLECULE_SCALE_STORAGE_KEY, state.moleculeScale);
+      applyGridPreferences();
+    });
+    document.getElementById('show-properties').addEventListener('click', () => {
+      state.showProperties = !state.showProperties;
+      store(SHOW_PROPERTIES_STORAGE_KEY, state.showProperties);
+      applyGridPreferences();
     });
     document.getElementById('copy-selected')?.addEventListener('click', copySelected);
     document.getElementById('export-smi')?.addEventListener('click', () => exportSmiles(cfg));
@@ -177,7 +221,40 @@
       refresh(cfg);
       input?.focus();
     });
-    window.addEventListener('scroll', () => scheduleAutoLoad(cfg), { passive: true });
+    root.querySelectorAll('[data-buret-grid-renderer]').forEach(button => {
+      button.addEventListener('click', () => requestRendererSwitch(button.getAttribute('data-buret-grid-renderer')));
+    });
+    applyGridPreferences();
+    initInfiniteLoading(cfg);
+  }
+
+  function applyGridPreferences() {
+    document.body.classList.toggle('buret-grid-size-compact', state.gridSize === 'compact');
+    document.body.classList.toggle('buret-grid-size-medium', state.gridSize === 'medium');
+    document.body.classList.toggle('buret-grid-size-large', state.gridSize === 'large');
+    document.body.classList.toggle('buret-hide-properties', !state.showProperties);
+    document.body.style.setProperty('--buret-molecule-scale', String(state.moleculeScale / 100));
+    document.querySelectorAll('[data-grid-size]').forEach(button => {
+      const active = button.dataset.gridSize === state.gridSize;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    const moleculeScaleInput = document.getElementById('molecule-scale');
+    const moleculeScaleLabel = document.getElementById('molecule-scale-label');
+    const loadBatchSelect = document.getElementById('load-batch');
+    const propertiesToggle = document.getElementById('show-properties');
+    if (moleculeScaleInput) moleculeScaleInput.value = String(state.moleculeScale);
+    if (moleculeScaleLabel) moleculeScaleLabel.textContent = `${state.moleculeScale}%`;
+    if (loadBatchSelect) loadBatchSelect.value = state.loadBatchChoice;
+    if (propertiesToggle) {
+      propertiesToggle.classList.toggle('active', state.showProperties);
+      propertiesToggle.setAttribute('aria-pressed', state.showProperties ? 'true' : 'false');
+    }
+  }
+
+  function storedNumberFromValue(value, fallback, min, max) {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.max(min, Math.min(max, Math.round(number))) : fallback;
   }
 
   function propertyOptions() {
@@ -201,8 +278,7 @@
 
   function requestRendererSwitch(renderer) {
     const value = normalizeRenderer(renderer);
-    const sent = post('setRenderer', `[grid] Switch renderer to ${value}.`, { value });
-    if (!sent) setStatus('Renderer switching is available only in the standalone app viewer.', 'error');
+    post('setRenderer', `[grid] Switch renderer to ${value}.`, { value });
   }
 
   function normalizeRenderer(renderer) {
@@ -217,7 +293,6 @@
       : state.all.slice();
     state.rows = filterBySMARTS(textRows);
     state.rows.sort((a, b) => compare(a, b, state.sort));
-    resetVisibleCount(cfg);
     render(cfg);
   }
 
@@ -277,41 +352,82 @@
     }) || Number(a.index) - Number(b.index);
   }
 
-  function resetVisibleCount(cfg) {
-    state.visibleCount = Math.min(state.rows.length, batchSize(cfg));
+  function initInfiniteLoading(cfg) {
+    const sentinel = document.getElementById('load-sentinel');
+    if (!sentinel) return;
+    state.loadObserver?.disconnect?.();
+    if (typeof IntersectionObserver === 'function') {
+      state.loadObserver = new IntersectionObserver(entries => {
+        if (entries.some(entry => entry.isIntersecting)) loadMore(cfg);
+      }, { root: null, rootMargin: '520px 0px' });
+      state.loadObserver.observe(sentinel);
+    }
+    if (state.scrollHandler) window.removeEventListener('scroll', state.scrollHandler);
+    state.scrollHandler = () => maybeLoadMore(cfg);
+    window.addEventListener('scroll', state.scrollHandler, { passive: true });
   }
 
-  function loadMore(cfg) {
-    if (state.visibleCount >= state.rows.length) return;
-    state.visibleCount = Math.min(state.rows.length, state.visibleCount + batchSize(cfg));
-    render(cfg);
+  function hasMoreRows() {
+    return state.renderedCount < state.rows.length;
   }
 
-  function scheduleAutoLoad(cfg) {
-    if (state.autoLoadScheduled || state.visibleCount >= state.rows.length) return;
-    state.autoLoadScheduled = true;
-    window.requestAnimationFrame(() => {
-      state.autoLoadScheduled = false;
-      const scrollBottom = window.scrollY + window.innerHeight;
-      const documentHeight = document.documentElement.scrollHeight;
-      if (scrollBottom >= documentHeight - 720) loadMore(cfg);
-    });
+  function maybeLoadMore(cfg) {
+    if (!hasMoreRows()) return;
+    const sentinel = document.getElementById('load-sentinel');
+    const rect = sentinel?.getBoundingClientRect();
+    if (!rect || rect.top <= window.innerHeight + 520) loadMore(cfg);
   }
 
   async function render(cfg) {
     const token = ++state.token;
     const grid = document.getElementById('grid');
-    const rows = state.rows.slice(0, state.visibleCount);
     grid.innerHTML = '';
-    if (!rows.length) grid.innerHTML = '<div class="buret-empty">No molecules match this search.</div>';
-    for (const row of rows) {
-      if (token !== state.token) return;
-      grid.appendChild(card(row, cfg));
-      if (grid.children.length % 16 === 0) await new Promise(resolve => setTimeout(resolve, 0));
+    state.renderedCount = 0;
+    state.visibleCount = Math.min(loadBatchSize(cfg), state.rows.length);
+    if (!state.rows.length) {
+      grid.innerHTML = '<div class="buret-empty">No molecules match this search.</div>';
+      updateChrome(cfg);
+      post('ready', 'ready');
+      return;
     }
-    updateChrome(cfg);
-    post('ready', 'ready');
-    if (status && !window.BurreteDebug) status.classList.add('hidden');
+    await appendVisibleRows(cfg, token);
+  }
+
+  async function loadMore(cfg) {
+    if (state.rendering) {
+      state.pendingLoad = hasMoreRows();
+      return;
+    }
+    if (!hasMoreRows()) return;
+    state.visibleCount = Math.min(state.rows.length, state.visibleCount + loadBatchSize(cfg));
+    await appendVisibleRows(cfg, state.token);
+  }
+
+  async function appendVisibleRows(cfg, token) {
+    const grid = document.getElementById('grid');
+    const rows = state.rows.slice(state.renderedCount, state.visibleCount);
+    state.rendering = true;
+    try {
+      for (const row of rows) {
+        if (token !== state.token) return;
+        grid.appendChild(card(row, cfg));
+        state.renderedCount++;
+        if (state.renderedCount % 16 === 0) await new Promise(resolve => setTimeout(resolve, 0));
+      }
+      updateChrome(cfg);
+      post('ready', 'ready');
+      if (status && !window.BurreteDebug) status.classList.add('hidden');
+    } finally {
+      state.rendering = false;
+      if (token === state.token) {
+        if (state.pendingLoad) {
+          state.pendingLoad = false;
+          loadMore(cfg);
+        } else {
+          requestAnimationFrame(() => maybeLoadMore(cfg));
+        }
+      }
+    }
   }
 
   function updateChrome(cfg) {
@@ -319,7 +435,7 @@
     const included = Number(cfg.recordsIncluded || state.all.length);
     document.getElementById('summary').textContent = [
       `${state.rows.length.toLocaleString()} visible`,
-      `${Math.min(state.visibleCount, state.rows.length).toLocaleString()} shown`,
+      `${state.renderedCount.toLocaleString()} shown`,
       `${included.toLocaleString()} loaded`,
       `${total.toLocaleString()} in file`,
       state.selected.size ? `${state.selected.size.toLocaleString()} selected` : ''
@@ -327,10 +443,12 @@
     if (state.smarts.trim() && !state.smartsError) {
       document.getElementById('summary').textContent += ` · SMARTS matches ${state.smartsMatches.size.toLocaleString()}`;
     }
-    const shownLabel = document.getElementById('shown-label');
-    if (shownLabel) shownLabel.textContent = `${Math.min(state.visibleCount, state.rows.length).toLocaleString()} / ${state.rows.length.toLocaleString()}`;
-    const loadMoreButton = document.getElementById('load-more');
-    if (loadMoreButton) loadMoreButton.disabled = state.visibleCount >= state.rows.length;
+    const loadStatus = document.getElementById('load-status');
+    if (loadStatus) {
+      loadStatus.textContent = hasMoreRows()
+        ? `${state.renderedCount.toLocaleString()} of ${state.rows.length.toLocaleString()} shown`
+        : 'All visible molecules loaded';
+    }
     const clearSMARTS = document.getElementById('clear-smarts');
     if (clearSMARTS) clearSMARTS.hidden = !state.smarts.trim();
     const smartsInput = document.getElementById('smarts');
@@ -338,8 +456,10 @@
     document.getElementById('footer').textContent = state.smartsError
       ? `SMARTS error: ${state.smartsError}`
       : (total > included
-          ? `Showing first ${included.toLocaleString()} of ${total.toLocaleString()} records.`
-          : 'Offline RDKit.js rendering. No network access required.');
+        ? `Showing first ${included.toLocaleString()} of ${total.toLocaleString()} records.`
+        : (hasMoreRows()
+          ? `Scroll to load more. ${state.renderedCount.toLocaleString()} of ${state.rows.length.toLocaleString()} visible molecules are rendered.`
+          : 'Offline RDKit.js rendering. No network access required.'));
   }
 
   function card(row, cfg) {
@@ -392,10 +512,10 @@
           ? mol.get_svg_with_highlights(JSON.stringify({
               atoms: match.atoms,
               bonds: match.bonds,
-              width: 172,
-              height: 124
+              width: 260,
+              height: 190
             }))
-          : mol.get_svg(172, 124);
+          : mol.get_svg(260, 190);
       } catch (_) {
         html = mol.get_svg();
       }
@@ -412,7 +532,7 @@
   }
 
   function metadata(row) {
-    const entries = Object.entries(row.props || {}).filter(([, value]) => String(value || '').length).slice(0, 3);
+    const entries = Object.entries(row.props || {}).filter(([, value]) => String(value || '').length).slice(0, 6);
     if (!entries.length) return '<div class="buret-no-metadata">No metadata</div>';
     return `<dl class="buret-metadata">${entries.map(([key, value]) => `<dt>${escapeHTML(key)}</dt><dd>${escapeHTML(value)}</dd>`).join('')}</dl>`;
   }

--- a/PreviewExtension/Web/grid.css
+++ b/PreviewExtension/Web/grid.css
@@ -9,6 +9,12 @@
   --buret-muted: rgba(193, 199, 209, 0.76);
   --buret-faint: rgba(193, 199, 209, 0.54);
   --buret-shadow: rgba(0, 0, 0, 0.24);
+  --buret-card-min: 230px;
+  --buret-card-gap: 12px;
+  --buret-picture-min-height: 190px;
+  --buret-drawing-max-width: 260px;
+  --buret-drawing-max-height: 190px;
+  --buret-molecule-scale: 1;
 }
 
 html[data-buret-theme="light"] {
@@ -22,6 +28,22 @@ html[data-buret-theme="light"] {
   --buret-muted: rgba(84, 89, 99, 0.78);
   --buret-faint: rgba(84, 89, 99, 0.55);
   --buret-shadow: rgba(0, 0, 0, 0.10);
+}
+
+body.buret-grid-size-compact {
+  --buret-card-min: 176px;
+  --buret-card-gap: 9px;
+  --buret-picture-min-height: 148px;
+  --buret-drawing-max-width: 210px;
+  --buret-drawing-max-height: 150px;
+}
+
+body.buret-grid-size-large {
+  --buret-card-min: 300px;
+  --buret-card-gap: 14px;
+  --buret-picture-min-height: 238px;
+  --buret-drawing-max-width: 340px;
+  --buret-drawing-max-height: 240px;
 }
 
 html,
@@ -50,15 +72,25 @@ select {
   font: inherit;
 }
 
-button {
+button,
+.buret-grid-toolbar input[type="search"],
+.buret-grid-toolbar select {
   border: 1px solid var(--buret-border);
-  border-radius: 8px;
+  border-radius: 9px;
   color: var(--buret-text);
   background: var(--buret-strong);
-  padding: 7px 10px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10);
+  outline: none;
 }
 
-button:not(:disabled):hover {
+button {
+  min-height: 34px;
+  padding: 7px 12px;
+}
+
+button:not(:disabled):hover,
+.buret-grid-toolbar input[type="search"]:hover,
+.buret-grid-toolbar select:hover {
   border-color: var(--buret-accent);
 }
 
@@ -69,7 +101,7 @@ button:disabled {
 .buret-grid-shell {
   box-sizing: border-box;
   min-height: 100vh;
-  padding: 12px;
+  padding: 18px 18px 24px;
 }
 
 .buret-grid-header {
@@ -77,7 +109,7 @@ button:disabled {
   justify-content: space-between;
   align-items: flex-start;
   gap: 16px;
-  margin-bottom: 10px;
+  margin-bottom: 14px;
 }
 
 .buret-grid-header h1 {
@@ -100,29 +132,46 @@ button:disabled {
 }
 
 .buret-actions,
-.buret-load-controls {
+.buret-load-status {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.buret-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .buret-grid-toolbar {
   position: sticky;
   top: 0;
   z-index: 20;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: end;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 10px;
-  padding: 8px;
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding: 10px 12px;
   border: 1px solid var(--buret-border);
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--buret-surface);
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
-  box-shadow: 0 12px 28px var(--buret-shadow);
+  box-shadow: 0 14px 32px var(--buret-shadow);
+}
+
+.buret-toolbar-row {
+  display: grid;
+  gap: 10px;
+  align-items: end;
+}
+
+.buret-toolbar-row-main {
+  grid-template-columns: minmax(220px, 1fr) minmax(160px, 220px) minmax(148px, 220px) minmax(104px, 132px) auto;
+}
+
+.buret-toolbar-row-view {
+  grid-template-columns: auto minmax(190px, 260px) auto auto auto;
+  justify-content: start;
 }
 
 .buret-grid-toolbar label {
@@ -134,37 +183,23 @@ button:disabled {
   text-transform: uppercase;
 }
 
-.buret-grid-toolbar label:first-child {
-  flex: 1 1 280px;
+.buret-search-control,
+.buret-smarts-control,
+.buret-sort-control,
+.buret-load-control {
+  min-width: 0;
 }
 
-.buret-grid-toolbar label:nth-child(2) {
-  flex: 0 1 220px;
-}
-
-.buret-grid-toolbar label:nth-child(3) {
-  flex: 0 1 220px;
-}
-
-.buret-grid-toolbar label:nth-child(4) {
-  flex: 0 0 132px;
-}
-
-.buret-grid-toolbar input,
+.buret-grid-toolbar input[type="search"],
 .buret-grid-toolbar select {
   box-sizing: border-box;
   width: 100%;
   min-height: 34px;
-  border: 1px solid var(--buret-border);
-  border-radius: 8px;
   padding: 7px 10px;
-  color: var(--buret-text);
-  background: var(--buret-strong);
-  outline: none;
   text-transform: none;
 }
 
-.buret-grid-toolbar input:focus,
+.buret-grid-toolbar input[type="search"]:focus,
 .buret-grid-toolbar select:focus {
   border-color: var(--buret-accent);
   box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.20);
@@ -175,49 +210,155 @@ button:disabled {
   box-shadow: 0 0 0 3px rgba(255, 143, 143, 0.18);
 }
 
-.buret-clear-smarts {
+.buret-load-status {
+  justify-content: flex-end;
+  color: var(--buret-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.buret-load-sentinel {
+  height: 1px;
+  margin-top: 1px;
+}
+
+.buret-segmented-control {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.buret-segmented-control legend,
+.buret-scale-control {
+  color: var(--buret-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.buret-segmented-control > div {
+  display: inline-flex;
+  gap: 2px;
   min-height: 34px;
+  padding: 2px;
+  border: 1px solid var(--buret-border);
+  border-radius: 10px;
+  background: var(--buret-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10);
+}
+
+.buret-segmented-control button {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--buret-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.buret-segmented-control button.active {
+  color: #fff;
+  background: var(--buret-accent);
+  box-shadow: 0 1px 4px var(--buret-shadow);
+}
+
+.buret-scale-control {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.buret-scale-control span {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 48px;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+}
+
+.buret-scale-control input[type="range"] {
+  width: 100%;
+  accent-color: var(--buret-accent);
+}
+
+.buret-scale-control output {
+  color: var(--buret-muted);
+  font-size: 12px;
+  font-weight: 650;
+  text-align: right;
+  text-transform: none;
+}
+
+.buret-toggle-button {
+  align-self: end;
+  min-height: 34px;
+  color: var(--buret-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.buret-toggle-button.active {
+  color: #fff;
+  border-color: var(--buret-accent);
+  background: var(--buret-accent);
+  box-shadow: 0 1px 4px var(--buret-shadow);
+}
+
+.buret-clear-smarts {
+  align-self: end;
 }
 
 .buret-grid-renderer-switch {
-  display: flex;
+  display: inline-flex;
+  align-self: end;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   min-height: 34px;
-  padding-left: 6px;
-  border-left: 1px solid var(--buret-border);
+  padding: 2px;
+  border: 1px solid var(--buret-border);
+  border-radius: 10px;
+  background: var(--buret-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10);
 }
 
 .buret-grid-renderer-switch button {
-  min-height: 34px;
-}
-
-.buret-load-controls {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  box-shadow: none;
   color: var(--buret-muted);
   font-size: 12px;
+  font-weight: 650;
 }
 
-.buret-load-controls button {
-  min-height: 34px;
-  padding: 4px 8px;
+.buret-grid-renderer-switch button:hover {
+  color: var(--buret-text);
+  background: rgba(143, 199, 255, 0.16);
 }
 
 .buret-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(164px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(var(--buret-card-min), 1fr));
+  gap: var(--buret-card-gap);
 }
 
 .buret-card {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: minmax(var(--buret-picture-min-height), auto) auto;
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--buret-border);
-  border-radius: 7px;
+  border-radius: 10px;
   background: var(--buret-surface);
-  box-shadow: 0 6px 14px var(--buret-shadow);
-  transition: transform 120ms ease, border-color 120ms ease;
+  box-shadow: 0 8px 20px var(--buret-shadow);
+  transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .buret-card[role="button"] {
@@ -228,32 +369,38 @@ button:disabled {
 .buret-card:focus-visible {
   transform: translateY(-1px);
   border-color: var(--buret-accent);
+  box-shadow: 0 12px 26px var(--buret-shadow);
   outline: none;
 }
 
 .buret-card.selected {
   border-color: var(--buret-accent);
-  box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.22), 0 6px 14px var(--buret-shadow);
+  box-shadow: 0 0 0 3px rgba(143, 199, 255, 0.22), 0 10px 22px var(--buret-shadow);
 }
 
 .buret-card.smarts-match {
   border-color: rgba(255, 188, 92, 0.72);
+  box-shadow: 0 0 0 3px rgba(255, 188, 92, 0.20), 0 10px 22px var(--buret-shadow);
 }
 
 .buret-molecule-picture {
   display: grid;
   place-items: center;
-  min-height: 128px;
-  padding: 4px;
-  background: #fff;
+  min-height: var(--buret-picture-min-height);
+  padding: 8px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #fff 0%, #fbfbfc 100%);
 }
 
 .buret-molecule-picture svg {
   display: block;
   width: 100%;
-  max-width: 172px;
+  max-width: var(--buret-drawing-max-width);
   height: auto;
-  max-height: 124px;
+  max-height: var(--buret-drawing-max-height);
+  transform: scale(var(--buret-molecule-scale));
+  transform-origin: center;
+  transition: transform 120ms ease;
 }
 
 .buret-molecule-error {
@@ -262,8 +409,8 @@ button:disabled {
   gap: 6px;
   box-sizing: border-box;
   width: 100%;
-  min-height: 116px;
-  padding: 8px;
+  min-height: 170px;
+  padding: 12px;
   color: #4a2b2b;
   text-align: center;
   background: #fff8f8;
@@ -281,7 +428,8 @@ button:disabled {
 
 .buret-card-body {
   min-width: 0;
-  padding: 8px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--buret-border);
 }
 
 .buret-match-badge {
@@ -300,7 +448,7 @@ button:disabled {
 }
 
 .buret-card h2 {
-  margin: 0 0 4px;
+  margin: 0 0 6px;
   overflow: hidden;
   color: var(--buret-text);
   font-size: 14px;
@@ -311,7 +459,7 @@ button:disabled {
 
 .buret-smiles {
   overflow: hidden;
-  margin-bottom: 6px;
+  margin-bottom: 9px;
   color: var(--buret-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
@@ -323,7 +471,7 @@ button:disabled {
 .buret-metadata {
   display: grid;
   grid-template-columns: minmax(64px, 0.45fr) minmax(0, 1fr);
-  gap: 3px 6px;
+  gap: 5px 8px;
   margin: 0;
   color: var(--buret-muted);
   font-size: 11px;
@@ -353,14 +501,28 @@ button:disabled {
   grid-column: 1 / -1;
   padding: 48px 20px;
   border: 1px dashed var(--buret-border);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--buret-muted);
   text-align: center;
   background: var(--buret-surface);
 }
 
+body.buret-hide-properties .buret-smiles,
+body.buret-hide-properties .buret-metadata,
+body.buret-hide-properties .buret-no-metadata {
+  display: none;
+}
+
+body.buret-hide-properties .buret-card-body {
+  padding: 9px 11px 10px;
+}
+
+body.buret-hide-properties .buret-card h2 {
+  margin-bottom: 0;
+}
+
 .buret-grid-footer {
-  padding: 10px 2px 4px;
+  padding: 16px 2px 4px;
 }
 
 #status {
@@ -401,7 +563,20 @@ button:disabled {
     flex-wrap: wrap;
   }
 
+  .buret-toolbar-row-main,
+  .buret-toolbar-row-view {
+    grid-template-columns: 1fr;
+  }
+
+  .buret-toolbar-row-view {
+    justify-content: stretch;
+  }
+
+  .buret-load-status {
+    justify-content: start;
+  }
+
   .buret-grid {
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
   }
 }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -108,15 +108,16 @@
     });
   }
 
-  const DEFAULT_VIEWER_UI_SCALE = 0.86;
-  const MIN_VIEWER_UI_SCALE = 0.72;
-  const MAX_VIEWER_UI_SCALE = 1.35;
+  const DEFAULT_VIEWER_UI_SCALE = 1.0;
+  const MIN_VIEWER_UI_SCALE = 1.0;
+  const MAX_VIEWER_UI_SCALE = 1.0;
   const VIEWER_UI_SCALE_STEP = 0.08;
 
   let panelControlsVisible = window.BurretePanelControlsVisible !== false;
   let transparentBackground = false;
   let viewerTheme = 'auto';
-  let canvasBackground = 'black';
+  let canvasBackground = 'auto';
+  let overlayOpacity = 0.90;
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
   let activeViewer = null;
   let keyboardShortcutsInstalled = false;
@@ -124,10 +125,9 @@
 
   function applyConfigOptions(config) {
     panelControlsVisible = config.showPanelControls !== undefined ? !!config.showPanelControls : panelControlsVisible;
-    viewerTheme = readStoredViewerTheme() || normalizeViewerTheme(config.theme);
+    viewerTheme = normalizeViewerTheme(config.theme);
     canvasBackground = normalizeCanvasBackground(config.canvasBackground);
-    if (viewerTheme === 'dark' && canvasBackground === 'white') canvasBackground = 'black';
-    if (viewerTheme === 'light' && canvasBackground === 'black') canvasBackground = 'white';
+    overlayOpacity = normalizeOverlayOpacity(config.overlayOpacity);
     transparentBackground = canvasBackground === 'transparent' || config.transparentBackground === true;
     applyDocumentBackground();
     viewerUIScale = resolveInitialViewerScale(config);
@@ -156,6 +156,8 @@
     document.body.classList.toggle('burette-transparent-background', transparentBackground);
     document.body.classList.toggle('burette-opaque-background', !transparentBackground);
     document.documentElement.style.setProperty('--buret-canvas-background', canvasBackgroundCSS());
+    document.documentElement.style.setProperty('--buret-overlay-opacity', overlayOpacity.toFixed(2));
+    document.documentElement.style.setProperty('--buret-overlay-strong-opacity', Math.min(overlayOpacity + 0.06, 0.99).toFixed(2));
     updateThemeButton();
   }
 
@@ -197,19 +199,32 @@
   }
 
   function normalizeCanvasBackground(value) {
-    return ['black', 'graphite', 'white', 'transparent'].includes(value) ? value : 'black';
+    return ['auto', 'black', 'graphite', 'white', 'transparent'].includes(value) ? value : 'auto';
+  }
+
+  function normalizeOverlayOpacity(value) {
+    const opacity = Number(value);
+    if (!Number.isFinite(opacity)) return 0.90;
+    return Math.min(Math.max(opacity, 0.72), 0.98);
+  }
+
+  function resolvedCanvasBackground() {
+    if (canvasBackground === 'auto') return resolveViewerTheme() === 'light' ? 'white' : 'black';
+    return canvasBackground;
   }
 
   function canvasBackgroundCSS() {
-    if (canvasBackground === 'white') return '#f7f7f2';
-    if (canvasBackground === 'graphite') return '#111317';
-    if (canvasBackground === 'transparent') return 'transparent';
+    const background = resolvedCanvasBackground();
+    if (background === 'white') return '#f7f7f2';
+    if (background === 'graphite') return '#111317';
+    if (background === 'transparent') return 'transparent';
     return '#000000';
   }
 
   function canvasBackgroundColor() {
-    if (canvasBackground === 'white') return 0xf7f7f2;
-    if (canvasBackground === 'graphite') return 0x111317;
+    const background = resolvedCanvasBackground();
+    if (background === 'white') return 0xf7f7f2;
+    if (background === 'graphite') return 0x111317;
     return 0x000000;
   }
 
@@ -223,11 +238,12 @@
   }
 
   function applyViewerUIScale(viewer = activeViewer) {
-    const scaleValue = viewerUIScale.toFixed(2);
-    const hostHandledScale = postHostMessage({ type: 'viewerZoom', value: viewerUIScale });
+    // Mol* WebGL picking uses unscaled client coordinates; page/body zoom makes
+    // hover and click loci drift away from the visible cursor position.
+    postHostMessage({ type: 'viewerZoom', value: DEFAULT_VIEWER_UI_SCALE });
     document.documentElement.style.setProperty('--buret-viewer-ui-scale', '1');
     if (document.body) {
-      document.body.style.zoom = hostHandledScale ? '' : scaleValue;
+      document.body.style.zoom = '';
     }
 
     const pluginRoot = document.querySelector('.msp-plugin');
@@ -414,40 +430,6 @@
     applyLayoutState(viewer);
   }
 
-  function initFastViewportReset(viewer) {
-    if (document.documentElement.dataset.buretFastViewportReset === '1') return;
-    document.documentElement.dataset.buretFastViewportReset = '1';
-    document.addEventListener('click', event => {
-      const button = event.target.closest('.msp-viewport-controls button[title="Reset Zoom"]');
-      if (!button) return;
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-      resetCameraInstantly(viewer);
-    }, true);
-  }
-
-  function resetCameraInstantly(viewer) {
-    let handled = false;
-    try {
-      if (typeof viewer?.plugin?.managers?.camera?.reset === 'function') {
-        viewer.plugin.managers.camera.reset(0);
-        handled = true;
-      }
-    } catch (error) {
-      debug('fast viewport reset via camera manager failed: ' + (error && error.message || String(error)));
-    }
-    try {
-      if (!handled && typeof viewer?.plugin?.canvas3d?.requestCameraReset === 'function') {
-        viewer.plugin.canvas3d.requestCameraReset(0);
-        handled = true;
-      }
-    } catch (error) {
-      debug('fast viewport reset via canvas3d failed: ' + (error && error.message || String(error)));
-    }
-    try { viewer?.plugin?.canvas3d?.requestDraw?.(); } catch (_) {}
-  }
-
   function restoreToolbarCollapsed(toolbar, viewer) {
     let collapsed = false;
     try {
@@ -496,6 +478,7 @@
     let drag = null;
     toolbar.addEventListener('pointerdown', event => {
       if (event.target.closest('[data-buret-toggle]')) return;
+      if (event.target.closest('select, input, textarea')) return;
       if (!event.target.closest('[data-drag-handle]') && event.target.closest('.buret-button')) return;
       const rect = toolbar.getBoundingClientRect();
       drag = {
@@ -1150,7 +1133,6 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     applyViewerUIScale(viewer);
     initViewerKeyboardShortcuts(viewer);
     initBuretToolbar(viewer);
-    initFastViewportReset(viewer);
 
     await waitForAnimationFrame();
     applyLayoutState(viewer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.16",
+      "version": "0.10.17",
       "dependencies": {
         "@rdkit/rdkit": "2025.3.4-1.0.0",
         "molstar": "5.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/agent-preview.mjs
+++ b/scripts/agent-preview.mjs
@@ -93,7 +93,7 @@ async function main() {
     showPanelControls: true,
     defaultLayoutState: { left: 'hidden', right: 'hidden', top: 'hidden', bottom: 'hidden' },
     theme: 'auto',
-    canvasBackground: 'black'
+    canvasBackground: 'auto'
   };
   const dataBase64 = bytes.toString('base64');
   const token = Math.random().toString(36).slice(2) + Date.now().toString(36);

--- a/scripts/force-preview.sh
+++ b/scripts/force-preview.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 FILE="${1:-}"
 if [[ -z "$FILE" || ! -f "$FILE" ]]; then
-  echo "usage: $0 /path/to/structure.pdb|cif|mmcif|sdf" >&2
+  echo "usage: $0 /path/to/structure.pdb|cif|mmcif|sdf|smi|csv|tsv|xyz" >&2
   exit 1
 fi
 case "${FILE##*.}" in
@@ -10,8 +10,10 @@ case "${FILE##*.}" in
   cif|CIF) TYPE="com.local.burrete10.cif" ;;
   mmcif|MMCIF|mcif|MCIF) TYPE="com.local.burrete10.mmcif" ;;
   bcif|BCIF) TYPE="com.local.burrete10.bcif" ;;
+  csv|CSV) TYPE="public.comma-separated-values-text" ;;
   sdf|SDF|sd|SD) TYPE="com.local.burrete10.sdf" ;;
   smi|SMI|smiles|SMILES) TYPE="com.local.burrete10.smiles" ;;
+  tsv|TSV) TYPE="public.tab-separated-values-text" ;;
   mol|MOL) TYPE="com.local.burrete10.mol" ;;
   mol2|MOL2) TYPE="com.local.burrete10.mol2" ;;
   xyz|XYZ) TYPE="com.local.burrete10.xyz" ;;

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -74,14 +74,18 @@ else if (ext === 'cif') {
 else if (['mmcif', 'mcif'].includes(ext)) format = 'mmcif';
 else if (ext === 'bcif') { format = 'mmcif'; binary = true; }
 else if (['sdf', 'sd'].includes(ext)) format = 'sdf';
+else if (ext === 'csv') format = 'csv';
 else if (['smi', 'smiles'].includes(ext)) format = 'smiles';
+else if (ext === 'tsv') format = 'tsv';
 else if (ext === 'mol') format = 'mol';
 else if (ext === 'mol2') format = 'mol2';
 else if (ext === 'xyz') format = 'xyz';
 else if (ext === 'gro') format = 'gro';
 
-const renderer = ext === 'xyz' ? 'xyz-fast' : 'molstar';
+const gridExts = new Set(['csv', 'sd', 'sdf', 'smi', 'smiles', 'tsv']);
+const renderer = gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : 'molstar');
 const config = {
+  mode: gridExts.has(ext) ? 'grid2d' : 'structure',
   label: path.basename(file),
   format,
   molstarFormat: format,
@@ -91,7 +95,7 @@ const config = {
   byteCount: data.length,
   previewByteCount: data.length,
   theme: 'auto',
-  canvasBackground: 'black',
+  canvasBackground: 'auto',
   transparentBackground: false,
   sdfGrid: true,
   showPanelControls: true
@@ -129,14 +133,21 @@ const xyzFast = fs.readFileSync(xyzFastPath, 'utf8');
 const configSource = fs.readFileSync(configPath, 'utf8');
 const dataSource = fs.readFileSync(dataPath, 'utf8');
 const contentView = fs.readFileSync('App/ContentView.swift', 'utf8');
+const appDelegate = fs.readFileSync('App/BurreteApp.swift', 'utf8');
 const appViewer = fs.readFileSync('App/MoleculeViewerWindowController.swift', 'utf8');
 const quickLookViewer = fs.readFileSync('PreviewExtension/PreviewViewController.swift', 'utf8');
 const quickLookInfo = fs.readFileSync('PreviewExtension/Info.plist', 'utf8');
+const appInfo = fs.readFileSync('App/Info.plist', 'utf8');
+const gridBuilder = fs.readFileSync('PreviewExtension/MoleculeGridPreview.swift', 'utf8');
+const gridViewer = fs.readFileSync('PreviewExtension/Web/grid-viewer.js', 'utf8');
+const gridCSS = fs.readFileSync('PreviewExtension/Web/grid.css', 'utf8');
 const buildScript = fs.readFileSync('scripts/build.sh', 'utf8');
 const releaseScript = fs.readFileSync('scripts/release.sh', 'utf8');
+const forcePreview = fs.readFileSync('scripts/force-preview.sh', 'utf8');
 const xcodeProject = fs.readFileSync('Burrete.xcodeproj/project.pbxproj', 'utf8');
 const config = JSON.parse(configSource.replace(/^window\.BurreteConfig = /, '').replace(/;\s*$/, ''));
 const ext = path.extname(sample).toLowerCase().slice(1);
+const gridExts = new Set(['csv', 'sd', 'sdf', 'smi', 'smiles', 'tsv']);
 
 function assert(condition, message) {
   if (!condition) {
@@ -171,15 +182,77 @@ assert(agent.includes('window.BurreteAgent'), 'burette-agent.js must expose the 
 assert(agent.includes('window.BuretteAgent'), 'burette-agent.js must expose the BuretteAgent alias');
 assert(appViewer.includes('burette-agent.js'), 'app viewer runtime must copy and load burette-agent.js');
 assert(quickLookViewer.includes('burette-agent.js'), 'Quick Look runtime must copy and load burette-agent.js');
-assert(appViewer.includes('window.contentView = webView'), 'app viewer should use the native NSWindow resize border directly');
-assert(!appViewer.includes('BurreteAppViewerContainerView'), 'app viewer must not wrap WKWebView in a custom rounded border');
-assert(appViewer.includes('window.isOpaque = true'), 'app viewer window should keep normal opaque AppKit chrome');
-assert(appViewer.includes('window.backgroundColor = .windowBackgroundColor'), 'app viewer window should use a system window background');
-assert(contentView.includes('File Type Behavior'), 'settings should explain renderer behavior by file type');
-assert(contentView.includes('PDB / mmCIF / BinaryCIF / GRO'), 'settings should document protein-like formats');
-assert(contentView.includes('SDF / SMILES / MOL / MOL2'), 'settings should document small-molecule formats');
-assert(contentView.includes('External xyzrender (optional)'), 'settings should hide external xyzrender behind an optional advanced section');
-assert(!contentView.includes('foregroundColor(.white'), 'settings rows should not hard-code white text on light cards');
+assert(appDelegate.includes('UserDefaults.didChangeNotification'), 'app delegate must watch display preference changes');
+assert(appDelegate.includes('viewerRuntimePreferencesDidChange'), 'app delegate must route runtime preference changes to open viewers');
+assert(appDelegate.includes('ViewerRuntimePreferences'), 'app delegate must compare the full viewer runtime preference set');
+assert(appDelegate.includes('structureRendererMode'), 'app delegate must react when the renderer picker changes');
+assert(appDelegate.includes('xyzFastStyle'), 'app delegate must react when the Fast XYZ style picker changes');
+assert(appDelegate.includes('xyzrenderCustomConfigPath'), 'app delegate must react when xyzrender custom config changes');
+assert(appDelegate.includes('xyzrenderExecutablePath'), 'app delegate must react when xyzrender executable path changes');
+assert(appDelegate.includes('MoleculeGridFileSupport.load()'), 'app delegate must react when grid file support toggles change');
+assert(appDelegate.includes('rendererSettingsDiffer'), 'renderer setting changes must clear temporary toolbar overrides');
+assert(appDelegate.includes('controller.reloadDisplayPreferences()'), 'open app viewers must reload when display preferences change');
+assert(appViewer.includes('func reloadSettingsPreferences()'), 'app viewer must expose a settings-preference reload hook');
+assert(contentView.includes('@AppStorage("viewerTheme") private var viewerTheme = "auto"'), 'settings UI theme should default to auto');
+assert(contentView.includes('@AppStorage("viewerCanvasBackground") private var viewerCanvasBackground = "auto"'), 'settings UI canvas background should default to auto');
+assert(appDelegate.includes('string(forKey: "viewerTheme") ?? "auto"'), 'app display preferences should default theme to auto');
+assert(appDelegate.includes('string(forKey: "viewerCanvasBackground") ?? "auto"'), 'app display preferences should default canvas background to auto');
+assert(appViewer.includes('string(forKey: "viewerTheme") ?? "auto"'), 'standalone app viewer should default theme to auto');
+assert(appViewer.includes('string(forKey: "viewerCanvasBackground") ?? "auto"'), 'standalone app viewer should default canvas background to auto');
+assert(quickLookViewer.includes('CFPreferencesCopyAppValue("viewerTheme" as CFString, appID) as? String) ?? "auto"'), 'Quick Look should default theme to auto');
+assert(quickLookViewer.includes('CFPreferencesCopyAppValue("viewerCanvasBackground" as CFString, appID) as? String) ?? "auto"'), 'Quick Look should default canvas background to auto');
+assert(appViewer.includes('func enterFullScreen()'), 'standalone app viewer must expose native fullscreen for Quick Look handoff');
+assert(appViewer.includes('window.toggleFullScreen(nil)'), 'standalone app viewer should use AppKit native fullscreen');
+assert(!appViewer.includes('exitFullScreenMode'), 'standalone app viewer must not call AppKit fullscreen exit during open');
+assert(appViewer.includes('func reloadDisplayPreferences()'), 'app viewer must expose a display-preference reload hook');
+assert(appViewer.includes('applyWindowDisplayPreferences'), 'app viewer must update native window appearance and material preferences');
+assert(appViewer.includes('NSVisualEffectView'), 'app viewer transparency must use native macOS material instead of a fully clear custom window');
+assert(appViewer.includes('viewerWindowOpacity'), 'app viewer must expose configurable window material opacity');
+assert(appViewer.includes('viewerOverlayOpacity'), 'app viewer must expose configurable overlay readability');
+assert(appViewer.includes('defaultViewerPageZoom: CGFloat = 1.0'), 'app viewer must keep WKWebView page zoom at 1.0 so Mol* mouse picking stays aligned');
+assert(quickLookViewer.includes('defaultViewerPageZoom: CGFloat = 1.0'), 'Quick Look viewer must keep WKWebView page zoom at 1.0 so Mol* mouse picking stays aligned');
+assert(quickLookViewer.includes('requiredAssets: runtimeAssets(for: renderer)'), 'Quick Look should copy only renderer-required assets');
+assert(quickLookViewer.includes('requiresRDKit: true'), 'Quick Look grid previews should opt into RDKit assets explicitly');
+assert(quickLookViewer.includes('copyAssetIfNeeded'), 'Quick Look should reuse unchanged runtime assets instead of recopying every preview');
+assert(quickLookViewer.includes('gridRecordsScriptWithRDKitWasm'), 'Quick Look grid previews must pass RDKit wasm without file:// fetch');
+assert(quickLookViewer.includes('"smi", "smiles"'), 'Quick Look should allow SMILES files before grid dispatch');
+assert(quickLookViewer.includes('"csv"'), 'Quick Look should allow CSV files before grid dispatch');
+assert(quickLookViewer.includes('"tsv"'), 'Quick Look should allow TSV files before grid dispatch');
+assert(appViewer.includes('gridRecordsScriptWithRDKitWasm'), 'standalone grid previews must pass RDKit wasm without file:// fetch');
+assert(appViewer.includes('fileSupport: MoleculeGridFileSupport.load()'), 'standalone grid previews must honor enabled grid file types');
+assert(gridViewer.includes('wasmBinary'), 'grid viewer must initialize RDKit with an in-memory wasmBinary fallback');
+assert(gridViewer.includes('buret.grid.cardSize'), 'grid viewer must persist card size controls');
+assert(gridViewer.includes('buret.grid.moleculeScale'), 'grid viewer must persist molecule zoom controls');
+assert(gridViewer.includes('data-grid-size="compact"'), 'grid viewer must use stable segmented card-size controls');
+assert(gridViewer.includes('buret.grid.loadBatch'), 'grid viewer must persist infinite-scroll batch size controls');
+assert(gridViewer.includes('load-sentinel'), 'grid viewer must use a sentinel for infinite scrolling');
+assert(gridViewer.includes('IntersectionObserver'), 'grid viewer must dynamically append molecules while scrolling');
+assert(!gridViewer.includes('page-label'), 'grid viewer must not expose page navigation labels');
+assert(gridViewer.includes('buret-hide-properties'), 'grid viewer must allow hiding card metadata properties');
+assert(gridCSS.includes('--buret-card-min'), 'grid CSS must expose card size variables');
+assert(gridCSS.includes('--buret-molecule-scale'), 'grid CSS must expose molecule zoom variables');
+assert(gridCSS.includes('.buret-toolbar-row-main'), 'grid CSS must use named toolbar rows instead of fragile child selectors');
+assert(gridCSS.includes('.buret-segmented-control'), 'grid CSS must style segmented grid-size controls');
+assert(gridCSS.includes('.buret-load-status'), 'grid CSS must style infinite-scroll load status');
+assert(gridBuilder.includes('case "csv"'), 'grid builder must parse CSV molecule tables');
+assert(gridBuilder.includes('canonical_smiles'), 'grid builder must recognize canonical_smiles CSV columns');
+assert(contentView.includes('CSV tables'), 'settings UI must expose CSV molecule table support');
+assert(contentView.includes('TSV tables'), 'settings UI must expose TSV molecule table support');
+assert(quickLookInfo.includes('public.comma-separated-values-text'), 'Quick Look should support CSV table content type');
+assert(!quickLookInfo.includes('<string>public.comma-separated-values-text</string>\n\t\t\t\t\t<string>public.data</string>'), 'Quick Look should not claim every generic data file');
+assert(quickLookInfo.includes('public.tab-separated-values-text'), 'Quick Look should support TSV table content type');
+assert(quickLookInfo.includes('net.sourceforge.openbabel.xyz'), 'Quick Look should support Open Babel XYZ content type');
+assert(appInfo.includes('net.sourceforge.openbabel.xyz'), 'app document types should support Open Babel XYZ content type');
+assert(quickLookInfo.includes('com.local.burettexyzrender.smiles'), 'Quick Look should support existing SMILES content type');
+assert(quickLookInfo.includes('com.local.molstarquicklook10.smiles'), 'Quick Look should support legacy SMILES content type');
+assert(appDelegate.includes('com.local.burettexyzrender.smiles'), 'default-handler registration should include existing SMILES content type');
+assert(appDelegate.includes('com.local.molstarquicklook10.smiles'), 'default-handler registration should include legacy SMILES content type');
+assert(appDelegate.includes('public.comma-separated-values-text'), 'default-handler registration should include CSV table content type');
+assert(appDelegate.includes('public.tab-separated-values-text'), 'default-handler registration should include TSV table content type');
+assert(appDelegate.includes('MoleculeGridFileSupport.load()'), 'default-handler registration should respect enabled grid file type settings');
+assert(forcePreview.includes('smi|SMI|smiles|SMILES'), 'force-preview should support SMILES files');
+assert(forcePreview.includes('csv|CSV'), 'force-preview should support CSV files');
+assert(forcePreview.includes('tsv|TSV'), 'force-preview should support TSV files');
 assert(buildScript.includes('PreviewExtension/Web/burette-agent.js'), 'build script must require and syntax-check burette-agent.js');
 assert(releaseScript.includes('PreviewExtension/Web/burette-agent.js'), 'release script must require and syntax-check burette-agent.js');
 assert(xcodeProject.includes('PreviewExtension/Web/burette-agent.js'), 'Xcode validation phase must track burette-agent.js');
@@ -194,58 +267,30 @@ assert(!viewer.includes('initMolstarRightPanelToggle'), 'viewer.js must keep Mol
 assert(viewer.includes('VIEWER_THEME_STORAGE_KEY'), 'viewer.js must persist the separate theme toggle');
 assert(!viewer.includes('initMolstarThemeToggle'), 'viewer.js must keep Mol* Illumination button native');
 assert(viewer.includes("event.target.closest('[data-buret-toggle]')"), 'toolbar drag should not capture panel toggle buttons');
-assert(viewer.includes('startedOnHandle'), 'toolbar handle clicks should survive pointer capture retargeting');
-assert(viewer.includes('const shouldToggle = !drag.moved && drag.startedOnHandle'), 'toolbar handle click should collapse without checking the retargeted pointerup target');
-assert(viewer.includes('initFastViewportReset(viewer)'), 'viewer.js must install the instant Mol* reset-zoom handler');
-assert(viewer.includes('.msp-viewport-controls button[title="Reset Zoom"]'), 'instant reset must target only the Mol* Reset Zoom viewport button');
-assert(viewer.includes('viewer.plugin.managers.camera.reset(0)'), 'Mol* Reset Zoom should skip the slow default animation');
+assert(viewer.includes("event.target.closest('select, input, textarea')"), 'toolbar drag should not capture picker controls');
+assert(viewer.includes('startedOnHandle'), 'toolbar grip clicks should survive pointer capture and toggle collapse');
 assert(viewer.includes('toolbarSafeTop'), 'toolbar drag should clamp to the safe top inset');
+assert(!viewer.includes('initFastViewportReset'), 'Mol* reset camera button should keep its native click behavior');
+assert(!appViewer.includes('outerDragInset'), 'standalone app viewer should use the native window frame instead of an inset fake frame');
 assert(viewer.includes('normalizeViewerTheme'), 'viewer.js must support viewer themes');
 assert(viewer.includes('canvasBackgroundColor'), 'viewer.js must support configurable canvas backgrounds');
+assert(viewer.includes('resolvedCanvasBackground'), 'viewer.js must resolve auto canvas backgrounds from the active theme');
+assert(viewer.includes("['auto', 'black', 'graphite', 'white', 'transparent']"), 'viewer.js must accept auto canvas background mode');
 assert(viewer.includes('viewportBackgroundColor'), 'viewer.js must seed Mol* with the requested canvas background');
-const gridViewer = fs.readFileSync('PreviewExtension/Web/grid-viewer.js', 'utf8');
-const gridCSS = fs.readFileSync('PreviewExtension/Web/grid.css', 'utf8');
-assert(gridViewer.includes('new URL(`../assets/rdkit/${file}`, document.baseURI).href'), 'grid viewer must resolve RDKit WASM to an absolute file URL from the preview document');
-assert(gridViewer.includes('embeddedRDKitWasmBinary'), 'grid viewer must use the embedded Quick Look RDKit WASM payload when available');
-assert(gridViewer.includes('options.wasmBinary = wasmBinary'), 'grid viewer must pass embedded RDKit WASM bytes into initRDKitModule');
-assert(gridViewer.includes('get_qmol'), 'grid viewer must compile SMARTS with RDKit get_qmol');
-assert(gridViewer.includes('get_substruct_match'), 'grid viewer must filter molecules by SMARTS substructure matches');
-assert(gridViewer.includes('get_svg_with_highlights'), 'grid viewer must highlight SMARTS matches in molecule drawings');
-assert(gridViewer.includes('SMARTS match'), 'grid viewer must mark cards that match the SMARTS query');
-assert(gridViewer.includes('id="display-count"'), 'grid viewer must let the user choose the visible batch size');
-assert(gridViewer.includes('function loadMore(cfg)'), 'grid viewer must dynamically append more molecules without rerunning the filters');
-assert(gridViewer.includes('function scheduleAutoLoad(cfg)'), 'grid viewer must auto-load the next molecule batch while scrolling');
-assert(gridViewer.includes('state.rows.slice(0, state.visibleCount)'), 'grid viewer must render only the current visible molecule batch');
-assert(gridViewer.includes('data-buret-grid-renderer="molstar"'), 'app grid should expose a Mol* renderer switch for SDF collections');
-assert(gridViewer.includes('data-buret-grid-renderer="xyzrender-external"'), 'app grid should expose an xyzrender switch for SDF collections');
-assert(gridViewer.includes("post('setRenderer'"), 'app grid renderer switch must call the native host');
-assert(gridCSS.includes('repeat(auto-fill, minmax(164px, 1fr))'), 'grid cards should use a compact desktop column width');
-assert(gridCSS.includes('min-height: 128px'), 'grid molecule drawings should use a compact picture area');
-assert(quickLookViewer.includes('preview-rdkit-wasm.js'), 'Quick Look grid previews must write and load embedded RDKit WASM bytes');
-assert(quickLookViewer.includes('BurreteRDKitWasmBase64Chunks'), 'Quick Look grid previews must encode RDKit WASM as chunked base64');
-assert(appViewer.includes('preview-rdkit-wasm.js'), 'app grid previews must write and load embedded RDKit WASM bytes');
-assert(appViewer.includes('BurreteRDKitWasmBase64Chunks'), 'app grid previews must encode RDKit WASM as chunked base64');
-assert(quickLookViewer.includes('maxRecords: 3000'), 'Quick Look grid previews should load enough records for large collection browsing');
-assert(appViewer.includes('maxRecords: 10000'), 'app grid previews should load a larger record window for large collection browsing');
-assert(appViewer.includes('bypassGridForRendererSwitch'), 'app viewer should let SDF grid switch into renderer mode');
-assert(appViewer.includes('(isXYZ || isSDF) ? "xyzrender-external" : "molstar"'), 'app viewer should allow external xyzrender for SDF and XYZ');
-assert(viewer.includes("format === 'xyz' || format === 'sdf'"), 'viewer toolbar should expose renderer switching for XYZ and SDF');
-assert(viewer.includes("button.classList.toggle('hidden', isFastXYZOnly && format !== 'xyz')"), 'viewer toolbar should hide the Fast XYZ button outside XYZ files');
-assert(fs.readFileSync('scripts/force-preview.sh', 'utf8').includes('com.local.burrete10.smiles'), 'force-preview should support .smi/.smiles Quick Look previews');
-assert(quickLookInfo.includes('com.local.burrete10.smiles') && quickLookInfo.includes('<string>smi</string>') && quickLookInfo.includes('<string>smiles</string>'), 'Quick Look extension must export the SMILES UTI for .smi/.smiles previews');
-assert(quickLookInfo.includes('com.local.molstarquicklook10.smiles'), 'Quick Look extension must accept legacy SMILES UTI registrations');
-assert(quickLookViewer.includes('"smi", "smiles"'), 'Quick Look native extension gate must allow .smi/.smiles files');
-assert(!gridViewer.includes("locateFile: file => `../assets/rdkit/${file}`"), 'grid viewer must not use a relative RDKit WASM path in file:// Quick Look previews');
+assert(viewer.includes('Mol* WebGL picking uses unscaled client coordinates'), 'viewer.js must document why Mol* cannot use page/body zoom');
 assert(dataSource.startsWith('window.BurreteDataBase64 = "'), 'preview data file must define BurreteDataBase64');
 assert(config.label === path.basename(sample), 'config label should match sample basename');
+if (ext === 'csv') assert(config.format === 'csv' && config.mode === 'grid2d', 'CSV samples should be dispatched as grid2d CSV previews');
+if (ext === 'tsv') assert(config.format === 'tsv' && config.mode === 'grid2d', 'TSV samples should be dispatched as grid2d TSV previews');
+if (['smi', 'smiles'].includes(ext)) assert(config.format === 'smiles' && config.mode === 'grid2d', 'SMILES samples should be dispatched as grid2d previews');
 assert(typeof config.byteCount === 'number' && config.byteCount > 0, 'config byteCount should be positive');
 assert(config.theme === 'auto', 'theme should default to auto');
-assert(config.canvasBackground === 'black', 'canvas background should default to black');
+assert(config.canvasBackground === 'auto', 'canvas background should default to auto');
 assert(config.transparentBackground === false, 'transparent background should be opt-in');
 assert(config.sdfGrid === true, 'SDF grid flag should be encoded');
 assert(config.molstarFormat === config.format, 'molstarFormat should mirror the resolved Mol* format');
 assert(config.allowMolstarFallback === true, 'Mol* fallback flag should be encoded');
-assert(config.renderer === (ext === 'xyz' ? 'xyz-fast' : 'molstar'), 'renderer should select Fast XYZ only for .xyz in web test auto mode');
+assert(config.renderer === (gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : 'molstar')), 'renderer should select grid2d for molecule collections, Fast XYZ for .xyz, and Mol* otherwise');
 if (ext === 'xyz') {
   assert(config.xyzFast && config.xyzFast.firstFrameOnly === true, 'XYZ web test should encode first-frame Fast XYZ options');
   assert(config.xyzFast.showCell === true, 'XYZ web test should encode cell drawing preference');
@@ -261,8 +306,6 @@ const expectedFormats = {
   bcif: 'mmcif',
   sdf: 'sdf',
   sd: 'sdf',
-  smi: 'smiles',
-  smiles: 'smiles',
   mol: 'mol',
   mol2: 'mol2',
   xyz: 'xyz',


### PR DESCRIPTION
## Summary
- apply viewer settings changes immediately in open app windows
- add configurable grid support for SDF, SMILES, CSV, and TSV files
- improve molecule grid controls, infinite loading, card sizing, molecule zoom, properties toggle, SMARTS highlighting, and renderer handoff
- preserve native fullscreen handoff and native Mol* reset behavior after rebase

## Validation
- npm run check:js
- npm run test:web -- --no-open /Users/nikolenko/Desktop/BurettePreviewSamples/xyz/single.xyz
- npm run test:web -- --no-open /Users/nikolenko/Desktop/BurettePreviewSamples/tables/compounds.csv
- ./scripts/build.sh
- pre-push npm run ci