### PR TITLE
Fix inactive window background dimming

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -275,7 +275,7 @@ struct SettingsView: View {
                         .symbolRenderingMode(.hierarchical)
                     Text("Burrete")
                         .font(.title2.weight(.semibold))
-                    Text("Version 0.10.24")
+                    Text("Version 0.10.25")
                         .foregroundStyle(.secondary)
                     HStack {
                         Button("Open Logs") { PlatformActions.openLogsDirectory() }

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.24;
+				MARKETING_VERSION = 0.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -445,7 +445,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.24;
+				MARKETING_VERSION = 0.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -469,7 +469,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.24;
+				MARKETING_VERSION = 0.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -494,7 +494,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.24;
+				MARKETING_VERSION = 0.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "0.10.24"
+version = "0.10.25"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
           "effects": [
             "hudWindow"
           ],
-          "state": "followsWindowActiveState"
+          "state": "active"
         },
         "decorations": true,
         "width": 1180,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "npm run dev -- --host 127.0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.24",
+      "version": "0.10.25",
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.1.2",
         "@hugeicons/react": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit grids.",
   "scripts": {

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -30,6 +30,7 @@ const [
   previewRuntimeViewer,
   previewRuntimeUtils,
   quickLookPreviewController,
+  tauriConfigSource,
 ] = await Promise.all([
   source('apps/desktop/src-tauri/src/commands/mod.rs'),
   source('apps/desktop/src-tauri/src/lib.rs'),
@@ -44,9 +45,15 @@ const [
   source('apps/desktop/src-tauri/src/preview/runtime_viewer.rs'),
   source('apps/desktop/src-tauri/src/preview/runtime_utils.rs'),
   source('PreviewExtension/Platform/PreviewViewController.swift'),
+  source('apps/desktop/src-tauri/tauri.conf.json'),
 ]);
 
+const tauriConfig = JSON.parse(tauriConfigSource);
+const mainWindowConfig = tauriConfig.app.windows.find((window) => window.label === 'main');
+
 assert.equal(await exists('apps/desktop/src-tauri/src/commands.rs'), false);
+assert.ok(mainWindowConfig);
+assert.equal(mainWindowConfig.windowEffects?.state, 'active');
 
 for (const moduleName of ['documents', 'preview_cache', 'quicklook', 'shell', 'startup']) {
   assert.match(commandsIndex, new RegExp(`pub\\(crate\\) mod ${moduleName};`));


### PR DESCRIPTION
## Summary
- Keep the macOS window effect material active when Burrete loses focus.
- Add a Tauri structure contract test so the window effect state does not regress.

## Root Cause
The main Tauri window used a focus-following window effect state, so macOS changed the HUD material on blur. Combined with the transparent window and translucent shell CSS, the app background could visually disappear or darken when unfocused.

## Validation
- npm run test:tauri-structure
- ./scripts/build.sh
- ./scripts/install.sh
- pre-push npm run ci