### PR TITLE
Fix Quick Look open handoff

### DIFF
--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -1106,11 +1106,31 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
 
     private func handleJavaScriptAction(_ action: String) {
         appendLog("JS action=\(action)")
+        if action == "open-burrete" {
+            openCurrentPreviewInBurrete()
+            return
+        }
         if action == "open-vesta" {
             openCurrentPreviewInVesta()
             return
         }
         appendLog("unknown JS action=\(action)")
+    }
+
+    private func openCurrentPreviewInBurrete() {
+        guard let url = currentPreviewURL else {
+            appendLog("openInBurrete.missingCurrentURL")
+            return
+        }
+        BurreteLauncher.open(fileURL: url) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                self.appendLog("openInBurrete.launched=\(url.path)")
+            case .failure(let error):
+                self.appendLog("openInBurrete.failed=\(error.localizedDescription)")
+            }
+        }
     }
 
     private func openCurrentPreviewInVesta() {
@@ -2042,7 +2062,7 @@ private struct PreviewPreferences {
             xyzrenderExtraArguments: xyzrenderExtraArguments,
             gridFileSupport: gridFileSupport,
             defaultLayoutState: [
-                "left": "collapsed",
+                "left": "hidden",
                 "right": "hidden",
                 "top": "hidden",
                 "bottom": "hidden"
@@ -2091,6 +2111,66 @@ private enum PreviewError: LocalizedError {
             return "Could not create preview config."
         case .couldNotCreateRuntimePreview(let reason):
             return "Could not create runtime preview files: \(reason)"
+        }
+    }
+}
+
+private enum BurreteLauncher {
+    static func open(fileURL: URL, completion: @escaping (Result<Void, Error>) -> Void) {
+        if let appURL = containingApplicationURL() {
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            NSWorkspace.shared.open([fileURL], withApplicationAt: appURL, configuration: configuration) { _, error in
+                DispatchQueue.main.async {
+                    if let error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(()))
+                    }
+                }
+            }
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", "Burrete", fileURL.path]
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        process.terminationHandler = { finished in
+            let data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+            DispatchQueue.main.async {
+                if finished.terminationStatus == 0 {
+                    completion(.success(()))
+                } else {
+                    completion(.failure(BurreteLaunchError.failed(message.trimmingCharacters(in: .whitespacesAndNewlines))))
+                }
+            }
+        }
+        do {
+            try process.run()
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    private static func containingApplicationURL() -> URL? {
+        let bundleURL = Bundle(for: PreviewViewController.self).bundleURL
+        let contentsURL = bundleURL.deletingLastPathComponent().deletingLastPathComponent()
+        guard contentsURL.lastPathComponent == "Contents" else { return nil }
+        let appURL = contentsURL.deletingLastPathComponent()
+        return appURL.pathExtension == "app" ? appURL : nil
+    }
+}
+
+private enum BurreteLaunchError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .failed(let message):
+            return message.isEmpty ? "Burrete could not be opened." : message
         }
     }
 }

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -12,6 +12,7 @@
         <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
         <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
         <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
+        <button class="buret-button" type="button" data-buret-action="open-burrete" aria-label="Open in Burrete" title="Open in Burrete">Open</button>
         <div class="buret-renderer-control" data-buret-renderer-control>
           <button class="buret-button buret-renderer-choice" type="button" data-buret-renderer="xyz-fast" aria-label="Use Fast XYZ SVG" title="Use Fast XYZ SVG">Fast</button>
           <button class="buret-button buret-renderer-choice" type="button" data-buret-renderer="molstar" aria-label="Use Mol* Interactive" title="Use Mol* Interactive">Mol*</button>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -638,6 +638,10 @@
     toolbar.querySelector('[data-buret-action="theme"]')?.addEventListener('click', () => {
       toggleViewerTheme(viewer);
     });
+    toolbar.querySelector('[data-buret-action="open-burrete"]')?.addEventListener('click', () => {
+      const sent = postHostMessage({ type: 'action', message: 'open-burrete' });
+      if (!sent) setStatus('Open in Burrete is available only in Quick Look.', 'error');
+    });
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
     installMolstarFloatingPanelTracking();
@@ -1132,7 +1136,7 @@
       canvasBackground: 'black',
       overlayOpacity: 0.9,
       defaultLayoutState: {
-        left: 'collapsed',
+        left: 'hidden',
         right: 'hidden',
         top: 'hidden',
         bottom: 'hidden'

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "url",
  "uuid",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri = { version = "2", features = ["macos-private-api", "protocol-asset", "tra
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+url = "2"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
@@ -72,7 +72,7 @@ pub(crate) fn create_runtime<R: Runtime>(
         "molstarAvailable": !format.external_only,
         "canOpenInVesta": format.can_open_in_vesta,
         "showPanelControls": true,
-        "defaultLayoutState": { "left": "collapsed", "right": "hidden", "top": "hidden", "bottom": "hidden" }
+        "defaultLayoutState": { "left": "hidden", "right": "hidden", "top": "hidden", "bottom": "hidden" }
     });
 
     if renderer == "xyz-fast" {

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -1,23 +1,74 @@
 use std::path::PathBuf;
 use tauri::{Emitter, Runtime};
+use url::Url;
 
 pub(crate) fn file_args_from_argv(argv: Vec<String>, cwd: Option<PathBuf>) -> Vec<String> {
     argv.into_iter()
         .skip(1)
         .filter_map(|arg| {
-            let candidate = PathBuf::from(arg);
-            let path = if candidate.is_absolute() {
-                candidate
-            } else {
-                cwd.as_ref()?.join(candidate)
-            };
+            let path = file_arg_to_path(&arg, cwd.as_ref())?;
             path.is_file().then(|| path.to_string_lossy().to_string())
         })
         .collect()
 }
 
+fn file_arg_to_path(arg: &str, cwd: Option<&PathBuf>) -> Option<PathBuf> {
+    if let Ok(url) = Url::parse(arg) {
+        if url.scheme() == "file" {
+            return url.to_file_path().ok();
+        }
+    }
+
+    let candidate = PathBuf::from(arg);
+    Some(if candidate.is_absolute() {
+        candidate
+    } else {
+        cwd?.join(candidate)
+    })
+}
+
 pub(crate) fn emit_open_documents<R: Runtime>(app: &tauri::AppHandle<R>, paths: Vec<String>) {
     if !paths.is_empty() {
         let _ = app.emit("open-documents", paths);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::file_args_from_argv;
+    use std::fs;
+
+    #[test]
+    fn accepts_file_url_arguments() {
+        let file = std::env::temp_dir().join(format!("burrete-startup-{}.pdb", std::process::id()));
+        fs::write(&file, "HEADER TEST\n").unwrap();
+
+        let argv = vec![
+            "burrete".to_string(),
+            url::Url::from_file_path(&file).unwrap().to_string(),
+        ];
+
+        assert_eq!(
+            file_args_from_argv(argv, None),
+            vec![file.to_string_lossy().to_string()]
+        );
+        fs::remove_file(file).unwrap();
+    }
+
+    #[test]
+    fn accepts_relative_path_arguments() {
+        let dir = std::env::temp_dir().join(format!("burrete-startup-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("mini.pdb");
+        fs::write(&file, "HEADER TEST\n").unwrap();
+
+        let argv = vec!["burrete".to_string(), "mini.pdb".to_string()];
+
+        assert_eq!(
+            file_args_from_argv(argv, Some(dir.clone())),
+            vec![file.to_string_lossy().to_string()]
+        );
+        fs::remove_file(file).unwrap();
+        fs::remove_dir(dir).unwrap();
     }
 }

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -122,7 +122,7 @@ function viewerHtml(
     molstarAvailable: !format.externalOnly,
     canOpenInVesta: format.canOpenInVesta,
     showPanelControls: true,
-    defaultLayoutState: { left: "collapsed", right: "hidden", top: "hidden", bottom: "hidden" },
+    defaultLayoutState: { left: "hidden", right: "hidden", top: "hidden", bottom: "hidden" },
     ...(renderer === "xyz-fast"
       ? {
           xyzFast: {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -48,6 +48,8 @@ const [
   updateSource,
   browserDevDocuments,
   readme,
+  viewerShell,
+  viewer,
 ] = await Promise.all([
   source('apps/desktop/src/App.tsx'),
   source('apps/desktop/src/stores/ui-store.ts'),
@@ -89,6 +91,8 @@ const [
   source('apps/desktop/src/update.ts'),
   source('apps/desktop/src/lib/browser-dev-documents.ts'),
   source('README.md'),
+  source('PreviewExtension/Web/viewer-shell.js'),
+  source('PreviewExtension/Web/viewer.js'),
 ]);
 
 assert.match(uiStore, /export const useUIStore = create<UIState>/);
@@ -134,6 +138,9 @@ for (const exportName of [
 assert.match(sidebarHook, /export function useSidebar\(/);
 assert.match(sidebarHook, /from "\.\.\/stores\/shell-store"/);
 assert.match(sidebarHook, /sidebarWidth/);
+assert.match(viewerShell, /data-buret-action="open-burrete"/);
+assert.match(viewer, /message: 'open-burrete'/);
+assert.match(viewer, /left: 'hidden'/);
 assert.match(sidebarHook, /toggleSidebar/);
 assert.match(shellStore, /export const useShellStore = create<ShellState>/);
 assert.match(shellStore, /name: "burrete\.shell\.ui"/);


### PR DESCRIPTION
## Summary
- hide the Quick Look Mol* left panel by default
- add an Open in Burrete action that opens the current preview file in the containing app
- accept file:// startup arguments so macOS Open With handoff opens the document

## Validation
- cargo test startup --quiet
- npm run check:js
- npm run test:ui
- ./scripts/build.sh
- ./scripts/install.sh
- ./scripts/force-preview.sh samples/mini.pdb rendered mini.pdb in the Quick Look log