### PR TITLE
Add xyzrender orientation handoff

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -355,10 +355,13 @@ enum BurreteFileAssociations {
         "com.local.burrete10.mol",
         "com.local.burrete10.mol2",
         "com.local.burrete10.xyz",
+        "com.local.burrete10.xyzrender-input",
         "net.sourceforge.openbabel.xyz",
         // LaunchServices resolves bare .xyz files to this dynamic UTI on current macOS.
         "dyn.ah62d4rv4ge81u8p4",
         "com.local.burrete10.gro",
+        "com.local.burrete10.molecular-dynamics",
+        "com.local.burrete10.schrodinger",
         // LaunchServices resolves bare .gro files to this dynamic UTI on current macOS.
         "dyn.ah62d4rv4ge80s6xt",
         "com.local.molstarquicklook10.pdb",

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -962,7 +962,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.18")
+                Text("Version 0.10.19")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -13,22 +13,40 @@
 			<array>
 				<string>bcif</string>
 				<string>cif</string>
+				<string>cms</string>
 				<string>csv</string>
+				<string>cub</string>
+				<string>cube</string>
+				<string>dcd</string>
 				<string>ent</string>
+				<string>gro</string>
 				<string>mcif</string>
 				<string>mmcif</string>
 				<string>mol</string>
 				<string>mol2</string>
+				<string>in</string>
+				<string>lammpstrj</string>
+				<string>log</string>
+				<string>mae</string>
+				<string>mae.gz</string>
+				<string>maegz</string>
+				<string>nctraj</string>
+				<string>out</string>
 				<string>pdb</string>
 				<string>pdbqt</string>
 				<string>pqr</string>
+				<string>prmtop</string>
+				<string>psf</string>
 				<string>sd</string>
 				<string>sdf</string>
 				<string>smi</string>
 				<string>smiles</string>
+				<string>top</string>
+				<string>trr</string>
 				<string>tsv</string>
+				<string>vasp</string>
+				<string>xtc</string>
 				<string>xyz</string>
-				<string>gro</string>
 			</array>
 			<key>CFBundleTypeName</key>
 			<string>Molecular structure files</string>
@@ -98,9 +116,12 @@
 					<string>public.comma-separated-values-text</string>
 					<string>public.tab-separated-values-text</string>
 					<string>com.local.burrete10.xyz</string>
+					<string>com.local.burrete10.xyzrender-input</string>
 					<string>net.sourceforge.openbabel.xyz</string>
 					<string>dyn.ah62d4rv4ge81u8p4</string>
 					<string>com.local.burrete10.gro</string>
+					<string>com.local.burrete10.molecular-dynamics</string>
+					<string>com.local.burrete10.schrodinger</string>
 					<string>dyn.ah62d4rv4ge80s6xt</string>
 				</array>
 			</dict>
@@ -150,6 +171,29 @@
 				<array>
 					<string>chemical/x-pdb</string>
 					<string>chemical/x-pdbqt</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>xyzrender-compatible molecular structure file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.xyzrender-input</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cub</string>
+					<string>cube</string>
+					<string>in</string>
+					<string>log</string>
+					<string>out</string>
+					<string>vasp</string>
 				</array>
 			</dict>
 		</dict>
@@ -349,6 +393,50 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>gro</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Molecular dynamics trajectory or topology file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.molecular-dynamics</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>xtc</string>
+					<string>trr</string>
+					<string>dcd</string>
+					<string>nctraj</string>
+					<string>lammpstrj</string>
+					<string>top</string>
+					<string>psf</string>
+					<string>prmtop</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Schrodinger molecular structure file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.schrodinger</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mae</string>
+					<string>mae.gz</string>
+					<string>maegz</string>
+					<string>cms</string>
 				</array>
 			</dict>
 		</dict>

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -46,6 +46,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     private var currentViewerPageZoom: CGFloat = 1.0
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
+    private var xyzrenderOrientationRefText: String?
     private var isInNativeFullScreen = false
     private var isEnteringNativeFullScreen = false
     private static let defaultViewerPageZoom: CGFloat = 1.0
@@ -130,7 +131,8 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
             let runtime = try AppViewerRuntime.create(
                 for: fileURL,
                 rendererModeOverride: rendererOverride,
-                xyzrenderPresetOverride: xyzrenderPresetOverride
+                xyzrenderPresetOverride: xyzrenderPresetOverride,
+                xyzrenderOrientationRefText: xyzrenderOrientationRefText
             )
             webView.loadFileURL(runtime.indexURL, allowingReadAccessTo: runtime.readAccessURL)
         } catch {
@@ -146,6 +148,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     func reloadSettingsPreferences() {
         rendererOverride = nil
         xyzrenderPresetOverride = nil
+        xyzrenderOrientationRefText = nil
         reloadDisplayPreferences()
     }
 
@@ -188,8 +191,16 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
             exportText(text, suggestedName: name)
             return
         }
+        if type == "action", let action = body["message"] as? String {
+            handleJavaScriptAction(action)
+            return
+        }
+        if type == "setXyzrenderOrientation" {
+            setXyzrenderOrientation(body["text"] as? String ?? body["value"] as? String)
+            return
+        }
         if type == "setRenderer", let value = body["value"] as? String {
-            setRendererOverride(value)
+            setRendererOverride(value, orientationRefText: body["orientationRef"] as? String)
             return
         }
         if type == "setXyzrenderPreset", let value = body["value"] as? String {
@@ -222,6 +233,38 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         }
     }
 
+    private func handleJavaScriptAction(_ action: String) {
+        if action == "open-vesta" {
+            openCurrentFileInVesta()
+            return
+        }
+        NSLog("[BurreteAppViewer] %@: unknown action %@", fileURL.lastPathComponent, action)
+    }
+
+    private func openCurrentFileInVesta() {
+        guard Self.canOpenInVesta(fileExtension: Self.structurePathExtension(for: fileURL)) else {
+            NSLog("[BurreteAppViewer] %@: VESTA handoff is unsupported for this file type", fileURL.lastPathComponent)
+            return
+        }
+        do {
+            try VestaLauncher.open(fileURL: fileURL)
+            NSLog("[BurreteAppViewer] %@: opened in VESTA", fileURL.lastPathComponent)
+        } catch {
+            NSLog("[BurreteAppViewer] %@: VESTA open failed: %@", fileURL.lastPathComponent, String(describing: error))
+        }
+    }
+
+    private static func structurePathExtension(for url: URL) -> String {
+        if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
+            return "maegz"
+        }
+        return url.pathExtension.lowercased()
+    }
+
+    private static func canOpenInVesta(fileExtension: String) -> Bool {
+        ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
+    }
+
     private func copyToPasteboard(_ text: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
@@ -249,9 +292,13 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         }
     }
 
-    private func setRendererOverride(_ value: String) {
+    private func setRendererOverride(_ value: String, orientationRefText: String? = nil) {
         let renderer = AppViewerRendererMode.normalize(value)
-        guard rendererOverride != renderer else { return }
+        let hasNewOrientation = setXyzrenderOrientation(orientationRefText)
+        if renderer != "xyzrender-external" {
+            xyzrenderOrientationRefText = nil
+        }
+        guard rendererOverride != renderer || hasNewOrientation else { return }
         rendererOverride = renderer
         load()
     }
@@ -262,6 +309,28 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         xyzrenderPresetOverride = preset
         rendererOverride = "xyzrender-external"
         load()
+    }
+
+    @discardableResult
+    private func setXyzrenderOrientation(_ text: String?) -> Bool {
+        let normalized = Self.normalizedXyzrenderOrientationRef(text)
+        guard xyzrenderOrientationRefText != normalized else { return false }
+        xyzrenderOrientationRefText = normalized
+        return true
+    }
+
+    private static func normalizedXyzrenderOrientationRef(_ text: String?) -> String? {
+        guard let text else { return nil }
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+        guard normalized.utf8.count <= 4 * 1024 * 1024 else { return nil }
+        let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let first = lines.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let atomCount = Int(first),
+              atomCount > 0,
+              lines.count >= atomCount + 2 else {
+            return nil
+        }
+        return normalized.hasSuffix("\n") ? normalized : normalized + "\n"
     }
 
     private static func errorHTML(_ error: Error) -> String {
@@ -329,7 +398,8 @@ private struct AppViewerRuntime {
     static func create(
         for fileURL: URL,
         rendererModeOverride: String? = nil,
-        xyzrenderPresetOverride: String? = nil
+        xyzrenderPresetOverride: String? = nil,
+        xyzrenderOrientationRefText: String? = nil
     ) throws -> AppViewerRuntime {
         guard let bundledWebDirectory = Bundle.main.resourceURL?.appendingPathComponent("Web", isDirectory: true),
               FileManager.default.fileExists(atPath: bundledWebDirectory.path) else {
@@ -429,9 +499,13 @@ private struct AppViewerRuntime {
                     preset: xyzrenderPreset,
                     customConfigPath: UserDefaults.standard.string(forKey: "xyzrenderCustomConfigPath") ?? "",
                     transparent: canvasIsTransparent,
-                    extraArguments: UserDefaults.standard.string(forKey: "xyzrenderExtraArguments") ?? ""
+                    extraArguments: UserDefaults.standard.string(forKey: "xyzrenderExtraArguments") ?? "",
+                    orientationRefText: xyzrenderOrientationRefText
                 )
             } catch {
+                if format.isExternalXyzrenderOnly {
+                    throw error
+                }
                 renderer = format.molstarFormat == "xyz" ? "xyz-fast" : "molstar"
                 externalStatus = [
                     "status": "fallback",
@@ -463,8 +537,11 @@ private struct AppViewerRuntime {
             "transparentBackground": canvasIsTransparent,
             "sdfGrid": true,
             "appViewer": true,
+            "xyzrenderViewer": renderer == "xyzrender-external",
+            "molstarAvailable": !format.isExternalXyzrenderOnly,
             "xyzrenderPreset": xyzrenderPreset,
             "xyzrenderPresetOptions": AppViewerXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] },
+            "canOpenInVesta": canOpenInVesta(fileExtension: structurePathExtension(for: fileURL)),
             "showPanelControls": UserDefaults.standard.object(forKey: "showPreviewPanelControls") as? Bool ?? true,
             "defaultLayoutState": [
                 "left": "collapsed",
@@ -493,6 +570,7 @@ private struct AppViewerRuntime {
                 "renderer": "xyzrender",
                 "preset": externalArtifact.preset,
                 "config": externalArtifact.configArgument,
+                "orientationRef": externalArtifact.usedOrientationRef,
                 "elapsedMs": externalArtifact.elapsedMs,
                 "log": externalArtifact.log
             ]
@@ -596,6 +674,9 @@ private struct AppViewerRuntime {
     }
 
     private static func resolveRenderer(for format: AppViewerStructureFormat, rendererMode: String) -> String {
+        if format.isExternalXyzrenderOnly {
+            return "xyzrender-external"
+        }
         let isXYZ = format.molstarFormat == "xyz" && !format.isBinary
         switch AppViewerRendererMode.normalize(rendererMode) {
         case "molstar":
@@ -607,6 +688,17 @@ private struct AppViewerRuntime {
         default:
             return isXYZ ? "xyz-fast" : "molstar"
         }
+    }
+
+    private static func structurePathExtension(for url: URL) -> String {
+        if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
+            return "maegz"
+        }
+        return url.pathExtension.lowercased()
+    }
+
+    private static func canOpenInVesta(fileExtension: String) -> Bool {
+        ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
     }
 
     private struct XYZFastPayload {
@@ -1176,6 +1268,7 @@ private struct AppViewerRuntime {
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
             <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
+            <button class="buret-button hidden" type="button" data-buret-action="open-vesta" aria-label="Open in VESTA" title="Open in VESTA">VESTA</button>
             <div class="buret-renderer-control" data-buret-renderer-control>
               <button class="buret-button" type="button" data-buret-renderer="xyz-fast" aria-label="Use Fast XYZ SVG" title="Use Fast XYZ SVG">Fast</button>
               <button class="buret-button" type="button" data-buret-renderer="molstar" aria-label="Use Mol* Interactive" title="Use Mol* Interactive">Mol*</button>
@@ -1206,12 +1299,21 @@ private struct ExternalXyzrenderArtifact {
     let outputType: String
     let preset: String
     let configArgument: String
+    let usedOrientationRef: Bool
     let elapsedMs: Int
     let log: String
 }
 
 private enum ExternalXyzrenderWorker {
-    static func render(inputURL: URL, outputDirectory: URL, preset: String, customConfigPath: String, transparent: Bool, extraArguments: String) throws -> ExternalXyzrenderArtifact {
+    static func render(
+        inputURL: URL,
+        outputDirectory: URL,
+        preset: String,
+        customConfigPath: String,
+        transparent: Bool,
+        extraArguments: String,
+        orientationRefText: String?
+    ) throws -> ExternalXyzrenderArtifact {
         let fileManager = FileManager.default
         let outputURL = outputDirectory.appendingPathComponent("xyzrender.svg")
         let logURL = outputDirectory.appendingPathComponent("xyzrender.log")
@@ -1220,18 +1322,16 @@ private enum ExternalXyzrenderWorker {
 
         let process = Process()
         let configuredExecutable = UserDefaults.standard.string(forKey: "xyzrenderExecutablePath")?.trimmingCharacters(in: .whitespacesAndNewlines)
-        var arguments: [String]
-        if let configuredExecutable, !configuredExecutable.isEmpty {
-            process.executableURL = URL(fileURLWithPath: configuredExecutable)
-            arguments = [inputURL.path, "-o", outputURL.path]
-        } else {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            arguments = ["xyzrender", inputURL.path, "-o", outputURL.path]
-        }
+        process.executableURL = URL(fileURLWithPath: try resolvedExecutable(configuredExecutable ?? ""))
+        var arguments = [inputURL.path, "-o", outputURL.path]
         let safePreset = AppViewerXyzrenderPreset.normalize(preset)
         let configArgument = resolveConfigArgument(preset: safePreset, customConfigPath: customConfigPath)
         let effectivePreset = safePreset == "custom" && configArgument == "default" ? "default" : safePreset
         arguments += ["--config", configArgument]
+        let orientationRefURL = try writeOrientationRef(orientationRefText, outputDirectory: outputDirectory)
+        if let orientationRefURL {
+            arguments += ["--ref", orientationRefURL.path]
+        }
         if transparent { arguments.append("--transparent") }
         arguments += sanitizedExtraArguments(extraArguments)
         process.arguments = arguments
@@ -1262,13 +1362,62 @@ private enum ExternalXyzrenderWorker {
             throw ExternalXyzrenderError.missingOutput
         }
         let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
-        return ExternalXyzrenderArtifact(relativePath: "xyzrender.svg", outputType: "svg", preset: effectivePreset, configArgument: configArgument, elapsedMs: elapsedMs, log: log)
+        return ExternalXyzrenderArtifact(
+            relativePath: "xyzrender.svg",
+            outputType: "svg",
+            preset: effectivePreset,
+            configArgument: configArgument,
+            usedOrientationRef: orientationRefURL != nil,
+            elapsedMs: elapsedMs,
+            log: log
+        )
     }
 
     private static func resolveConfigArgument(preset: String, customConfigPath: String) -> String {
         guard preset == "custom" else { return preset }
         let trimmed = customConfigPath.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "default" : trimmed
+    }
+
+    private static func writeOrientationRef(_ text: String?, outputDirectory: URL) throws -> URL? {
+        guard let text, !text.isEmpty else { return nil }
+        let url = outputDirectory.appendingPathComponent("xyzrender-orientation-ref.xyz")
+        try Data(text.utf8).write(to: url, options: [.atomic])
+        return url
+    }
+
+    private static func resolvedExecutable(_ configuredExecutable: String) throws -> String {
+        if !configuredExecutable.isEmpty { return configuredExecutable }
+        let fileManager = FileManager.default
+        for directory in executableSearchPaths() {
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent("xyzrender").path
+            if fileManager.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+        throw ExternalXyzrenderError.missingExecutable
+    }
+
+    private static func executableSearchPaths() -> [String] {
+        let containerHome = FileManager.default.homeDirectoryForCurrentUser.path
+        let userHome = "/Users/\(NSUserName())"
+        var paths = [
+            "\(userHome)/.local/bin",
+            "\(userHome)/bin",
+            "\(containerHome)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        ]
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            paths += path.split(separator: ":").map(String.init)
+        }
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
     }
 
     private static func sanitizedExtraArguments(_ value: String) -> [String] {
@@ -1333,7 +1482,7 @@ private enum ExternalXyzrenderWorker {
 
     private static func mergedEnvironment() -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
-        let defaultPath = "/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let defaultPath = executableSearchPaths().joined(separator: ":")
         if let path = environment["PATH"], !path.isEmpty {
             environment["PATH"] = defaultPath + ":" + path
         } else {
@@ -1344,12 +1493,15 @@ private enum ExternalXyzrenderWorker {
 }
 
 private enum ExternalXyzrenderError: LocalizedError {
+    case missingExecutable
     case timedOut
     case missingOutput
     case failed(status: Int32, log: String)
 
     var errorDescription: String? {
         switch self {
+        case .missingExecutable:
+            return "External xyzrender executable was not found. Set an absolute xyzrender path in Burrete settings."
         case .timedOut:
             return "External xyzrender timed out after 25 seconds."
         case .missingOutput:
@@ -1365,9 +1517,10 @@ private struct AppViewerStructureFormat {
     let molstarFormat: String
     let isBinary: Bool
     var prefersTransparentBackground: Bool { molstarFormat == "sdf" }
+    var isExternalXyzrenderOnly: Bool { molstarFormat == "xyzrender" }
 
     init(url: URL, data: Data) {
-        let ext = url.pathExtension.lowercased()
+        let ext = url.lastPathComponent.lowercased().hasSuffix(".mae.gz") ? "maegz" : url.pathExtension.lowercased()
         switch ext {
         case "pdb", "ent", "pqr":
             molstarFormat = "pdb"
@@ -1401,6 +1554,18 @@ private struct AppViewerStructureFormat {
             isBinary = false
         case "gro":
             molstarFormat = "gro"
+            isBinary = false
+        case "xtc", "trr", "dcd", "nctraj":
+            molstarFormat = ext
+            isBinary = true
+        case "lammpstrj", "top", "psf", "prmtop":
+            molstarFormat = ext
+            isBinary = false
+        case "mae", "maegz", "cms":
+            molstarFormat = "xyzrender"
+            isBinary = false
+        case "cub", "cube", "in", "log", "out", "vasp":
+            molstarFormat = "xyzrender"
             isBinary = false
         default:
             molstarFormat = "mmcif"
@@ -1449,6 +1614,34 @@ private enum AppViewerError: LocalizedError {
             return "\(name) is too large for the Burrete app viewer (\(size) bytes; limit \(limit) bytes). Open it in a dedicated molecular viewer."
         case .missingCacheDirectory:
             return "Could not locate the app cache directory."
+        }
+    }
+}
+
+private enum VestaLauncher {
+    static func open(fileURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", "VESTA", fileURL.path]
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+            throw VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+}
+
+private enum VestaLaunchError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .failed(let message):
+            return message.isEmpty ? "VESTA could not be opened." : message
         }
     }
 }

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.18;
+				MARKETING_VERSION = 0.10.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -427,7 +427,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.18;
+				MARKETING_VERSION = 0.10.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -451,7 +451,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.18;
+				MARKETING_VERSION = 0.10.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.18;
+				MARKETING_VERSION = 0.10.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -86,6 +86,73 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Molecular dynamics trajectory or topology file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.molecular-dynamics</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>xtc</string>
+					<string>trr</string>
+					<string>dcd</string>
+					<string>nctraj</string>
+					<string>lammpstrj</string>
+					<string>top</string>
+					<string>psf</string>
+					<string>prmtop</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Schrodinger molecular structure file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.schrodinger</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mae</string>
+					<string>mae.gz</string>
+					<string>maegz</string>
+					<string>cms</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>xyzrender-compatible molecular structure file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.xyzrender-input</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cub</string>
+					<string>cube</string>
+					<string>in</string>
+					<string>log</string>
+					<string>out</string>
+					<string>vasp</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 	<key>NSExtension</key>
 	<dict>
@@ -152,9 +219,12 @@
 					<string>public.tab-separated-values-text</string>
 						<string>com.schrodinger.sdf</string>
 						<string>com.local.burrete10.xyz</string>
+						<string>com.local.burrete10.xyzrender-input</string>
 						<string>net.sourceforge.openbabel.xyz</string>
 						<string>dyn.ah62d4rv4ge81u8p4</string>
 						<string>com.local.burrete10.gro</string>
+						<string>com.local.burrete10.molecular-dynamics</string>
+						<string>com.local.burrete10.schrodinger</string>
 						<string>dyn.ah62d4rv4ge80s6xt</string>
 						<string>com.schrodinger.pdb</string>
 					</array>

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -16,6 +16,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private var currentPreviewURL: URL?
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
+    private var xyzrenderOrientationRefText: String?
     private static let showDebugOverlay = false
     private static let verboseLogging = false
     private static let defaultViewerPageZoom: CGFloat = 1.0
@@ -134,6 +135,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         currentPreviewURL = url
         rendererOverride = nil
         xyzrenderPresetOverride = nil
+        xyzrenderOrientationRefText = nil
         resetLog()
         hasRenderedTerminationError = false
         appendLog("preparePreviewOfFile called")
@@ -211,18 +213,19 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static let supportedStructureExtensions: Set<String> = [
-        "bcif", "cif", "csv", "ent", "gro", "mcif", "mmcif", "mol", "mol2", "pdb", "pdbqt", "pqr", "sd", "sdf", "smi", "smiles", "tsv", "xyz"
+        "bcif", "cif", "cms", "csv", "cub", "cube", "dcd", "ent", "gro", "in", "lammpstrj", "log", "mae", "maegz", "mcif", "mmcif", "mol", "mol2", "nctraj", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz"
     ]
 
     private static func buildInlinePreviewHTML(
         for url: URL,
         rendererOverride: String? = nil,
-        xyzrenderPresetOverride: String? = nil
+        xyzrenderPresetOverride: String? = nil,
+        xyzrenderOrientationRefText: String? = nil
     ) throws -> BuildResult {
         var diagnostics: [String] = []
         func diag(_ message: String) { diagnostics.append("[build] " + message) }
 
-        let pathExtension = url.pathExtension.lowercased()
+        let pathExtension = structurePathExtension(for: url)
         guard supportedStructureExtensions.contains(pathExtension) else {
             throw PreviewError.unsupportedStructureFile(url.lastPathComponent)
         }
@@ -295,13 +298,27 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             throw PreviewError.unsupportedStructureFile(url.lastPathComponent)
         }
 
-        let format = StructureFormat(url: url, data: structureData)
+        var format = StructureFormat(url: url, data: structureData)
         var renderer = resolvedRenderer(for: format, preferences: preferences, rendererOverride: rendererOverride)
+        var structureDataForWeb = structureData
         var externalArtifact: PreviewExternalXyzrenderArtifact?
         var externalArtifactSourceURL: URL?
         var externalStatus: [String: Any]?
         var temporaryExternalDirectory: URL?
         let xyzrenderPreset = PreviewXyzrenderPreset.normalize(xyzrenderPresetOverride ?? preferences.xyzrenderPreset)
+        if renderer == "xyzrender-external",
+           rendererOverride == nil,
+           format.isExternalXyzrenderOnly,
+           let convertedXYZ = PreviewStructureTextConverter.xyzData(
+            from: structureData,
+            fileExtension: pathExtension,
+            label: url.lastPathComponent
+           ) {
+            renderer = "xyz-fast"
+            format = .xyzFastCompatible
+            structureDataForWeb = convertedXYZ
+            diag("xyzrender.default=built-in-text-parser")
+        }
         if renderer == "xyzrender-external" {
             let renderDirectory = fileManager.temporaryDirectory
                 .appendingPathComponent("BurreteXYZRender-\(UUID().uuidString)", isDirectory: true)
@@ -316,17 +333,37 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                     customConfigPath: preferences.xyzrenderCustomConfigPath,
                     transparent: preferences.canvasBackground == "transparent",
                     executablePath: preferences.xyzrenderExecutablePath,
-                    extraArguments: preferences.xyzrenderExtraArguments
+                    extraArguments: preferences.xyzrenderExtraArguments,
+                    orientationRefText: xyzrenderOrientationRefText
                 )
                 externalArtifactSourceURL = renderDirectory.appendingPathComponent("xyzrender.svg")
             } catch {
-                renderer = "xyz-fast"
-                externalStatus = [
-                    "status": "fallback",
-                    "requested": "xyzrender-external",
-                    "message": error.localizedDescription
-                ]
-                diag("xyzrender.fallback=\(error.localizedDescription)")
+                if format.isExternalXyzrenderOnly,
+                   let convertedXYZ = PreviewStructureTextConverter.xyzData(
+                    from: structureData,
+                    fileExtension: pathExtension,
+                    label: url.lastPathComponent
+                   ) {
+                    renderer = "xyz-fast"
+                    format = .xyzFastCompatible
+                    structureDataForWeb = convertedXYZ
+                    externalStatus = [
+                        "status": "fallback",
+                        "requested": "xyzrender-external",
+                        "message": "Using built-in text structure parser because external xyzrender is unavailable in Quick Look."
+                    ]
+                    diag("xyzrender.fallback=built-in-text-parser error=\(error.localizedDescription)")
+                } else if format.isExternalXyzrenderOnly {
+                    throw error
+                } else {
+                    renderer = "xyz-fast"
+                    externalStatus = [
+                        "status": "fallback",
+                        "requested": "xyzrender-external",
+                        "message": error.localizedDescription
+                    ]
+                    diag("xyzrender.fallback=\(error.localizedDescription)")
+                }
             }
         }
         defer {
@@ -334,8 +371,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 try? fileManager.removeItem(at: temporaryExternalDirectory)
             }
         }
-        let xyzFastPayload = renderer == "xyz-fast" ? makeXYZFastPayload(from: structureData) : nil
-        let structureDataForWeb = xyzFastPayload?.data ?? structureData
+        let xyzFastPayload = renderer == "xyz-fast" ? makeXYZFastPayload(from: structureDataForWeb) : nil
+        structureDataForWeb = xyzFastPayload?.data ?? structureDataForWeb
         diag("detected.format=\(format.molstarFormat) binary=\(format.isBinary) renderer=\(renderer)")
         if let xyzFastPayload {
             diag("xyzFast.firstFrame.bytes=\(xyzFastPayload.data.count) atoms=\(xyzFastPayload.atomCount ?? -1) frames=\(xyzFastPayload.frameCount ?? -1)")
@@ -351,6 +388,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             externalArtifact: externalArtifact,
             externalStatus: externalStatus,
             xyzrenderPreset: xyzrenderPreset,
+            originalFileExtension: pathExtension,
             preferences: preferences
         )
         let base64 = structureDataForWeb.base64EncodedString(options: [])
@@ -578,6 +616,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         externalArtifact: PreviewExternalXyzrenderArtifact?,
         externalStatus: [String: Any]?,
         xyzrenderPreset: String,
+        originalFileExtension: String,
         preferences: PreviewPreferences
     ) throws -> String {
         var payload: [String: Any] = [
@@ -598,8 +637,17 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "transparentBackground": preferences.canvasBackground == "transparent",
             "sdfGrid": true,
             "showPanelControls": preferences.showPanelControls,
-            "defaultLayoutState": preferences.defaultLayoutState
+            "defaultLayoutState": preferences.defaultLayoutState,
+            "canOpenInVesta": canOpenInVesta(fileExtension: originalFileExtension)
         ]
+        if renderer == "xyzrender-external" {
+            payload["xyzrenderViewer"] = true
+            payload["molstarAvailable"] = !format.isExternalXyzrenderOnly
+            payload["quickLookViewer"] = true
+            payload["requestedRenderer"] = "auto"
+            payload["xyzrenderPreset"] = xyzrenderPreset
+            payload["xyzrenderPresetOptions"] = PreviewXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] }
+        }
         if format.molstarFormat == "xyz" && !format.isBinary {
             payload["quickLookViewer"] = true
             payload["requestedRenderer"] = "auto"
@@ -626,6 +674,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 "renderer": "xyzrender",
                 "preset": externalArtifact.preset,
                 "config": externalArtifact.configArgument,
+                "orientationRef": externalArtifact.usedOrientationRef,
                 "elapsedMs": externalArtifact.elapsedMs,
                 "log": externalArtifact.log
             ]
@@ -1205,6 +1254,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
             <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
             <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
+            <button class="buret-button hidden" type="button" data-buret-action="open-vesta" aria-label="Open in VESTA" title="Open in VESTA">VESTA</button>
             <div class="buret-renderer-control" data-buret-renderer-control>
               <button class="buret-button" type="button" data-buret-renderer="xyz-fast" aria-label="Use Fast XYZ SVG" title="Use Fast XYZ SVG">Fast</button>
               <button class="buret-button" type="button" data-buret-renderer="molstar" aria-label="Use Mol* Interactive" title="Use Mol* Interactive">Mol*</button>
@@ -1295,6 +1345,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static func resolvedRenderer(for format: StructureFormat, preferences _: PreviewPreferences, rendererOverride: String?) -> String {
+        if format.isExternalXyzrenderOnly {
+            return "xyzrender-external"
+        }
         let isXYZ = format.molstarFormat == "xyz" && !format.isBinary
         guard let rendererOverride else { return isXYZ ? "xyz-fast" : "molstar" }
         switch normalizeRendererMode(rendererOverride) {
@@ -1369,18 +1422,31 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     private static func quickLookSizeLimit(for url: URL) -> Int64 {
         let mib: Int64 = 1024 * 1024
-        switch url.pathExtension.lowercased() {
+        switch structurePathExtension(for: url) {
         case "pdb", "ent", "pdbqt", "pqr":
             return 35 * mib
         case "cif", "mmcif", "mcif":
             return 40 * mib
         case "bcif":
             return 50 * mib
-        case "csv", "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles", "tsv":
+        case "csv", "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles", "tsv", "cub", "cube", "in", "log", "out", "vasp", "lammpstrj", "top", "psf", "prmtop", "mae", "maegz", "cms":
             return 25 * mib
+        case "xtc", "trr", "dcd", "nctraj":
+            return 75 * mib
         default:
             return 20 * mib
         }
+    }
+
+    private static func structurePathExtension(for url: URL) -> String {
+        if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
+            return "maegz"
+        }
+        return url.pathExtension.lowercased()
+    }
+
+    private static func canOpenInVesta(fileExtension: String) -> Bool {
+        ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
     }
 
     private func scheduleRenderTimeout(for requestID: UUID) {
@@ -1460,11 +1526,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 return
             }
             if type == "setRenderer", let value = body["value"] as? String {
-                setRendererOverride(value)
+                setRendererOverride(value, orientationRefText: body["orientationRef"] as? String)
                 return
             }
             if type == "setXyzrenderPreset", let value = body["value"] as? String {
                 setXyzrenderPresetOverride(value)
+                return
+            }
+            if type == "setXyzrenderOrientation" {
+                setXyzrenderOrientation(body["text"] as? String ?? body["value"] as? String)
                 return
             }
             appendLog("JS message type=\(type): \(text.prefix(1600))")
@@ -1484,12 +1554,37 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     private func handleJavaScriptAction(_ action: String) {
         appendLog("JS action=\(action)")
+        if action == "open-vesta" {
+            openCurrentPreviewInVesta()
+            return
+        }
         appendLog("unknown JS action=\(action)")
     }
 
-    private func setRendererOverride(_ value: String) {
+    private func openCurrentPreviewInVesta() {
+        guard let url = currentPreviewURL else {
+            appendLog("openInVesta.missingCurrentURL")
+            return
+        }
+        guard Self.canOpenInVesta(fileExtension: Self.structurePathExtension(for: url)) else {
+            appendLog("openInVesta.unsupportedExtension=\(Self.structurePathExtension(for: url))")
+            return
+        }
+        do {
+            try VestaLauncher.open(fileURL: url)
+            appendLog("openInVesta.launched=\(url.path)")
+        } catch {
+            appendLog("openInVesta.failed=\(error.localizedDescription)")
+        }
+    }
+
+    private func setRendererOverride(_ value: String, orientationRefText: String? = nil) {
         let renderer = Self.normalizeRendererMode(value)
-        guard rendererOverride != renderer else { return }
+        let hasNewOrientation = setXyzrenderOrientation(orientationRefText)
+        if renderer != "xyzrender-external" {
+            xyzrenderOrientationRefText = nil
+        }
+        guard rendererOverride != renderer || hasNewOrientation else { return }
         rendererOverride = renderer
         reloadCurrentPreview()
     }
@@ -1502,6 +1597,28 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         reloadCurrentPreview()
     }
 
+    @discardableResult
+    private func setXyzrenderOrientation(_ text: String?) -> Bool {
+        let normalized = Self.normalizedXyzrenderOrientationRef(text)
+        guard xyzrenderOrientationRefText != normalized else { return false }
+        xyzrenderOrientationRefText = normalized
+        return true
+    }
+
+    private static func normalizedXyzrenderOrientationRef(_ text: String?) -> String? {
+        guard let text else { return nil }
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+        guard normalized.utf8.count <= 4 * 1024 * 1024 else { return nil }
+        let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let first = lines.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let atomCount = Int(first),
+              atomCount > 0,
+              lines.count >= atomCount + 2 else {
+            return nil
+        }
+        return normalized.hasSuffix("\n") ? normalized : normalized + "\n"
+    }
+
     private func reloadCurrentPreview() {
         guard let url = currentPreviewURL else { return }
         let requestID = UUID()
@@ -1510,14 +1627,16 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         hasRenderedTerminationError = false
         let rendererOverride = rendererOverride
         let xyzrenderPresetOverride = xyzrenderPresetOverride
-        appendLog("reloading preview rendererOverride=\(rendererOverride ?? "nil") xyzrenderPresetOverride=\(xyzrenderPresetOverride ?? "nil")")
+        let xyzrenderOrientationRefText = xyzrenderOrientationRefText
+        appendLog("reloading preview rendererOverride=\(rendererOverride ?? "nil") xyzrenderPresetOverride=\(xyzrenderPresetOverride ?? "nil") orientationRef=\(xyzrenderOrientationRefText == nil ? "nil" : "set")")
         statusLabel.stringValue = "[native] Switching renderer...\n\(url.lastPathComponent)"
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
                 let result = try Self.buildInlinePreviewHTML(
                     for: url,
                     rendererOverride: rendererOverride,
-                    xyzrenderPresetOverride: xyzrenderPresetOverride
+                    xyzrenderPresetOverride: xyzrenderPresetOverride,
+                    xyzrenderOrientationRefText: xyzrenderOrientationRefText
                 )
                 DispatchQueue.main.async { [weak self] in
                     guard let self, self.activePreviewRequestID == requestID else { return }
@@ -1756,13 +1875,258 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 }
 
+private enum PreviewStructureTextConverter {
+    private struct Atom {
+        let symbol: String
+        let x: Double
+        let y: Double
+        let z: Double
+    }
+
+    private typealias Vec3 = (Double, Double, Double)
+
+    static func xyzData(from data: Data, fileExtension: String, label: String) -> Data? {
+        let text = decodeText(data)
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let atoms: [Atom]?
+        switch fileExtension.lowercased() {
+        case "cub", "cube":
+            atoms = parseCube(lines)
+        case "vasp":
+            atoms = parseVasp(lines)
+        case "in":
+            atoms = parseQuantumEspressoInput(lines)
+        case "out":
+            atoms = parseOrcaOutput(lines)
+        case "log":
+            atoms = parseGaussianOutput(lines) ?? parseOrcaOutput(lines)
+        default:
+            atoms = nil
+        }
+        guard let atoms, !atoms.isEmpty else { return nil }
+        var xyz = "\(atoms.count)\nConverted from \(label)\n"
+        for atom in atoms {
+            xyz += "\(atom.symbol) \(format(atom.x)) \(format(atom.y)) \(format(atom.z))\n"
+        }
+        return Data(xyz.utf8)
+    }
+
+    private static func parseCube(_ lines: [String]) -> [Atom]? {
+        guard lines.count >= 6 else { return nil }
+        let countFields = fields(lines[2])
+        guard let atomCountToken = countFields.first, let atomCount = Int(atomCountToken), atomCount != 0 else { return nil }
+        let count = abs(atomCount)
+        guard lines.count >= 6 + count else { return nil }
+        return (0..<count).compactMap { index in
+            let parts = fields(lines[6 + index])
+            guard parts.count >= 5, let number = Int(parts[0]),
+                  let x = Double(parts[2]), let y = Double(parts[3]), let z = Double(parts[4]) else { return nil }
+            return Atom(symbol: symbol(for: number), x: x, y: y, z: z)
+        }
+    }
+
+    private static func parseVasp(_ lines: [String]) -> [Atom]? {
+        guard lines.count >= 8, let scale = Double(lines[1].trimmingCharacters(in: .whitespacesAndNewlines)) else { return nil }
+        guard let a = parseVector(lines[2], scale: scale),
+              let b = parseVector(lines[3], scale: scale),
+              let c = parseVector(lines[4], scale: scale) else { return nil }
+        let symbols = fields(lines[5])
+        let counts = fields(lines[6]).compactMap(Int.init)
+        guard !symbols.isEmpty, symbols.count == counts.count else { return nil }
+        var index = 7
+        if index < lines.count && lines[index].trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("s") {
+            index += 1
+        }
+        guard index < lines.count else { return nil }
+        let mode = lines[index].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let direct = mode.hasPrefix("d")
+        index += 1
+        var atoms: [Atom] = []
+        for (symbolIndex, symbol) in symbols.enumerated() {
+            for _ in 0..<counts[symbolIndex] {
+                guard index < lines.count else { return atoms.isEmpty ? nil : atoms }
+                let parts = fields(lines[index])
+                index += 1
+                guard parts.count >= 3, let x = Double(parts[0]), let y = Double(parts[1]), let z = Double(parts[2]) else { continue }
+                let position = direct ? combine(x, a, y, b, z, c) : (x * scale, y * scale, z * scale)
+                atoms.append(Atom(symbol: symbol, x: position.0, y: position.1, z: position.2))
+            }
+        }
+        return atoms
+    }
+
+    private static func parseQuantumEspressoInput(_ lines: [String]) -> [Atom]? {
+        var cell: [Vec3] = []
+        var cellScale = 1.0
+        var atomStart: Int?
+        var direct = false
+        for index in lines.indices {
+            let lower = lines[index].lowercased()
+            if lower.trimmingCharacters(in: .whitespaces).hasPrefix("cell_parameters") {
+                if lower.contains("bohr") { cellScale = 0.529177210903 }
+                cell = (1...3).compactMap { offset in
+                    guard index + offset < lines.count else { return nil }
+                    return parseVector(lines[index + offset], scale: cellScale)
+                }
+            }
+            if lower.trimmingCharacters(in: .whitespaces).hasPrefix("atomic_positions") {
+                atomStart = index + 1
+                direct = lower.contains("crystal")
+            }
+        }
+        guard let atomStart else { return nil }
+        var atoms: [Atom] = []
+        for line in lines[atomStart...] {
+            let parts = fields(line)
+            guard parts.count >= 4 else { break }
+            guard let x = Double(parts[1]), let y = Double(parts[2]), let z = Double(parts[3]) else { break }
+            let position: Vec3
+            if direct, cell.count == 3 {
+                position = combine(x, cell[0], y, cell[1], z, cell[2])
+            } else {
+                position = (x, y, z)
+            }
+            atoms.append(Atom(symbol: parts[0], x: position.0, y: position.1, z: position.2))
+        }
+        return atoms.isEmpty ? nil : atoms
+    }
+
+    private static func parseOrcaOutput(_ lines: [String]) -> [Atom]? {
+        var best: [Atom]?
+        var index = 0
+        while index < lines.count {
+            if lines[index].contains("CARTESIAN COORDINATES (ANGSTROEM)") {
+                var atoms: [Atom] = []
+                index += 1
+                while index < lines.count && !(fields(lines[index]).first.map { isElementSymbol($0) } ?? false) {
+                    index += 1
+                }
+                while index < lines.count {
+                    let parts = fields(lines[index])
+                    guard parts.count >= 4, isElementSymbol(parts[0]),
+                          let x = Double(parts[1]), let y = Double(parts[2]), let z = Double(parts[3]) else { break }
+                    atoms.append(Atom(symbol: parts[0], x: x, y: y, z: z))
+                    index += 1
+                }
+                if !atoms.isEmpty { best = atoms }
+            } else {
+                index += 1
+            }
+        }
+        return best
+    }
+
+    private static func parseGaussianOutput(_ lines: [String]) -> [Atom]? {
+        var best: [Atom]?
+        var index = 0
+        while index < lines.count {
+            if lines[index].contains("Standard orientation:") || lines[index].contains("Input orientation:") {
+                var atoms: [Atom] = []
+                index += 1
+                var separators = 0
+                while index < lines.count && separators < 2 {
+                    if lines[index].contains("-----") { separators += 1 }
+                    index += 1
+                }
+                while index < lines.count {
+                    if lines[index].contains("-----") { break }
+                    let parts = fields(lines[index])
+                    guard parts.count >= 6, let number = Int(parts[1]),
+                          let x = Double(parts[3]), let y = Double(parts[4]), let z = Double(parts[5]) else {
+                        index += 1
+                        continue
+                    }
+                    atoms.append(Atom(symbol: symbol(for: number), x: x, y: y, z: z))
+                    index += 1
+                }
+                if !atoms.isEmpty { best = atoms }
+            } else {
+                index += 1
+            }
+        }
+        return best ?? parseGaussianSymbolicZMatrix(lines)
+    }
+
+    private static func parseGaussianSymbolicZMatrix(_ lines: [String]) -> [Atom]? {
+        guard let start = lines.firstIndex(where: { $0.contains("Symbolic Z-matrix:") }) else { return nil }
+        var atoms: [Atom] = []
+        for line in lines[(start + 1)...] {
+            let parts = fields(line)
+            if parts.isEmpty { continue }
+            if parts.first == "Charge" { continue }
+            guard parts.count >= 4, isElementSymbol(parts[0]),
+                  let x = Double(parts[1]), let y = Double(parts[2]), let z = Double(parts[3]) else {
+                if !atoms.isEmpty { break }
+                continue
+            }
+            atoms.append(Atom(symbol: parts[0], x: x, y: y, z: z))
+        }
+        return atoms.isEmpty ? nil : atoms
+    }
+
+    private static func fields(_ line: String) -> [String] {
+        line.split { $0 == " " || $0 == "\t" }.map(String.init)
+    }
+
+    private static func parseVector(_ line: String, scale: Double) -> Vec3? {
+        let parts = fields(line)
+        guard parts.count >= 3, let x = Double(parts[0]), let y = Double(parts[1]), let z = Double(parts[2]) else { return nil }
+        return (x * scale, y * scale, z * scale)
+    }
+
+    private static func combine(_ x: Double, _ a: Vec3, _ y: Double, _ b: Vec3, _ z: Double, _ c: Vec3) -> Vec3 {
+        (x * a.0 + y * b.0 + z * c.0, x * a.1 + y * b.1 + z * c.1, x * a.2 + y * b.2 + z * c.2)
+    }
+
+    private static func isElementSymbol(_ value: String) -> Bool {
+        symbolsByNumber.contains { $0 == value.capitalized }
+    }
+
+    private static func symbol(for atomicNumber: Int) -> String {
+        guard atomicNumber > 0, atomicNumber <= symbolsByNumber.count else { return "X" }
+        return symbolsByNumber[atomicNumber - 1]
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.6f", value)
+    }
+
+    private static func decodeText(_ data: Data) -> String {
+        if let value = String(data: data, encoding: .utf8) { return value }
+        if let value = String(data: data, encoding: .isoLatin1) { return value }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static let symbolsByNumber = [
+        "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne",
+        "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca",
+        "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+        "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y", "Zr",
+        "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
+        "Sb", "Te", "I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd",
+        "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
+        "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg",
+        "Tl", "Pb", "Bi", "Po", "At", "Rn"
+    ]
+}
+
 private struct StructureFormat {
     let molstarFormat: String
     let isBinary: Bool
     var prefersTransparentBackground: Bool { molstarFormat == "sdf" }
+    var isExternalXyzrenderOnly: Bool { molstarFormat == "xyzrender" }
+
+    static let xyzFastCompatible = StructureFormat(molstarFormat: "xyz", isBinary: false)
+
+    private init(molstarFormat: String, isBinary: Bool) {
+        self.molstarFormat = molstarFormat
+        self.isBinary = isBinary
+    }
 
     init(url: URL, data: Data) {
-        let ext = url.pathExtension.lowercased()
+        let ext = url.lastPathComponent.lowercased().hasSuffix(".mae.gz") ? "maegz" : url.pathExtension.lowercased()
         switch ext {
         case "pdb", "ent", "pqr":
             self.molstarFormat = "pdb"
@@ -1793,6 +2157,18 @@ private struct StructureFormat {
             self.isBinary = false
         case "gro":
             self.molstarFormat = "gro"
+            self.isBinary = false
+        case "xtc", "trr", "dcd", "nctraj":
+            self.molstarFormat = ext
+            self.isBinary = true
+        case "lammpstrj", "top", "psf", "prmtop":
+            self.molstarFormat = ext
+            self.isBinary = false
+        case "mae", "maegz", "cms":
+            self.molstarFormat = "xyzrender"
+            self.isBinary = false
+        case "cub", "cube", "in", "log", "out", "vasp":
+            self.molstarFormat = "xyzrender"
             self.isBinary = false
         default:
             self.molstarFormat = "mmcif"
@@ -1860,6 +2236,7 @@ private struct PreviewExternalXyzrenderArtifact {
     let outputType: String
     let preset: String
     let configArgument: String
+    let usedOrientationRef: Bool
     let elapsedMs: Int
     let log: String
 }
@@ -1873,7 +2250,8 @@ private enum PreviewExternalXyzrenderWorker {
         customConfigPath: String,
         transparent: Bool,
         executablePath: String,
-        extraArguments: String
+        extraArguments: String,
+        orientationRefText: String?
     ) throws -> PreviewExternalXyzrenderArtifact {
         let fileManager = FileManager.default
         let inputURL = outputDirectory.appendingPathComponent(safeInputFilename(sourceFilename))
@@ -1885,19 +2263,17 @@ private enum PreviewExternalXyzrenderWorker {
 
         let process = Process()
         let configuredExecutable = executablePath.trimmingCharacters(in: .whitespacesAndNewlines)
-        var arguments: [String]
-        if configuredExecutable.isEmpty {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            arguments = ["xyzrender", inputURL.path, "-o", outputURL.path]
-        } else {
-            process.executableURL = URL(fileURLWithPath: configuredExecutable)
-            arguments = [inputURL.path, "-o", outputURL.path]
-        }
+        process.executableURL = URL(fileURLWithPath: try resolvedExecutable(configuredExecutable))
+        var arguments = [inputURL.path, "-o", outputURL.path]
 
         let safePreset = PreviewXyzrenderPreset.normalize(preset)
         let configArgument = resolveConfigArgument(preset: safePreset, customConfigPath: customConfigPath)
         let effectivePreset = safePreset == "custom" && configArgument == "default" ? "default" : safePreset
         arguments += ["--config", configArgument]
+        let orientationRefURL = try writeOrientationRef(orientationRefText, outputDirectory: outputDirectory)
+        if let orientationRefURL {
+            arguments += ["--ref", orientationRefURL.path]
+        }
         if transparent { arguments.append("--transparent") }
         arguments += sanitizedExtraArguments(extraArguments)
         process.arguments = arguments
@@ -1933,6 +2309,7 @@ private enum PreviewExternalXyzrenderWorker {
             outputType: "svg",
             preset: effectivePreset,
             configArgument: configArgument,
+            usedOrientationRef: orientationRefURL != nil,
             elapsedMs: elapsedMs,
             log: log
         )
@@ -1941,6 +2318,47 @@ private enum PreviewExternalXyzrenderWorker {
     private static func safeInputFilename(_ filename: String) -> String {
         let ext = URL(fileURLWithPath: filename).pathExtension
         return ext.isEmpty ? "input.xyz" : "input.\(ext)"
+    }
+
+    private static func writeOrientationRef(_ text: String?, outputDirectory: URL) throws -> URL? {
+        guard let text, !text.isEmpty else { return nil }
+        let url = outputDirectory.appendingPathComponent("xyzrender-orientation-ref.xyz")
+        try Data(text.utf8).write(to: url, options: [.atomic])
+        return url
+    }
+
+    private static func resolvedExecutable(_ configuredExecutable: String) throws -> String {
+        if !configuredExecutable.isEmpty { return configuredExecutable }
+        let fileManager = FileManager.default
+        for directory in executableSearchPaths() {
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent("xyzrender").path
+            if fileManager.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+        throw PreviewExternalXyzrenderError.missingExecutable
+    }
+
+    private static func executableSearchPaths() -> [String] {
+        let containerHome = FileManager.default.homeDirectoryForCurrentUser.path
+        let userHome = "/Users/\(NSUserName())"
+        var paths = [
+            "\(userHome)/.local/bin",
+            "\(userHome)/bin",
+            "\(containerHome)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        ]
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            paths += path.split(separator: ":").map(String.init)
+        }
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
     }
 
     private static func resolveConfigArgument(preset: String, customConfigPath: String) -> String {
@@ -2011,7 +2429,7 @@ private enum PreviewExternalXyzrenderWorker {
 
     private static func mergedEnvironment() -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
-        let defaultPath = "/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let defaultPath = executableSearchPaths().joined(separator: ":")
         if let path = environment["PATH"], !path.isEmpty {
             environment["PATH"] = defaultPath + ":" + path
         } else {
@@ -2022,12 +2440,15 @@ private enum PreviewExternalXyzrenderWorker {
 }
 
 private enum PreviewExternalXyzrenderError: LocalizedError {
+    case missingExecutable
     case timedOut
     case missingOutput
     case failed(status: Int32, log: String)
 
     var errorDescription: String? {
         switch self {
+        case .missingExecutable:
+            return "External xyzrender executable was not found. Set an absolute xyzrender path in Burrete settings."
         case .timedOut:
             return "External xyzrender timed out after 25 seconds."
         case .missingOutput:
@@ -2131,6 +2552,34 @@ private enum PreviewError: LocalizedError {
             return "Could not create preview config."
         case .couldNotCreateRuntimePreview(let reason):
             return "Could not create runtime preview files: \(reason)"
+        }
+    }
+}
+
+private enum VestaLauncher {
+    static func open(fileURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", "VESTA", fileURL.path]
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+            throw VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+}
+
+private enum VestaLaunchError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .failed(let message):
+            return message.isEmpty ? "VESTA could not be opened." : message
         }
     }
 }

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -490,6 +490,7 @@
     <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
     <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
     <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
+    <button class="buret-button hidden" type="button" data-buret-action="open-vesta" aria-label="Open in VESTA" title="Open in VESTA">VESTA</button>
     <div class="buret-renderer-control" data-buret-renderer-control>
       <button class="buret-button" type="button" data-buret-renderer="xyz-fast" aria-label="Use Fast XYZ SVG" title="Use Fast XYZ SVG">Fast</button>
       <button class="buret-button" type="button" data-buret-renderer="molstar" aria-label="Use Mol* Interactive" title="Use Mol* Interactive">Mol*</button>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -120,6 +120,9 @@
   let overlayOpacity = 0.90;
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
   let activeViewer = null;
+  let activeConfig = null;
+  let latestXyzrenderOrientationRef = null;
+  let orientationTrackingCleanup = null;
   let keyboardShortcutsInstalled = false;
   let themeListenerInstalled = false;
 
@@ -351,8 +354,10 @@
     const control = document.querySelector('[data-buret-renderer-control]');
     if (!control) return;
     const format = normalizeFormat(config.molstarFormat || config.format);
+    const xyzrenderViewer = config.xyzrenderViewer === true;
     const canSwitchRenderer = (config.appViewer === true && (format === 'xyz' || format === 'sdf')) ||
-      (config.quickLookViewer === true && format === 'xyz');
+      (config.quickLookViewer === true && format === 'xyz') ||
+      xyzrenderViewer;
     control.classList.toggle('visible', canSwitchRenderer);
     if (!canSwitchRenderer) return;
 
@@ -360,7 +365,11 @@
     control.querySelectorAll('[data-buret-renderer]').forEach(button => {
       const value = button.getAttribute('data-buret-renderer');
       const isFastXYZOnly = value === 'xyz-fast';
-      button.classList.toggle('hidden', isFastXYZOnly && format !== 'xyz');
+      const needsMolstar = value === 'molstar';
+      button.classList.toggle('hidden',
+        (isFastXYZOnly && format !== 'xyz') ||
+        (needsMolstar && config.molstarAvailable === false)
+      );
       button.classList.toggle('active', value === renderer);
       if (control.dataset.rendererBound !== '1') {
         button.addEventListener('click', () => requestRendererSwitch(value));
@@ -401,7 +410,20 @@
 
   function requestRendererSwitch(renderer) {
     const value = normalizeRenderer(renderer);
-    const sent = postHostMessage({ type: 'setRenderer', value });
+    const orientationRef = value === 'xyzrender-external' ? captureCurrentXyzrenderOrientationRef() : null;
+    if (orientationRef) {
+      postHostMessage({
+        type: 'setXyzrenderOrientation',
+        text: orientationRef.text,
+        atomCount: orientationRef.atomCount
+      });
+    }
+    const payload = { type: 'setRenderer', value };
+    if (orientationRef) {
+      payload.orientationRef = orientationRef.text;
+      payload.orientationAtomCount = orientationRef.atomCount;
+    }
+    const sent = postHostMessage(payload);
     if (!sent) setStatus('Renderer switching is available only in the app or Quick Look viewer.', 'error');
   }
 
@@ -409,6 +431,192 @@
     const value = normalizeXyzrenderPreset(preset);
     const sent = postHostMessage({ type: 'setXyzrenderPreset', value });
     if (!sent) setStatus('xyzrender preset switching is available only in the app or Quick Look viewer.', 'error');
+  }
+
+  function requestOpenInVesta() {
+    const sent = postHostMessage({ type: 'action', message: 'open-vesta' });
+    if (!sent) setStatus('Opening in VESTA is available only in the app or Quick Look viewer.', 'error');
+  }
+
+  function captureCurrentXyzrenderOrientationRef() {
+    const config = activeConfig || {};
+    const format = normalizeFormat(config.molstarFormat || config.format);
+    if (format !== 'xyz' || config.binary === true || !activeViewer) return null;
+    const nextRef = buildXyzrenderOrientationRef(activeViewer, config);
+    if (nextRef) latestXyzrenderOrientationRef = nextRef;
+    return nextRef || latestXyzrenderOrientationRef;
+  }
+
+  function trackMolstarOrientation(viewer, config) {
+    if (orientationTrackingCleanup) {
+      try { orientationTrackingCleanup(); } catch (_) {}
+      orientationTrackingCleanup = null;
+    }
+    latestXyzrenderOrientationRef = null;
+    if (normalizeFormat(config.molstarFormat || config.format) !== 'xyz' || config.binary === true) return;
+
+    const disposers = [];
+    const update = debounce(() => {
+      const nextRef = buildXyzrenderOrientationRef(viewer, config);
+      if (nextRef) latestXyzrenderOrientationRef = nextRef;
+    }, 120);
+
+    const changed = viewer?.plugin?.canvas3d?.camera?.changed;
+    if (changed && typeof changed.subscribe === 'function') {
+      try {
+        const subscription = changed.subscribe(update);
+        disposers.push(() => subscription?.unsubscribe?.());
+      } catch (error) {
+        debug('camera subscription failed: ' + (error && error.message || String(error)));
+      }
+    }
+
+    ['pointerup', 'wheel', 'keyup', 'mouseup'].forEach(eventName => {
+      document.addEventListener(eventName, update, true);
+      disposers.push(() => document.removeEventListener(eventName, update, true));
+    });
+
+    update();
+    orientationTrackingCleanup = () => {
+      disposers.forEach(dispose => {
+        try { dispose(); } catch (_) {}
+      });
+    };
+  }
+
+  function debounce(fn, delayMs) {
+    let timer = 0;
+    return () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = 0;
+        fn();
+      }, delayMs);
+    };
+  }
+
+  function buildXyzrenderOrientationRef(viewer, config) {
+    const frame = parseFirstXYZFrame(rawStructureData({ ...config, binary: false }));
+    if (!frame || !frame.atoms.length || frame.atoms.length > 50000) return null;
+    const snapshot = readCameraSnapshot(viewer);
+    const basis = cameraBasis(snapshot, frame.atoms);
+    if (!basis) return null;
+
+    const lines = [
+      String(frame.atoms.length),
+      `Burrete Mol* orientation reference for ${config.label || 'structure'}`
+    ];
+    for (const atom of frame.atoms) {
+      const x = atom.x - basis.origin.x;
+      const y = atom.y - basis.origin.y;
+      const z = atom.z - basis.origin.z;
+      lines.push([
+        atom.symbol,
+        formatCoordinate(dot3({ x, y, z }, basis.right)),
+        formatCoordinate(dot3({ x, y, z }, basis.up)),
+        formatCoordinate(dot3({ x, y, z }, basis.forward))
+      ].join(' '));
+    }
+    const text = lines.join('\n') + '\n';
+    if (text.length > 4 * 1024 * 1024) return null;
+    return { text, atomCount: frame.atoms.length };
+  }
+
+  function parseFirstXYZFrame(text) {
+    const lines = String(text || '').replace(/\r\n?/gu, '\n').split('\n');
+    let start = 0;
+    while (start < lines.length && !lines[start].trim()) start += 1;
+    const atomCount = Number.parseInt(lines[start]?.trim().split(/\s+/u)[0] || '', 10);
+    if (!Number.isFinite(atomCount) || atomCount <= 0 || start + atomCount + 1 >= lines.length) return null;
+    const atoms = [];
+    for (let i = start + 2; i < Math.min(lines.length, start + 2 + atomCount); i += 1) {
+      const parts = lines[i].trim().split(/\s+/u);
+      if (parts.length < 4) return null;
+      const x = Number(parts[1]);
+      const y = Number(parts[2]);
+      const z = Number(parts[3]);
+      if (![x, y, z].every(Number.isFinite)) return null;
+      atoms.push({ symbol: normalizeElementSymbol(parts[0]), x, y, z });
+    }
+    return atoms.length === atomCount ? { atoms } : null;
+  }
+
+  function normalizeElementSymbol(value) {
+    const match = String(value || 'X').trim().match(/[A-Za-z]{1,3}/u);
+    if (!match) return 'X';
+    return match[0].slice(0, 1).toUpperCase() + match[0].slice(1).toLowerCase();
+  }
+
+  function readCameraSnapshot(viewer) {
+    const camera = viewer?.plugin?.canvas3d?.camera;
+    if (!camera) return null;
+    let snapshot = null;
+    try { snapshot = typeof camera.getSnapshot === 'function' ? camera.getSnapshot() : null; } catch (_) {}
+    snapshot = snapshot || camera.state || camera;
+    const position = vectorFrom(snapshot.position || camera.position);
+    const target = vectorFrom(snapshot.target || camera.target);
+    const up = vectorFrom(snapshot.up || camera.up);
+    return position && target && up ? { position, target, up } : null;
+  }
+
+  function cameraBasis(snapshot, atoms) {
+    const centroidValue = centroid(atoms);
+    if (!snapshot) return null;
+    const origin = snapshot.target || centroidValue;
+    const forward = normalize3(sub3(snapshot.position, origin));
+    if (!forward) return null;
+    const rawUp = normalize3(snapshot.up) || { x: 0, y: 1, z: 0 };
+    const right = normalize3(cross3(rawUp, forward));
+    if (!right) return null;
+    const up = normalize3(cross3(forward, right));
+    if (!up) return null;
+    return { origin, right, up, forward };
+  }
+
+  function vectorFrom(value) {
+    if (!value) return null;
+    if (Array.isArray(value) || typeof value.length === 'number') {
+      const x = Number(value[0]);
+      const y = Number(value[1]);
+      const z = Number(value[2]);
+      return [x, y, z].every(Number.isFinite) ? { x, y, z } : null;
+    }
+    const x = Number(value.x);
+    const y = Number(value.y);
+    const z = Number(value.z);
+    return [x, y, z].every(Number.isFinite) ? { x, y, z } : null;
+  }
+
+  function centroid(atoms) {
+    const sum = atoms.reduce((acc, atom) => ({ x: acc.x + atom.x, y: acc.y + atom.y, z: acc.z + atom.z }), { x: 0, y: 0, z: 0 });
+    const count = Math.max(1, atoms.length);
+    return { x: sum.x / count, y: sum.y / count, z: sum.z / count };
+  }
+
+  function sub3(a, b) {
+    return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+  }
+
+  function dot3(a, b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+  }
+
+  function cross3(a, b) {
+    return {
+      x: a.y * b.z - a.z * b.y,
+      y: a.z * b.x - a.x * b.z,
+      z: a.x * b.y - a.y * b.x
+    };
+  }
+
+  function normalize3(v) {
+    const length = Math.hypot(v.x, v.y, v.z);
+    if (!Number.isFinite(length) || length < 1e-8) return null;
+    return { x: v.x / length, y: v.y / length, z: v.z / length };
+  }
+
+  function formatCoordinate(value) {
+    return Number(value).toFixed(6).replace(/\.?0+$/u, match => (match === '.' ? '' : ''));
   }
 
   function initBuretToolbar(viewer) {
@@ -423,6 +631,11 @@
     toolbar.querySelector('[data-buret-action="theme"]')?.addEventListener('click', () => {
       toggleViewerTheme(viewer);
     });
+    const vestaButton = toolbar.querySelector('[data-buret-action="open-vesta"]');
+    if (vestaButton) {
+      vestaButton.classList.toggle('hidden', activeConfig?.canOpenInVesta !== true);
+      vestaButton.addEventListener('click', () => requestOpenInVesta());
+    }
 
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
@@ -709,7 +922,7 @@
     if (!base64 || typeof base64 !== 'string') {
       throw new Error('preview-data.js did not define window.BurreteDataBase64.');
     }
-    return config.binary ? Array.from(base64ToBytes(base64)) : base64ToText(base64);
+    return config.binary ? base64ToBytes(base64) : base64ToText(base64);
   }
 
   function normalizeRenderer(renderer) {
@@ -1090,6 +1303,7 @@
     }
 
     const config = requireConfig();
+    activeConfig = config;
     applyConfigOptions(config);
     debug('config=' + JSON.stringify(config));
     const renderer = normalizeRenderer(config.renderer);
@@ -1155,6 +1369,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
     } catch (error) {
       debug('BurreteAgent notifyStructureLoaded failed: ' + (error && error.message || String(error)));
     }
+    trackMolstarOrientation(viewer, config);
 
     window.addEventListener('resize', () => scheduleViewerResize(viewer, 100));
     await waitForAnimationFrame();

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">Finder-native molecular structure previews for macOS, powered by Mol* and a fast SVG path for XYZ.</p>
 
 <p align="center">
-  <img alt="Version 0.10.18" src="https://img.shields.io/badge/version-0.10.18-0f8f72.svg?style=flat-square" />
+  <img alt="Version 0.10.19" src="https://img.shields.io/badge/version-0.10.19-0f8f72.svg?style=flat-square" />
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square" /></a>
   <img alt="macOS 12+" src="https://img.shields.io/badge/macOS-12%2B-blue.svg?style=flat-square" />
   <img alt="Quick Look" src="https://img.shields.io/badge/Quick%20Look-extension-57606a.svg?style=flat-square" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.18",
+      "version": "0.10.19",
       "dependencies": {
         "@rdkit/rdkit": "2025.3.4-1.0.0",
         "molstar": "5.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular structure previews powered by Mol*.",
   "scripts": {

--- a/scripts/force-preview.sh
+++ b/scripts/force-preview.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 FILE="${1:-}"
 if [[ -z "$FILE" || ! -f "$FILE" ]]; then
-  echo "usage: $0 /path/to/structure.pdb|cif|mmcif|sdf|smi|csv|tsv|xyz" >&2
+  echo "usage: $0 /path/to/structure.pdb|cif|mmcif|sdf|smi|csv|tsv|xyz|gro|xtc|trr|cube|vasp|mae" >&2
   exit 1
 fi
+if [[ "${FILE,,}" == *.mae.gz ]]; then
+  TYPE="com.local.burrete10.schrodinger"
+else
 case "${FILE##*.}" in
   pdb|PDB|ent|ENT|pdbqt|PDBQT|pqr|PQR) TYPE="com.local.burrete10.pdb" ;;
   cif|CIF) TYPE="com.local.burrete10.cif" ;;
@@ -17,7 +20,11 @@ case "${FILE##*.}" in
   mol|MOL) TYPE="com.local.burrete10.mol" ;;
   mol2|MOL2) TYPE="com.local.burrete10.mol2" ;;
   xyz|XYZ) TYPE="com.local.burrete10.xyz" ;;
+  cub|CUB|cube|CUBE|in|IN|log|LOG|out|OUT|vasp|VASP) TYPE="com.local.burrete10.xyzrender-input" ;;
   gro|GRO) TYPE="com.local.burrete10.gro" ;;
+  xtc|XTC|trr|TRR|dcd|DCD|nctraj|NCTRAJ|lammpstrj|LAMMPSTRJ|top|TOP|psf|PSF|prmtop|PRMTOP) TYPE="com.local.burrete10.molecular-dynamics" ;;
+  mae|MAE|maegz|MAEGZ|cms|CMS) TYPE="com.local.burrete10.schrodinger" ;;
   *) TYPE="$(mdls -raw -name kMDItemContentType "$FILE" 2>/dev/null || true)" ;;
 esac
+fi
 qlmanage -p -c "$TYPE" "$FILE"

--- a/scripts/test-web-preview.sh
+++ b/scripts/test-web-preview.sh
@@ -58,11 +58,14 @@ cp -R PreviewExtension/Web "$TMP/Web"
 node - "$SAMPLE" "$TMP/Web/preview-config.js" "$TMP/Web/preview-data.js" <<'JS'
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const file = process.argv[2];
 const configOut = process.argv[3];
 const dataOut = process.argv[4];
-const ext = path.extname(file).toLowerCase().slice(1);
+const basename = path.basename(file).toLowerCase();
+const ext = basename.endsWith('.mae.gz') ? 'maegz' : path.extname(file).toLowerCase().slice(1);
 const data = fs.readFileSync(file);
+const xyzrenderExts = new Set(['cub', 'cube', 'in', 'log', 'out', 'vasp', 'mae', 'maegz', 'cms']);
 
 let format = 'mmcif';
 let binary = false;
@@ -81,9 +84,13 @@ else if (ext === 'mol') format = 'mol';
 else if (ext === 'mol2') format = 'mol2';
 else if (ext === 'xyz') format = 'xyz';
 else if (ext === 'gro') format = 'gro';
+else if (['xtc', 'trr', 'dcd', 'nctraj'].includes(ext)) { format = ext; binary = true; }
+else if (['lammpstrj', 'top', 'psf', 'prmtop'].includes(ext)) format = ext;
+else if (xyzrenderExts.has(ext)) format = 'xyzrender';
 
 const gridExts = new Set(['csv', 'sd', 'sdf', 'smi', 'smiles', 'tsv']);
-const renderer = gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : 'molstar');
+const renderer = gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : (xyzrenderExts.has(ext) ? 'xyzrender-external' : 'molstar'));
+const vestaExts = new Set(['xyz', 'cub', 'cube']);
 const config = {
   mode: gridExts.has(ext) ? 'grid2d' : 'structure',
   label: path.basename(file),
@@ -98,8 +105,48 @@ const config = {
   canvasBackground: 'auto',
   transparentBackground: false,
   sdfGrid: true,
-  showPanelControls: true
+  showPanelControls: true,
+  canOpenInVesta: vestaExts.has(ext)
 };
+if (renderer === 'xyzrender-external') {
+  const artifactPath = path.join(path.dirname(configOut), 'xyzrender.svg');
+  const started = Date.now();
+  const result = spawnSync('xyzrender', [file, '-o', artifactPath, '--config', 'default'], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 10
+  });
+  if (result.status !== 0 || !fs.existsSync(artifactPath) || fs.statSync(artifactPath).size <= 0) {
+    const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim();
+    throw new Error(`xyzrender failed for ${file}: ${output}`);
+  }
+  config.quickLookViewer = true;
+  config.xyzrenderViewer = true;
+  config.molstarAvailable = false;
+  config.xyzrenderPreset = 'default';
+  config.xyzrenderPresetOptions = [
+    { value: 'default', label: 'Default' },
+    { value: 'flat', label: 'Flat' },
+    { value: 'paton', label: 'Paton' },
+    { value: 'pmol', label: 'PMol' },
+    { value: 'skeletal', label: 'Skeletal' },
+    { value: 'bubble', label: 'Bubble' },
+    { value: 'tube', label: 'Tube' },
+    { value: 'btube', label: 'BTube' },
+    { value: 'mtube', label: 'MTube' },
+    { value: 'wire', label: 'Wire' },
+    { value: 'graph', label: 'Graph' },
+    { value: 'custom', label: 'Custom JSON' }
+  ];
+  config.externalArtifact = {
+    path: 'xyzrender.svg',
+    type: 'svg',
+    renderer: 'xyzrender',
+    preset: 'default',
+    config: 'default',
+    elapsedMs: Date.now() - started,
+    log: `${result.stdout || ''}\n${result.stderr || ''}`.trim()
+  };
+}
 if (renderer === 'xyz-fast') {
   config.xyzFast = {
     style: 'default',
@@ -146,8 +193,10 @@ const releaseScript = fs.readFileSync('scripts/release.sh', 'utf8');
 const forcePreview = fs.readFileSync('scripts/force-preview.sh', 'utf8');
 const xcodeProject = fs.readFileSync('Burrete.xcodeproj/project.pbxproj', 'utf8');
 const config = JSON.parse(configSource.replace(/^window\.BurreteConfig = /, '').replace(/;\s*$/, ''));
-const ext = path.extname(sample).toLowerCase().slice(1);
+const sampleBasename = path.basename(sample).toLowerCase();
+const ext = sampleBasename.endsWith('.mae.gz') ? 'maegz' : path.extname(sample).toLowerCase().slice(1);
 const gridExts = new Set(['csv', 'sd', 'sdf', 'smi', 'smiles', 'tsv']);
+const xyzrenderExts = new Set(['cub', 'cube', 'in', 'log', 'out', 'vasp', 'mae', 'maegz', 'cms']);
 
 function assert(condition, message) {
   if (!condition) {
@@ -163,6 +212,7 @@ assert(index.includes('aria-label="Collapse controls"'), 'toolbar handle should 
 assert(index.includes('aria-expanded="true"'), 'toolbar handle should expose expanded state');
 assert(index.includes('top: var(--buret-toolbar-safe-top); right: 12px; left: auto'), 'toolbar should honor the safe top inset');
 assert(index.includes('data-buret-action="theme"'), 'toolbar should expose a separate theme toggle');
+assert(index.includes('data-buret-action="open-vesta"'), 'toolbar should expose a VESTA handoff button');
 assert(index.includes('--buret-molstar-panel-background'), 'preview HTML must define Mol* theme panel colors');
 assert(index.includes('.msp-viewport-controls-panel'), 'preview HTML must theme Mol* viewport panels');
 assert(index.includes('.msp-viewport-controls-panel .msp-control-group-header > button'), 'preview HTML must style Mol* floating settings panel headers');
@@ -177,7 +227,11 @@ assert(!index.includes('aria-label="Fullscreen"'), 'stale Fullscreen aria-label 
 assert(!index.includes('title="Fullscreen"'), 'stale Fullscreen title found');
 assert(index.includes('./burette-agent.js'), 'preview HTML must load the Burette agent bridge before viewer.js');
 assert(viewer.includes('window.BurreteConfig'), 'viewer.js must read BurreteConfig');
+assert(viewer.includes('config.binary ? base64ToBytes(base64) : base64ToText(base64)'), 'viewer.js must pass binary molecular data as Uint8Array');
 assert(viewer.includes('BurreteAgent?.attach'), 'viewer.js must attach the Burette agent bridge');
+assert(viewer.includes('requestOpenInVesta'), 'viewer.js must request VESTA handoff from the host app');
+assert(viewer.includes('setXyzrenderOrientation'), 'viewer.js must send Mol* orientation references before xyzrender handoff');
+assert(viewer.includes('buildXyzrenderOrientationRef'), 'viewer.js must build xyzrender reference XYZ from Mol* camera orientation');
 assert(agent.includes('window.BurreteAgent'), 'burette-agent.js must expose the BurreteAgent alias');
 assert(agent.includes('window.BuretteAgent'), 'burette-agent.js must expose the BuretteAgent alias');
 assert(appViewer.includes('burette-agent.js'), 'app viewer runtime must copy and load burette-agent.js');
@@ -216,6 +270,10 @@ assert(quickLookViewer.includes('requiredAssets: runtimeAssets(for: renderer)'),
 assert(quickLookViewer.includes('quickLookViewer'), 'Quick Look XYZ previews should expose renderer switching controls');
 assert(quickLookViewer.includes('setRendererOverride'), 'Quick Look should handle renderer switching from the toolbar');
 assert(quickLookViewer.includes('setXyzrenderPresetOverride'), 'Quick Look should handle xyzrender preset switching from the toolbar');
+assert(quickLookViewer.includes('canOpenInVesta'), 'Quick Look should expose VESTA handoff eligibility');
+assert(quickLookViewer.includes('VestaLauncher.open'), 'Quick Look should hand eligible XYZ/Cube files to VESTA');
+assert(quickLookViewer.includes('xyzrenderOrientationRefText'), 'Quick Look should keep the latest Mol* orientation reference');
+assert(quickLookViewer.includes('arguments += ["--ref", orientationRefURL.path]'), 'Quick Look xyzrender launch should pass orientation refs with --ref');
 assert(quickLookViewer.includes('PreviewExternalXyzrenderWorker.render'), 'Quick Look should support xyzrender artifacts for XYZ files');
 assert(quickLookViewer.includes('externalArtifactSourceURL'), 'Quick Look should copy generated xyzrender artifacts into the preview runtime');
 assert(quickLookViewer.includes('return isXYZ ? "xyz-fast" : "molstar"'), 'Quick Look auto renderer should remain Fast XYZ by default');
@@ -227,6 +285,40 @@ assert(quickLookViewer.includes('gridRecordsScriptWithRDKitWasm'), 'Quick Look g
 assert(quickLookViewer.includes('"smi", "smiles"'), 'Quick Look should allow SMILES files before grid dispatch');
 assert(quickLookViewer.includes('"csv"'), 'Quick Look should allow CSV files before grid dispatch');
 assert(quickLookViewer.includes('"tsv"'), 'Quick Look should allow TSV files before grid dispatch');
+assert(quickLookViewer.includes('"cub", "cube"'), 'Quick Look should allow Gaussian cube files before xyzrender dispatch');
+assert(quickLookViewer.includes('"in", "log"'), 'Quick Look should allow quantum input/log files before xyzrender dispatch');
+assert(quickLookViewer.includes('"out"'), 'Quick Look should allow quantum output files before xyzrender dispatch');
+assert(quickLookViewer.includes('"vasp"'), 'Quick Look should allow VASP files before xyzrender dispatch');
+assert(quickLookViewer.includes('"xtc", "trr", "dcd", "nctraj"'), 'Quick Look should map binary MD trajectories to Mol* formats');
+assert(quickLookViewer.includes('"lammpstrj", "top", "psf", "prmtop"'), 'Quick Look should map text MD trajectory/topology files to Mol* formats');
+assert(quickLookViewer.includes('"mae", "maegz", "cms"'), 'Quick Look should allow Schrodinger files before xyzrender dispatch');
+assert(quickLookViewer.includes('PreviewStructureTextConverter'), 'Quick Look should have a sandbox-safe text-to-XYZ fallback for xyzrender-only formats');
+assert(quickLookViewer.includes('xyzrender.default=built-in-text-parser'), 'Quick Look should use the built-in parser by default for xyzrender-only formats');
+assert(quickLookViewer.includes('parseCube'), 'Quick Look fallback should parse cube/cub atom sections');
+assert(quickLookViewer.includes('parseVasp'), 'Quick Look fallback should parse VASP POSCAR files');
+assert(quickLookViewer.includes('parseQuantumEspressoInput'), 'Quick Look fallback should parse Quantum ESPRESSO input files');
+assert(quickLookViewer.includes('parseOrcaOutput'), 'Quick Look fallback should parse ORCA output files');
+assert(quickLookViewer.includes('parseGaussianOutput'), 'Quick Look fallback should parse Gaussian log files');
+assert(quickLookInfo.includes('com.local.burrete10.xyzrender-input'), 'Quick Look Info.plist must register xyzrender-only input types');
+assert(quickLookInfo.includes('com.local.burrete10.molecular-dynamics'), 'Quick Look Info.plist must register molecular dynamics content types');
+assert(quickLookInfo.includes('com.local.burrete10.schrodinger'), 'Quick Look Info.plist must register Schrodinger content types');
+assert(quickLookInfo.includes('mae.gz'), 'Quick Look Info.plist must register compressed Schrodinger Maestro files');
+assert(appInfo.includes('com.local.burrete10.xyzrender-input'), 'app Info.plist must register xyzrender-only input types');
+assert(appInfo.includes('com.local.burrete10.molecular-dynamics'), 'app Info.plist must register molecular dynamics content types');
+assert(appInfo.includes('com.local.burrete10.schrodinger'), 'app Info.plist must register Schrodinger content types');
+assert(appInfo.includes('mae.gz'), 'app Info.plist must register compressed Schrodinger Maestro files');
+assert(appDelegate.includes('com.local.burrete10.xyzrender-input'), 'app runtime default-handler registration must include xyzrender-only input types');
+assert(appDelegate.includes('com.local.burrete10.molecular-dynamics'), 'app runtime default-handler registration must include molecular dynamics content types');
+assert(appDelegate.includes('com.local.burrete10.schrodinger'), 'app runtime default-handler registration must include Schrodinger content types');
+assert(appViewer.includes('isExternalXyzrenderOnly'), 'standalone app viewer must route xyzrender-only formats away from Mol*');
+assert(appViewer.includes('canOpenInVesta'), 'standalone app viewer should expose VESTA handoff eligibility');
+assert(appViewer.includes('VestaLauncher.open'), 'standalone app viewer should hand eligible XYZ/Cube files to VESTA');
+assert(appViewer.includes('xyzrenderOrientationRefText'), 'standalone app viewer should keep the latest Mol* orientation reference');
+assert(appViewer.includes('arguments += ["--ref", orientationRefURL.path]'), 'standalone app xyzrender launch should pass orientation refs with --ref');
+assert(quickLookViewer.includes('isExternalXyzrenderOnly'), 'Quick Look viewer must route xyzrender-only formats away from Mol*');
+assert(!appViewer.includes('URL(fileURLWithPath: "/usr/bin/env")'), 'standalone app xyzrender launch must not depend on /usr/bin/env');
+assert(!quickLookViewer.includes('URL(fileURLWithPath: "/usr/bin/env")'), 'Quick Look xyzrender launch must not depend on /usr/bin/env');
+assert(viewer.includes('xyzrenderViewer'), 'web viewer must expose xyzrender controls for xyzrender-only formats');
 assert(appViewer.includes('gridRecordsScriptWithRDKitWasm'), 'standalone grid previews must pass RDKit wasm without file:// fetch');
 assert(appViewer.includes('fileSupport: MoleculeGridFileSupport.load()'), 'standalone grid previews must honor enabled grid file types');
 assert(gridViewer.includes('wasmBinary'), 'grid viewer must initialize RDKit with an in-memory wasmBinary fallback');
@@ -268,6 +360,7 @@ assert(xcodeProject.includes('PreviewExtension/Web/burette-agent.js'), 'Xcode va
 assert(viewer.includes('startXYZFast'), 'viewer.js must support Fast XYZ rendering');
 assert(viewer.includes('startExternalArtifact'), 'viewer.js must support external xyzrender artifacts');
 assert(viewer.includes("config.quickLookViewer === true && format === 'xyz'"), 'viewer.js must show renderer controls for Quick Look XYZ previews');
+assert(viewer.includes('xyzrenderViewer'), 'viewer.js must show xyzrender preset controls for xyzrender-only previews');
 assert(xyzFast.includes('BurreteXYZFast'), 'xyz-fast.js must expose BurreteXYZFast');
 assert(viewer.includes('buret.toolbar.collapsed'), 'viewer.js must remember compact toolbar state');
 assert(viewer.includes('TOOLBAR_POSITION_VERSION'), 'viewer.js must reset stale toolbar positions');
@@ -300,10 +393,15 @@ assert(config.transparentBackground === false, 'transparent background should be
 assert(config.sdfGrid === true, 'SDF grid flag should be encoded');
 assert(config.molstarFormat === config.format, 'molstarFormat should mirror the resolved Mol* format');
 assert(config.allowMolstarFallback === true, 'Mol* fallback flag should be encoded');
-assert(config.renderer === (gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : 'molstar')), 'renderer should select grid2d for molecule collections, Fast XYZ for .xyz, and Mol* otherwise');
+assert(config.renderer === (gridExts.has(ext) ? 'grid2d' : (ext === 'xyz' ? 'xyz-fast' : (xyzrenderExts.has(ext) ? 'xyzrender-external' : 'molstar'))), 'renderer should select grid2d for molecule collections, Fast XYZ for .xyz, xyzrender for xyzrender-only formats, and Mol* otherwise');
 if (ext === 'xyz') {
   assert(config.xyzFast && config.xyzFast.firstFrameOnly === true, 'XYZ web test should encode first-frame Fast XYZ options');
   assert(config.xyzFast.showCell === true, 'XYZ web test should encode cell drawing preference');
+}
+if (xyzrenderExts.has(ext)) {
+  assert(config.xyzrenderViewer === true, 'xyzrender-only web test should expose xyzrender controls');
+  assert(config.molstarAvailable === false, 'xyzrender-only web test should hide Mol* switching');
+  assert(config.externalArtifact && config.externalArtifact.path === 'xyzrender.svg', 'xyzrender-only web test should generate an SVG artifact');
 }
 
 const expectedFormats = {
@@ -319,13 +417,36 @@ const expectedFormats = {
   mol: 'mol',
   mol2: 'mol2',
   xyz: 'xyz',
-  gro: 'gro'
+  gro: 'gro',
+  xtc: 'xtc',
+  trr: 'trr',
+  dcd: 'dcd',
+  nctraj: 'nctraj',
+  lammpstrj: 'lammpstrj',
+  top: 'top',
+  psf: 'psf',
+  prmtop: 'prmtop',
+  cub: 'xyzrender',
+  cube: 'xyzrender',
+  in: 'xyzrender',
+  log: 'xyzrender',
+  out: 'xyzrender',
+  vasp: 'xyzrender',
+  mae: 'xyzrender',
+  maegz: 'xyzrender',
+  cms: 'xyzrender'
 };
 if (expectedFormats[ext]) {
   assert(config.format === expectedFormats[ext], `expected ${ext} to map to ${expectedFormats[ext]}, got ${config.format}`);
 }
 if (ext === 'bcif') {
   assert(config.binary === true, 'BCIF should be marked binary');
+}
+if (['xtc', 'trr', 'dcd', 'nctraj'].includes(ext)) {
+  assert(config.binary === true, `${ext.toUpperCase()} should be marked binary`);
+}
+if (['xyz', 'cub', 'cube'].includes(ext)) {
+  assert(config.canOpenInVesta === true, `${ext.toUpperCase()} should expose VESTA handoff`);
 }
 console.log('Validated web preview contract');
 JS


### PR DESCRIPTION
## Summary
- add Mol* camera orientation capture for XYZ previews before switching to xyzrender
- pass generated orientation reference XYZ files to xyzrender with --ref in Quick Look and app viewers
- add VESTA handoff controls for XYZ/Cube files and expand supported structure formats

## Verification
- npm run check:js
- npm run test:agent
- plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
- git diff --check
- ./scripts/test-web-preview.sh --no-open /Users/nikolenko/Desktop/xyzrender-main/examples/structures/benzene.xyz
- ./scripts/test-web-preview.sh --no-open /Users/nikolenko/Desktop/xyzrender-main/examples/structures/caffeine_homo.cube
- xcodebuild -project Burrete.xcodeproj -scheme Burrete -configuration Debug -derivedDataPath build COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES build