### PR TITLE
Document published package manager installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ brew tap SergeiNikolenko/burrete
 brew install --cask burrete
 ```
 
+You can also install it with npm or pnpm:
+
+```bash
+npm exec --package burrete -- burrete install
+pnpm dlx burrete install
+```
+
 Or download Burrete from the GitHub Releases page:
 
 [Download the latest Burrete release](https://github.com/SergeiNikolenko/Burrete/releases/latest)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -92,7 +92,7 @@ release metadata as `sha256:<digest>`.
 
 The npm package lives in `packages/burrete`. It is a thin CLI installer for the
 macOS app, not the app bundle itself. Publish it from that workspace package
-after npm authentication and OTP:
+after npm authentication:
 
 ```bash
 npm publish --workspace packages/burrete


### PR DESCRIPTION
Updates install docs now that burrete@0.10.33 is published to npm.

Validation:
- npm run check:js
- npm view burrete name version dist-tags --json
- npm exec --package burrete -- burrete latest
- pnpm dlx burrete latest