### PR TITLE
Polish xyzrender preview runtime parity

### DIFF
--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -18,6 +18,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     private var rendererOverride: String?
     private var xyzrenderPresetOverride: String?
     private var xyzrenderOrientationRefText: String?
+    private var xyzrenderControlsOverride: [String: Any]?
     private static let showDebugOverlay = false
     private static let verboseLogging = false
     private static let defaultViewerPageZoom: CGFloat = 1.0
@@ -80,6 +81,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         rendererOverride = nil
         xyzrenderPresetOverride = nil
         xyzrenderOrientationRefText = nil
+        xyzrenderControlsOverride = nil
         resetLog()
         hasRenderedTerminationError = false
         appendLog("preparePreviewOfFile called")
@@ -170,7 +172,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         requestID: String,
         rendererOverride: String? = nil,
         xyzrenderPresetOverride: String? = nil,
-        xyzrenderOrientationRefText: String? = nil
+        xyzrenderOrientationRefText: String? = nil,
+        xyzrenderControlsOverride: [String: Any]? = nil
     ) throws -> BuildResult {
         var diagnostics: [String] = []
         func diag(_ message: String) { diagnostics.append("[build] " + message) }
@@ -285,7 +288,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                     transparent: preferences.canvasBackground == "transparent",
                     executablePath: preferences.xyzrenderExecutablePath,
                     extraArguments: preferences.xyzrenderExtraArguments,
-                    orientationRefText: xyzrenderOrientationRefText
+                    orientationRefText: xyzrenderOrientationRefText,
+                    controls: xyzrenderControlsOverride
                 )
                 externalArtifactSourceURL = renderDirectory.appendingPathComponent("xyzrender.svg")
             } catch {
@@ -341,6 +345,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             externalArtifact: externalArtifact,
             externalStatus: externalStatus,
             xyzrenderPreset: xyzrenderPreset,
+            xyzrenderControls: xyzrenderControlsOverride,
             originalFileExtension: pathExtension,
             rendererPolicy: rendererPolicy,
             preferences: preferences
@@ -579,6 +584,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         externalArtifact: PreviewExternalXyzrenderArtifact?,
         externalStatus: [String: Any]?,
         xyzrenderPreset: String,
+        xyzrenderControls: [String: Any]?,
         originalFileExtension: String,
         rendererPolicy: BurreteRendererPolicy,
         preferences: PreviewPreferences
@@ -613,11 +619,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             payload["quickLookViewer"] = true
             payload["xyzrenderPreset"] = xyzrenderPreset
             payload["xyzrenderPresetOptions"] = BurreteXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] }
+            if let xyzrenderControls { payload["xyzrenderControls"] = xyzrenderControls }
         }
         if format.molstarFormat == "xyz" && !format.isBinary {
             payload["quickLookViewer"] = true
             payload["xyzrenderPreset"] = xyzrenderPreset
             payload["xyzrenderPresetOptions"] = BurreteXyzrenderPreset.pickerOptions.map { ["value": $0.0, "label": $0.1] }
+            if let xyzrenderControls { payload["xyzrenderControls"] = xyzrenderControls }
         }
         if renderer == BurreteRendererMode.xyzFast {
             var xyzFast: [String: Any] = [
@@ -1068,6 +1076,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                 setXyzrenderPresetOverride(value)
                 return
             }
+            if type == "setXyzrenderControls" {
+                setXyzrenderControlsOverride(body["controls"] as? [String: Any] ?? [:])
+                return
+            }
             if type == "setXyzrenderOrientation" {
                 setXyzrenderOrientation(body["text"] as? String ?? body["value"] as? String)
                 return
@@ -1178,6 +1190,15 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         reloadCurrentPreview()
     }
 
+    private func setXyzrenderControlsOverride(_ value: [String: Any]) {
+        let normalized = PreviewExternalXyzrenderWorker.normalizedControls(value)
+        guard NSDictionary(dictionary: xyzrenderControlsOverride ?? [:]).isEqual(to: normalized) == false
+            || rendererOverride != BurreteRendererMode.xyzrenderExternal else { return }
+        xyzrenderControlsOverride = normalized
+        rendererOverride = BurreteRendererMode.xyzrenderExternal
+        reloadCurrentPreview()
+    }
+
     @discardableResult
     private func setXyzrenderOrientation(_ text: String?) -> Bool {
         let normalized = Self.normalizedXyzrenderOrientationRef(text)
@@ -1209,7 +1230,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         let rendererOverride = rendererOverride
         let xyzrenderPresetOverride = xyzrenderPresetOverride
         let xyzrenderOrientationRefText = xyzrenderOrientationRefText
-        appendLog("reloading preview rendererOverride=\(rendererOverride ?? "nil") xyzrenderPresetOverride=\(xyzrenderPresetOverride ?? "nil") orientationRef=\(xyzrenderOrientationRefText == nil ? "nil" : "set")")
+        let xyzrenderControlsOverride = xyzrenderControlsOverride
+        appendLog("reloading preview rendererOverride=\(rendererOverride ?? "nil") xyzrenderPresetOverride=\(xyzrenderPresetOverride ?? "nil") orientationRef=\(xyzrenderOrientationRefText == nil ? "nil" : "set") controls=\(xyzrenderControlsOverride == nil ? "nil" : "set")")
         previewStatus = "[native] Switching renderer...\n\(url.lastPathComponent)"
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
@@ -1218,7 +1240,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
                     requestID: requestID.uuidString,
                     rendererOverride: rendererOverride,
                     xyzrenderPresetOverride: xyzrenderPresetOverride,
-                    xyzrenderOrientationRefText: xyzrenderOrientationRefText
+                    xyzrenderOrientationRefText: xyzrenderOrientationRefText,
+                    xyzrenderControlsOverride: xyzrenderControlsOverride
                 )
                 DispatchQueue.main.async { [weak self] in
                     guard let self, self.activePreviewRequestID == requestID else { return }
@@ -1816,7 +1839,8 @@ private enum PreviewExternalXyzrenderWorker {
         transparent: Bool,
         executablePath: String,
         extraArguments: String,
-        orientationRefText: String?
+        orientationRefText: String?,
+        controls: [String: Any]?
     ) throws -> PreviewExternalXyzrenderArtifact {
         let fileManager = FileManager.default
         let inputURL = outputDirectory.appendingPathComponent(safeInputFilename(sourceFilename))
@@ -1832,15 +1856,22 @@ private enum PreviewExternalXyzrenderWorker {
         var arguments = [inputURL.path, "-o", outputURL.path]
 
         let safePreset = BurreteXyzrenderPreset.normalize(preset)
-        let configArgument = resolveConfigArgument(preset: safePreset, customConfigPath: customConfigPath)
+        let normalizedControls = normalizedControls(controls ?? [:])
+        let configArgument = resolveConfigArgument(
+            preset: safePreset,
+            customConfigPath: normalizedControls["customConfigPath"] as? String ?? customConfigPath
+        )
         let effectivePreset = safePreset == "custom" && configArgument == "default" ? "default" : safePreset
         arguments += ["--config", configArgument]
         let orientationRefURL = try writeOrientationRef(orientationRefText, outputDirectory: outputDirectory)
         if let orientationRefURL {
             arguments += ["--ref", orientationRefURL.path]
         }
-        if transparent { arguments.append("--transparent") }
-        arguments += sanitizedExtraArguments(extraArguments)
+        if (normalizedControls["transparentBackground"] as? Bool) == true || transparent {
+            arguments.append("--transparent")
+        }
+        arguments += cliArguments(from: normalizedControls)
+        arguments += sanitizedExtraArguments((normalizedControls["extraArguments"] as? String) ?? extraArguments)
         process.arguments = arguments
         process.environment = mergedEnvironment()
 
@@ -1932,8 +1963,139 @@ private enum PreviewExternalXyzrenderWorker {
         return trimmed.isEmpty ? "default" : trimmed
     }
 
+    static func normalizedControls(_ value: [String: Any]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        copyBoolean(value, key: "transparentBackground", into: &result)
+        copyNumber(value, key: "canvasSize", into: &result)
+        copyNumber(value, key: "atomScale", into: &result)
+        copyNumber(value, key: "bondWidth", into: &result)
+        copyNumber(value, key: "atomStrokeWidth", into: &result)
+        copyText(value, key: "molColor", into: &result)
+        copyBoolean(value, key: "gradients", into: &result)
+        copyBoolean(value, key: "fog", into: &result)
+        copyNumber(value, key: "fogStrength", into: &result)
+        copyBoolean(value, key: "showVdw", into: &result)
+        copyNumber(value, key: "vdwOpacity", into: &result)
+        copyNumber(value, key: "vdwScale", into: &result)
+        copyBoolean(value, key: "hideBonds", into: &result)
+        copyBoolean(value, key: "showCell", into: &result)
+        copyBoolean(value, key: "showGhosts", into: &result)
+        copyBoolean(value, key: "showAxes", into: &result)
+        copyNumber(value, key: "cellWidth", into: &result)
+        copyText(value, key: "customConfigPath", into: &result)
+        copyText(value, key: "extraArguments", into: &result)
+        if let supercell = normalizeSupercell(value["supercell"]) {
+            result["supercell"] = supercell
+        }
+        return result
+    }
+
+    private static func cliArguments(from controls: [String: Any]) -> [String] {
+        var arguments: [String] = []
+        if let value = finitePositive(controls["canvasSize"]) {
+            arguments += ["-S", formatCLI(value)]
+        }
+        if let value = finitePositive(controls["atomScale"]) {
+            arguments += ["-a", formatCLI(value)]
+        }
+        if let value = finitePositive(controls["bondWidth"]) {
+            arguments += ["-b", formatCLI(value)]
+        }
+        if let value = finitePositive(controls["atomStrokeWidth"]) {
+            arguments += ["-s", formatCLI(value)]
+        }
+        if let value = controls["molColor"] as? String {
+            arguments += ["--mol-color", value]
+        }
+        if let value = controls["gradients"] as? Bool {
+            arguments.append(value ? "--grad" : "--no-grad")
+        }
+        if let value = controls["fog"] as? Bool {
+            arguments.append(value ? "--fog" : "--no-fog")
+        }
+        if let value = finitePositive(controls["fogStrength"]) {
+            arguments += ["-F", formatCLI(value)]
+        }
+        if (controls["showVdw"] as? Bool) == true {
+            arguments.append("--vdw")
+        }
+        if let value = finitePositive(controls["vdwOpacity"]) {
+            arguments += ["--vdw-opacity", formatCLI(value)]
+        }
+        if let value = finitePositive(controls["vdwScale"]) {
+            arguments += ["--vdw-scale", formatCLI(value)]
+        }
+        if (controls["hideBonds"] as? Bool) == true {
+            arguments.append("--no-bonds")
+        }
+        if let value = controls["showCell"] as? Bool {
+            arguments.append(value ? "--cell" : "--no-cell")
+        }
+        if let value = controls["showGhosts"] as? Bool {
+            arguments.append(value ? "--ghosts" : "--no-ghosts")
+        }
+        if let value = controls["showAxes"] as? Bool {
+            arguments.append(value ? "--axes" : "--no-axes")
+        }
+        if let value = finitePositive(controls["cellWidth"]) {
+            arguments += ["--cell-width", formatCLI(value)]
+        }
+        if let supercell = controls["supercell"] as? [Int], supercell.count == 3, supercell.allSatisfy({ $0 > 0 }) {
+            arguments.append("--supercell")
+            arguments += supercell.map(String.init)
+        }
+        return arguments
+    }
+
+    private static func copyBoolean(_ source: [String: Any], key: String, into result: inout [String: Any]) {
+        if let value = source[key] as? Bool {
+            result[key] = value
+        }
+    }
+
+    private static func copyNumber(_ source: [String: Any], key: String, into result: inout [String: Any]) {
+        if let value = finitePositive(source[key]) {
+            result[key] = value
+        }
+    }
+
+    private static func copyText(_ source: [String: Any], key: String, into result: inout [String: Any]) {
+        if let value = nonEmptyText(source[key] as? String) {
+            result[key] = value
+        }
+    }
+
+    private static func finitePositive(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            let resolved = number.doubleValue
+            return resolved.isFinite && resolved > 0 ? resolved : nil
+        }
+        if let text = value as? String, let resolved = Double(text), resolved.isFinite, resolved > 0 {
+            return resolved
+        }
+        return nil
+    }
+
+    private static func nonEmptyText(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizeSupercell(_ value: Any?) -> [Int]? {
+        guard let values = value as? [Any], values.count == 3 else { return nil }
+        let parsed = values.compactMap { (($0 as? NSNumber)?.intValue) ?? Int(($0 as? String) ?? "") }
+        guard parsed.count == 3, parsed.allSatisfy({ $0 > 0 }) else { return nil }
+        return parsed
+    }
+
+    private static func formatCLI(_ value: Double) -> String {
+        let text = String(format: "%.6f", value)
+        return text.replacingOccurrences(of: #"(\.\d*?[1-9])0+$"#, with: "$1", options: .regularExpression)
+            .replacingOccurrences(of: #"\.0+$"#, with: "", options: .regularExpression)
+    }
+
     private static func sanitizedExtraArguments(_ value: String) -> [String] {
-        let outputFlags = Set(["-o", "--output", "-go", "--gif-output", "--config"])
+        let outputFlags = Set(["-o", "--output", "-go", "--gif-output", "--config", "--ref"])
         var result: [String] = []
         var skipNext = false
         for token in splitCommandLine(value) {

--- a/PreviewExtension/RendererPolicy.swift
+++ b/PreviewExtension/RendererPolicy.swift
@@ -47,7 +47,7 @@ struct BurreteRendererPolicy: Equatable {
             case BurreteRendererMode.xyzrenderExternal:
                 renderer = isXYZ ? BurreteRendererMode.xyzrenderExternal : BurreteRendererMode.molstar
             default:
-                renderer = isXYZ ? BurreteRendererMode.xyzFast : BurreteRendererMode.molstar
+                renderer = isXYZ ? BurreteRendererMode.xyzrenderExternal : BurreteRendererMode.molstar
             }
         }
 

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -25,6 +25,16 @@
   --buret-molstar-accent: #8fc7ff;
   --buret-molstar-shadow: rgba(0, 0, 0, 0.38);
   --buret-molstar-panel-radius: 10px;
+  --buret-menu-background: #2a2d33;
+  --buret-menu-section-background: #31343b;
+  --buret-menu-input-background: #383c44;
+  --buret-menu-input-focus-background: #40454e;
+  --buret-menu-border: rgba(255, 255, 255, 0.08);
+  --buret-menu-divider: rgba(255, 255, 255, 0.06);
+  --buret-menu-toggle-track: rgba(255, 255, 255, 0.20);
+  --buret-menu-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+  --buret-menu-accent: #0a84ff;
+  --buret-select-chevron: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='rgba(255,255,255,0.62)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M3 4.5l3 3 3-3'/></svg>");
 }
 html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
 html.buret-transparent-background,
@@ -51,6 +61,16 @@ body.buret-theme-light {
   --buret-molstar-muted-text: rgba(86, 88, 92, 0.82);
   --buret-molstar-accent: #006bd6;
   --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
+  --buret-menu-background: #f6f6f4;
+  --buret-menu-section-background: #efefec;
+  --buret-menu-input-background: #e8e8e5;
+  --buret-menu-input-focus-background: #e0e0dc;
+  --buret-menu-border: rgba(0, 0, 0, 0.08);
+  --buret-menu-divider: rgba(0, 0, 0, 0.06);
+  --buret-menu-toggle-track: rgba(0, 0, 0, 0.16);
+  --buret-menu-shadow: 0 16px 36px rgba(0, 0, 0, 0.15);
+  --buret-menu-accent: #0a84ff;
+  --buret-select-chevron: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='rgba(51,54,59,0.66)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M3 4.5l3 3 3-3'/></svg>");
   color: #161719;
 }
 body.buret-theme-dark {
@@ -493,7 +513,7 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
   max-width: calc(100vw - 24px);
   justify-content: flex-start;
   align-content: center;
-  overflow: hidden;
+  overflow: visible;
 }
 #buret-toolbar > * { flex: 0 0 auto; }
 #buret-toolbar.buret-dragging { transition: none; }
@@ -543,11 +563,15 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 .buret-button {
-  min-width: 30px; height: 30px; border: 0; border-radius: 8px; padding: 0 8px;
+  min-width: 30px; height: 30px; border: 0; border-radius: 8px; padding: 0 7px;
   color: inherit; background: transparent; font: 600 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
   display: grid; place-items: center;
 }
 .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
+.buret-xyzrender-tune.active {
+  background: var(--buret-menu-input-background);
+  box-shadow: inset 0 0 0 1px var(--buret-menu-border);
+}
 .buret-button.hidden { display: none; }
 .buret-button svg { width: 17px; height: 17px; display: block; }
 .buret-grip { width: 30px; padding: 0; cursor: grab; color: currentColor; opacity: 0.66; }
@@ -556,14 +580,235 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
   border-left: 1px solid var(--buret-toolbar-border);
 }
 .buret-renderer-control.visible { display: flex; }
-.buret-renderer-choice { min-width: 42px; }
+.buret-renderer-choice { min-width: 38px; }
 .buret-xyzrender-preset-slot { display: none; align-items: center; }
 .buret-xyzrender-preset-slot.visible { display: flex; }
+.buret-xyzrender-tune.hidden { display: none; }
 .buret-select {
-  height: 30px; max-width: 118px; border: 0; border-radius: 8px; padding: 0 22px 0 8px;
+  height: 30px; max-width: 96px; border: 0; border-radius: 8px; padding: 0 22px 0 8px;
   color: inherit; background: transparent; font: 600 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
 }
 .buret-select:hover, .buret-select:focus { background: var(--buret-toolbar-hover); outline: none; }
+.buret-xyzrender-popover {
+  position: absolute; top: calc(100% + 6px); right: 0; left: auto;
+  width: min(216px, calc(100vw - 20px));
+  max-height: min(56vh, 336px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  box-sizing: border-box;
+  padding: 5px;
+  display: grid;
+  gap: 5px;
+  border: 1px solid var(--buret-menu-border);
+  border-radius: 10px;
+  color: var(--buret-toolbar-color);
+  background: var(--buret-menu-background);
+  box-shadow: var(--buret-menu-shadow);
+}
+.buret-xyzrender-popover.hidden { display: none; }
+.buret-xyzrender-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 1px 4px 0;
+}
+.buret-xyzrender-popover-title {
+  font: 600 11px -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  color: var(--buret-toolbar-color);
+}
+.buret-xyzrender-header-action {
+  min-width: auto;
+  height: 22px;
+  padding: 0 8px;
+  color: var(--buret-molstar-muted-text);
+  font: 600 11px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  border-radius: 999px;
+}
+.buret-xyzrender-header-action:hover {
+  background: var(--buret-menu-input-background);
+  color: var(--buret-toolbar-color);
+}
+.buret-xyzrender-section {
+  display: grid;
+  gap: 4px;
+  padding: 5px 8px;
+  border-radius: 9px;
+  border: 1px solid var(--buret-menu-border);
+  background: var(--buret-menu-section-background);
+}
+.buret-xyzrender-section-flags {
+  gap: 0;
+  padding: 0 5px 1px;
+  border: 0;
+  background: transparent;
+}
+.buret-xyzrender-section-title { font: 600 11px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; letter-spacing: 0; color: var(--buret-molstar-muted-text); }
+.buret-flag-list { display: grid; gap: 0; }
+.buret-field-grid { display: grid; gap: 7px; grid-template-columns: 1fr; }
+.buret-field { display: grid; gap: 4px; font: 500 11px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: var(--buret-toolbar-color); }
+.buret-field-full { grid-column: 1 / -1; }
+.buret-flag-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  padding: 5px 0;
+  border-radius: 8px;
+  background: transparent;
+  transition: background 120ms ease, color 120ms ease;
+}
+.buret-flag-row + .buret-flag-row { border-top: 1px solid var(--buret-menu-divider); }
+.buret-flag-row:hover { background: color-mix(in srgb, var(--buret-menu-input-background) 82%, var(--buret-menu-background)); }
+.buret-flag-copy { display: block; min-width: 0; }
+.buret-flag-label { font: 500 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; color: var(--buret-toolbar-color); }
+.buret-flag-row input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  inline-size: 36px;
+  block-size: 20px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--buret-menu-toggle-track);
+  position: relative;
+  margin: 0;
+  transition: background 160ms ease;
+}
+.buret-flag-row input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  inset: 2px auto auto 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  transition: transform 160ms ease;
+}
+.buret-flag-row input[type="checkbox"]:checked {
+  background: var(--buret-menu-accent);
+}
+.buret-flag-row input[type="checkbox"]:checked::after {
+  transform: translateX(16px);
+}
+.buret-input, .buret-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 7px 9px;
+  color: inherit;
+  background: var(--buret-menu-input-background);
+  font: 500 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+.buret-flag-row select.buret-input {
+  width: 78px;
+  min-width: 78px;
+  min-height: 30px;
+  padding-right: 24px;
+  appearance: none;
+  background-image: var(--buret-select-chevron);
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px 12px;
+}
+.buret-input:focus, .buret-textarea:focus {
+  outline: none;
+  border-color: var(--buret-menu-accent);
+  background: var(--buret-menu-input-focus-background);
+}
+.buret-textarea { resize: vertical; min-height: 72px; }
+.buret-field.hidden { display: none; }
+.buret-xyzrender-advanced {
+  border: 1px solid var(--buret-menu-border);
+  border-radius: 9px;
+  background: var(--buret-menu-section-background);
+}
+.buret-xyzrender-advanced.hidden { display: none; }
+.buret-xyzrender-advanced summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 6px 10px;
+  font: 500 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  color: var(--buret-molstar-muted-text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: color 120ms ease, background 120ms ease;
+}
+.buret-xyzrender-advanced summary:hover { color: var(--buret-toolbar-color); }
+.buret-xyzrender-advanced summary::-webkit-details-marker { display: none; }
+.buret-xyzrender-advanced summary::after {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 140ms ease;
+}
+.buret-xyzrender-advanced[open] summary::after {
+  transform: rotate(225deg) translate(-1px, -1px);
+}
+.buret-xyzrender-advanced[open] summary {
+  color: var(--buret-toolbar-color);
+  border-bottom: 1px solid var(--buret-menu-divider);
+}
+.buret-xyzrender-section-advanced {
+  border: 0;
+  border-radius: 0 0 9px 9px;
+  background: var(--buret-menu-section-background);
+}
+@media (max-width: 640px) {
+  .buret-xyzrender-popover {
+    width: min(216px, calc(100vw - 18px));
+    max-height: min(56vh, 328px);
+    padding: 5px;
+  }
+}
+@media (max-width: 420px) {
+  #buret-toolbar[data-active-renderer="xyzrender-external"] {
+    gap: 4px;
+    padding: 4px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-toggle="left"],
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-toggle="right"],
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-toggle="sequence"],
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-toggle="log"] {
+    display: none;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-button {
+    min-width: 28px;
+    height: 28px;
+    padding: 0 6px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-grip {
+    width: 28px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-action="theme"] {
+    display: none;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] [data-buret-renderer="xyz-fast"] {
+    display: none;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-renderer-control {
+    gap: 2px;
+    padding-left: 4px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-renderer-choice {
+    min-width: 34px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-select {
+    max-width: 56px;
+    height: 28px;
+    padding: 0 18px 0 6px;
+    font-size: 11px;
+  }
+  #buret-toolbar[data-active-renderer="xyzrender-external"] .buret-toolbar-content {
+    gap: 4px;
+  }
+}
 body.burette-quicklook-host .msp-plugin .msp-layout-left,
 body.burette-quicklook-host .msp-plugin .msp-layout-right,
 body.burette-quicklook-host .msp-plugin .msp-layout-top,

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -16,6 +16,9 @@
           <div class="buret-xyzrender-preset-slot" data-buret-xyzrender-preset-slot>
             <select class="buret-select" data-buret-xyzrender-preset aria-label="External xyzrender preset" title="External xyzrender preset"></select>
           </div>
+          <button class="buret-button buret-xyzrender-tune hidden" type="button" data-buret-action="xyzrender-tune" aria-label="Tune xyzrender" title="Tune xyzrender">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 5H4v2h6V5Zm10 0h-6v2h6V5ZM14 11H4v2h10v-2Zm6 0h-2v2h2v-2ZM8 17H4v2h4v-2Zm12 0h-8v2h8v-2Z" fill="currentColor"/></svg>
+          </button>
           <div class="buret-renderer-control" data-buret-renderer-control>
             <button class="buret-button buret-renderer-choice" type="button" data-buret-renderer="xyz-fast" aria-label="Use Fast XYZ SVG" title="Use Fast XYZ SVG">Fast</button>
             <button class="buret-button buret-renderer-choice" type="button" data-buret-renderer="molstar" aria-label="Use Mol* Interactive" title="Use Mol* Interactive">Mol*</button>
@@ -25,6 +28,70 @@
         <button class="buret-button buret-grip" type="button" data-drag-handle aria-label="Collapse controls" aria-expanded="true" title="Collapse controls">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h2v2H8V5Zm6 0h2v2h-2V5ZM8 11h2v2H8v-2Zm6 0h2v2h-2v-2ZM8 17h2v2H8v-2Zm6 0h2v2h-2v-2Z" fill="currentColor"/></svg>
         </button>
+          <div class="buret-xyzrender-popover hidden" data-buret-xyzrender-popover role="dialog" aria-label="xyzrender controls">
+            <div class="buret-xyzrender-popover-header">
+              <div class="buret-xyzrender-popover-title">xyzrender</div>
+              <button class="buret-button buret-xyzrender-header-action" type="button" data-buret-action="xyzrender-reset">Reset</button>
+            </div>
+            <div class="buret-xyzrender-section buret-xyzrender-section-flags">
+              <div class="buret-flag-list">
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Transparent</span></span>
+                  <input type="checkbox" data-buret-xctrl="transparentBackground" />
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Gradients</span></span>
+                  <select class="buret-input" data-buret-xctrl="gradients"><option value="">Default</option><option value="on">On</option><option value="off">Off</option></select>
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Fog</span></span>
+                  <select class="buret-input" data-buret-xctrl="fog"><option value="">Default</option><option value="on">On</option><option value="off">Off</option></select>
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">VdW</span></span>
+                  <input type="checkbox" data-buret-xctrl="showVdw" />
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Hide bonds</span></span>
+                  <input type="checkbox" data-buret-xctrl="hideBonds" />
+                </label>
+              </div>
+            </div>
+          <details class="buret-xyzrender-advanced buret-xyzrender-crystal hidden" data-buret-xyzrender-crystal>
+            <summary>Crystal</summary>
+            <div class="buret-xyzrender-section buret-xyzrender-section-advanced">
+              <div class="buret-flag-list">
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Cell</span></span>
+                  <select class="buret-input" data-buret-xctrl="showCell"><option value="">Default</option><option value="on">On</option><option value="off">Off</option></select>
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Ghosts</span></span>
+                  <select class="buret-input" data-buret-xctrl="showGhosts"><option value="">Default</option><option value="on">On</option><option value="off">Off</option></select>
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Axes</span></span>
+                  <select class="buret-input" data-buret-xctrl="showAxes"><option value="">Default</option><option value="on">On</option><option value="off">Off</option></select>
+                </label>
+                <label class="buret-flag-row">
+                  <span class="buret-flag-copy"><span class="buret-flag-label">Supercell</span></span>
+                  <input class="buret-input" type="text" placeholder="2 2 1" data-buret-xctrl="supercell" />
+                </label>
+              </div>
+            </div>
+          </details>
+          <details class="buret-xyzrender-advanced" data-buret-xyzrender-appearance>
+            <summary>Appearance</summary>
+            <div class="buret-xyzrender-section buret-xyzrender-section-advanced">
+              <div class="buret-field-grid">
+                <label class="buret-field"><span>Atom scale</span><input class="buret-input" type="number" min="0" step="0.05" data-buret-xctrl="atomScale" /></label>
+                <label class="buret-field"><span>Bond width</span><input class="buret-input" type="number" min="0" step="0.1" data-buret-xctrl="bondWidth" /></label>
+                <label class="buret-field"><span>VdW scale</span><input class="buret-input" type="number" min="0" step="0.05" data-buret-xctrl="vdwScale" /></label>
+                <label class="buret-field buret-field-full"><span>Mol color</span><input class="buret-input" type="text" placeholder="#rrggbb or name" data-buret-xctrl="molColor" /></label>
+              </div>
+            </div>
+          </details>
+        </div>
       </div>
       <button id="buret-open-in-app" class="buret-corner-button" type="button" aria-label="Open in Burrete" title="Open in Burrete">Open in Burrete</button>
     `);

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -27,6 +27,30 @@
     { value: 'graph', label: 'Graph' },
     { value: 'custom', label: 'Custom JSON' }
   ];
+  const DEFAULT_XYZRENDER_CONTROLS = {
+    transparentBackground: false,
+    canvasSize: null,
+    atomScale: null,
+    bondWidth: null,
+    atomStrokeWidth: null,
+    molColor: null,
+    gradients: null,
+    fog: null,
+    fogStrength: null,
+    showVdw: false,
+    vdwOpacity: null,
+    vdwScale: null,
+    hideBonds: false,
+    showCell: null,
+    showGhosts: null,
+    showAxes: null,
+    cellWidth: null,
+    supercell: null,
+    customConfigPath: null,
+    extraArguments: null
+  };
+  const XYZRENDER_POPOVER_OPEN_KEY_PREFIX = 'buret.xyzrender.popover.open';
+  let xyzrenderControlsApplyTimer = 0;
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
   function post(type, message) {
@@ -41,6 +65,9 @@
   function postHostMessage(payload) {
     try {
       const body = { ...(payload || {}) };
+      if (window.BurreteConfig && window.BurreteConfig.documentId) {
+        body.documentId = String(window.BurreteConfig.documentId);
+      }
       if (window.BurreteConfig && window.BurreteConfig.previewRequestID) {
         body.requestID = String(window.BurreteConfig.previewRequestID);
       }
@@ -409,12 +436,17 @@
     const canSwitchRenderer = (config.appViewer === true && (format === 'xyz' || format === 'sdf')) ||
       (config.quickLookViewer === true && format === 'xyz') ||
       xyzrenderViewer;
+    const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
+    const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
     control.classList.toggle('visible', canSwitchRenderer);
     const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
     presetSlot?.classList.remove('visible');
+    tuneButton?.classList.add('hidden');
+    popover?.classList.add('hidden');
     if (!canSwitchRenderer) return;
 
     const renderer = normalizeRenderer(config.renderer);
+    toolbar.dataset.activeRenderer = renderer;
     control.querySelectorAll('[data-buret-renderer]').forEach(button => {
       const value = button.getAttribute('data-buret-renderer');
       const isFastXYZOnly = value === 'xyz-fast';
@@ -425,7 +457,10 @@
       );
       button.classList.toggle('active', value === renderer);
       if (control.dataset.rendererBound !== '1') {
-        button.addEventListener('click', () => requestRendererSwitch(value));
+        button.addEventListener('click', () => {
+          applyPendingRendererSelection(toolbar, value);
+          requestRendererSwitch(value);
+        });
       }
     });
 
@@ -439,8 +474,31 @@
         select.addEventListener('change', () => requestXyzrenderPreset(select.value));
       }
     }
+    if (tuneButton) {
+      tuneButton.classList.toggle('hidden', renderer !== 'xyzrender-external');
+      tuneButton.classList.remove('active');
+      tuneButton.removeAttribute('data-open');
+      if (renderer === 'xyzrender-external') {
+        populateXyzrenderControlsForm(toolbar, normalizeXyzrenderControls(config.xyzrenderControls || DEFAULT_XYZRENDER_CONTROLS, config));
+        updateXyzrenderFormVisibility(toolbar);
+        if (shouldRestoreXyzrenderPopoverOpen()) {
+          setXyzrenderPopoverVisibility(toolbar, true);
+        }
+      }
+      if (control.dataset.tuneBound !== '1') {
+        tuneButton.addEventListener('click', () => {
+          const hidden = popover?.classList.contains('hidden') !== false;
+          if (hidden) {
+            populateXyzrenderControlsForm(toolbar, normalizeXyzrenderControls((activeConfig && activeConfig.xyzrenderControls) || DEFAULT_XYZRENDER_CONTROLS, activeConfig || {}));
+          }
+          setXyzrenderPopoverVisibility(toolbar, hidden);
+        });
+      }
+    }
     control.dataset.rendererBound = '1';
     control.dataset.presetBound = '1';
+    control.dataset.tuneBound = '1';
+    requestAnimationFrame(() => syncToolbarViewport(toolbar, renderer));
   }
 
   function populateXyzrenderPresetSelect(select, options) {
@@ -462,6 +520,91 @@
     return DEFAULT_XYZRENDER_PRESETS.some(row => row.value === raw) ? raw : 'default';
   }
 
+  function xyzrenderPopoverStorageKey() {
+    const documentId = String(window.BurreteConfig?.documentId || '').trim();
+    return documentId ? `${XYZRENDER_POPOVER_OPEN_KEY_PREFIX}:${documentId}` : XYZRENDER_POPOVER_OPEN_KEY_PREFIX;
+  }
+
+  function setXyzrenderPopoverVisibility(toolbar, open) {
+    const popover = toolbar?.querySelector('[data-buret-xyzrender-popover]');
+    const tuneButton = toolbar?.querySelector('[data-buret-action="xyzrender-tune"]');
+    if (!popover) return;
+    popover.classList.toggle('hidden', !open);
+    if (tuneButton) {
+      tuneButton.classList.toggle('active', open);
+      tuneButton.toggleAttribute('data-open', open);
+    }
+    setXyzrenderPopoverOpenPersisted(open);
+    if (open) {
+      popover.scrollTop = 0;
+      positionXyzrenderPopover(toolbar);
+    }
+  }
+
+  function setXyzrenderPopoverOpenPersisted(open) {
+    try {
+      const key = xyzrenderPopoverStorageKey();
+      if (open) window.localStorage?.setItem(key, '1');
+      else window.localStorage?.removeItem(key);
+    } catch (_) {}
+  }
+
+  function shouldRestoreXyzrenderPopoverOpen() {
+    try {
+      return window.localStorage?.getItem(xyzrenderPopoverStorageKey()) === '1';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function normalizeXyzrenderControls(value, config = {}) {
+    const source = value && typeof value === 'object' ? value : {};
+    return {
+      transparentBackground: source.transparentBackground === true || (source.transparentBackground == null && config.transparentBackground === true),
+      canvasSize: positiveNumberOrNull(source.canvasSize),
+      atomScale: positiveNumberOrNull(source.atomScale),
+      bondWidth: positiveNumberOrNull(source.bondWidth),
+      atomStrokeWidth: positiveNumberOrNull(source.atomStrokeWidth),
+      molColor: nonEmptyText(source.molColor),
+      gradients: triStateBoolean(source.gradients),
+      fog: triStateBoolean(source.fog),
+      fogStrength: positiveNumberOrNull(source.fogStrength),
+      showVdw: source.showVdw === true,
+      vdwOpacity: positiveNumberOrNull(source.vdwOpacity),
+      vdwScale: positiveNumberOrNull(source.vdwScale),
+      hideBonds: source.hideBonds === true,
+      showCell: triStateBoolean(source.showCell),
+      showGhosts: triStateBoolean(source.showGhosts),
+      showAxes: triStateBoolean(source.showAxes),
+      cellWidth: positiveNumberOrNull(source.cellWidth),
+      supercell: normalizeSupercellValue(source.supercell),
+      customConfigPath: nonEmptyText(source.customConfigPath),
+      extraArguments: nonEmptyText(source.extraArguments)
+    };
+  }
+
+  function positiveNumberOrNull(value) {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? number : null;
+  }
+
+  function triStateBoolean(value) {
+    return value === true ? true : value === false ? false : null;
+  }
+
+  function nonEmptyText(value) {
+    const text = String(value || '').trim();
+    return text ? text : null;
+  }
+
+  function normalizeSupercellValue(value) {
+    const text = Array.isArray(value) ? value.join(' ') : String(value || '').trim();
+    const parts = text.split(/[\s,]+/u).filter(Boolean);
+    if (parts.length !== 3) return null;
+    const values = parts.map(part => Number.parseInt(part, 10));
+    return values.every(number => Number.isFinite(number) && number > 0) ? values : null;
+  }
+
   function requestRendererSwitch(renderer) {
     const value = normalizeRenderer(renderer);
     const orientationRef = value === 'xyzrender-external' ? captureCurrentXyzrenderOrientationRef() : null;
@@ -481,10 +624,154 @@
     if (!sent) setStatus('Renderer switching is available only in the app or Quick Look viewer.', 'error');
   }
 
+  function applyPendingRendererSelection(toolbar, renderer) {
+    if (!toolbar) return;
+    const normalized = normalizeRenderer(renderer);
+    toolbar.dataset.activeRenderer = normalized;
+    toolbar.querySelectorAll('[data-buret-renderer]').forEach(button => {
+      button.classList.toggle('active', button.getAttribute('data-buret-renderer') === normalized);
+    });
+    const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
+    const preset = toolbar.querySelector('[data-buret-xyzrender-preset]');
+    const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
+    const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+    const external = normalized === 'xyzrender-external';
+    presetSlot?.classList.toggle('visible', external);
+    if (preset) preset.disabled = !external;
+    tuneButton?.classList.toggle('hidden', !external);
+    if (!external) {
+      tuneButton?.classList.remove('active');
+      tuneButton?.removeAttribute('data-open');
+      popover?.classList.add('hidden');
+      setXyzrenderPopoverOpenPersisted(false);
+    }
+    requestAnimationFrame(() => syncToolbarViewport(toolbar, normalized));
+  }
+
   function requestXyzrenderPreset(preset) {
     const value = normalizeXyzrenderPreset(preset);
     const sent = postHostMessage({ type: 'setXyzrenderPreset', value });
     if (!sent) setStatus('xyzrender preset switching is available only in the app or Quick Look viewer.', 'error');
+  }
+
+  function populateXyzrenderControlsForm(toolbar, controls) {
+    if (!toolbar) return;
+    toolbar.dataset.syncingXyzrenderForm = '1';
+    const normalized = normalizeXyzrenderControls(controls, activeConfig || {});
+    const setValue = (name, value) => {
+      const field = toolbar.querySelector(`[data-buret-xctrl="${name}"]`);
+      if (!field) return;
+      if (field.type === 'checkbox') {
+        field.checked = value === true;
+        return;
+      }
+      if (field.tagName === 'SELECT') {
+        field.value = value === true ? 'on' : value === false ? 'off' : '';
+        return;
+      }
+      field.value = Array.isArray(value) ? value.join(' ') : value == null ? '' : String(value);
+    };
+    Object.entries(normalized).forEach(([name, value]) => setValue(name, value));
+    updateXyzrenderFormVisibility(toolbar);
+    toolbar.dataset.syncingXyzrenderForm = '0';
+  }
+
+  function updateXyzrenderFormVisibility(toolbar) {
+    const advanced = toolbar.querySelector('[data-buret-xyzrender-appearance]');
+    const crystal = toolbar.querySelector('[data-buret-xyzrender-crystal]');
+    const controls = toolbar.dataset.syncingXyzrenderForm === '1'
+      ? normalizeXyzrenderControls((activeConfig && activeConfig.xyzrenderControls) || DEFAULT_XYZRENDER_CONTROLS, activeConfig || {})
+      : readXyzrenderControlsForm(toolbar);
+    const looksCrystalLike = shouldShowCrystalControls(activeConfig || {}, controls);
+    const crystalActive = controls.showCell != null || controls.showGhosts != null || controls.showAxes != null || Array.isArray(controls.supercell);
+    const advancedActive = !!(
+      controls.atomScale != null ||
+      controls.bondWidth != null ||
+      controls.vdwScale != null ||
+      controls.molColor
+    );
+    if (advanced) {
+      advanced.open = advancedActive;
+    }
+    if (crystal) {
+      crystal.classList.toggle('hidden', !looksCrystalLike && !crystalActive);
+      crystal.open = crystalActive;
+    }
+    positionXyzrenderPopover(toolbar);
+  }
+
+  function shouldShowCrystalControls(config, controls) {
+    const hint = [config?.label, config?.documentId, config?.format, config?.molstarFormat]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return /cell|extxyz|cryst|lattice|periodic|supercell/iu.test(hint) ||
+      controls.showCell != null ||
+      controls.showGhosts != null ||
+      controls.showAxes != null ||
+      Array.isArray(controls.supercell);
+  }
+
+  function readXyzrenderControlsForm(toolbar) {
+    const current = normalizeXyzrenderControls((activeConfig && activeConfig.xyzrenderControls) || DEFAULT_XYZRENDER_CONTROLS, activeConfig || {});
+    const readField = name => toolbar.querySelector(`[data-buret-xctrl="${name}"]`);
+    const readCheckbox = name => {
+      const field = readField(name);
+      return field ? !!field.checked : current[name];
+    };
+    const readNumber = name => {
+      const field = readField(name);
+      return field ? positiveNumberOrNull(field.value) : current[name];
+    };
+    const readText = name => {
+      const field = readField(name);
+      return field ? nonEmptyText(field.value) : current[name];
+    };
+    const readTriState = name => {
+      const field = readField(name);
+      if (!field) return current[name];
+      const value = field.value;
+      return value === 'on' ? true : value === 'off' ? false : null;
+    };
+    return normalizeXyzrenderControls({
+      transparentBackground: readCheckbox('transparentBackground'),
+      canvasSize: current.canvasSize,
+      atomScale: readNumber('atomScale'),
+      bondWidth: readNumber('bondWidth'),
+      atomStrokeWidth: current.atomStrokeWidth,
+      molColor: readText('molColor'),
+      gradients: readTriState('gradients'),
+      fog: readTriState('fog'),
+      fogStrength: current.fogStrength,
+      showVdw: readCheckbox('showVdw'),
+      vdwOpacity: current.vdwOpacity,
+      vdwScale: readNumber('vdwScale'),
+      hideBonds: readCheckbox('hideBonds'),
+      showCell: readTriState('showCell'),
+      showGhosts: readTriState('showGhosts'),
+      showAxes: readTriState('showAxes'),
+      cellWidth: current.cellWidth,
+      supercell: normalizeSupercellValue(readField('supercell')?.value),
+      customConfigPath: readText('customConfigPath'),
+      extraArguments: readText('extraArguments')
+    }, activeConfig || {});
+  }
+
+  function requestXyzrenderControls(toolbar) {
+    const controls = readXyzrenderControlsForm(toolbar);
+    const sent = postHostMessage({ type: 'setXyzrenderControls', controls });
+    if (!sent) {
+      setStatus('xyzrender controls are available only in the app or Quick Look viewer.', 'error');
+    }
+  }
+
+  function scheduleXyzrenderControlsApply(toolbar, delayMs = 220) {
+    if (!toolbar || toolbar.dataset.syncingXyzrenderForm === '1') return;
+    if (xyzrenderControlsApplyTimer) clearTimeout(xyzrenderControlsApplyTimer);
+    xyzrenderControlsApplyTimer = setTimeout(() => {
+      xyzrenderControlsApplyTimer = 0;
+      requestXyzrenderControls(toolbar);
+    }, delayMs);
   }
 
   function captureCurrentXyzrenderOrientationRef() {
@@ -679,12 +966,50 @@
     });
     bindThemeButton(toolbar, viewer);
     bindQuickLookOpenButton();
+    bindXyzrenderControls(toolbar);
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
     installMolstarFloatingPanelTracking();
     updateToolbarVisibility();
     updateThemeButton();
     applyLayoutState(viewer);
+  }
+
+  function bindXyzrenderControls(toolbar) {
+    if (!toolbar || toolbar.dataset.xyzrenderControlsBound === '1') return;
+    toolbar.querySelector('[data-buret-xyzrender-preset]')?.addEventListener('change', () => updateXyzrenderFormVisibility(toolbar));
+    toolbar.querySelector('[data-buret-action="xyzrender-reset"]')?.addEventListener('click', () => {
+      populateXyzrenderControlsForm(toolbar, {});
+      requestXyzrenderControls(toolbar);
+    });
+    toolbar.querySelectorAll('[data-buret-xctrl]').forEach(field => {
+      field.addEventListener('change', () => {
+        updateXyzrenderFormVisibility(toolbar);
+        scheduleXyzrenderControlsApply(toolbar, 0);
+      });
+      if (field.tagName !== 'SELECT' && field.type !== 'checkbox') {
+        field.addEventListener('input', () => {
+          updateXyzrenderFormVisibility(toolbar);
+          scheduleXyzrenderControlsApply(toolbar, 260);
+        });
+      }
+    });
+    document.addEventListener('click', event => {
+      const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+      if (!popover || popover.classList.contains('hidden')) return;
+      if (toolbar.contains(event.target)) return;
+      setXyzrenderPopoverVisibility(toolbar, false);
+    }, true);
+    document.addEventListener('keydown', event => {
+      if (event.key !== 'Escape') return;
+      const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+      if (!popover || popover.classList.contains('hidden')) return;
+      setXyzrenderPopoverVisibility(toolbar, false);
+    }, true);
+    toolbar.querySelectorAll('.buret-xyzrender-advanced').forEach(section => {
+      section.addEventListener('toggle', () => positionXyzrenderPopover(toolbar));
+    });
+    toolbar.dataset.xyzrenderControlsBound = '1';
   }
 
   function bindThemeButton(toolbar, viewer) {
@@ -829,7 +1154,30 @@
     window.addEventListener('resize', () => {
       repositionToolbar(toolbar);
       updateFloatingLayoutOffsets();
+      positionXyzrenderPopover(toolbar);
     });
+  }
+
+  function positionXyzrenderPopover(toolbar) {
+    const popover = toolbar?.querySelector('[data-buret-xyzrender-popover]');
+    if (!popover || popover.classList.contains('hidden')) return;
+    const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
+    popover.style.left = 'auto';
+    popover.style.right = '0';
+    popover.style.maxHeight = Math.max(220, Math.min(430, window.innerHeight - toolbarSafeTop() - 36)) + 'px';
+    const margin = 12;
+    if (tuneButton) {
+      const toolbarRect = toolbar.getBoundingClientRect();
+      const tuneRect = tuneButton.getBoundingClientRect();
+      const preferredLeft = tuneRect.right - toolbarRect.left - popover.offsetWidth;
+      const minLeft = margin - toolbarRect.left;
+      const maxLeft = window.innerWidth - margin - toolbarRect.left - popover.offsetWidth;
+      popover.style.left = Math.min(Math.max(minLeft, preferredLeft), maxLeft) + 'px';
+      popover.style.right = 'auto';
+      return;
+    }
+    const rect = popover.getBoundingClientRect();
+    if (rect.left < margin) popover.style.left = margin + 'px';
   }
 
   function repositionToolbar(toolbar) {
@@ -885,6 +1233,27 @@
     const content = toolbar.querySelector('[data-buret-toolbar-content]');
     if (content) {
       content.style.maxWidth = Math.max(0, availableWidth - TOOLBAR_MARGIN * 2 - 36) + 'px';
+    }
+  }
+
+  function syncToolbarViewport(toolbar, renderer) {
+    const content = toolbar?.querySelector('[data-buret-toolbar-content]');
+    if (!content) return;
+    const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
+    const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
+    let target = toolbar.querySelector(`[data-buret-renderer="${renderer}"]`);
+    if (renderer === 'xyzrender-external') {
+      if (tuneButton && !tuneButton.classList.contains('hidden')) target = tuneButton;
+      else if (presetSlot && presetSlot.classList.contains('visible')) target = presetSlot;
+    }
+    if (!(target instanceof HTMLElement)) return;
+    const contentRect = content.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const padding = 6;
+    if (targetRect.left < contentRect.left + padding) {
+      content.scrollLeft -= contentRect.left + padding - targetRect.left;
+    } else if (targetRect.right > contentRect.right - padding) {
+      content.scrollLeft += targetRect.right - (contentRect.right - padding);
     }
   }
 
@@ -1402,6 +1771,7 @@
     if (!toolbar) return;
     toolbar.querySelectorAll('.buret-panel-toggle').forEach(button => { button.classList.add('hidden'); });
     bindThemeButton(toolbar, null);
+    bindXyzrenderControls(toolbar);
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, null);
   }

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Burrete supports common structure and small-molecule collection formats:
 - CSV and TSV tables with SMILES-like columns
 - XYZ, extXYZ, CUBE, GRO, GROMACS-style trajectories/topologies, and related text outputs
 
-XYZ files use the lightweight Fast XYZ renderer by default in Quick Look for
-instant first-frame previews. You can switch to Mol* for interactive rotation or
-to external `xyzrender` for high-quality SVG output. If you rotate the molecule
-in Mol* and then switch to `xyzrender`, Burrete passes the current orientation to
-`xyzrender` through its reference-file workflow.
+XYZ files open with external `xyzrender` by default when it is available, with
+Fast XYZ kept as the lightweight static fallback. You can still switch to Mol*
+for interactive rotation or to Fast XYZ for a minimal first-frame preview. If
+you rotate the molecule in Mol* and then switch to `xyzrender`, Burrete passes
+the current orientation to `xyzrender` through its reference-file workflow.
 
 CUBE and XYZ previews also expose an optional VESTA handoff when VESTA is
 installed. Double-clicking a supported file can open it in Burrete; pressing

--- a/apps/desktop/src-tauri/src/preview/formats.rs
+++ b/apps/desktop/src-tauri/src/preview/formats.rs
@@ -77,7 +77,7 @@ pub(crate) fn resolve_renderer(format: &FormatInfo, requested: &str) -> String {
             "molstar"
         }
         .to_string(),
-        _ => if is_xyz { "xyz-fast" } else { "molstar" }.to_string(),
+        _ => if is_xyz { "xyzrender-external" } else { "molstar" }.to_string(),
     }
 }
 
@@ -99,9 +99,9 @@ mod tests {
     }
 
     #[test]
-    fn keeps_xyz_fast_as_default_for_xyz_files() {
+    fn keeps_xyzrender_as_default_for_xyz_files() {
         let xyz = format_for_extension("xyz").expect("xyz should be supported");
-        assert_eq!(resolve_renderer(&xyz, "auto"), "xyz-fast");
+        assert_eq!(resolve_renderer(&xyz, "auto"), "xyzrender-external");
         assert_eq!(resolve_renderer(&xyz, "mol*"), "molstar");
         assert_eq!(
             resolve_renderer(&xyz, "external-xyzrender"),

--- a/apps/desktop/src-tauri/src/preview/runtime.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime.rs
@@ -24,6 +24,32 @@ pub(crate) struct ViewerPreferences {
 pub(crate) struct ViewerReloadOptions {
     pub(crate) xyzrender_orientation_ref: Option<String>,
     pub(crate) xyzrender_preset: Option<String>,
+    pub(crate) xyzrender_controls: Option<XyzrenderControls>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct XyzrenderControls {
+    pub(crate) transparent_background: Option<bool>,
+    pub(crate) canvas_size: Option<f64>,
+    pub(crate) atom_scale: Option<f64>,
+    pub(crate) bond_width: Option<f64>,
+    pub(crate) atom_stroke_width: Option<f64>,
+    pub(crate) mol_color: Option<String>,
+    pub(crate) gradients: Option<bool>,
+    pub(crate) fog: Option<bool>,
+    pub(crate) fog_strength: Option<f64>,
+    pub(crate) show_vdw: Option<bool>,
+    pub(crate) vdw_opacity: Option<f64>,
+    pub(crate) vdw_scale: Option<f64>,
+    pub(crate) hide_bonds: Option<bool>,
+    pub(crate) show_cell: Option<bool>,
+    pub(crate) show_ghosts: Option<bool>,
+    pub(crate) show_axes: Option<bool>,
+    pub(crate) cell_width: Option<f64>,
+    pub(crate) supercell: Option<[i32; 3]>,
+    pub(crate) custom_config_path: Option<String>,
+    pub(crate) extra_arguments: Option<String>,
 }
 
 impl ViewerPreferences {

--- a/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
@@ -48,6 +48,7 @@ pub(crate) fn create_runtime<R: Runtime>(
                 .and_then(|options| options.xyzrender_preset.as_deref()),
             reload_options
                 .and_then(|options| options.xyzrender_orientation_ref.as_deref()),
+            reload_options.and_then(|options| options.xyzrender_controls.as_ref()),
         ) {
             Ok(artifact) => {
                 external_artifact = Some(artifact);
@@ -127,6 +128,9 @@ pub(crate) fn create_runtime<R: Runtime>(
         config["xyzrenderViewer"] = json!(true);
         config["xyzrenderPreset"] = json!(artifact.preset);
         config["xyzrenderPresetOptions"] = xyzrender_preset_options();
+        if let Some(controls) = reload_options.and_then(|options| options.xyzrender_controls.as_ref()) {
+            config["xyzrenderControls"] = serde_json::to_value(controls).map_err(|err| err.to_string())?;
+        }
         config["externalArtifact"] = json!({
             "path": artifact.relative_path,
             "type": artifact.output_type,

--- a/apps/desktop/src-tauri/src/preview/xyzrender.rs
+++ b/apps/desktop/src-tauri/src/preview/xyzrender.rs
@@ -8,6 +8,8 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use super::runtime::XyzrenderControls;
+
 const XYZRENDER_TIMEOUT: Duration = Duration::from_secs(20);
 const XYZRENDER_LOG_CAPTURE_BYTES: usize = 64 * 1024;
 
@@ -15,7 +17,7 @@ pub(crate) struct XyzrenderArtifact {
     pub(crate) relative_path: &'static str,
     pub(crate) output_type: &'static str,
     pub(crate) preset: &'static str,
-    pub(crate) config_argument: &'static str,
+    pub(crate) config_argument: String,
     pub(crate) elapsed_ms: u128,
     pub(crate) log: String,
 }
@@ -25,6 +27,7 @@ pub(crate) fn create_xyzrender_artifact(
     output_directory: &Path,
     preset: Option<&str>,
     orientation_ref_text: Option<&str>,
+    controls: Option<&XyzrenderControls>,
 ) -> Result<XyzrenderArtifact, String> {
     let output_path = output_directory.join("xyzrender.svg");
     let log_path = output_directory.join("xyzrender.log");
@@ -34,13 +37,23 @@ pub(crate) fn create_xyzrender_artifact(
     let _ = fs::remove_file(&orientation_ref_path);
     let started = Instant::now();
     let resolved_preset = normalize_preset(preset);
+    let resolved_config_argument = resolve_config_argument(resolved_preset, controls).to_string();
+    let effective_preset =
+        if resolved_preset == "custom" && resolved_config_argument == "default" {
+            "default"
+        } else {
+            resolved_preset
+        };
     let (status, log) = run_xyzrender_command(
         &resolve_xyzrender_executable()?,
-        input_path,
-        &output_path,
+        build_xyzrender_args(
+            input_path,
+            &output_path,
+            resolved_preset,
+            write_orientation_ref(orientation_ref_text, &orientation_ref_path)?,
+            controls,
+        ),
         &log_path,
-        resolved_preset,
-        write_orientation_ref(orientation_ref_text, &orientation_ref_path)?,
         XYZRENDER_TIMEOUT,
     )?;
     if !status.success() {
@@ -59,8 +72,8 @@ pub(crate) fn create_xyzrender_artifact(
     Ok(XyzrenderArtifact {
         relative_path: "xyzrender.svg",
         output_type: "svg",
-        preset: resolved_preset,
-        config_argument: resolved_preset,
+        preset: effective_preset,
+        config_argument: resolved_config_argument,
         elapsed_ms: started.elapsed().as_millis(),
         log,
     })
@@ -116,25 +129,183 @@ fn normalize_preset(value: Option<&str>) -> &'static str {
     }
 }
 
-fn run_xyzrender_command(
-    executable: &Path,
+fn build_xyzrender_args(
     input_path: &Path,
     output_path: &Path,
-    log_path: &Path,
-    preset: &str,
+    preset: &'static str,
     orientation_ref_path: Option<&Path>,
+    controls: Option<&XyzrenderControls>,
+) -> Vec<String> {
+    let mut args = vec![
+        input_path.display().to_string(),
+        "-o".to_string(),
+        output_path.display().to_string(),
+        "--config".to_string(),
+        resolve_config_argument(preset, controls).to_string(),
+    ];
+    if let Some(path) = orientation_ref_path {
+        args.push("--ref".to_string());
+        args.push(path.display().to_string());
+    }
+    if let Some(controls) = controls {
+        if controls.transparent_background == Some(true) {
+            args.push("--transparent".to_string());
+        }
+        if let Some(value) = finite_positive(controls.canvas_size) {
+            args.push("-S".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = finite_positive(controls.atom_scale) {
+            args.push("-a".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = finite_positive(controls.bond_width) {
+            args.push("-b".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = finite_positive(controls.atom_stroke_width) {
+            args.push("-s".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = non_empty_text(controls.mol_color.as_deref()) {
+            args.push("--mol-color".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = controls.gradients {
+            args.push(if value { "--grad" } else { "--no-grad" }.to_string());
+        }
+        if let Some(value) = controls.fog {
+            args.push(if value { "--fog" } else { "--no-fog" }.to_string());
+        }
+        if let Some(value) = finite_positive(controls.fog_strength) {
+            args.push("-F".to_string());
+            args.push(value.to_string());
+        }
+        if controls.show_vdw == Some(true) {
+            args.push("--vdw".to_string());
+        }
+        if let Some(value) = finite_positive(controls.vdw_opacity) {
+            args.push("--vdw-opacity".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(value) = finite_positive(controls.vdw_scale) {
+            args.push("--vdw-scale".to_string());
+            args.push(value.to_string());
+        }
+        if controls.hide_bonds == Some(true) {
+            args.push("--no-bonds".to_string());
+        }
+        if let Some(value) = controls.show_cell {
+            args.push(if value { "--cell" } else { "--no-cell" }.to_string());
+        }
+        if let Some(value) = controls.show_ghosts {
+            args.push(if value { "--ghosts" } else { "--no-ghosts" }.to_string());
+        }
+        if let Some(value) = controls.show_axes {
+            args.push(if value { "--axes" } else { "--no-axes" }.to_string());
+        }
+        if let Some(value) = finite_positive(controls.cell_width) {
+            args.push("--cell-width".to_string());
+            args.push(value.to_string());
+        }
+        if let Some(values) = controls.supercell.filter(|row| row.iter().all(|value| *value > 0)) {
+            args.push("--supercell".to_string());
+            args.extend(values.iter().map(ToString::to_string));
+        }
+        args.extend(sanitized_extra_arguments(controls.extra_arguments.as_deref()));
+    }
+    args
+}
+
+fn resolve_config_argument<'a>(preset: &'static str, controls: Option<&'a XyzrenderControls>) -> &'a str {
+    if preset != "custom" {
+        return preset;
+    }
+    controls
+        .and_then(|value| non_empty_text(value.custom_config_path.as_deref()))
+        .unwrap_or("default")
+}
+
+fn finite_positive(value: Option<f64>) -> Option<f64> {
+    let number = value?;
+    (number.is_finite() && number > 0.0).then_some(number)
+}
+
+fn non_empty_text(value: Option<&str>) -> Option<&str> {
+    let text = value?.trim();
+    (!text.is_empty()).then_some(text)
+}
+
+fn sanitized_extra_arguments(value: Option<&str>) -> Vec<String> {
+    let blocked = ["-o", "--output", "-go", "--gif-output", "--config", "--ref"];
+    let mut result = Vec::new();
+    let mut skip_next = false;
+    for token in split_command_line(value.unwrap_or_default()) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if blocked.contains(&token.as_str()) {
+            skip_next = true;
+            continue;
+        }
+        if blocked.iter().any(|flag| token.starts_with(&format!("{flag}="))) {
+            continue;
+        }
+        result.push(token);
+    }
+    result
+}
+
+fn split_command_line(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for character in value.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+            continue;
+        }
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            } else {
+                current.push(character);
+            }
+            continue;
+        }
+        if character == '\'' || character == '"' {
+            quote = Some(character);
+            continue;
+        }
+        if character.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        current.push(character);
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn run_xyzrender_command(
+    executable: &Path,
+    args: Vec<String>,
+    log_path: &Path,
     timeout: Duration,
 ) -> Result<(ExitStatus, String), String> {
     let mut command = Command::new(executable);
-    command
-        .arg(input_path)
-        .arg("-o")
-        .arg(output_path)
-        .arg("--config")
-        .arg(preset);
-    if let Some(path) = orientation_ref_path {
-        command.arg("--ref").arg(path);
-    }
+    command.args(&args);
     let mut child = command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -299,11 +470,14 @@ mod tests {
 
         let result = run_xyzrender_command(
             &executable,
-            &directory.join("input.xyz"),
-            &directory.join("xyzrender.svg"),
+            vec![
+                directory.join("input.xyz").display().to_string(),
+                "-o".to_string(),
+                directory.join("xyzrender.svg").display().to_string(),
+                "--config".to_string(),
+                "default".to_string(),
+            ],
             &directory.join("xyzrender.log"),
-            "default",
-            None,
             Duration::from_millis(100),
         );
 
@@ -319,5 +493,57 @@ mod tests {
 
         assert!(text.len() < XYZRENDER_LOG_CAPTURE_BYTES + 128);
         assert!(text.contains("log truncated"));
+    }
+
+    #[test]
+    fn builds_structured_xyzrender_args() {
+        let input = PathBuf::from("/tmp/in.xyz");
+        let output = PathBuf::from("/tmp/out.svg");
+        let controls = XyzrenderControls {
+            transparent_background: Some(true),
+            canvas_size: Some(1024.0),
+            atom_scale: Some(1.2),
+            bond_width: Some(4.0),
+            atom_stroke_width: Some(0.8),
+            mol_color: Some("#ff00aa".into()),
+            gradients: Some(false),
+            fog: Some(true),
+            fog_strength: Some(0.5),
+            show_vdw: Some(true),
+            vdw_opacity: Some(0.4),
+            vdw_scale: Some(1.1),
+            hide_bonds: Some(true),
+            show_cell: Some(true),
+            show_ghosts: Some(false),
+            show_axes: Some(true),
+            cell_width: Some(2.0),
+            supercell: Some([2, 3, 4]),
+            custom_config_path: Some("/tmp/custom.json".into()),
+            extra_arguments: Some("--output hacked.svg --axis 111 --measure d".into()),
+        };
+
+        let args = build_xyzrender_args(
+            &input,
+            &output,
+            "custom",
+            Some(Path::new("/tmp/ref.xyz")),
+            Some(&controls),
+        );
+
+        let joined = args.join(" ");
+        assert!(joined.contains("--config /tmp/custom.json"));
+        assert!(joined.contains("--ref /tmp/ref.xyz"));
+        assert!(joined.contains("--transparent"));
+        assert!(joined.contains("--no-grad"));
+        assert!(joined.contains("--fog"));
+        assert!(joined.contains("--vdw"));
+        assert!(joined.contains("--no-bonds"));
+        assert!(joined.contains("--cell"));
+        assert!(joined.contains("--no-ghosts"));
+        assert!(joined.contains("--axes"));
+        assert!(joined.contains("--supercell 2 3 4"));
+        assert!(joined.contains("--axis 111"));
+        assert!(joined.contains("--measure d"));
+        assert!(!joined.contains("hacked.svg"));
     }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -95,6 +95,7 @@ export default function App() {
   const openedBrowserDevFilesRef = useRef(false);
   const syncingBrowserDevFilesRef = useRef(false);
   const pendingViewerReloadOptionsRef = useRef<ViewerReloadOptions | null>(null);
+  const pendingViewerReloadDocumentIdRef = useRef<string | null>(null);
   const xyzrenderOrientationRefRef = useRef<string | null>(null);
   const skipNextPreferenceRefreshRef = useRef(false);
   const statusSequenceRef = useRef(0);
@@ -254,11 +255,15 @@ export default function App() {
   useOpenEvents(openDocuments, pushErrorStatus);
   const { dropActive, handleBrowserDrag, handleBrowserDragLeave, handleBrowserDrop } = useOpenDrop(openDocuments, pushStatus);
   const reloadActive = useCallback(async () => {
-    if (!activeDocument) return;
+    const targetDocument = (pendingViewerReloadDocumentIdRef.current
+      ? documents.find((document) => document.id === pendingViewerReloadDocumentIdRef.current)
+      : null) ?? activeDocument;
+    if (!targetDocument) return;
     const reloadOptions = pendingViewerReloadOptionsRef.current ?? undefined;
     pendingViewerReloadOptionsRef.current = null;
-    await openDocuments([activeDocument.path], reloadOptions);
-  }, [activeDocument, openDocuments]);
+    pendingViewerReloadDocumentIdRef.current = null;
+    await openDocuments([targetDocument.path], reloadOptions);
+  }, [activeDocument, documents, openDocuments]);
   const setUpdatePreferences = useCallback((preferences: UpdatePreferences) => {
     saveUpdatePreferences(preferences);
     setUpdate((previous) => ({
@@ -391,6 +396,7 @@ export default function App() {
           documentId?: string;
           orientationRef?: string | null;
           text?: string | null;
+          controls?: ViewerReloadOptions["xyzrenderControls"];
         };
       } | undefined;
       if (data?.source !== "burrete-viewer" && data?.source !== "burrete-grid") return;
@@ -405,9 +411,21 @@ export default function App() {
         return;
       }
       if (body?.type === "setXyzrenderPreset") {
+        pendingViewerReloadDocumentIdRef.current = body.documentId ?? null;
         pendingViewerReloadOptionsRef.current = {
           xyzrenderPreset: body.value ?? null,
           xyzrenderOrientationRef: xyzrenderOrientationRefRef.current,
+          xyzrenderControls: pendingViewerReloadOptionsRef.current?.xyzrenderControls ?? null,
+        };
+        void reloadActive();
+        return;
+      }
+      if (body?.type === "setXyzrenderControls") {
+        pendingViewerReloadDocumentIdRef.current = body.documentId ?? null;
+        pendingViewerReloadOptionsRef.current = {
+          xyzrenderPreset: pendingViewerReloadOptionsRef.current?.xyzrenderPreset ?? null,
+          xyzrenderOrientationRef: xyzrenderOrientationRefRef.current,
+          xyzrenderControls: body.controls ?? null,
         };
         void reloadActive();
         return;
@@ -415,18 +433,31 @@ export default function App() {
       if (body?.type === "setRenderer") {
         const renderer = body.value;
         if (renderer === "auto" || renderer === "xyz-fast" || renderer === "molstar" || renderer === "xyzrender-external") {
+          const targetDocument = (body.documentId
+            ? documents.find((document) => document.id === body.documentId)
+            : null) ?? activeDocument;
           const reloadOptions = renderer === "xyzrender-external" && body.orientationRef
             ? { xyzrenderOrientationRef: body.orientationRef }
             : undefined;
           if (renderer === "xyzrender-external" && body.orientationRef) {
             xyzrenderOrientationRefRef.current = body.orientationRef;
           }
-          pendingViewerReloadOptionsRef.current = reloadOptions ?? null;
+          pendingViewerReloadOptionsRef.current = renderer === "xyzrender-external" && body.orientationRef
+            ? {
+                xyzrenderOrientationRef: body.orientationRef,
+                xyzrenderPreset: pendingViewerReloadOptionsRef.current?.xyzrenderPreset ?? null,
+                xyzrenderControls: pendingViewerReloadOptionsRef.current?.xyzrenderControls ?? null,
+              }
+            : null;
+          pendingViewerReloadDocumentIdRef.current = renderer === "xyzrender-external" && body.orientationRef
+            ? body.documentId ?? null
+            : null;
           skipNextPreferenceRefreshRef.current = true;
           setPreference("rendererMode", renderer);
-          if (activeDocument) {
+          if (targetDocument) {
             pendingViewerReloadOptionsRef.current = null;
-            void openDocuments([activeDocument.path], reloadOptions, { rendererMode: renderer });
+            pendingViewerReloadDocumentIdRef.current = null;
+            void openDocuments([targetDocument.path], reloadOptions, { rendererMode: renderer });
           }
         }
       }

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -1,4 +1,4 @@
-import type { OpenDocumentsResult, ViewerDocument, ViewerPreferences, ViewerReloadOptions } from "../types";
+import type { OpenDocumentsResult, ViewerDocument, ViewerPreferences, ViewerReloadOptions, XyzrenderControls } from "../types";
 import previewFormatRegistry from "../../../../config/preview-formats.json";
 
 type FormatInfo = {
@@ -101,9 +101,19 @@ async function openBrowserDevDocument(
 
   const format = formatForExtension(extension);
   const requestedRenderer = resolveRenderer(format, preferences.rendererMode);
-  const { renderer, externalRendererStatus, externalArtifact, xyzrenderPresetOptions } =
+  const { renderer, externalRendererStatus, externalArtifact, xyzrenderPresetOptions, xyzrenderControls } =
     await browserRendererPlan(path, format, requestedRenderer, reloadOptions);
-  const html = viewerHtml(path, format, renderer, bytes, preferences, externalRendererStatus, externalArtifact, xyzrenderPresetOptions);
+  const html = viewerHtml(
+    path,
+    format,
+    renderer,
+    bytes,
+    preferences,
+    externalRendererStatus,
+    externalArtifact,
+    xyzrenderPresetOptions,
+    xyzrenderControls,
+  );
   return browserDocument(path, extension, renderer, html, bytes.length);
 }
 
@@ -134,6 +144,7 @@ function viewerHtml(
   externalRendererStatus?: Record<string, string>,
   externalArtifact?: BrowserDevExternalArtifact,
   xyzrenderPresetOptions?: Array<{ value: string; label: string }>,
+  xyzrenderControls?: XyzrenderControls | null,
 ) {
   const label = fileTitle(path);
   const visuals = resolvePreviewVisuals(preferences);
@@ -165,6 +176,7 @@ function viewerHtml(
     defaultLayoutState: { left: "hidden", right: "hidden", top: "hidden", bottom: "hidden" },
     ...(externalArtifact ? { externalArtifact } : {}),
     ...(xyzrenderPresetOptions ? { xyzrenderPresetOptions } : {}),
+    ...(xyzrenderControls ? { xyzrenderControls } : {}),
     ...(externalRendererStatus ? { externalRendererStatus } : {}),
     ...(renderer === "xyz-fast"
       ? {
@@ -218,6 +230,7 @@ async function browserRendererPlan(
       path,
       reloadOptions?.xyzrenderPreset ?? "default",
       reloadOptions?.xyzrenderOrientationRef ?? null,
+      reloadOptions?.xyzrenderControls ?? null,
     );
     return {
       renderer: "xyzrender-external",
@@ -230,6 +243,7 @@ async function browserRendererPlan(
         log: result.log,
       },
       xyzrenderPresetOptions: result.xyzrenderPresetOptions,
+      xyzrenderControls: result.xyzrenderControls ?? reloadOptions?.xyzrenderControls ?? null,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -261,6 +275,7 @@ async function requestBrowserDevXyzrender(
   path: string,
   preset: string,
   orientationRef: string | null,
+  controls: XyzrenderControls | null,
 ) {
   const url = new URL("/__burette/xyzrender", window.location.origin);
   const response = await fetch(url, {
@@ -270,6 +285,7 @@ async function requestBrowserDevXyzrender(
       path,
       preset,
       orientationRef: orientationRef || undefined,
+      controls: controls || undefined,
     }),
   });
   const payload = await response.json().catch(() => ({}));
@@ -285,6 +301,7 @@ async function requestBrowserDevXyzrender(
     configArgument: typeof payload?.configArgument === "string" ? payload.configArgument : "default",
     elapsedMs: Number(payload?.elapsedMs) || 0,
     log: typeof payload?.log === "string" ? payload.log : "",
+    xyzrenderControls: typeof payload?.xyzrenderControls === "object" && payload?.xyzrenderControls ? payload.xyzrenderControls as XyzrenderControls : undefined,
     xyzrenderPresetOptions: Array.isArray(payload?.xyzrenderPresetOptions) ? payload.xyzrenderPresetOptions : undefined,
   };
 }
@@ -516,7 +533,7 @@ function resolveRenderer(format: FormatInfo, requested: ViewerPreferences["rende
   if (normalized === "molstar") return "molstar";
   if (normalized === "xyz-fast") return isXyz ? "xyz-fast" : "molstar";
   if (normalized === "xyzrender-external") return isXyz ? "xyzrender-external" : "molstar";
-  return isXyz ? "xyz-fast" : "molstar";
+  return isXyz ? "xyzrender-external" : "molstar";
 }
 
 function normalizeRendererMode(raw: string) {

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1,3 +1,26 @@
+export type XyzrenderControls = {
+  transparentBackground?: boolean | null;
+  canvasSize?: number | null;
+  atomScale?: number | null;
+  bondWidth?: number | null;
+  atomStrokeWidth?: number | null;
+  molColor?: string | null;
+  gradients?: boolean | null;
+  fog?: boolean | null;
+  fogStrength?: number | null;
+  showVdw?: boolean | null;
+  vdwOpacity?: number | null;
+  vdwScale?: number | null;
+  hideBonds?: boolean | null;
+  showCell?: boolean | null;
+  showGhosts?: boolean | null;
+  showAxes?: boolean | null;
+  cellWidth?: number | null;
+  supercell?: [number, number, number] | null;
+  customConfigPath?: string | null;
+  extraArguments?: string | null;
+};
+
 export type OpenDocumentsResult = {
   documents: ViewerDocument[];
   errors: string[];
@@ -6,6 +29,7 @@ export type OpenDocumentsResult = {
 export type ViewerReloadOptions = {
   xyzrenderOrientationRef?: string | null;
   xyzrenderPreset?: string | null;
+  xyzrenderControls?: XyzrenderControls | null;
 };
 
 export type ViewerDocument = {

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -28,6 +28,165 @@ const XYZRENDER_PRESET_OPTIONS = [
   { value: "custom", label: "Custom JSON" },
 ];
 
+function readOptionalNumber(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
+
+function readOptionalInteger(value: unknown) {
+  const number = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(number) ? number : null;
+}
+
+function readOptionalBoolean(value: unknown) {
+  if (value === true || value === false) return value;
+  return null;
+}
+
+function readOptionalText(value: unknown) {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text ? text : null;
+}
+
+function normalizeSupercell(value: unknown) {
+  if (!Array.isArray(value) || value.length !== 3) return null;
+  const parsed = value.map((item) => readOptionalInteger(item));
+  if (parsed.some((item) => !item || item < 1)) return null;
+  return parsed as [number, number, number];
+}
+
+function normalizeXyzrenderControls(value: unknown) {
+  const source = value && typeof value === "object" ? value as Record<string, unknown> : {};
+  return {
+    transparentBackground: readOptionalBoolean(source.transparentBackground),
+    canvasSize: readOptionalNumber(source.canvasSize),
+    atomScale: readOptionalNumber(source.atomScale),
+    bondWidth: readOptionalNumber(source.bondWidth),
+    atomStrokeWidth: readOptionalNumber(source.atomStrokeWidth),
+    molColor: readOptionalText(source.molColor),
+    gradients: readOptionalBoolean(source.gradients),
+    fog: readOptionalBoolean(source.fog),
+    fogStrength: readOptionalNumber(source.fogStrength),
+    showVdw: readOptionalBoolean(source.showVdw),
+    vdwOpacity: readOptionalNumber(source.vdwOpacity),
+    vdwScale: readOptionalNumber(source.vdwScale),
+    hideBonds: readOptionalBoolean(source.hideBonds),
+    showCell: readOptionalBoolean(source.showCell),
+    showGhosts: readOptionalBoolean(source.showGhosts),
+    showAxes: readOptionalBoolean(source.showAxes),
+    cellWidth: readOptionalNumber(source.cellWidth),
+    supercell: normalizeSupercell(source.supercell),
+    customConfigPath: readOptionalText(source.customConfigPath),
+    extraArguments: readOptionalText(source.extraArguments),
+  };
+}
+
+function splitCommandLine(value: string) {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === "\"") {
+      quote = character;
+      continue;
+    }
+    if (/\s/u.test(character)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += character;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function sanitizedExtraArguments(value: string | null) {
+  if (!value) return [];
+  const blocked = new Set(["-o", "--output", "-go", "--gif-output", "--config", "--ref"]);
+  const blockedPrefixes = [...blocked].map((flag) => `${flag}=`);
+  const result: string[] = [];
+  let skipNext = false;
+  for (const token of splitCommandLine(value)) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (blocked.has(token)) {
+      skipNext = true;
+      continue;
+    }
+    if (blockedPrefixes.some((flag) => token.startsWith(flag))) continue;
+    result.push(token);
+  }
+  return result;
+}
+
+function resolveConfigArgument(preset: string, controls: ReturnType<typeof normalizeXyzrenderControls>) {
+  if (preset !== "custom") return preset;
+  return controls.customConfigPath || "default";
+}
+
+function resolveEffectivePreset(preset: string, controls: ReturnType<typeof normalizeXyzrenderControls>) {
+  return preset === "custom" && resolveConfigArgument(preset, controls) === "default" ? "default" : preset;
+}
+
+function buildXyzrenderArgs(
+  inputPath: string,
+  outputPath: string,
+  preset: string,
+  orientationRefPath: string | null,
+  controls: ReturnType<typeof normalizeXyzrenderControls>,
+) {
+  const args = [inputPath, "-o", outputPath, "--config", resolveConfigArgument(preset, controls)];
+  if (orientationRefPath) args.push("--ref", orientationRefPath);
+  if (controls.transparentBackground === true) args.push("--transparent");
+  if (controls.canvasSize) args.push("-S", String(controls.canvasSize));
+  if (controls.atomScale) args.push("-a", String(controls.atomScale));
+  if (controls.bondWidth) args.push("-b", String(controls.bondWidth));
+  if (controls.atomStrokeWidth) args.push("-s", String(controls.atomStrokeWidth));
+  if (controls.molColor) args.push("--mol-color", controls.molColor);
+  if (controls.gradients === true) args.push("--grad");
+  if (controls.gradients === false) args.push("--no-grad");
+  if (controls.fog === true) args.push("--fog");
+  if (controls.fog === false) args.push("--no-fog");
+  if (controls.fogStrength) args.push("-F", String(controls.fogStrength));
+  if (controls.showVdw === true) args.push("--vdw");
+  if (controls.vdwOpacity) args.push("--vdw-opacity", String(controls.vdwOpacity));
+  if (controls.vdwScale) args.push("--vdw-scale", String(controls.vdwScale));
+  if (controls.hideBonds === true) args.push("--no-bonds");
+  if (controls.showCell === true) args.push("--cell");
+  if (controls.showCell === false) args.push("--no-cell");
+  if (controls.showGhosts === true) args.push("--ghosts");
+  if (controls.showGhosts === false) args.push("--no-ghosts");
+  if (controls.showAxes === true) args.push("--axes");
+  if (controls.showAxes === false) args.push("--no-axes");
+  if (controls.cellWidth) args.push("--cell-width", String(controls.cellWidth));
+  if (controls.supercell) args.push("--supercell", ...controls.supercell.map(String));
+  args.push(...sanitizedExtraArguments(controls.extraArguments));
+  return args;
+}
+
 function normalizeXyzrenderPreset(value: string | null) {
   const normalized = String(value || "default").trim().toLowerCase();
   return XYZRENDER_PRESET_OPTIONS.some((option) => option.value === normalized) ? normalized : "default";
@@ -67,6 +226,7 @@ function browserDevXyzrenderPlugin() {
           }
           const preset = normalizeXyzrenderPreset(typeof body.preset === "string" ? body.preset : null);
           const orientationRef = normalizeOrientationRef(typeof body.orientationRef === "string" ? body.orientationRef : null);
+          const controls = normalizeXyzrenderControls(body.controls);
           const executable = resolveXyzrenderExecutable();
           if (!executable) {
             reply(404, { error: "External xyzrender executable was not found." });
@@ -77,10 +237,15 @@ function browserDevXyzrenderPlugin() {
           const orientationRefPath = join(tempDirectory, "orientation-ref.xyz");
           const startedAt = Date.now();
           try {
-            const args = [inputPath, "-o", outputPath, "--config", preset];
+            const args = buildXyzrenderArgs(
+              inputPath,
+              outputPath,
+              preset,
+              orientationRef ? orientationRefPath : null,
+              controls,
+            );
             if (orientationRef) {
               await writeFile(orientationRefPath, orientationRef, "utf8");
-              args.push("--ref", orientationRefPath);
             }
             const { stdout, stderr } = await execFileAsync(
               executable,
@@ -94,10 +259,11 @@ function browserDevXyzrenderPlugin() {
             }
             reply(200, {
               svg,
-              preset,
-              configArgument: preset,
+              preset: resolveEffectivePreset(preset, controls),
+              configArgument: resolveConfigArgument(preset, controls),
               elapsedMs: Date.now() - startedAt,
               log: `${stdout || ""}${stderr || ""}`,
+              xyzrenderControls: controls,
               xyzrenderPresetOptions: XYZRENDER_PRESET_OPTIONS,
             });
           } finally {

--- a/docs/renderer-support.md
+++ b/docs/renderer-support.md
@@ -22,8 +22,9 @@ Mol* interactive preview is used for:
 - MOL, MOL2
 - XYZ and GRO when selected or resolved by policy
 
-Fast XYZ is used for text XYZ input when selected or when `auto` resolves to the
-fast path.
+External `xyzrender` is used for text XYZ input when selected or when `auto`
+resolves to the default preview path. Fast XYZ remains available when selected
+or when external `xyzrender` falls back.
 
 External `xyzrender` is used for XYZ-like text inputs when selected. It is also
 the required path for external-renderer-only groups:

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -16,5 +16,6 @@ historical migration notes.
 - [Preview open latency spec](burette-preview-open-latency-spec.md)
 - [Preview task cancellation spec](burette-preview-task-cancellation-spec.md)
 - [Preview theme and background spec](burette-preview-theme-and-background-spec.md)
+- [xyzrender controls spec](burette-xyzrender-controls-spec.md)
 - [Titlebar window behavior spec](burette-titlebar-window-behavior-spec.md)
 - [UI accessibility spec](burette-ui-a11y-spec.md)

--- a/docs/specs/burette-xyzrender-controls-spec.md
+++ b/docs/specs/burette-xyzrender-controls-spec.md
@@ -1,0 +1,183 @@
+# Burrete xyzrender Controls Spec
+
+## Summary
+
+Add a shared compact `xyzrender` controls menu to the preview runtime so the
+desktop app, browser-dev runtime, and Quick Look can expose the most useful
+`xyzrender` flags without overloading the top toolbar or turning preview into
+an export workstation.
+
+The feature must preserve the existing hybrid renderer boundary:
+
+- Mol* remains the interactive 3D viewer.
+- Fast XYZ remains the lightweight static fallback.
+- External `xyzrender` remains the publication-oriented SVG renderer.
+
+## Goals
+
+- Keep the top toolbar compact while exposing a small, meaningful set of
+  `xyzrender` controls.
+- Use one shared runtime menu for browser-dev, the Tauri app, and Quick Look.
+- Send structured `xyzrender` controls through the preview reload contract
+  instead of relying on ad hoc string parsing in the viewer.
+- Support a first-class set of common controls that make sense in preview:
+  - transparent background;
+  - gradients on/off/default;
+  - fog on/off/default;
+  - VdW spheres toggle;
+  - hide bonds;
+  - cell on/off/default;
+  - ghosts on/off/default;
+  - axes on/off/default;
+  - supercell dimensions.
+- Keep a smaller appearance subsection for the few preview-safe numeric/style
+  controls that still matter in runtime preview:
+  - atom scale;
+  - bond width;
+  - VdW scale;
+  - molecular flat color.
+
+## Non-Goals
+
+- Rebuilding preview around every `xyzrender` CLI flag in one pass.
+- Turning Quick Look into a heavyweight export workstation.
+- Supporting GIF/export-only flows from the preview menu.
+- Allowing preview users to override output paths, reference-file paths, or
+  renderer executable paths from the runtime toolbar.
+
+## UX
+
+### Toolbar
+
+The top toolbar stays short.
+
+When `renderer === "xyzrender-external"`:
+
+- show the preset select;
+- show a `Tune` action;
+- keep renderer switching visible.
+
+When any other renderer is active:
+
+- hide the `Tune` action;
+- hide the `xyzrender` advanced menu.
+
+### Advanced Menu
+
+The `Tune` action opens a popover anchored to the toolbar.
+
+The popover contains these sections:
+
+- `Main`
+  - transparent background
+  - gradients
+  - fog
+  - VdW
+  - hide bonds
+- `Crystal`
+  - cell
+  - ghosts
+  - axes
+  - supercell
+- `Appearance`
+  - atom scale
+  - bond width
+  - VdW scale
+  - mol color
+
+The menu uses live editing:
+
+- changing a field updates local form state and automatically reloads the
+  active preview after a short debounce;
+- `Reset` clears the advanced controls back to runtime defaults for the current
+  document.
+
+## Data Contract
+
+`ViewerReloadOptions` gains a new optional object:
+
+- `xyzrenderControls`
+
+`xyzrenderControls` contains a structured subset of CLI behavior:
+
+- `transparentBackground?: boolean | null`
+- `atomScale?: number | null`
+- `bondWidth?: number | null`
+- `molColor?: string | null`
+- `gradients?: boolean | null`
+- `fog?: boolean | null`
+- `showVdw?: boolean | null`
+- `vdwScale?: number | null`
+- `hideBonds?: boolean | null`
+- `showCell?: boolean | null`
+- `showGhosts?: boolean | null`
+- `showAxes?: boolean | null`
+- `supercell?: [number, number, number] | null`
+- `customConfigPath?: string | null`
+- `extraArguments?: string | null`
+
+The runtime config returned to the viewer also includes:
+
+- `xyzrenderControls`
+
+This allows the shared viewer menu to reflect the current active state after
+reloads and when switching tabs.
+
+## Runtime Rules
+
+- Structured controls must compile to explicit CLI arguments in the worker
+  layer, not in the shell UI.
+- `preset` remains the owner of `--config` unless an external host default
+  explicitly supplies `customConfigPath`.
+- `customConfigPath` and `extraArguments` remain host/runtime fields but are
+  not part of the shared compact preview popover.
+- The advanced CLI field, when supplied by the host, is appended after
+  structured controls.
+- Unsafe flags must be stripped from the advanced CLI field:
+  - `-o`, `--output`
+  - `-go`, `--gif-output`
+  - `--config`
+  - `--ref`
+- Renderer switching from Mol* to `xyzrender` must continue to preserve
+  orientation through the existing reference-file workflow.
+
+## Implementation Notes
+
+- Shared viewer UI:
+  - `PreviewExtension/Web/viewer-shell.js`
+  - `PreviewExtension/Web/viewer.js`
+  - `PreviewExtension/Web/viewer-runtime.css`
+- Desktop/browser-dev contract:
+  - `apps/desktop/src/types.ts`
+  - `apps/desktop/src/App.tsx`
+  - `apps/desktop/src/lib/browser-dev-documents.ts`
+  - `apps/desktop/vite.config.ts`
+- Tauri worker/runtime:
+  - `apps/desktop/src-tauri/src/preview/runtime.rs`
+  - `apps/desktop/src-tauri/src/preview/runtime_viewer.rs`
+  - `apps/desktop/src-tauri/src/preview/xyzrender.rs`
+- Quick Look bridge/worker:
+  - `PreviewExtension/Platform/PreviewViewController.swift`
+
+## Acceptance Criteria
+
+- `xyzrender` exposes a `Tune` control without enlarging the default toolbar
+  into a multi-row card.
+- The advanced menu opens in the same place and with the same behavior in
+  browser-dev, Tauri, and Quick Look.
+- The main visible controls are the compact preview-safe set:
+  - transparent background
+  - gradients
+  - fog
+  - VdW
+  - hide bonds
+- Editing controls updates the active preview automatically and preserves the
+  current document/tab.
+- Runtime-supplied `customConfigPath` and `extraArguments` continue to work
+  across Tauri, browser-dev, and Quick Look, minus the blocked unsafe flags,
+  without turning the shared preview menu into a generic CLI editor.
+- Existing checks continue to pass:
+  - `npm run check:js`
+  - `npm run test:ui`
+  - `npm --prefix apps/desktop run typecheck`
+  - `cargo check`

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -43,7 +43,9 @@ const [
   windowTitle,
   instance,
   browserDevDocuments,
+  viteConfig,
   previewRuntimeViewer,
+  previewXyzrender,
   previewViewController,
   shortcutDocs,
   styles,
@@ -91,7 +93,9 @@ const [
   source('apps/desktop/src/components/window-title/index.tsx'),
   source('apps/desktop/src/lib/instance.ts'),
   source('apps/desktop/src/lib/browser-dev-documents.ts'),
+  source('apps/desktop/vite.config.ts'),
   source('apps/desktop/src-tauri/src/preview/runtime_viewer.rs'),
+  source('apps/desktop/src-tauri/src/preview/xyzrender.rs'),
   source('PreviewExtension/Platform/PreviewViewController.swift'),
   source('docs/keyboard-shortcuts.md'),
   source('apps/desktop/src/styles.css'),
@@ -150,6 +154,43 @@ assert.match(sidebarHook, /from "\.\.\/stores\/shell-store"/);
 assert.match(sidebarHook, /sidebarWidth/);
 assert.match(viewerShell, /id="buret-open-in-app"/);
 assert.match(viewer, /message: 'open-burrete'/);
+assert.doesNotMatch(viewerShell, /data-buret-action="open-burrete"/);
+assert.doesNotMatch(viewerShell, /data-buret-action="xyzrender-apply"/);
+assert.match(viewerShell, /data-buret-action="xyzrender-reset"/);
+assert.match(viewerShell, /<div class="buret-xyzrender-popover-title">xyzrender<\/div>/);
+assert.match(viewerShell, /data-buret-xyzrender-crystal/);
+assert.match(viewerShell, /Transparent/);
+assert.match(viewerShell, /Gradients/);
+assert.match(viewerShell, /Fog/);
+assert.match(viewerShell, /VdW/);
+assert.match(viewerShell, /Hide bonds/);
+assert.match(viewerShell, /<summary>Appearance<\/summary>/);
+assert.match(viewerShell, /data-buret-xyzrender-appearance/);
+assert.doesNotMatch(viewerShell, /Custom JSON path/);
+assert.doesNotMatch(viewerShell, /Additional CLI flags/);
+assert.doesNotMatch(viewerShell, /Auto-applies/);
+assert.doesNotMatch(viewerShell, /Main flags/);
+assert.doesNotMatch(viewerShell, /Applies live to the current preview/);
+assert.match(viewer, /scheduleXyzrenderControlsApply/);
+assert.match(viewer, /requestXyzrenderControls\(toolbar\);/);
+assert.match(viewer, /updateXyzrenderFormVisibility\(toolbar\);\s*scheduleXyzrenderControlsApply\(toolbar, 0\);/);
+assert.match(viewer, /updateXyzrenderFormVisibility\(toolbar\);\s*scheduleXyzrenderControlsApply\(toolbar, 260\);/);
+assert.match(viewer, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
+assert.match(viewer, /function bindXyzrenderControls\(toolbar\)/);
+assert.match(viewer, /XYZRENDER_POPOVER_OPEN_KEY_PREFIX/);
+assert.match(viewer, /function setXyzrenderPopoverVisibility\(toolbar, open\)/);
+assert.match(viewer, /function shouldRestoreXyzrenderPopoverOpen\(\)/);
+assert.match(viewer, /setXyzrenderPopoverOpenPersisted\(open\)/);
+assert.match(viewer, /setXyzrenderPopoverVisibility\(toolbar, hidden\)/);
+assert.match(viewer, /setXyzrenderPopoverVisibility\(toolbar, false\)/);
+assert.match(viewer, /if \(renderer === 'xyzrender-external'\) \{\s*if \(tuneButton && !tuneButton\.classList\.contains\('hidden'\)\) target = tuneButton;\s*else if \(presetSlot && presetSlot\.classList\.contains\('visible'\)\) target = presetSlot;/);
+assert.match(previewRuntimeCss, /#buret-toolbar\[data-active-renderer="xyzrender-external"\] \[data-buret-toggle="left"\],/);
+assert.match(previewRuntimeCss, /#buret-toolbar\[data-active-renderer="xyzrender-external"\] \[data-buret-toggle="log"\] \{\s*display: none;/);
+assert.match(browserDevDocuments, /return isXyz \? "xyzrender-external" : "molstar";/);
+assert.match(browserDevDocuments, /requestedRenderer: normalizeRendererMode\(preferences\.rendererMode\)/);
+assert.match(viteConfig, /return Number\.isFinite\(number\) && number > 0 \? number : null;/);
+assert.match(previewViewController, /Set\(\["-o", "--output", "-go", "--gif-output", "--config", "--ref"\]\)/);
+assert.match(previewXyzrender, /config_argument: resolved_config_argument/);
 assert.match(viewer, /left: 'hidden'/);
 assert.match(viewer, /const mainRect = visibleRect\('\.msp-plugin \.msp-layout-main'\);/);
 assert.match(viewer, /const rightEdge = mainRect \? mainRect\.right : window\.innerWidth;/);
@@ -378,20 +419,24 @@ assert.match(app, /useMenuEvents\(\{ chooseFiles, openSettings, checkForUpdates 
 assert.match(app, /await invoke<string\[]>\("pick_open_targets"\)/);
 assert.match(app, /<WindowTitle activeDocument=\{activeDocument\} \/>/);
 assert.match(app, /const pendingViewerReloadOptionsRef = useRef<ViewerReloadOptions \| null>\(null\)/);
+assert.match(app, /const pendingViewerReloadDocumentIdRef = useRef<string \| null>\(null\)/);
 assert.match(app, /const xyzrenderOrientationRefRef = useRef<string \| null>\(null\)/);
 assert.match(app, /const skipNextPreferenceRefreshRef = useRef\(false\)/);
 assert.match(app, /body\?\.type === "error"/);
 assert.match(app, /summarizeErrors\(result\.errors\)/);
 assert.match(app, /if \(body\?\.type === "setXyzrenderOrientation"\)/);
 assert.match(app, /if \(body\?\.type === "setXyzrenderPreset"\)/);
+assert.match(app, /pendingViewerReloadDocumentIdRef\.current = body\.documentId \?\? null/);
 assert.match(app, /xyzrenderPreset: body\.value \?\? null/);
 assert.match(app, /const reloadOptions = renderer === "xyzrender-external" && body\.orientationRef/);
-assert.match(app, /pendingViewerReloadOptionsRef\.current = reloadOptions \?\? null/);
+assert.match(app, /const targetDocument = \(body\.documentId/);
+assert.match(app, /pendingViewerReloadDocumentIdRef\.current = renderer === "xyzrender-external" && body\.orientationRef/);
 assert.match(app, /skipNextPreferenceRefreshRef\.current = true/);
 assert.match(app, /setPreference\("rendererMode", renderer\)/);
-assert.match(app, /void openDocuments\(\[activeDocument\.path\], reloadOptions, \{ rendererMode: renderer \}\)/);
+assert.match(app, /void openDocuments\(\[targetDocument\.path\], reloadOptions, \{ rendererMode: renderer \}\)/);
+assert.match(app, /const targetDocument = \(pendingViewerReloadDocumentIdRef\.current/);
 assert.match(app, /const reloadOptions = pendingViewerReloadOptionsRef\.current \?\? undefined/);
-assert.match(app, /await openDocuments\(\[activeDocument\.path\], reloadOptions\)/);
+assert.match(app, /await openDocuments\(\[targetDocument\.path\], reloadOptions\)/);
 assert.match(openDropHook, /export function useOpenDrop/);
 assert.match(openEventsHook, /export function useOpenEvents/);
 assert.match(menuEventsHook, /export function useMenuEvents/);


### PR DESCRIPTION
## Summary
- align xyzrender preview behavior across browser-dev, Tauri, and Quick Look
- default auto xyz files to xyzrender and tighten preset/control parity
- polish the shared xyzrender menu and update docs/contracts

## Verification
- npm run check:js
- npm run test:ui
- npm --prefix apps/desktop run typecheck
- cargo check
- cargo test xyzrender --quiet
- git diff --check