### PR TITLE
Fix viewer hit testing

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -275,7 +275,7 @@ struct SettingsView: View {
                         .symbolRenderingMode(.hierarchical)
                     Text("Burrete")
                         .font(.title2.weight(.semibold))
-                    Text("Version 0.10.23")
+                    Text("Version 0.10.24")
                         .foregroundStyle(.secondary)
                     HStack {
                         Button("Open Logs") { PlatformActions.openLogsDirectory() }

--- a/App/MoleculeViewerScene.swift
+++ b/App/MoleculeViewerScene.swift
@@ -64,6 +64,7 @@ struct MoleculeViewerScene: View {
                     .overlay {
                         RoundedRectangle(cornerRadius: surfaceCornerRadius, style: .continuous)
                             .strokeBorder(Color.secondary.opacity(0.24), lineWidth: 1)
+                            .allowsHitTesting(false)
                     }
                     .shadow(color: Color.black.opacity(transparentWindow ? 0.18 : 0.09), radius: 9, x: 0, y: 2)
                     .padding(surfaceInset)

--- a/App/Platform/MoleculeViewerWindowController.swift
+++ b/App/Platform/MoleculeViewerWindowController.swift
@@ -58,7 +58,7 @@ final class MoleculeViewerWindowController: NSWindowController, WKNavigationDele
         window.representedURL = fileURL
         window.titleVisibility = .visible
         window.titlebarAppearsTransparent = false
-        window.isMovableByWindowBackground = true
+        window.isMovableByWindowBackground = false
         window.collectionBehavior.insert(.fullScreenPrimary)
         window.minSize = NSSize(width: 820, height: 500)
         if #available(macOS 11.0, *) {

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.23;
+				MARKETING_VERSION = 0.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -445,7 +445,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.23;
+				MARKETING_VERSION = 0.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -469,7 +469,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.23;
+				MARKETING_VERSION = 0.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -494,7 +494,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.23;
+				MARKETING_VERSION = 0.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.23",
+      "version": "0.10.24",
       "dependencies": {
         "@rdkit/rdkit": "2025.3.4-1.0.0",
         "@tauri-apps/api": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit grids.",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burrete"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "0.10.23"
+version = "0.10.24"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",


### PR DESCRIPTION
## Summary
- Stop the decorative SwiftUI border overlay from intercepting clicks over the embedded WKWebView.
- Disable whole-window background dragging so interactive viewer controls keep receiving mouse events.
- Bump release metadata to 0.10.24.

## Checks
- `node scripts/check-release-version.mjs`
- `git diff --check`
- `./scripts/build.sh`
- `npm run ci` via pre-push hook
