### PR TITLE
Harden previews and table fallback

### DIFF
--- a/App/BurreteApp.swift
+++ b/App/BurreteApp.swift
@@ -27,57 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             BurreteUpdater.shared.checkAutomaticallyIfNeeded()
         }
-        if UserDefaults.standard.object(forKey: "openSettingsAtLaunch") == nil {
-            UserDefaults.standard.set(false, forKey: "openSettingsAtLaunch")
-        }
-        if UserDefaults.standard.object(forKey: "showPreviewPanelControls") == nil {
-            UserDefaults.standard.set(true, forKey: "showPreviewPanelControls")
-        }
-        if UserDefaults.standard.object(forKey: "useTransparentPreviewBackground") == nil {
-            UserDefaults.standard.set(false, forKey: "useTransparentPreviewBackground")
-        }
-        if UserDefaults.standard.object(forKey: "viewerTheme") == nil {
-            UserDefaults.standard.set("auto", forKey: "viewerTheme")
-        }
-        if UserDefaults.standard.object(forKey: "viewerCanvasBackground") == nil {
-            UserDefaults.standard.set("auto", forKey: "viewerCanvasBackground")
-        }
-        if UserDefaults.standard.object(forKey: "structureRendererMode") == nil {
-            UserDefaults.standard.set("auto", forKey: "structureRendererMode")
-        }
-        if UserDefaults.standard.object(forKey: "xyzFastStyle") == nil {
-            UserDefaults.standard.set("default", forKey: "xyzFastStyle")
-        }
-        if UserDefaults.standard.object(forKey: "xyzrenderPreset") == nil {
-            UserDefaults.standard.set("default", forKey: "xyzrenderPreset")
-        }
-        if UserDefaults.standard.object(forKey: "xyzrenderCustomConfigPath") == nil {
-            UserDefaults.standard.set("", forKey: "xyzrenderCustomConfigPath")
-        }
-        if UserDefaults.standard.object(forKey: "xyzrenderExecutablePath") == nil {
-            UserDefaults.standard.set("", forKey: "xyzrenderExecutablePath")
-        }
-        if UserDefaults.standard.object(forKey: "xyzrenderExtraArguments") == nil {
-            UserDefaults.standard.set("", forKey: "xyzrenderExtraArguments")
-        }
-        if UserDefaults.standard.object(forKey: "viewerWindowOpacity") == nil {
-            UserDefaults.standard.set(0.82, forKey: "viewerWindowOpacity")
-        }
-        if UserDefaults.standard.object(forKey: "viewerOverlayOpacity") == nil {
-            UserDefaults.standard.set(0.90, forKey: "viewerOverlayOpacity")
-        }
-        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.sdfKey) == nil {
-            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.sdfKey)
-        }
-        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.smilesKey) == nil {
-            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.smilesKey)
-        }
-        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.csvKey) == nil {
-            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.csvKey)
-        }
-        if UserDefaults.standard.object(forKey: MoleculeGridFileSupport.tsvKey) == nil {
-            UserDefaults.standard.set(true, forKey: MoleculeGridFileSupport.tsvKey)
-        }
+        registerDefaultSettings()
         viewerRuntimePreferences = ViewerRuntimePreferences.load()
         NotificationCenter.default.addObserver(
             self,
@@ -122,6 +72,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             openViewer(for: URL(fileURLWithPath: filename))
         }
         sender.reply(toOpenOrPrint: .success)
+    }
+
+    private func registerDefaultSettings() {
+        let defaults = UserDefaults.standard
+        for (key, value) in [
+            ("openSettingsAtLaunch", false as Any),
+            ("showPreviewPanelControls", true as Any),
+            ("useTransparentPreviewBackground", false as Any),
+            ("viewerTheme", "auto" as Any),
+            ("viewerCanvasBackground", "auto" as Any),
+            ("structureRendererMode", "auto" as Any),
+            ("xyzFastStyle", "default" as Any),
+            ("xyzrenderPreset", "default" as Any),
+            ("xyzrenderCustomConfigPath", "" as Any),
+            ("xyzrenderExecutablePath", "" as Any),
+            ("xyzrenderExtraArguments", "" as Any),
+            ("viewerWindowOpacity", 0.82 as Any),
+            ("viewerOverlayOpacity", 0.90 as Any)
+        ] {
+            setDefaultValueIfNeeded(value, forKey: key, defaults: defaults)
+        }
+        for key in [
+            MoleculeGridFileSupport.sdfKey,
+            MoleculeGridFileSupport.smilesKey,
+            MoleculeGridFileSupport.csvKey,
+            MoleculeGridFileSupport.tsvKey
+        ] {
+            setDefaultValueIfNeeded(true, forKey: key, defaults: defaults)
+        }
+    }
+
+    private func setDefaultValueIfNeeded(_ value: Any, forKey key: String, defaults: UserDefaults) {
+        if defaults.object(forKey: key) == nil {
+            defaults.set(value, forKey: key)
+        }
     }
 
     private func installStatusItem() {

--- a/App/BurreteUpdater.swift
+++ b/App/BurreteUpdater.swift
@@ -373,6 +373,58 @@ final class BurreteUpdater: ObservableObject {
         guard FileManager.default.isExecutableFile(atPath: executable.path) else {
             throw BurreteUpdateError.invalidDownloadedApp("The downloaded app executable is missing.")
         }
+
+        try validateDownloadedAppSignature(appURL)
+    }
+
+    private func validateDownloadedAppSignature(_ appURL: URL) throws {
+        try runProcess("/usr/bin/codesign", arguments: ["--verify", "--deep", "--strict", appURL.path])
+
+        let currentSignature = try codeSignatureDescriptor(for: Bundle.main.bundleURL.standardizedFileURL)
+        let downloadedSignature = try codeSignatureDescriptor(for: appURL)
+
+        guard downloadedSignature.identifier == "com.local.BurreteV10" else {
+            throw BurreteUpdateError.signatureValidationFailed("Downloaded app signature identifier is invalid.")
+        }
+
+        if let currentTeam = currentSignature.teamIdentifier, !currentTeam.isEmpty {
+            guard downloadedSignature.teamIdentifier == currentTeam else {
+                throw BurreteUpdateError.signatureValidationFailed("Downloaded app TeamIdentifier does not match the installed app.")
+            }
+            if downloadedSignature.isAdHoc {
+                throw BurreteUpdateError.signatureValidationFailed("Downloaded app is ad-hoc signed while installed app uses a developer signature.")
+            }
+        }
+    }
+
+    private func codeSignatureDescriptor(for appURL: URL) throws -> BurreteCodeSignatureDescriptor {
+        let output = try runProcessCapturingCombinedOutput(
+            "/usr/bin/codesign",
+            arguments: ["-dv", "--verbose=4", appURL.path]
+        )
+        var identifier: String?
+        var teamIdentifier: String?
+        var isAdHoc = false
+
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("Identifier=") {
+                identifier = String(line.dropFirst("Identifier=".count))
+            } else if line.hasPrefix("TeamIdentifier=") {
+                let value = String(line.dropFirst("TeamIdentifier=".count))
+                if !value.isEmpty && value != "not set" {
+                    teamIdentifier = value
+                }
+            } else if line == "Signature=adhoc" || line.contains("(adhoc") {
+                isAdHoc = true
+            }
+        }
+
+        return BurreteCodeSignatureDescriptor(
+            identifier: identifier,
+            teamIdentifier: teamIdentifier,
+            isAdHoc: isAdHoc
+        )
     }
 
     private func runProcess(_ executable: String, arguments: [String]) throws {
@@ -384,6 +436,28 @@ final class BurreteUpdater: ObservableObject {
         guard process.terminationStatus == 0 else {
             throw BurreteUpdateError.processFailed(URL(fileURLWithPath: executable).lastPathComponent, process.terminationStatus)
         }
+    }
+
+    private func runProcessCapturingCombinedOutput(_ executable: String, arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw BurreteUpdateError.signatureValidationFailed(
+                "\(URL(fileURLWithPath: executable).lastPathComponent) failed with status \(process.terminationStatus): \(output.trimmingCharacters(in: .whitespacesAndNewlines))"
+            )
+        }
+        return output
     }
 
     private func installerScript(appPID: Int32, newAppURL: URL, destinationAppURL: URL, logURL: URL) -> String {
@@ -508,6 +582,7 @@ private enum BurreteUpdateError: LocalizedError {
     case installerLaunchFailed(String)
     case invalidAsset(String)
     case downloadedAssetSizeMismatch(expected: Int, actual: Int)
+    case signatureValidationFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -532,8 +607,16 @@ private enum BurreteUpdateError: LocalizedError {
             return message
         case let .downloadedAssetSizeMismatch(expected, actual):
             return "Downloaded update archive size mismatch: expected \(expected) bytes, got \(actual) bytes."
+        case .signatureValidationFailed(let reason):
+            return "Downloaded app signature validation failed. \(reason)"
         }
     }
+}
+
+private struct BurreteCodeSignatureDescriptor {
+    let identifier: String?
+    let teamIdentifier: String?
+    let isAdHoc: Bool
 }
 
 private struct BurreteVersion: Comparable {

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -962,7 +962,7 @@ private struct AboutPanel: View {
                 Text("Burrete")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
-                Text("Version 0.10.19")
+                Text("Version 0.10.20")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(.secondary)
             }

--- a/App/MoleculeViewerWindowController.swift
+++ b/App/MoleculeViewerWindowController.swift
@@ -43,6 +43,8 @@ enum AppViewerXyzrenderPreset {
 final class MoleculeViewerWindowController: NSWindowController, WKNavigationDelegate, WKScriptMessageHandler {
     private let fileURL: URL
     private let webView: WKWebView
+    private var currentRuntimeReadAccessURL: URL?
+    private var activeLoadRequestID = UUID()
     private var currentViewerPageZoom: CGFloat = 1.0
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
@@ -127,17 +129,52 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     }
 
     func load() {
-        do {
-            let runtime = try AppViewerRuntime.create(
-                for: fileURL,
-                rendererModeOverride: rendererOverride,
-                xyzrenderPresetOverride: xyzrenderPresetOverride,
-                xyzrenderOrientationRefText: xyzrenderOrientationRefText
-            )
-            webView.loadFileURL(runtime.indexURL, allowingReadAccessTo: runtime.readAccessURL)
-        } catch {
-            webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
+        let requestID = UUID()
+        activeLoadRequestID = requestID
+        currentRuntimeReadAccessURL = nil
+        webView.loadHTMLString(Self.loadingHTML(fileURL.lastPathComponent), baseURL: nil)
+
+        let fileURL = fileURL
+        let rendererOverride = rendererOverride
+        let xyzrenderPresetOverride = xyzrenderPresetOverride
+        let xyzrenderOrientationRefText = xyzrenderOrientationRefText
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                let runtime = try AppViewerRuntime.create(
+                    for: fileURL,
+                    rendererModeOverride: rendererOverride,
+                    xyzrenderPresetOverride: xyzrenderPresetOverride,
+                    xyzrenderOrientationRefText: xyzrenderOrientationRefText
+                )
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.activeLoadRequestID == requestID else { return }
+                    self.currentRuntimeReadAccessURL = runtime.readAccessURL.standardizedFileURL
+                    self.webView.loadFileURL(runtime.indexURL, allowingReadAccessTo: runtime.readAccessURL)
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.activeLoadRequestID == requestID else { return }
+                    self.currentRuntimeReadAccessURL = nil
+                    self.webView.loadHTMLString(Self.errorHTML(error), baseURL: nil)
+                }
+            }
         }
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+        if isTrustedRuntimeURL(url) || url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+        if navigationAction.navigationType == .linkActivated {
+            NSWorkspace.shared.open(url)
+        }
+        NSLog("[BurreteAppViewer] blocked navigation to %@", url.absoluteString)
+        decisionHandler(.cancel)
     }
 
     func reloadDisplayPreferences() {
@@ -172,6 +209,10 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard isTrustedScriptMessage(message) else {
+            NSLog("[BurreteAppViewer] %@: blocked script message from untrusted frame", fileURL.lastPathComponent)
+            return
+        }
         guard message.name == "burrete",
               let body = message.body as? [String: Any],
               let type = body["type"] as? String else {
@@ -211,6 +252,21 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         NSLog("[BurreteAppViewer] %@: %@ %@", fileURL.lastPathComponent, type, text)
     }
 
+    private func isTrustedScriptMessage(_ message: WKScriptMessage) -> Bool {
+        guard message.webView === webView else { return false }
+        guard message.frameInfo.isMainFrame else { return false }
+        guard let sourceURL = message.frameInfo.request.url ?? message.webView?.url else { return false }
+        return isTrustedRuntimeURL(sourceURL)
+    }
+
+    private func isTrustedRuntimeURL(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        guard let allowed = currentRuntimeReadAccessURL?.standardizedFileURL else { return false }
+        let allowedPath = allowed.path.hasSuffix("/") ? allowed.path : allowed.path + "/"
+        let path = url.standardizedFileURL.path
+        return path == allowed.path || path.hasPrefix(allowedPath)
+    }
+
     private func applyWindowDisplayPreferences(_ preferences: AppViewerDisplayPreferences) {
         let backgroundColor = preferences.isWindowTransparent ? NSColor.clear : NSColor.windowBackgroundColor
         window?.appearance = preferences.windowAppearance
@@ -242,27 +298,19 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
     }
 
     private func openCurrentFileInVesta() {
-        guard Self.canOpenInVesta(fileExtension: Self.structurePathExtension(for: fileURL)) else {
+        guard canOpenInVesta(fileExtension: structurePathExtension(for: fileURL)) else {
             NSLog("[BurreteAppViewer] %@: VESTA handoff is unsupported for this file type", fileURL.lastPathComponent)
             return
         }
-        do {
-            try VestaLauncher.open(fileURL: fileURL)
-            NSLog("[BurreteAppViewer] %@: opened in VESTA", fileURL.lastPathComponent)
-        } catch {
-            NSLog("[BurreteAppViewer] %@: VESTA open failed: %@", fileURL.lastPathComponent, String(describing: error))
+        VestaLauncher.open(fileURL: fileURL) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                NSLog("[BurreteAppViewer] %@: opened in VESTA", self.fileURL.lastPathComponent)
+            case .failure(let error):
+                NSLog("[BurreteAppViewer] %@: VESTA open failed: %@", self.fileURL.lastPathComponent, String(describing: error))
+            }
         }
-    }
-
-    private static func structurePathExtension(for url: URL) -> String {
-        if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
-            return "maegz"
-        }
-        return url.pathExtension.lowercased()
-    }
-
-    private static func canOpenInVesta(fileExtension: String) -> Bool {
-        ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
     }
 
     private func copyToPasteboard(_ text: String) {
@@ -340,6 +388,17 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         body{box-sizing:border-box;padding:24px;font:13px -apple-system,BlinkMacSystemFont,sans-serif}
         h1{font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;background:#24262a;padding:12px;border-radius:8px}
         </style></head><body><h1>Burrete could not open this file</h1><pre>\(escapeHTML(String(describing: error)))</pre></body></html>
+        """
+    }
+
+    private static func loadingHTML(_ filename: String) -> String {
+        """
+        <!doctype html><html><head><meta charset="utf-8"><style>
+        html,body{margin:0;width:100%;height:100%;background:transparent;color:#6c6c70}
+        body{display:grid;place-items:center;font:13px -apple-system,BlinkMacSystemFont,sans-serif}
+        div{padding:16px 18px;border-radius:12px;background:rgba(255,255,255,.72);box-shadow:0 10px 30px rgba(0,0,0,.12)}
+        @media (prefers-color-scheme: dark){body{color:#d1d1d6}div{background:rgba(28,28,30,.72)}}
+        </style></head><body><div>Loading \(escapeHTML(filename))...</div></body></html>
         """
     }
 
@@ -688,17 +747,6 @@ private struct AppViewerRuntime {
         default:
             return isXYZ ? "xyz-fast" : "molstar"
         }
-    }
-
-    private static func structurePathExtension(for url: URL) -> String {
-        if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
-            return "maegz"
-        }
-        return url.pathExtension.lowercased()
-    }
-
-    private static func canOpenInVesta(fileExtension: String) -> Bool {
-        ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
     }
 
     private struct XYZFastPayload {
@@ -1619,18 +1667,27 @@ private enum AppViewerError: LocalizedError {
 }
 
 private enum VestaLauncher {
-    static func open(fileURL: URL) throws {
+    static func open(fileURL: URL, completion: @escaping (Result<Void, Error>) -> Void) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         process.arguments = ["-a", "VESTA", fileURL.path]
         let errorPipe = Pipe()
         process.standardError = errorPipe
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
+        process.terminationHandler = { finished in
             let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
             let message = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
-            throw VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+            DispatchQueue.main.async {
+                if finished.terminationStatus == 0 {
+                    completion(.success(()))
+                } else {
+                    completion(.failure(VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))))
+                }
+            }
+        }
+        do {
+            try process.run()
+        } catch {
+            completion(.failure(error))
         }
     }
 }
@@ -1698,6 +1755,19 @@ private final class BurreteAppViewerContainerView: NSView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+}
+
+private let vestaSupportedStructureExtensions: Set<String> = ["xyz", "cub", "cube"]
+
+private func structurePathExtension(for url: URL) -> String {
+    if url.lastPathComponent.lowercased().hasSuffix(".mae.gz") {
+        return "maegz"
+    }
+    return url.pathExtension.lowercased()
+}
+
+private func canOpenInVesta(fileExtension: String) -> Bool {
+    vestaSupportedStructureExtensions.contains(fileExtension.lowercased())
 }
 
 private func escapeHTML(_ value: String) -> String {

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.19;
+				MARKETING_VERSION = 0.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -427,7 +427,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.19;
+				MARKETING_VERSION = 0.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -451,7 +451,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.19;
+				MARKETING_VERSION = 0.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.19;
+				MARKETING_VERSION = 0.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/PreviewExtension/MoleculeGridPreview.swift
+++ b/PreviewExtension/MoleculeGridPreview.swift
@@ -95,7 +95,7 @@ enum MoleculeGridPreviewBuilder {
 
         switch ext {
         case "csv":
-            collection = try parseDelimitedTable(text, separator: ",", format: "csv", maxRecords: recordLimit)
+            collection = try parseDelimitedTableWithFallback(text, separator: ",", format: "csv", maxRecords: recordLimit)
             guard collection.recordsTotal > 0 else { return nil }
         case "smi", "smiles":
             collection = parseSmiles(text, maxRecords: recordLimit)
@@ -104,7 +104,7 @@ enum MoleculeGridPreviewBuilder {
             collection = parseSDF(text, maxRecords: recordLimit)
             guard collection.recordsTotal > 1 else { return nil }
         case "tsv":
-            collection = try parseDelimitedTable(text, separator: "\t", format: "tsv", maxRecords: recordLimit)
+            collection = try parseDelimitedTableWithFallback(text, separator: "\t", format: "tsv", maxRecords: recordLimit)
             guard collection.recordsTotal > 0 else { return nil }
         default:
             return nil
@@ -274,6 +274,61 @@ enum MoleculeGridPreviewBuilder {
         return MoleculeGridCollection(format: format, records: records, recordsTotal: recordsTotal)
     }
 
+    private static func parseDelimitedTableWithFallback(
+        _ text: String,
+        separator: Character,
+        format: String,
+        maxRecords: Int
+    ) throws -> MoleculeGridCollection {
+        do {
+            return try parseDelimitedTable(text, separator: separator, format: format, maxRecords: maxRecords)
+        } catch MoleculeGridPreviewError.missingMoleculeColumn {
+            return parseDelimitedRowsAsSmiles(text, separator: separator, format: format, maxRecords: maxRecords)
+        }
+    }
+
+    private static func parseDelimitedRowsAsSmiles(
+        _ text: String,
+        separator: Character,
+        format: String,
+        maxRecords: Int
+    ) -> MoleculeGridCollection {
+        let rows = normalizedLines(text).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !rows.isEmpty else {
+            return MoleculeGridCollection(format: format, records: [], recordsTotal: 0)
+        }
+        let firstRowCells = parseDelimitedLine(rows[0], separator: separator).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let startIndex = isLikelyDelimitedHeader(firstRowCells) ? 1 : 0
+        var records: [MoleculeGridRecord] = []
+        var recordsTotal = 0
+        for row in rows.dropFirst(startIndex) {
+            let rawCells = parseDelimitedLine(row, separator: separator).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            let cells = rawCells.filter { !$0.isEmpty }
+            guard let smiles = cells.first, looksLikeSmiles(smiles) else { continue }
+            defer { recordsTotal += 1 }
+            guard records.count < maxRecords else { continue }
+            let rawName = cells.dropFirst().first ?? ""
+            let name = rawName.isEmpty ? "Molecule \(recordsTotal + 1)" : rawName
+            var props: [String: String] = [:]
+            if cells.count > 2 {
+                for (offset, value) in cells.dropFirst(2).enumerated() where props.count < 64 {
+                    let clippedValue = clipped(value, limit: 500)
+                    if !clippedValue.isEmpty {
+                        props["Column \(offset + 3)"] = clippedValue
+                    }
+                }
+            }
+            records.append(MoleculeGridRecord(
+                index: recordsTotal,
+                name: clipped(name, limit: 160),
+                smiles: clipped(smiles, limit: 2048),
+                molblock: nil,
+                props: props
+            ))
+        }
+        return MoleculeGridCollection(format: format, records: records, recordsTotal: recordsTotal)
+    }
+
     private static func parseDelimitedLine(_ line: String, separator: Character) -> [String] {
         let chars = Array(line)
         var fields: [String] = []
@@ -302,7 +357,52 @@ enum MoleculeGridPreviewBuilder {
     }
 
     private static func isSmilesColumn(_ value: String) -> Bool {
-        ["smiles", "canonical_smiles", "isomeric_smiles", "cxsmiles", "smiles_string"].contains(value)
+        ["smiles", "smile", "canonical_smiles", "isomeric_smiles", "cxsmiles", "smiles_string"].contains(value)
+    }
+
+    private static func isLikelyDelimitedHeader(_ cells: [String]) -> Bool {
+        let normalized = cells.map { $0.lowercased().replacingOccurrences(of: " ", with: "_") }
+        if normalized.contains(where: isSmilesColumn) { return true }
+        let commonHeaders: Set<String> = ["id", "name", "title", "compound", "molecule", "structure", "inchi"]
+        return normalized.contains { commonHeaders.contains($0) }
+    }
+
+    private static func looksLikeSmiles(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return false }
+        let lowered = trimmed.lowercased()
+        let knownHeaders: Set<String> = ["smiles", "smile", "id", "name", "title", "compound", "molecule", "structure", "inchi"]
+        if knownHeaders.contains(lowered) { return false }
+        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return false }
+        let characters = Array(trimmed)
+        var index = 0
+        var hasAtom = false
+        var hasAromaticAtom = false
+        var hasStructuralMarker = false
+        while index < characters.count {
+            let character = characters[index]
+            if character.isNumber {
+                hasStructuralMarker = true
+            } else if "[]=#@+-/\\().,:".contains(character) {
+                hasStructuralMarker = true
+            } else if character == "B", index + 1 < characters.count, characters[index + 1] == "r" {
+                hasAtom = true
+                index += 1
+            } else if character == "C", index + 1 < characters.count, characters[index + 1] == "l" {
+                hasAtom = true
+                index += 1
+            } else if "BCNOFPSIKH".contains(character) {
+                hasAtom = true
+            } else if "bcnops".contains(character) {
+                hasAtom = true
+                hasAromaticAtom = true
+            } else {
+                return false
+            }
+            index += 1
+        }
+        guard hasAtom else { return false }
+        return !hasAromaticAtom || hasStructuralMarker
     }
 
     private static func normalizedLines(_ text: String) -> [String] {

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -14,6 +14,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private var hasRenderedTerminationError = false
     private var currentViewerPageZoom: CGFloat = 1.0
     private var currentPreviewURL: URL?
+    private var currentRuntimeDirectory: URL?
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
     private var xyzrenderOrientationRefText: String?
@@ -133,6 +134,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         activePreviewRequestID = requestID
         pendingCompletion = handler
         currentPreviewURL = url
+        currentRuntimeDirectory = nil
         rendererOverride = nil
         xyzrenderPresetOverride = nil
         xyzrenderOrientationRefText = nil
@@ -147,7 +149,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
-                let result = try Self.buildInlinePreviewHTML(for: url)
+                let result = try Self.buildInlinePreviewHTML(for: url, requestID: requestID.uuidString)
                 DispatchQueue.main.async { [weak self] in
                     guard let self else {
                         handler(nil)
@@ -161,6 +163,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                     for line in result.diagnostics { self.appendLog(line) }
                     self.statusLabel.stringValue = "[native] Loading file preview into WKWebView…\n\(url.lastPathComponent)"
                     self.appendLog("calling WKWebView.loadFileURL; html.bytes=\(result.html.utf8.count); indexURL=\(result.indexURL.path); readAccessURL=\(result.readAccessURL.path)")
+                    self.currentRuntimeDirectory = result.indexURL.deletingLastPathComponent()
                     self.webView.loadFileURL(result.indexURL, allowingReadAccessTo: result.readAccessURL)
                     self.scheduleRenderTimeout(for: requestID)
                     if Self.showDebugOverlay {
@@ -179,8 +182,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                         return
                     }
                     self.appendLog("native build error: \(Self.describe(error))")
-                    self.renderNativeError(error, fileURL: url)
-                    self.finishPreviewIfNeeded(nil, requestID: requestID)
+                    if Self.shouldAllowSystemFallback(for: error, fileExtension: Self.structurePathExtension(for: url)) {
+                        self.finishPreviewIfNeeded(error, requestID: requestID)
+                    } else {
+                        self.renderNativeError(error, fileURL: url)
+                        self.finishPreviewIfNeeded(nil, requestID: requestID)
+                    }
                 }
             }
         }
@@ -218,6 +225,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     private static func buildInlinePreviewHTML(
         for url: URL,
+        requestID: String,
         rendererOverride: String? = nil,
         xyzrenderPresetOverride: String? = nil,
         xyzrenderOrientationRefText: String? = nil
@@ -277,7 +285,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             let runtimePreview = try createRuntimePreview(
                 bundledWebDirectory: webDirectory,
                 html: html,
-                configJSON: gridPreview.configJSON,
+                configJSON: configJSONWithRequestID(gridPreview.configJSON, requestID: requestID),
                 structureBase64: nil,
                 gridRecordsScript: gridRecordsScript,
                 requiredAssets: ["grid-viewer.js", "grid.css"],
@@ -299,7 +307,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         }
 
         var format = StructureFormat(url: url, data: structureData)
-        var renderer = resolvedRenderer(for: format, preferences: preferences, rendererOverride: rendererOverride)
+        let requestedRendererMode = normalizeRendererMode(rendererOverride ?? preferences.rendererMode)
+        var renderer = resolvedRenderer(for: format, rendererMode: requestedRendererMode)
         var structureDataForWeb = structureData
         var externalArtifact: PreviewExternalXyzrenderArtifact?
         var externalArtifactSourceURL: URL?
@@ -381,6 +390,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         let configJSON = try previewConfigJSON(
             format: format,
             label: url.lastPathComponent,
+            requestID: requestID,
+            requestedRendererMode: requestedRendererMode,
             byteCount: structureData.count,
             previewByteCount: structureDataForWeb.count,
             renderer: renderer,
@@ -469,6 +480,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             diagnostics.append("[build] runtime.externalArtifact=\(destination.lastPathComponent)")
         }
         return RuntimePreview(runtimeDirectory: runtimeDirectory, indexURL: indexURL, readAccessURL: previewsDirectory)
+    }
+
+    private static func configJSONWithRequestID(_ configJSON: String, requestID: String) throws -> String {
+        let data = Data(configJSON.utf8)
+        var payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        payload["previewRequestID"] = requestID
+        let nextData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .withoutEscapingSlashes])
+        guard let json = String(data: nextData, encoding: .utf8) else { throw PreviewError.couldNotCreatePreviewConfig }
+        return json
     }
 
     private static func pruneRuntimePreviews(
@@ -609,6 +629,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private static func previewConfigJSON(
         format: StructureFormat,
         label: String,
+        requestID: String,
+        requestedRendererMode: String,
         byteCount: Int,
         previewByteCount: Int,
         renderer: String,
@@ -624,8 +646,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "molstarFormat": format.molstarFormat,
             "binary": format.isBinary,
             "renderer": renderer,
+            "requestedRenderer": requestedRendererMode,
             "allowMolstarFallback": true,
             "label": label,
+            "previewRequestID": requestID,
             "byteCount": byteCount,
             "previewByteCount": previewByteCount,
             "quickLookBuild": "v10-product",
@@ -644,13 +668,11 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             payload["xyzrenderViewer"] = true
             payload["molstarAvailable"] = !format.isExternalXyzrenderOnly
             payload["quickLookViewer"] = true
-            payload["requestedRenderer"] = "auto"
             payload["xyzrenderPreset"] = xyzrenderPreset
             payload["xyzrenderPresetOptions"] = PreviewXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] }
         }
         if format.molstarFormat == "xyz" && !format.isBinary {
             payload["quickLookViewer"] = true
-            payload["requestedRenderer"] = "auto"
             payload["xyzrenderPreset"] = xyzrenderPreset
             payload["xyzrenderPresetOptions"] = PreviewXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] }
         }
@@ -700,7 +722,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           <script>
             (function () {
               function post(type, message, payload) {
-                try { window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.burrete.postMessage(Object.assign({ type: type, message: String(message || '') }, payload || {})); } catch (_) {}
+                var body = Object.assign({ type: type, message: String(message || '') }, payload || {});
+                if (window.BurreteConfig && window.BurreteConfig.previewRequestID) body.requestID = String(window.BurreteConfig.previewRequestID);
+                try { window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.burrete.postMessage(body); } catch (_) {}
               }
               window.__mqlPost = post;
             })();
@@ -1185,8 +1209,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
           </style>
           <script>
             (function () {
-              function post(type, message) {
-                try { window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.burrete.postMessage({ type: type, message: String(message || '') }); } catch (_) {}
+              function post(type, message, payload) {
+                var body = Object.assign({ type: type, message: String(message || '') }, payload || {});
+                if (window.BurreteConfig && window.BurreteConfig.previewRequestID) body.requestID = String(window.BurreteConfig.previewRequestID);
+                try { window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.burrete.postMessage(body); } catch (_) {}
               }
               function shouldReportStatus(text, kind) {
                 if (kind === 'error' || window.BurreteDebug) return true;
@@ -1344,13 +1370,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         throw PreviewError.ubiquitousFileNotDownloaded(url.lastPathComponent)
     }
 
-    private static func resolvedRenderer(for format: StructureFormat, preferences _: PreviewPreferences, rendererOverride: String?) -> String {
+    private static func resolvedRenderer(for format: StructureFormat, rendererMode: String) -> String {
         if format.isExternalXyzrenderOnly {
             return "xyzrender-external"
         }
         let isXYZ = format.molstarFormat == "xyz" && !format.isBinary
-        guard let rendererOverride else { return isXYZ ? "xyz-fast" : "molstar" }
-        switch normalizeRendererMode(rendererOverride) {
+        switch rendererMode {
         case "molstar":
             return "molstar"
         case "xyz-fast":
@@ -1449,6 +1474,18 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         ["xyz", "cub", "cube"].contains(fileExtension.lowercased())
     }
 
+    private static func shouldAllowSystemFallback(for error: Error, fileExtension: String) -> Bool {
+        let lowercasedExtension = fileExtension.lowercased()
+        guard ["csv", "tsv"].contains(lowercasedExtension) else { return false }
+        guard let previewError = error as? PreviewError else { return false }
+        switch previewError {
+        case .unsupportedStructureFile, .gridFileTypeDisabled:
+            return true
+        default:
+            return false
+        }
+    }
+
     private func scheduleRenderTimeout(for requestID: UUID) {
         renderTimeoutWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
@@ -1476,6 +1513,20 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         appendLog("WK didStartProvisionalNavigation url=\(webView.url?.absoluteString ?? "nil")")
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else {
+            appendLog("blocked navigation with missing URL")
+            decisionHandler(.cancel)
+            return
+        }
+        if isTrustedRuntimeURL(url) || url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+        appendLog("blocked navigation to \(url.absoluteString)")
+        decisionHandler(.cancel)
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
@@ -1513,10 +1564,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == "burrete" else { return }
+        guard isTrustedScriptMessage(message) else { return }
         if let body = message.body as? [String: Any] {
             let type = body["type"] as? String ?? "unknown"
             let text = body["message"] as? String ?? String(describing: body)
+            let messageRequestID = (body["requestID"] as? String).flatMap(UUID.init(uuidString:))
+            if let messageRequestID, messageRequestID != activePreviewRequestID {
+                appendLog("ignoring stale JS message type=\(type) requestID=\(messageRequestID.uuidString)")
+                return
+            }
             if type == "action" {
                 handleJavaScriptAction(text)
                 return
@@ -1539,9 +1595,17 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             }
             appendLog("JS message type=\(type): \(text.prefix(1600))")
             if type == "ready" {
-                finishPreviewIfNeeded(nil, requestID: activePreviewRequestID)
+                guard let messageRequestID else {
+                    appendLog("ignoring ready without requestID")
+                    return
+                }
+                finishPreviewIfNeeded(nil, requestID: messageRequestID)
             } else if type == "error" {
-                finishPreviewIfNeeded(nil, requestID: activePreviewRequestID)
+                guard let messageRequestID else {
+                    appendLog("ignoring error without requestID")
+                    return
+                }
+                finishPreviewIfNeeded(nil, requestID: messageRequestID)
             }
             if Self.showDebugOverlay || type == "error" {
                 statusLabel.isHidden = false
@@ -1550,6 +1614,22 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         } else {
             appendLog("JS message raw: \(String(describing: message.body))")
         }
+    }
+
+    private func isTrustedScriptMessage(_ message: WKScriptMessage) -> Bool {
+        guard message.name == "burrete" else { return false }
+        guard message.webView === webView, message.frameInfo.isMainFrame else { return false }
+        let messageURL = message.frameInfo.request.url ?? webView.url
+        guard let messageURL, messageURL.isFileURL else { return false }
+        return isTrustedRuntimeURL(messageURL)
+    }
+
+    private func isTrustedRuntimeURL(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        guard let currentRuntimeDirectory else { return false }
+        let rootPath = currentRuntimeDirectory.standardizedFileURL.path
+        let messagePath = url.standardizedFileURL.path
+        return messagePath == rootPath || messagePath.hasPrefix(rootPath + "/")
     }
 
     private func handleJavaScriptAction(_ action: String) {
@@ -1570,11 +1650,14 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             appendLog("openInVesta.unsupportedExtension=\(Self.structurePathExtension(for: url))")
             return
         }
-        do {
-            try VestaLauncher.open(fileURL: url)
-            appendLog("openInVesta.launched=\(url.path)")
-        } catch {
-            appendLog("openInVesta.failed=\(error.localizedDescription)")
+        VestaLauncher.open(fileURL: url) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                self.appendLog("openInVesta.launched=\(url.path)")
+            case .failure(let error):
+                self.appendLog("openInVesta.failed=\(error.localizedDescription)")
+            }
         }
     }
 
@@ -1634,6 +1717,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             do {
                 let result = try Self.buildInlinePreviewHTML(
                     for: url,
+                    requestID: requestID.uuidString,
                     rendererOverride: rendererOverride,
                     xyzrenderPresetOverride: xyzrenderPresetOverride,
                     xyzrenderOrientationRefText: xyzrenderOrientationRefText
@@ -1641,6 +1725,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 DispatchQueue.main.async { [weak self] in
                     guard let self, self.activePreviewRequestID == requestID else { return }
                     for line in result.diagnostics { self.appendLog(line) }
+                    self.currentRuntimeDirectory = result.indexURL.deletingLastPathComponent()
                     self.webView.loadFileURL(result.indexURL, allowingReadAccessTo: result.readAccessURL)
                     self.scheduleRenderTimeout(for: requestID)
                 }
@@ -2557,18 +2642,27 @@ private enum PreviewError: LocalizedError {
 }
 
 private enum VestaLauncher {
-    static func open(fileURL: URL) throws {
+    static func open(fileURL: URL, completion: @escaping (Result<Void, Error>) -> Void) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         process.arguments = ["-a", "VESTA", fileURL.path]
         let errorPipe = Pipe()
         process.standardError = errorPipe
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
+        process.terminationHandler = { finished in
             let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
             let message = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
-            throw VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))
+            DispatchQueue.main.async {
+                if finished.terminationStatus == 0 {
+                    completion(.success(()))
+                } else {
+                    completion(.failure(VestaLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))))
+                }
+            }
+        }
+        do {
+            try process.run()
+        } catch {
+            completion(.failure(error))
         }
     }
 }

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -36,7 +36,13 @@
   function post(type, message, payload = {}) {
     try {
       if (window.__mqlPost) window.__mqlPost(type, message || '', payload);
-      else window.webkit?.messageHandlers?.burrete?.postMessage({ type, message: String(message || ''), ...payload });
+      else {
+        const body = { type, message: String(message || ''), ...payload };
+        if (window.BurreteConfig && window.BurreteConfig.previewRequestID) {
+          body.requestID = String(window.BurreteConfig.previewRequestID);
+        }
+        window.webkit?.messageHandlers?.burrete?.postMessage(body);
+      }
     } catch (_) {}
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -36,7 +36,11 @@
 
   function postHostMessage(payload) {
     try {
-      window.webkit?.messageHandlers?.burrete?.postMessage(payload);
+      const body = { ...(payload || {}) };
+      if (window.BurreteConfig && window.BurreteConfig.previewRequestID) {
+        body.requestID = String(window.BurreteConfig.previewRequestID);
+      }
+      window.webkit?.messageHandlers?.burrete?.postMessage(body);
       return !!window.webkit?.messageHandlers?.burrete;
     } catch (_) {
       return false;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">Finder-native molecular structure previews for macOS: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit molecule grids.</p>
 
 <p align="center">
-  <img alt="Version 0.10.19" src="https://img.shields.io/badge/version-0.10.19-0f8f72.svg?style=flat-square" />
+  <img alt="Version 0.10.20" src="https://img.shields.io/badge/version-0.10.20-0f8f72.svg?style=flat-square" />
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square" /></a>
   <img alt="macOS 12+" src="https://img.shields.io/badge/macOS-12%2B-blue.svg?style=flat-square" />
   <img alt="Quick Look" src="https://img.shields.io/badge/Quick%20Look-extension-57606a.svg?style=flat-square" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.19",
+      "version": "0.10.20",
       "dependencies": {
         "@rdkit/rdkit": "2025.3.4-1.0.0",
         "molstar": "5.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit grids.",
   "scripts": {


### PR DESCRIPTION
## Summary
- harden update installation and WKWebView script-message/navigation trust checks
- make Quick Look preview requests ignore stale JS ready/error messages and honor renderer preferences
- keep non-molecular CSV/TSV tables on the system Quick Look path while still supporting molecule tables
- move app viewer runtime creation and VESTA handoff off the UI-blocking path
- bump version to 0.10.20

## Testing
- npm run check:release
- npm run check:js
- bash scripts/test-web-preview.sh --no-open
- npm run test:agent
- plutil -lint App/Info.plist PreviewExtension/Info.plist App/Burrete.entitlements PreviewExtension/BurretePreview.entitlements
- git diff --check
- ./scripts/build.sh
- npm run ci