### PR TITLE
Add in-app update installation flow

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -275,7 +275,7 @@ struct SettingsView: View {
                         .symbolRenderingMode(.hierarchical)
                     Text("Burrete")
                         .font(.title2.weight(.semibold))
-                    Text("Version 0.10.28")
+                    Text("Version 0.10.29")
                         .foregroundStyle(.secondary)
                     HStack {
                         Button("Open Logs") { PlatformActions.openLogsDirectory() }

--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.28;
+				MARKETING_VERSION = 0.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -443,7 +443,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", );
-				MARKETING_VERSION = 0.10.28;
+				MARKETING_VERSION = 0.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -467,7 +467,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.28;
+				MARKETING_VERSION = 0.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -492,7 +492,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.28;
+				MARKETING_VERSION = 0.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burrete"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod preview_cache;
 pub(crate) mod quicklook;
 pub(crate) mod shell;
 pub(crate) mod startup;
+pub(crate) mod updater;

--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -1,0 +1,472 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tauri::Manager;
+
+const APP_ID: &str = "com.local.BurreteV10";
+const EXTENSION_ID: &str = "com.local.BurreteV10.Preview";
+const RELEASE_DOWNLOAD_PREFIX: &str =
+    "https://github.com/SergeiNikolenko/Burrete/releases/download/";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpdateInstallRequest {
+    tag_name: String,
+    asset_name: String,
+    browser_download_url: String,
+    size: u64,
+}
+
+#[tauri::command]
+pub(crate) async fn install_update(
+    app: tauri::AppHandle,
+    request: UpdateInstallRequest,
+) -> Result<(), String> {
+    let package_version = app.package_info().version.to_string();
+    let app_data_dir = app.path().app_data_dir().map_err(|err| err.to_string())?;
+    let app_bundle = current_app_bundle()?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let archive = download_update(&app_data_dir, &package_version, &request)?;
+        let staged_app =
+            unpack_and_validate_update(&app_data_dir, &archive, &package_version, &request)?;
+        launch_installer(&app_data_dir, &staged_app, &app_bundle, &request.tag_name)
+    })
+    .await
+    .map_err(|err| err.to_string())??;
+
+    app.exit(0);
+    Ok(())
+}
+
+fn download_update(
+    app_data_dir: &Path,
+    package_version: &str,
+    request: &UpdateInstallRequest,
+) -> Result<PathBuf, String> {
+    validate_request(request)?;
+    let updates_dir = update_dir(app_data_dir, &request.tag_name)?;
+    let archive = updates_dir.join(safe_path_component(&request.asset_name));
+    let temporary = updates_dir.join(format!(
+        "{}.download",
+        safe_path_component(&request.asset_name)
+    ));
+    remove_path_if_exists(&temporary)?;
+    remove_path_if_exists(&archive)?;
+
+    let status = Command::new("/usr/bin/curl")
+        .args(["--fail", "--location", "--silent", "--show-error"])
+        .args([
+            "--header",
+            &format!("User-Agent: Burrete/{package_version}"),
+        ])
+        .arg("--output")
+        .arg(&temporary)
+        .arg(&request.browser_download_url)
+        .status()
+        .map_err(|err| format!("Could not start curl: {err}"))?;
+    if !status.success() {
+        return Err(format!("curl failed with status {status}."));
+    }
+
+    let downloaded_size = fs::metadata(&temporary)
+        .map_err(|err| err.to_string())?
+        .len();
+    if downloaded_size != request.size {
+        remove_path_if_exists(&temporary)?;
+        return Err(format!(
+            "Downloaded update archive size mismatch: expected {} bytes, got {} bytes.",
+            request.size, downloaded_size
+        ));
+    }
+
+    fs::rename(&temporary, &archive).map_err(|err| err.to_string())?;
+    Ok(archive)
+}
+
+fn unpack_and_validate_update(
+    app_data_dir: &Path,
+    archive: &Path,
+    current_version: &str,
+    request: &UpdateInstallRequest,
+) -> Result<PathBuf, String> {
+    let updates_dir = update_dir(app_data_dir, &request.tag_name)?;
+    let staging_dir = updates_dir.join(format!("Install-{}", safe_path_component(&uuid())));
+    fs::create_dir_all(&staging_dir).map_err(|err| err.to_string())?;
+
+    run_status(
+        "/usr/bin/ditto",
+        &["-x", "-k", path_str(archive)?, path_str(&staging_dir)?],
+    )?;
+
+    let app = find_downloaded_app(&staging_dir)?;
+    validate_downloaded_app(&app, current_version, &request.tag_name)?;
+    Ok(app)
+}
+
+fn validate_request(request: &UpdateInstallRequest) -> Result<(), String> {
+    if !request
+        .browser_download_url
+        .starts_with(RELEASE_DOWNLOAD_PREFIX)
+    {
+        return Err("Only Burette GitHub release assets can be installed.".into());
+    }
+    if !request.asset_name.to_lowercase().ends_with(".zip") {
+        return Err("Automatic installation supports zipped Burette app archives only.".into());
+    }
+    if request.size == 0 {
+        return Err("Release asset reports zero bytes.".into());
+    }
+    Ok(())
+}
+
+fn find_downloaded_app(directory: &Path) -> Result<PathBuf, String> {
+    let mut stack = vec![directory.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        for entry in fs::read_dir(&path).map_err(|err| err.to_string())? {
+            let entry = entry.map_err(|err| err.to_string())?;
+            let path = entry.path();
+            if path.extension().is_some_and(|extension| extension == "app")
+                && read_plist_value(&path.join("Contents/Info.plist"), "CFBundleIdentifier")
+                    .as_deref()
+                    == Ok(APP_ID)
+            {
+                return Ok(path);
+            }
+            if path.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    Err("The update archive does not contain Burrete.app.".into())
+}
+
+fn validate_downloaded_app(
+    app: &Path,
+    current_version: &str,
+    release_tag: &str,
+) -> Result<(), String> {
+    let info_plist = app.join("Contents/Info.plist");
+    let bundle_id = read_plist_value(&info_plist, "CFBundleIdentifier")?;
+    if bundle_id != APP_ID {
+        return Err("The archive does not contain com.local.BurreteV10.".into());
+    }
+
+    let downloaded_version = read_plist_value(&info_plist, "CFBundleShortVersionString")?;
+    if compare_versions(&downloaded_version, current_version) <= 0 {
+        return Err(format!(
+            "Downloaded version {downloaded_version} is not newer than {current_version}."
+        ));
+    }
+    let release_version = release_tag.trim_start_matches('v');
+    if compare_versions(&downloaded_version, release_version) != 0 {
+        return Err(format!(
+            "Downloaded version {downloaded_version} does not match release {release_tag}."
+        ));
+    }
+
+    let executable = app.join("Contents/MacOS/burrete");
+    if !executable.is_file() {
+        return Err("The downloaded app executable is missing.".into());
+    }
+
+    validate_downloaded_app_signature(app)
+}
+
+fn validate_downloaded_app_signature(app: &Path) -> Result<(), String> {
+    run_status(
+        "/usr/bin/codesign",
+        &["--verify", "--deep", "--strict", path_str(app)?],
+    )?;
+
+    let current_signature = code_signature_descriptor(&current_app_bundle()?)?;
+    let downloaded_signature = code_signature_descriptor(app)?;
+    if downloaded_signature.identifier.as_deref() != Some(APP_ID) {
+        return Err("Downloaded app signature identifier is invalid.".into());
+    }
+    if let Some(current_team) = current_signature.team_identifier {
+        if downloaded_signature.team_identifier.as_deref() != Some(current_team.as_str()) {
+            return Err("Downloaded app TeamIdentifier does not match the installed app.".into());
+        }
+        if downloaded_signature.is_ad_hoc {
+            return Err(
+                "Downloaded app is ad-hoc signed while installed app uses a developer signature."
+                    .into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn launch_installer(
+    app_data_dir: &Path,
+    staged_app: &Path,
+    destination_app: &Path,
+    release_tag: &str,
+) -> Result<(), String> {
+    let updates_dir = update_dir(app_data_dir, release_tag)?;
+    let script = updates_dir.join(format!("install-{}.sh", safe_path_component(release_tag)));
+    let log = updates_dir.join(format!("install-{}.log", safe_path_component(release_tag)));
+    let body = installer_script(std::process::id(), staged_app, destination_app, &log)?;
+    fs::write(&script, body).map_err(|err| err.to_string())?;
+    let mut permissions = fs::metadata(&script)
+        .map_err(|err| err.to_string())?
+        .permissions();
+    use std::os::unix::fs::PermissionsExt;
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).map_err(|err| err.to_string())?;
+
+    Command::new("/bin/bash")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|err| format!("Could not launch the updater helper: {err}"))?;
+    Ok(())
+}
+
+fn installer_script(
+    app_pid: u32,
+    staged_app: &Path,
+    destination_app: &Path,
+    log: &Path,
+) -> Result<String, String> {
+    Ok(format!(
+        r#"#!/bin/bash
+set -euo pipefail
+
+APP_PID={app_pid}
+NEW_APP={new_app}
+DEST_APP={destination_app}
+APP_ID='{APP_ID}'
+EXT_ID='{EXTENSION_ID}'
+LOG_FILE={log}
+
+mkdir -p "$(dirname "$LOG_FILE")"
+exec >>"$LOG_FILE" 2>&1
+echo "== Burrete updater $(date) =="
+echo "new app: $NEW_APP"
+echo "destination: $DEST_APP"
+
+for _ in $(seq 1 80); do
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+if kill -0 "$APP_PID" 2>/dev/null; then
+  echo "error: Burrete did not quit in time"
+  exit 1
+fi
+
+clean_detritus() {{
+  local path="$1"
+  [ -e "$path" ] || return 0
+  /usr/bin/xattr -cr "$path" 2>/dev/null || true
+  /usr/bin/dot_clean -m "$path" 2>/dev/null || true
+  /usr/bin/find "$path" \( -name '._*' -o -name '.DS_Store' \) -delete 2>/dev/null || true
+}}
+
+PARENT_DIR="$(dirname "$DEST_APP")"
+TMP_APP="${{DEST_APP}}.updating"
+BACKUP_APP="${{DEST_APP}}.previous"
+mkdir -p "$PARENT_DIR"
+rm -rf "$TMP_APP"
+/bin/cp -R "$NEW_APP" "$TMP_APP"
+clean_detritus "$TMP_APP"
+
+ACTUAL_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$TMP_APP/Contents/Info.plist")"
+if [ "$ACTUAL_ID" != "$APP_ID" ]; then
+  echo "error: bundle id mismatch: $ACTUAL_ID"
+  rm -rf "$TMP_APP"
+  exit 1
+fi
+
+rm -rf "$BACKUP_APP"
+if [ -d "$DEST_APP" ]; then
+  /bin/mv "$DEST_APP" "$BACKUP_APP"
+fi
+if ! /bin/mv "$TMP_APP" "$DEST_APP"; then
+  if [ -d "$BACKUP_APP" ]; then
+    /bin/mv "$BACKUP_APP" "$DEST_APP"
+  fi
+  exit 1
+fi
+rm -rf "$BACKUP_APP"
+
+APPEX="$DEST_APP/Contents/PlugIns/BurretePreview.appex"
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+[ -x "$LSREGISTER" ] && "$LSREGISTER" -f -R "$DEST_APP" || true
+[ -d "$APPEX" ] && /usr/bin/pluginkit -a "$APPEX" 2>/dev/null || true
+/usr/bin/pluginkit -e use -i "$EXT_ID" 2>/dev/null || true
+/usr/bin/qlmanage -r >/dev/null 2>&1 || true
+/usr/bin/qlmanage -r cache >/dev/null 2>&1 || true
+/usr/bin/killall quicklookd >/dev/null 2>&1 || true
+/usr/bin/open "$DEST_APP"
+echo "update installed"
+"#,
+        new_app = shell_quote(path_str(staged_app)?),
+        destination_app = shell_quote(path_str(destination_app)?),
+        log = shell_quote(path_str(log)?),
+    ))
+}
+
+fn current_app_bundle() -> Result<PathBuf, String> {
+    let executable = std::env::current_exe().map_err(|err| err.to_string())?;
+    let macos_dir = executable
+        .parent()
+        .ok_or_else(|| "Could not resolve app executable directory.".to_string())?;
+    let contents_dir = macos_dir
+        .parent()
+        .ok_or_else(|| "Could not resolve app Contents directory.".to_string())?;
+    let app = contents_dir
+        .parent()
+        .ok_or_else(|| "Could not resolve app bundle directory.".to_string())?;
+    Ok(app.to_path_buf())
+}
+
+fn update_dir(app_data_dir: &Path, release_tag: &str) -> Result<PathBuf, String> {
+    let directory = app_data_dir
+        .join("Updates")
+        .join(safe_path_component(release_tag));
+    fs::create_dir_all(&directory).map_err(|err| err.to_string())?;
+    Ok(directory)
+}
+
+fn read_plist_value(plist: &Path, key: &str) -> Result<String, String> {
+    let output = Command::new("/usr/libexec/PlistBuddy")
+        .args(["-c", &format!("Print :{key}")])
+        .arg(plist)
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        return Err(format!("Could not read {key} from {}.", plist.display()));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn code_signature_descriptor(app: &Path) -> Result<CodeSignatureDescriptor, String> {
+    let output = Command::new("/usr/bin/codesign")
+        .args(["-dv", "--verbose=4"])
+        .arg(app)
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        return Err(format!("codesign failed for {}.", app.display()));
+    }
+    let text = String::from_utf8_lossy(&output.stderr);
+    let mut identifier = None;
+    let mut team_identifier = None;
+    let mut is_ad_hoc = false;
+    for line in text.lines().map(str::trim) {
+        if let Some(value) = line.strip_prefix("Identifier=") {
+            identifier = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("TeamIdentifier=") {
+            if !value.is_empty() && value != "not set" {
+                team_identifier = Some(value.to_string());
+            }
+        } else if line == "Signature=adhoc" || line.contains("(adhoc") {
+            is_ad_hoc = true;
+        }
+    }
+    Ok(CodeSignatureDescriptor {
+        identifier,
+        team_identifier,
+        is_ad_hoc,
+    })
+}
+
+struct CodeSignatureDescriptor {
+    identifier: Option<String>,
+    team_identifier: Option<String>,
+    is_ad_hoc: bool,
+}
+
+fn run_status(executable: &str, arguments: &[&str]) -> Result<(), String> {
+    let status = Command::new(executable)
+        .args(arguments)
+        .status()
+        .map_err(|err| format!("Could not start {executable}: {err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{executable} exited with status {status}."))
+    }
+}
+
+fn remove_path_if_exists(path: &Path) -> Result<(), String> {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            fs::remove_dir_all(path).map_err(|err| err.to_string())
+        }
+        Ok(_) => fs::remove_file(path).map_err(|err| err.to_string()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn path_str(path: &Path) -> Result<&str, String> {
+    path.to_str()
+        .ok_or_else(|| format!("Path is not valid UTF-8: {}", path.display()))
+}
+
+fn safe_path_component(value: &str) -> String {
+    let safe: String = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = safe.trim_matches(['.', '-']);
+    if trimmed.is_empty() {
+        "release".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+fn compare_versions(left: &str, right: &str) -> i8 {
+    let left_parts = version_parts(left);
+    let right_parts = version_parts(right);
+    let count = left_parts.len().max(right_parts.len());
+    for index in 0..count {
+        let left = left_parts.get(index).copied().unwrap_or(0);
+        let right = right_parts.get(index).copied().unwrap_or(0);
+        if left != right {
+            return if left > right { 1 } else { -1 };
+        }
+    }
+    0
+}
+
+fn version_parts(value: &str) -> Vec<u64> {
+    value
+        .trim()
+        .trim_start_matches('v')
+        .split(['-', '+'])
+        .next()
+        .unwrap_or(value)
+        .split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse::<u64>()
+                .unwrap_or(0)
+        })
+        .collect()
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -32,6 +32,9 @@ pub fn run() {
                     menu::emit_to_focused_window(app, menu::MENU_OPEN_SETTINGS_EVENT)
                 }
                 "file.open" => menu::emit_to_focused_window(app, menu::MENU_OPEN_FILES_EVENT),
+                "updater.check" => {
+                    menu::emit_to_focused_window(app, menu::MENU_CHECK_UPDATES_EVENT)
+                }
                 _ => {}
             });
             #[cfg(target_os = "macos")]
@@ -48,6 +51,7 @@ pub fn run() {
             commands::shell::open_logs_folder,
             commands::shell::open_external_url,
             commands::quicklook::reset_quick_look,
+            commands::updater::install_update,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Burrete Tauri application")

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -3,6 +3,7 @@ use tauri::{Emitter, Manager, Runtime};
 
 pub(crate) const MENU_OPEN_SETTINGS_EVENT: &str = "menu:open-settings";
 pub(crate) const MENU_OPEN_FILES_EVENT: &str = "menu:open-files";
+pub(crate) const MENU_CHECK_UPDATES_EVENT: &str = "menu:check-updates";
 
 pub(crate) fn configure_menu<R: Runtime>(app: &tauri::App<R>) -> tauri::Result<()> {
     let settings = MenuItemBuilder::with_id("settings.open", "Settings...")
@@ -11,9 +12,13 @@ pub(crate) fn configure_menu<R: Runtime>(app: &tauri::App<R>) -> tauri::Result<(
     let open = MenuItemBuilder::with_id("file.open", "Open...")
         .accelerator("CmdOrCtrl+O")
         .build(app)?;
+    let updates = MenuItemBuilder::with_id("updater.check", "Check for Updates...")
+        .accelerator("CmdOrCtrl+U")
+        .build(app)?;
     let app_menu = SubmenuBuilder::new(app, "Burrete")
         .items(&[
             &settings,
+            &updates,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::hide(app, None)?,
             &PredefinedMenuItem::hide_others(app, None)?,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/plugin-dialog";
+import { ask, open } from "@tauri-apps/plugin-dialog";
 import { AppLayout } from "./components/app-layout";
 import { CommandPalette } from "./components/command-palette";
 import type { ShellActions, ShellViewState } from "./components/types";
@@ -43,8 +43,8 @@ import {
 import { useSetViewerPreference, useViewerPreferences } from "./hooks/use-settings";
 import { isTauriRuntime } from "./lib/tauri";
 import type { OpenDocumentsResult, RecentStructure } from "./types";
-import { checkForUpdates as requestUpdateCheck, loadUpdatePreferences, markAutomaticCheck, releasePageUrl, saveUpdatePreferences, shouldCheckAutomatically } from "./update";
-import type { UpdatePreferences, UpdateState } from "./update";
+import { checkForUpdates as requestUpdateCheck, clearDismissedUpdate, dismissUpdate, loadUpdatePreferences, markAutomaticCheck, releasePageUrl, saveUpdatePreferences, shouldCheckAutomatically, shouldPromptForUpdate } from "./update";
+import type { UpdatePreferences, UpdateRelease, UpdateState } from "./update";
 
 const filters = [
   {
@@ -83,6 +83,7 @@ export default function App() {
   const [update, setUpdate] = useState<UpdateState>(() => ({
     preferences: loadUpdatePreferences(),
     isChecking: false,
+    isInstalling: false,
     statusText: "No update check has run yet.",
     availableRelease: null,
   }));
@@ -149,7 +150,6 @@ export default function App() {
     openSettingsTab();
   }, [openSettingsTab]);
 
-  useMenuEvents({ chooseFiles, openSettings });
   useOpenEvents(openDocuments, setStatus);
   const { dropActive, handleBrowserDrag, handleBrowserDragLeave, handleBrowserDrop } = useOpenDrop(openDocuments, setStatus);
 
@@ -168,6 +168,72 @@ export default function App() {
     }));
   }, []);
 
+  const installUpdate = useCallback(async (releaseOverride?: UpdateRelease | null) => {
+    const release = releaseOverride ?? update.availableRelease;
+    if (!release) return;
+    if (!release.installAsset) {
+      const url = releasePageUrl(release);
+      if (isTauriRuntime()) {
+        await invoke("open_external_url", { url });
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+      setStatus("Opened release page");
+      return;
+    }
+
+    if (!isTauriRuntime()) {
+      window.open(release.htmlUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    setUpdate((previous) => ({
+      ...previous,
+      isInstalling: true,
+      statusText: "Installing " + release.displayName + "... Burrete will restart when the update is ready.",
+    }));
+    setStatus("Installing update...");
+    try {
+      clearDismissedUpdate();
+      await invoke("install_update", {
+        request: {
+          tagName: release.tagName,
+          assetName: release.installAsset.name,
+          browserDownloadUrl: release.installAsset.browserDownloadUrl,
+          size: release.installAsset.size,
+        },
+      });
+    } catch (error) {
+      setUpdate((previous) => ({
+        ...previous,
+        isInstalling: false,
+        statusText: "Update install failed: " + (error instanceof Error ? error.message : String(error)),
+      }));
+      setStatus("Update install failed");
+    }
+  }, [update.availableRelease]);
+
+  const promptForUpdate = useCallback(async (release: UpdateRelease, automatic: boolean) => {
+    if (!shouldPromptForUpdate(release, automatic)) return;
+    const canInstall = release.installAsset !== null;
+    const message = canInstall
+      ? "Burrete " + release.tagName + " is available. Install it now and restart Burrete when the update is ready?"
+      : "Burrete " + release.tagName + " is available, but this release does not include an installable app archive.";
+    const accepted = isTauriRuntime()
+      ? await ask(message, {
+        title: "Update Available",
+        kind: "info",
+        okLabel: canInstall ? "Install and Restart" : "Open Release Page",
+        cancelLabel: "Later",
+      })
+      : window.confirm(message);
+    if (accepted) {
+      await installUpdate(release);
+    } else {
+      dismissUpdate(release);
+    }
+  }, [installUpdate]);
+
   const checkForUpdates = useCallback(async (automatic = false, channelOverride?: UpdatePreferences["channel"]) => {
     const channel = channelOverride ?? update.preferences.channel;
     setUpdate((previous) => ({
@@ -185,6 +251,11 @@ export default function App() {
           ? "Update available: " + release.displayName + " (" + release.tagName + ")." + (release.installAsset ? "" : " No downloadable app archive is attached to this release.")
           : "Burrete is up to date on " + channel + ".",
       }));
+      if (release) {
+        await promptForUpdate(release, automatic);
+      } else {
+        clearDismissedUpdate();
+      }
       if (automatic) markAutomaticCheck(true);
     } catch (error) {
       setUpdate((previous) => ({
@@ -194,7 +265,9 @@ export default function App() {
       }));
       if (automatic) markAutomaticCheck(false);
     }
-  }, [update.preferences.channel]);
+  }, [promptForUpdate, update.preferences.channel]);
+
+  useMenuEvents({ chooseFiles, openSettings, checkForUpdates });
 
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
@@ -297,6 +370,9 @@ export default function App() {
     checkForUpdates: async () => {
       await checkForUpdates(false);
     },
+    installUpdate: async () => {
+      await installUpdate();
+    },
     openUpdateRelease: async () => {
       const url = releasePageUrl(update.availableRelease);
       if (isTauriRuntime()) {
@@ -308,7 +384,7 @@ export default function App() {
     },
     setPreference,
     setUpdatePreferences,
-  }), [canNavigateBack, canNavigateForward, chooseFiles, checkForUpdates, clearRecentStructures, closeActiveDocument, closeDocument, closeTab, closeAllDocuments, focusSidebarSearch, navigateBack, navigateForward, openCommandPalette, openNewTab, openRecentStructure, openSettings, selectDocument, setActiveTab, setPreference, setUpdatePreferences, toggleSidebar, update.availableRelease]);
+  }), [canNavigateBack, canNavigateForward, chooseFiles, checkForUpdates, clearRecentStructures, closeActiveDocument, closeDocument, closeTab, closeAllDocuments, focusSidebarSearch, installUpdate, navigateBack, navigateForward, openCommandPalette, openNewTab, openRecentStructure, openSettings, selectDocument, setActiveTab, setPreference, setUpdatePreferences, toggleSidebar, update.availableRelease]);
 
   const page = activeTab?.location.kind === "settings" ? "settings" : "viewer";
 

--- a/apps/desktop/src/components/settings-panel/index.tsx
+++ b/apps/desktop/src/components/settings-panel/index.tsx
@@ -45,7 +45,9 @@ export function SettingsPanel({ state, actions }: { state: ShellViewState; actio
           {update.availableRelease && (
             <div className="settings-action-row">
               <span>{update.availableRelease.installAsset ? update.availableRelease.installAsset.name : "Current " + CURRENT_VERSION + ", latest " + update.availableRelease.tagName}</span>
-              <SettingsActionButton onClick={() => void actions.openUpdateRelease()}>Open Release Page</SettingsActionButton>
+              <SettingsActionButton onClick={() => void actions.installUpdate()} disabled={update.isInstalling}>
+                {update.availableRelease.installAsset ? (update.isInstalling ? "Installing..." : "Install and Restart") : "Open Release Page"}
+              </SettingsActionButton>
             </div>
           )}
         </div>

--- a/apps/desktop/src/components/types.ts
+++ b/apps/desktop/src/components/types.ts
@@ -27,6 +27,7 @@ export type ShellActions = {
   resetQuickLook: () => void | Promise<void>;
   openLogs: () => void | Promise<void>;
   checkForUpdates: () => void | Promise<void>;
+  installUpdate: () => void | Promise<void>;
   openUpdateRelease: () => void | Promise<void>;
   setPreference: <K extends keyof ViewerPreferences>(key: K, value: ViewerPreferences[K]) => void;
   setUpdatePreferences: (preferences: UpdatePreferences) => void;

--- a/apps/desktop/src/hooks/use-menu-events.ts
+++ b/apps/desktop/src/hooks/use-menu-events.ts
@@ -4,19 +4,23 @@ import { isTauriRuntime } from "../lib/tauri";
 
 const MENU_OPEN_SETTINGS_EVENT = "menu:open-settings";
 const MENU_OPEN_FILES_EVENT = "menu:open-files";
+const MENU_CHECK_UPDATES_EVENT = "menu:check-updates";
 
 export function useMenuEvents({
   chooseFiles,
   openSettings,
+  checkForUpdates,
 }: {
   chooseFiles: () => void | Promise<void>;
   openSettings: () => void;
+  checkForUpdates: () => void | Promise<void>;
 }) {
   useEffect(() => {
     if (!isTauriRuntime()) return undefined;
 
     let unlistenSettings: (() => void) | undefined;
     let unlistenOpenFiles: (() => void) | undefined;
+    let unlistenCheckUpdates: (() => void) | undefined;
 
     void listen(MENU_OPEN_SETTINGS_EVENT, openSettings).then((next) => {
       unlistenSettings = next;
@@ -26,10 +30,16 @@ export function useMenuEvents({
     }).then((next) => {
       unlistenOpenFiles = next;
     });
+    void listen(MENU_CHECK_UPDATES_EVENT, () => {
+      void checkForUpdates();
+    }).then((next) => {
+      unlistenCheckUpdates = next;
+    });
 
     return () => {
       unlistenSettings?.();
       unlistenOpenFiles?.();
+      unlistenCheckUpdates?.();
     };
-  }, [chooseFiles, openSettings]);
+  }, [checkForUpdates, chooseFiles, openSettings]);
 }

--- a/apps/desktop/src/update.ts
+++ b/apps/desktop/src/update.ts
@@ -24,6 +24,7 @@ export type UpdateRelease = {
 export type UpdateState = {
   preferences: UpdatePreferences;
   isChecking: boolean;
+  isInstalling: boolean;
   statusText: string;
   availableRelease: UpdateRelease | null;
 };
@@ -82,6 +83,27 @@ export function markAutomaticCheck(success: boolean) {
   try {
     localStorage.setItem(STORAGE_PREFIX + (success ? "lastAutomaticSuccessAt" : "lastAutomaticFailureAt"), String(Date.now()));
     if (success) localStorage.removeItem(STORAGE_PREFIX + "lastAutomaticFailureAt");
+  } catch (_) {}
+}
+
+export function shouldPromptForUpdate(release: UpdateRelease, automatic: boolean) {
+  if (!automatic) return true;
+  try {
+    return localStorage.getItem(STORAGE_PREFIX + "dismissedVersion") !== release.tagName;
+  } catch (_) {
+    return true;
+  }
+}
+
+export function dismissUpdate(release: UpdateRelease) {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + "dismissedVersion", release.tagName);
+  } catch (_) {}
+}
+
+export function clearDismissedUpdate() {
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + "dismissedVersion");
   } catch (_) {}
 }
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -76,6 +76,14 @@ Every release app bundle must satisfy:
 - Finder Quick Look can preview PDB, CIF, and XYZ samples.
 - Update metadata points to the Burette release endpoint.
 
+## In-App Updates
+
+The shipped app is the Tauri bundle from `apps/desktop/src-tauri`. It checks the
+Burette GitHub Releases endpoint on launch and from the app menu. A newer
+release offers `Install and Restart`; the installer command downloads the zipped
+`Burrete.app` release asset, validates the bundle, replaces the installed app,
+refreshes Quick Look registration, and relaunches Burrete.
+
 ## License Follow-Up
 
 License alignment is a release/legal task and should be handled deliberately in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "burrete",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "burrete",
-      "version": "0.10.28",
+      "version": "0.10.29",
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.1.2",
         "@hugeicons/react": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit grids.",
   "scripts": {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -283,7 +283,7 @@ assert.match(commandPalette, /ArrowUp/);
 assert.match(commandPalette, /aria-selected=\{index === selectedIndex\}/);
 assert.match(app, /useOpenDrop\(openDocuments, setStatus\)/);
 assert.match(app, /useOpenEvents\(openDocuments, setStatus\)/);
-assert.match(app, /useMenuEvents\(\{ chooseFiles, openSettings \}\)/);
+assert.match(app, /useMenuEvents\(\{ chooseFiles, openSettings, checkForUpdates \}\)/);
 assert.match(app, /<WindowTitle activeDocument=\{activeDocument\} \/>/);
 assert.match(openDropHook, /export function useOpenDrop/);
 assert.match(openEventsHook, /export function useOpenEvents/);


### PR DESCRIPTION
## Summary
- add Tauri-side install_update command that downloads and validates zipped Burrete app release assets
- wire update prompts, Install and Restart UI, and Check for Updates menu event in the shipped desktop shell
- document the Tauri updater release flow and bump release version to 0.10.29

## Verification
- cargo check
- npm run build:web using bundled Node
- npm run check:js
- npm run test:ui
- npm run ci