### PR TITLE
Fix settings scroll fade mask compositing

### DIFF
--- a/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
+++ b/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
@@ -40,6 +40,8 @@ export function EditorScrollContainer({
         style={{
           WebkitMaskImage: FADE_MASK,
           maskImage: FADE_MASK,
+          WebkitMaskComposite: "source-over",
+          maskComposite: "add",
           borderTop: "12px solid transparent",
           borderBottom: "12px solid transparent",
         }}


### PR DESCRIPTION
## Summary
- Match Writer's explicit CSS mask compositing for the shared editor/settings scroll container.
- Prevent the top fade mask from combining incorrectly with the scrollbar gutter mask in WebKit.

## Validation
- npm run ci:fast
- pre-commit hooks: plist, js-syntax
- browser visual smoke check on settings page