### PR TITLE
Fix xyzrender CI regression

### DIFF
--- a/apps/desktop/src-tauri/src/preview/xyzrender.rs
+++ b/apps/desktop/src-tauri/src/preview/xyzrender.rs
@@ -302,6 +302,8 @@ mod tests {
             &directory.join("input.xyz"),
             &directory.join("xyzrender.svg"),
             &directory.join("xyzrender.log"),
+            "default",
+            None,
             Duration::from_millis(100),
         );
 


### PR DESCRIPTION
## Summary
- update the xyzrender timeout test for the expanded helper signature
- keep the runtime path untouched and only repair the broken test invocation

## Verification
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml xyzrender --quiet
- bun run ci:fast