### PR TITLE
Add package manager distribution

### DIFF
--- a/Casks/b/burrete.rb
+++ b/Casks/b/burrete.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+cask "burrete" do
+  version "0.10.33"
+  sha256 "8f0f2ba2d1886a37132290c261741f55a88068d75110b7946e533e4841f6d0d6"
+
+  url "https://github.com/SergeiNikolenko/Burrete/releases/download/v#{version}/Burrete-#{version}.zip"
+  name "Burrete"
+  desc "Finder-native molecular structure previews"
+  homepage "https://github.com/SergeiNikolenko/Burrete"
+
+  depends_on macos: ">= :monterey"
+
+  app "Burrete.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.local.BurreteV10",
+    "~/Library/Caches/com.local.BurreteV10",
+    "~/Library/Containers/com.local.BurreteV10",
+    "~/Library/Containers/com.local.BurreteV10.Preview",
+  ]
+
+  caveats <<~EOS
+    Open Burrete once after installation so macOS registers the Quick Look extension.
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ modeling environment.
 
 ## Download
 
-The easiest way to install Burrete is from the GitHub Releases page:
+The easiest way to install Burrete is with the Burrete Homebrew tap:
+
+```bash
+brew tap SergeiNikolenko/burrete
+brew install --cask burrete
+```
+
+Or download Burrete from the GitHub Releases page:
 
 [Download the latest Burrete release](https://github.com/SergeiNikolenko/Burrete/releases/latest)
 
@@ -94,7 +101,7 @@ Burrete runs as a menu bar app. Its settings window includes:
 
 ## Build From Source
 
-Most users should download Burrete from
+Most users should install Burrete with Homebrew, npm, pnpm, or
 [GitHub Releases](https://github.com/SergeiNikolenko/Burrete/releases/latest).
 If you want to build it yourself, clone the repository and run:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -71,6 +71,39 @@ Every release app bundle must satisfy:
 - Finder Quick Look can preview PDB, CIF, and XYZ samples.
 - Update metadata points to the Burrete release endpoint.
 
+## Package Managers
+
+Homebrew uses the cask in `Casks/b/burrete.rb` and the public tap at
+`SergeiNikolenko/homebrew-burrete`. The working user command is:
+
+```bash
+brew tap SergeiNikolenko/burrete
+brew install --cask burrete
+```
+
+The shorter default-tap command, `brew install --cask burrete`, works only if
+the cask is accepted into `Homebrew/homebrew-cask`. The first upstream PR was
+blocked because the app is not Apple-signed/notarized and the project does not
+meet the default tap notability threshold yet.
+
+After each GitHub release, update the cask `version` and `sha256` to match the
+uploaded `Burrete-<version>.zip` asset. GitHub exposes the asset digest in the
+release metadata as `sha256:<digest>`.
+
+The npm package lives in `packages/burrete`. It is a thin CLI installer for the
+macOS app, not the app bundle itself. Publish it from that workspace package
+after npm authentication and OTP:
+
+```bash
+npm publish --workspace packages/burrete
+```
+
+pnpm uses the same npm package:
+
+```bash
+pnpm dlx burrete install
+```
+
 ## In-App Updates
 
 The desktop app checks Burrete GitHub Releases on launch and from the app menu.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "name": "burrete",
       "version": "0.10.33",
+      "workspaces": [
+        "apps/*",
+        "packages/*",
+        "tools/*"
+      ],
       "dependencies": {
         "@hugeicons/core-free-icons": "^4.1.2",
         "@hugeicons/react": "^1.1.6",
@@ -28,6 +33,9 @@
         "typescript": "~5.8.3",
         "vite": "^7.0.4"
       }
+    },
+    "apps/desktop": {
+      "name": "@burrete/desktop"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -360,6 +368,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@burrete/desktop": {
+      "resolved": "apps/desktop",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -2036,6 +2048,10 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/burrete": {
+      "resolved": "packages/burrete",
+      "link": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -6514,6 +6530,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/burrete": {
+      "version": "0.10.33",
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "burrete": "bin/burrete.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.10.33",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, fast XYZ, xyzrender SVG, and RDKit grids.",
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "tools/*"
+  ],
   "scripts": {
     "vendor:molstar": "node scripts/vendor-molstar.mjs",
     "vendor:rdkit": "node scripts/vendor-rdkit.mjs",
@@ -12,7 +17,7 @@
     "test:agent": "node tests/test-burette-agent.mjs && node tests/test-agent-preview-server.mjs",
     "test:ui": "node tests/test-ui-shell-contract.mjs",
     "test:tauri-structure": "node tests/test-tauri-structure.mjs",
-    "check:js": "node --check PreviewExtension/Web/viewer.js && node --check PreviewExtension/Web/viewer-shell.js && node --check PreviewExtension/Web/burette-agent.js && node --check PreviewExtension/Web/grid-viewer.js && node --check PreviewExtension/Web/xyz-fast.js && node --check scripts/vendor-molstar.mjs && node --check scripts/vendor-rdkit.mjs && node --check scripts/agent-preview.mjs && node --check scripts/check-release-version.mjs && node --check scripts/check-preview-format-registry.mjs",
+    "check:js": "node --check PreviewExtension/Web/viewer.js && node --check PreviewExtension/Web/viewer-shell.js && node --check PreviewExtension/Web/burette-agent.js && node --check PreviewExtension/Web/grid-viewer.js && node --check scripts/vendor-molstar.mjs && node --check scripts/vendor-rdkit.mjs && node --check scripts/agent-preview.mjs && node --check scripts/check-release-version.mjs && node --check scripts/check-preview-format-registry.mjs && node --check packages/burrete/bin/burrete.mjs",
     "check:formats": "node scripts/check-preview-format-registry.mjs",
     "check:release": "node scripts/check-release-version.mjs",
     "ci:fast": "bash scripts/ci-fast.sh",

--- a/packages/burrete/README.md
+++ b/packages/burrete/README.md
@@ -1,0 +1,15 @@
+# Burrete npm installer
+
+This package provides the `burrete` command for installing the Burrete macOS
+app from GitHub Releases.
+
+```bash
+npm exec --package burrete -- burrete install
+pnpm dlx burrete install
+```
+
+The command downloads the latest non-prerelease `Burrete-<version>.zip`,
+verifies the GitHub release asset SHA-256 digest when GitHub provides one, and
+installs `Burrete.app` into `~/Applications` by default.
+
+Use `burrete install --system` to install into `/Applications`.

--- a/packages/burrete/bin/burrete.mjs
+++ b/packages/burrete/bin/burrete.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { spawnSync } from 'node:child_process';
+
+const OWNER = 'SergeiNikolenko';
+const REPO = 'Burrete';
+const API_URL = `https://api.github.com/repos/${OWNER}/${REPO}/releases/latest`;
+const APP_NAME = 'Burrete.app';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0] || 'help';
+
+  if (command === 'help' || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  if (process.platform !== 'darwin') {
+    fail('Burrete is a macOS app. This installer only runs on macOS.');
+  }
+
+  if (command === 'latest') {
+    const release = await fetchLatestRelease();
+    const asset = findZipAsset(release);
+    console.log(`${release.tag_name} ${asset.browser_download_url}`);
+    return;
+  }
+
+  if (command === 'install') {
+    await install(args.slice(1));
+    return;
+  }
+
+  fail(`Unknown command: ${command}`);
+}
+
+async function install(args) {
+  const system = args.includes('--system');
+  const installDir = system ? '/Applications' : path.join(homedir(), 'Applications');
+  const release = await fetchLatestRelease();
+  const asset = findZipAsset(release);
+  const workDir = path.join(tmpdir(), `burrete-${process.pid}`);
+  const zipPath = path.join(workDir, asset.name);
+  const extractDir = path.join(workDir, 'extract');
+
+  await mkdir(extractDir, { recursive: true });
+  await download(asset.browser_download_url, zipPath);
+  await verifyDigest(zipPath, asset.digest);
+
+  run('/usr/bin/ditto', ['-x', '-k', zipPath, extractDir], 'Failed to unzip Burrete release.');
+  await mkdir(installDir, { recursive: true });
+
+  const sourceApp = path.join(extractDir, APP_NAME);
+  await ensureExists(sourceApp, `Release archive does not contain ${APP_NAME}.`);
+  const targetApp = path.join(installDir, APP_NAME);
+  await rm(targetApp, { recursive: true, force: true });
+  run('/usr/bin/ditto', [sourceApp, targetApp], 'Failed to install Burrete.app.');
+  run('/usr/bin/qlmanage', ['-r'], 'Installed Burrete, but Quick Look refresh failed.', { allowFailure: true });
+  await rm(workDir, { recursive: true, force: true });
+
+  console.log(`Installed ${APP_NAME} ${release.tag_name} to ${targetApp}`);
+  console.log('Open Burrete once so macOS registers the Quick Look extension.');
+}
+
+async function fetchLatestRelease() {
+  const response = await fetch(API_URL, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'burrete-npm-installer',
+    },
+  });
+  if (!response.ok) {
+    fail(`Could not fetch latest Burrete release: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function findZipAsset(release) {
+  const asset = release.assets?.find(item => /^Burrete-.+\.zip$/.test(item.name));
+  if (!asset) {
+    fail(`Release ${release.tag_name || 'unknown'} does not include a Burrete zip asset.`);
+  }
+  return asset;
+}
+
+async function download(url, targetPath) {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'burrete-npm-installer',
+    },
+  });
+  if (!response.ok || !response.body) {
+    fail(`Could not download Burrete release: HTTP ${response.status}`);
+  }
+  await pipeline(response.body, createWriteStream(targetPath));
+}
+
+async function verifyDigest(filePath, digest) {
+  if (!digest) return;
+
+  const match = /^sha256:(?<expected>[a-f0-9]{64})$/i.exec(digest);
+  if (!match) return;
+
+  const actual = await sha256(filePath);
+  if (actual !== match.groups.expected.toLowerCase()) {
+    fail(`Downloaded release checksum mismatch: expected ${match.groups.expected}, got ${actual}`);
+  }
+}
+
+async function sha256(filePath) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}
+
+async function ensureExists(filePath, message) {
+  try {
+    await stat(filePath);
+  } catch {
+    fail(message);
+  }
+}
+
+function run(command, args, errorMessage, options = {}) {
+  const result = spawnSync(command, args, { stdio: options.allowFailure ? 'pipe' : 'inherit' });
+  if (result.status !== 0 && !options.allowFailure) {
+    fail(errorMessage);
+  }
+}
+
+function printHelp() {
+  console.log(`Burrete installer
+
+Usage:
+  burrete install [--system]
+  burrete latest
+
+Commands:
+  install   Download the latest Burrete release and install Burrete.app.
+  latest    Print the latest release tag and zip URL.
+
+Options:
+  --system  Install to /Applications instead of ~/Applications.
+`);
+}
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+main().catch(error => fail(error?.message || String(error)));

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "burrete",
+  "version": "0.10.33",
+  "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "latest": "node bin/burrete.mjs latest"
+  },
+  "bin": {
+    "burrete": "bin/burrete.mjs"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SergeiNikolenko/Burrete.git",
+    "directory": "packages/burrete"
+  },
+  "bugs": {
+    "url": "https://github.com/SergeiNikolenko/Burrete/issues"
+  },
+  "homepage": "https://github.com/SergeiNikolenko/Burrete#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Adds package-manager distribution scaffolding for Burrete.

Changes:
- Add a Homebrew cask definition for the Burrete release zip.
- Add a small npm CLI installer package under packages/burrete.
- Add npm and pnpm workspace metadata and lockfiles.
- Update README and release docs with the currently working Homebrew tap flow and publish notes.

Validation:
- npm run check:js
- brew style Casks/b/burrete.rb
- npm publish --dry-run --workspace packages/burrete
- npm exec --package ./packages/burrete -- burrete latest
- pnpm --filter burrete run latest

Notes:
- The default Homebrew cask PR was closed by upstream checks because the app is not Apple-signed/notarized and the project does not meet the default tap notability threshold yet.
- npm publish still requires the npm OTP for the account.