### PR TITLE
Fix UI overlay clipping

### DIFF
--- a/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
+++ b/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
@@ -40,6 +40,8 @@ export function EditorScrollContainer({
         style={{
           WebkitMaskImage: FADE_MASK,
           maskImage: FADE_MASK,
+          WebkitMaskComposite: "source-over",
+          maskComposite: "add",
           borderTop: "12px solid transparent",
           borderBottom: "12px solid transparent",
         }}

--- a/apps/desktop/src/components/sidebar/index.tsx
+++ b/apps/desktop/src/components/sidebar/index.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import {
   Cancel01Icon,
   File02Icon,
@@ -16,28 +16,66 @@ export const Sidebar = forwardRef<HTMLButtonElement, {
   actions: ShellActions;
 }>(({ state, actions }, searchRef) => {
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
+  const [workspaceMenuPosition, setWorkspaceMenuPosition] = useState({
+    left: 12,
+    top: 528,
+    width: 210,
+    maxHeight: 260,
+  });
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const workspaceButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const updateWorkspaceMenuPosition = useCallback(() => {
+    const button = workspaceButtonRef.current;
+    if (!button) return;
+    const margin = 8;
+    const menuHeight = 68;
+    const rect = button.getBoundingClientRect();
+    const width = Math.min(Math.max(rect.width, 210), window.innerWidth - margin * 2);
+    setWorkspaceMenuPosition({
+      left: Math.max(margin, Math.min(rect.left, window.innerWidth - width - margin)),
+      top: Math.max(margin, rect.top - menuHeight - margin),
+      width,
+      maxHeight: Math.max(48, rect.top - margin * 2),
+    });
+  }, []);
 
   useEffect(() => {
     if (!workspaceMenuOpen) return undefined;
+    updateWorkspaceMenuPosition();
     const onPointerDown = (event: PointerEvent) => {
       if (!menuRef.current?.contains(event.target as Node)) setWorkspaceMenuOpen(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setWorkspaceMenuOpen(false);
     };
+    const onResize = () => updateWorkspaceMenuPosition();
     window.addEventListener("pointerdown", onPointerDown);
     window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("resize", onResize);
     return () => {
       window.removeEventListener("pointerdown", onPointerDown);
       window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("resize", onResize);
     };
-  }, [workspaceMenuOpen]);
+  }, [updateWorkspaceMenuPosition, workspaceMenuOpen]);
 
   const runWorkspaceAction = (action: () => void | Promise<void>) => {
     setWorkspaceMenuOpen(false);
     void action();
   };
+
+  const toggleWorkspaceMenu = () => {
+    if (!workspaceMenuOpen) updateWorkspaceMenuPosition();
+    setWorkspaceMenuOpen((open) => !open);
+  };
+
+  const workspaceMenuStyle = {
+    "--workspace-menu-left": workspaceMenuPosition.left + "px",
+    "--workspace-menu-top": workspaceMenuPosition.top + "px",
+    "--workspace-menu-width": workspaceMenuPosition.width + "px",
+    "--workspace-menu-max-height": workspaceMenuPosition.maxHeight + "px",
+  } as CSSProperties;
 
   return (
     <aside className="sidebar" style={{ width: state.sidebarWidth }}>
@@ -130,7 +168,7 @@ export const Sidebar = forwardRef<HTMLButtonElement, {
       </ScrollFade>
       <div className="sidebar-footer" ref={menuRef}>
         {workspaceMenuOpen && (
-          <div className="sidebar-workspace-menu" role="menu" aria-label="Workspace actions">
+          <div className="sidebar-workspace-menu" role="menu" aria-label="Workspace actions" style={workspaceMenuStyle}>
             <button type="button" role="menuitem" onClick={() => runWorkspaceAction(actions.chooseWorkspace)}>
               Choose workspace...
             </button>
@@ -140,9 +178,10 @@ export const Sidebar = forwardRef<HTMLButtonElement, {
           </div>
         )}
         <button
+          ref={workspaceButtonRef}
           type="button"
           className="sidebar-product"
-          onClick={() => setWorkspaceMenuOpen((open) => !open)}
+          onClick={toggleWorkspaceMenu}
           aria-haspopup="menu"
           aria-expanded={workspaceMenuOpen}
           aria-label={"Open workspace menu for " + appInstanceLabel}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -368,11 +368,14 @@ kbd { color: var(--text-faint); font-size: 12px; font-family: inherit; font-weig
 .sidebar-product-icon { width: 20px; height: 16px; flex: 0 0 20px; display: inline-flex; align-items: center; justify-content: center; color: var(--text-icon-muted); }
 .sidebar-product-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sidebar-workspace-menu {
-  position: absolute;
-  left: 10px;
-  width: 210px;
-  bottom: 48px;
-  z-index: 20;
+  position: fixed;
+  left: var(--workspace-menu-left);
+  top: var(--workspace-menu-top);
+  width: var(--workspace-menu-width);
+  max-height: var(--workspace-menu-max-height);
+  z-index: 50;
+  box-sizing: border-box;
+  overflow-y: auto;
   padding: 5px;
   border: 1px solid color-mix(in srgb, var(--fg-base) 14%, transparent);
   border-radius: 10px;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -24,6 +24,7 @@ const [
   commandPalette,
   editorArea,
   editorTabs,
+  editorScrollContainer,
   settingsPanel,
   settingControl,
   pageKinds,
@@ -62,6 +63,7 @@ const [
   source('apps/desktop/src/components/command-palette/index.tsx'),
   source('apps/desktop/src/components/editor-area/index.tsx'),
   source('apps/desktop/src/components/editor-area/editor-tabs.tsx'),
+  source('apps/desktop/src/components/editor-area/editor-scroll-container.tsx'),
   source('apps/desktop/src/components/settings-panel/index.tsx'),
   source('apps/desktop/src/components/settings-panel/setting-control.tsx'),
   source('apps/desktop/src/components/editor-area/page-kinds/index.ts'),
@@ -267,6 +269,13 @@ assert.match(sidebar, /from "\.\.\/\.\.\/lib\/instance"/);
 assert.match(sidebar, /appInstanceLabel/);
 assert.match(sidebar, /className="sidebar-product"/);
 assert.match(sidebar, /sidebar-workspace-menu/);
+assert.match(sidebar, /workspaceButtonRef/);
+assert.match(sidebar, /workspaceMenuPosition/);
+assert.match(styles, /\.sidebar-workspace-menu \{[^}]*position: fixed/s);
+assert.match(styles, /--workspace-menu-left/);
+assert.match(styles, /--workspace-menu-top/);
+assert.match(styles, /--workspace-menu-max-height/);
+assert.doesNotMatch(styles, /\.sidebar-workspace-menu \{[^}]*bottom: 48px/s);
 assert.match(sidebar, /Choose workspace\.\.\./);
 assert.match(sidebar, /Open folder/);
 assert.doesNotMatch(sidebar, /actions\.openSettings/);
@@ -283,6 +292,8 @@ assert.doesNotMatch(appLayout + sidebar + editorTabs, /◧|◨/);
 assert.match(settingsPanel, /<h1>Preferences<\/h1>/);
 assert.match(settingsPanel, /className="settings-panel"/);
 assert.match(settingsPanel, /<EditorScrollContainer>/);
+assert.match(editorScrollContainer, /WebkitMaskComposite:\s*"source-over"/);
+assert.match(editorScrollContainer, /maskComposite:\s*"add"/);
 assert.match(settingsPanel, /title="Display"/);
 assert.match(settingsPanel, /title="Structure Rendering"/);
 assert.match(settingsPanel, /title="System"/);


### PR DESCRIPTION
## Summary
- fix settings scroll fade mask compositing to avoid dark band artifacts
- render the workspace menu as a viewport-positioned popover so the sidebar does not clip it
- add UI shell contract coverage for both overlay fixes

## Tests
- PATH=/opt/homebrew/bin:/Users/nikolenko/.codex/tmp/arg0/codex-arg0Qlakr1:/Users/nikolenko/.pixi/bin:/Users/nikolenko/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/nikolenko/bin:/Users/nikolenko/.local/bin:/Users/nikolenko/.local/share/mamba/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Applications/quarto/bin:/Users/nikolenko/.cargo/bin:/Users/nikolenko/.fzf/bin npm run test:ui
- PATH=/opt/homebrew/bin:/Users/nikolenko/.codex/tmp/arg0/codex-arg0Qlakr1:/Users/nikolenko/.pixi/bin:/Users/nikolenko/.bun/bin:/Applications/Codex.app/Contents/Resources:/Users/nikolenko/bin:/Users/nikolenko/.local/bin:/Users/nikolenko/.local/share/mamba/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Applications/quarto/bin:/Users/nikolenko/.cargo/bin:/Users/nikolenko/.fzf/bin npm run build:web