### PR TITLE
Streamline PR validation flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,46 @@ on:
       - main
 
 jobs:
+  changes:
+    name: Detect Build Scope
+    runs-on: macos-latest
+    outputs:
+      native: ${{ steps.scope.outputs.native }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect native/package changes
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --quiet origin "${{ github.base_ref }}"
+            changed="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
+          else
+            before="${{ github.event.before }}"
+            if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]]; then
+              changed="$(git diff --name-only HEAD~1 HEAD)"
+            else
+              changed="$(git diff --name-only "$before" HEAD)"
+            fi
+          fi
+
+          native=false
+          while IFS= read -r path; do
+            case "$path" in
+              App/*|PreviewExtension/*|Burrete.xcodeproj/*|apps/desktop/src-tauri/*|scripts/build*.sh|scripts/install*.sh|scripts/ci.sh|package.json|package-lock.json|.github/workflows/ci.yml)
+                native=true
+                ;;
+            esac
+          done <<< "$changed"
+          echo "native=$native" >> "$GITHUB_OUTPUT"
+
   validate:
-    name: Validate and Build
+    name: Fast PR Validation
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -22,5 +60,30 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Run CI
-        run: npm run ci
+      - name: Run fast CI
+        run: npm run ci:fast
+
+  native-build:
+    name: Native Bundle Build
+    needs:
+      - changes
+      - validate
+    if: needs.changes.outputs.native == 'true'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build native bundle
+        run: ./scripts/build.sh samples/mini.sdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -35,10 +36,17 @@ jobs:
         run: |
           version="$(node -p "require('./package.json').version")"
           tag="v${version}"
-          if git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            if [[ "${GITHUB_REF_NAME:-}" != "${tag}" ]]; then
+              echo "Tag ${GITHUB_REF_NAME:-unknown} does not match package version ${version}." >&2
+              exit 1
+            fi
+          elif git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
             echo "Release tag ${tag} already exists. Bump package.json before merging another PR." >&2
             exit 1
           fi
+
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,14 +57,17 @@ killall quicklookd 2>/dev/null || true
 
 ## CI And Releases
 
-Pull requests run the full CI workflow on macOS: npm dependency restore, release
-version checks, JavaScript syntax checks, plist linting, and a local Xcode build.
-Every PR intended for merge must bump `package.json`, `package-lock.json`,
-`MARKETING_VERSION`, and the visible About version together.
+Pull requests run fast macOS validation by default: npm dependency restore,
+JavaScript syntax checks, agent/UI/structure tests, and plist linting. PRs that
+touch native, packaging, or bundle layout paths also run the native bundle build.
 
-Merging to `main` builds the app and publishes a GitHub Release tagged with the
-same package version. If the tag already exists, the release workflow fails so
-the next PR cannot overwrite an existing release.
+Feature PRs do not need a version bump. Release PRs must bump `package.json`,
+`package-lock.json`, `MARKETING_VERSION`, and the visible About version
+together, then pass `npm run check:release`.
+
+Releases are explicit. Push a `v*` tag or run the release workflow manually to
+build the app and publish a GitHub Release tagged with the package version. If
+the tag already exists, bump the version before creating another release.
 
 Local hooks use lefthook:
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Useful local checks:
 
 ```bash
 npm run check:js
-npm run check:release
 npm run test:agent
+npm run ci:fast
 ```
 
 The Quick Look extension caches generated runtime files under the extension

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,7 +14,8 @@ Burette-specific:
 
 ## Version Discipline
 
-Before a release, keep these versions aligned:
+Feature PRs do not need a version bump. Before a release, keep these versions
+aligned:
 
 - root `package.json`
 - root `package-lock.json`
@@ -30,16 +31,13 @@ npm run check:release
 
 ## Pre-Release Checks
 
-Run the lightweight checks first:
+Run the fast PR checks first:
 
 ```bash
-npm run check:js
-npm run test:ui
-npm run test:agent
-npm run build:web
+npm run ci:fast
 ```
 
-Then build the macOS bundle:
+For native, packaging, Quick Look, or release changes, build the macOS bundle:
 
 ```bash
 ./scripts/build.sh
@@ -58,7 +56,7 @@ If Quick Look or renderer behavior changed, install and run forced previews:
 
 ## Release Script
 
-Use the project release helper when preparing a tagged artifact:
+Use the project release helper when preparing a tagged artifact locally:
 
 ```bash
 ./scripts/release.sh
@@ -67,8 +65,10 @@ Use the project release helper when preparing a tagged artifact:
 The helper mirrors the GitHub release workflow locally: it builds the Tauri app,
 embeds `BurretePreview.appex`, and writes `build/release/Burrete.zip`.
 
-The release process must not overwrite existing tags. If a tag already exists,
-bump the version and rerun the release checks.
+GitHub releases are explicit: push a `v*` tag that matches `package.json`, or
+run the Release workflow manually. The release process must not overwrite
+existing tags. If a tag already exists, bump the version and rerun the release
+checks.
 
 ## Artifact Requirements
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,7 @@
 pre-commit:
   parallel: true
   commands:
-    release-version:
-      run: npm run check:release
     js-syntax:
       run: npm run check:js
     plist:
       run: plutil -lint apps/desktop/src-tauri/AppMetadata.plist PreviewExtension/Info.plist PreviewExtension/BurretePreview.entitlements
-
-pre-push:
-  commands:
-    ci:
-      run: npm run ci

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:tauri-structure": "node tests/test-tauri-structure.mjs",
     "check:js": "node --check PreviewExtension/Web/viewer.js && node --check PreviewExtension/Web/burette-agent.js && node --check PreviewExtension/Web/grid-viewer.js && node --check PreviewExtension/Web/xyz-fast.js && node --check scripts/vendor-molstar.mjs && node --check scripts/vendor-rdkit.mjs && node --check scripts/agent-preview.mjs && node --check scripts/check-release-version.mjs",
     "check:release": "node scripts/check-release-version.mjs",
+    "ci:fast": "bash scripts/ci-fast.sh",
     "ci": "bash scripts/ci.sh",
     "prepare": "lefthook install",
     "dev:tauri": "npm --prefix apps/desktop run dev:tauri",

--- a/scripts/ci-fast.sh
+++ b/scripts/ci-fast.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+export npm_config_cache="$ROOT/build/npm-cache"
+
+npm ci --ignore-scripts
+npm run check:js
+npm run test:agent
+npm run test:ui
+npm run test:tauri-structure
+plutil -lint apps/desktop/src-tauri/AppMetadata.plist PreviewExtension/Info.plist PreviewExtension/BurretePreview.entitlements


### PR DESCRIPTION
## Summary
- add a fast PR validation script and make CI use it by default
- run the native bundle build only for native/package changes
- make releases explicit via manual workflow dispatch or v* tags

## Verification
- npm run ci:fast