### PR TITLE
Enable titlebar drag region

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -53,7 +53,11 @@ export function AppLayout({
       <button className="chrome-button sidebar-toggle-root" onClick={onToggleSidebar} title={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"} aria-label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"}>
         <HugeiconsIcon icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
       </button>
-      <header className="topbar" style={{ left: tabChromeLeft, transition: state.sidebarDragging ? "none" : undefined }}>
+      <header
+        className="topbar"
+        data-tauri-drag-region
+        style={{ left: tabChromeLeft, transition: state.sidebarDragging ? "none" : undefined }}
+      >
         <EditorTabs state={layoutState} actions={actions} />
       </header>
       <section className="workspace">

--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -4,7 +4,7 @@ import { pageKind } from "./page-kinds";
 export function EditorTabs({ state, actions }: { state: ShellViewState; actions: ShellActions }) {
   const activeTabIndex = state.tabs.findIndex((tab) => tab.id === state.activeTabId);
   return (
-    <div className="tab-strip" role="tablist" aria-label="Open structures">
+    <div className="tab-strip" role="tablist" aria-label="Open structures" data-tauri-drag-region>
       <div className="tab-history-controls" data-tauri-drag-region>
         <button
           type="button"

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -48,6 +48,14 @@
 html, body, #root { width: 100%; height: 100%; margin: 0; overflow: hidden; background: transparent; }
 button, select, input { font: inherit; }
 button { color: inherit; cursor: default; }
+*[data-tauri-drag-region] {
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+button, select, input, textarea, .tab, .new-tab, .chrome-button, .sidebar-search-row, .project, .splitter {
+  app-region: no-drag;
+  -webkit-app-region: no-drag;
+}
 
 .app-shell {
   position: relative;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -212,6 +212,8 @@ assert.match(editorTabs, /actions\.navigateBack/);
 assert.match(editorTabs, /actions\.canNavigateForward/);
 assert.match(editorTabs, /\+/);
 assert.match(editorTabs, /×/);
+assert.match(appLayout, /<header\s+className="topbar"[^>]*data-tauri-drag-region/s);
+assert.match(editorTabs, /className="tab-strip"[^>]*data-tauri-drag-region/);
 assert.match(editorTabs, /className="tab-strip-spacer" data-tauri-drag-region/);
 assert.match(pageKinds, /const kinds = \[fileKind, launcherKind, settingsKind\] as const/);
 assert.match(pageKinds, /export function pageKind/);
@@ -233,6 +235,8 @@ assert.doesNotMatch(gridViewer, /const theme = cfg\.theme === 'light' \? 'light'
 assert.match(styles, /\.molecule-stage/);
 assert.match(styles, /inset: var\(--chrome-height\) 0 0/);
 assert.match(styles, /--chrome-drag-height: 56px/);
+assert.match(styles, /\*\[data-tauri-drag-region\] \{[^}]*app-region: drag;[^}]*-webkit-app-region: drag;[^}]*\}/s);
+assert.match(styles, /button, select, input, textarea, \.tab, \.new-tab, \.chrome-button, \.sidebar-search-row, \.project, \.splitter \{[^}]*app-region: no-drag;[^}]*-webkit-app-region: no-drag;[^}]*\}/s);
 assert.match(styles, /\.drag-region \{[^}]*height: var\(--chrome-drag-height\);[^}]*z-index: 2/s);
 assert.match(styles, /\.main-stage \{[^}]*overflow: hidden/s);
 assert.match(styles, /\.sidebar-product:hover/);


### PR DESCRIPTION
## Summary
- make the custom topbar and tab strip participate in Tauri window dragging
- add app-region drag/no-drag CSS so controls stay clickable
- extend UI shell contract coverage for titlebar drag behavior

## Tests
- npm run test:ui
- npm run test:tauri-structure
- PATH=/Users/nikolenko/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/nikolenko/.codex/tmp/arg0/codex-arg0Qlakr1:/Users/nikolenko/.pixi/bin:/Users/nikolenko/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/nikolenko/bin:/Users/nikolenko/.local/bin:/Users/nikolenko/.local/share/mamba/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Applications/quarto/bin:/Users/nikolenko/.cargo/bin:/Users/nikolenko/.fzf/bin npm run build:web