### PR TITLE
Fix grid RDKit runtime loading and error dedup

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -42,10 +42,12 @@
   }
 
   function setStatus(message, kind = 'info') {
+    const cfg = window.BurreteConfig && typeof window.BurreteConfig === 'object' ? window.BurreteConfig : {};
     if (status) {
       status.textContent = String(message || '');
       status.classList.toggle('error', kind === 'error');
       status.classList.toggle('hidden', kind !== 'error' && !window.BurreteDebug);
+      if (kind === 'error' && status && !window.BurreteDebug && cfg.appViewer === true) status.classList.add('hidden');
     }
     if (kind === 'error' || window.BurreteDebug) post(kind === 'error' ? 'error' : 'status', message || '');
   }
@@ -628,7 +630,6 @@
     } catch (error) {
       const message = error && error.stack ? error.stack : String(error);
       setStatus(message, 'error');
-      post('error', message);
     }
   }
 

--- a/apps/desktop/src-tauri/src/preview/runtime_grid.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_grid.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::fs;
@@ -65,6 +66,10 @@ pub(crate) fn create_grid_runtime<R: Runtime>(
     prune_runtime_dirs(&base);
 
     let records_included = collection.records.len();
+    let rdkit_wasm_base64 = base64::engine::general_purpose::STANDARD.encode(
+        fs::read(assets.join("rdkit").join("RDKit_minimal.wasm"))
+            .map_err(|err| format!("read RDKit wasm: {err}"))?,
+    );
     let records_payload: Vec<_> = collection
         .records
         .iter()
@@ -102,7 +107,7 @@ pub(crate) fn create_grid_runtime<R: Runtime>(
         "recordsIncluded": records_included,
         "recordsTruncated": collection.records_total > records_included,
         "pageSize": 96,
-        "rdkitWasmPath": asset_url(&assets.join("rdkit").join("RDKit_minimal.wasm")),
+        "rdkitWasmPath": "../assets/rdkit/RDKit_minimal.wasm",
         "capabilities": {
             "selection": true,
             "export": true,
@@ -125,6 +130,11 @@ pub(crate) fn create_grid_runtime<R: Runtime>(
     fs::write(
         runtime.join("preview-grid-records.js"),
         format!("window.BurreteGridRecords = {records_text};\n"),
+    )
+    .map_err(|err| err.to_string())?;
+    fs::write(
+        runtime.join("preview-rdkit-wasm.js"),
+        format!("window.BurreteRDKitWasmBase64 = {:?};\n", rdkit_wasm_base64),
     )
     .map_err(|err| err.to_string())?;
     Ok(Some(runtime.join("index.html")))
@@ -150,6 +160,7 @@ fn grid_html(
     let grid_css = versioned_asset_url(&assets.join("grid.css"));
     let config_js = asset_url(&runtime.join("preview-config.js"));
     let records_js = asset_url(&runtime.join("preview-grid-records.js"));
+    let rdkit_wasm_js = asset_url(&runtime.join("preview-rdkit-wasm.js"));
     let rdkit_js = versioned_asset_url(&assets.join("rdkit").join("RDKit_minimal.js"));
     let grid_js = versioned_asset_url(&assets.join("grid-viewer.js"));
     format!(
@@ -177,6 +188,7 @@ fn grid_html(
   <div id="status">Loading molecule grid...</div>
   <script src="{config_js}"></script>
   <script src="{records_js}"></script>
+  <script src="{rdkit_wasm_js}"></script>
   <script src="{rdkit_js}"></script>
   <script src="{grid_js}"></script>
 </body>
@@ -185,7 +197,7 @@ fn grid_html(
 }
 
 fn versioned_asset_url(path: &Path) -> String {
-    format!("{}?v=grid-ui-v4", asset_url(path))
+    format!("{}?v=grid-ui-v5", asset_url(path))
 }
 
 fn grid_can_preview(extension: &str) -> bool {

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -17,7 +17,7 @@ type GridRecord = {
 };
 
 const MAX_STRUCTURE_FILE_SIZE = 75 * 1024 * 1024;
-const GRID_ASSET_VERSION = "grid-ui-v4";
+const GRID_ASSET_VERSION = "grid-ui-v5";
 const REPO_ROOT = String(import.meta.env.BURRETE_REPO_ROOT || "");
 const WEB_ASSETS_BASE = fsUrl(`${REPO_ROOT}/PreviewExtension/Web/`);
 

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -262,8 +262,10 @@ assert.match(previewRuntimeViewer, /window\.BurretePreviewDataScriptURL = \{data
 assert.match(previewRuntimeViewer, /window\.BurreteDataURL = \{data_bin_js:\?\};/);
 assert.match(previewRuntimeViewer, /window\.BurreteMolstarURL = \{molstar_js:\?\};/);
 assert.match(previewRuntimeViewer, /window\.BurreteXyzFastURL = \{xyz_fast_js:\?\};/);
-assert.doesNotMatch(previewRuntimeGrid, /BurreteRDKitWasmBase64/);
-assert.match(previewRuntimeGrid, /"rdkitWasmPath": asset_url/);
+assert.match(previewRuntimeGrid, /window\.BurreteRDKitWasmBase64 = \{:\?\};\\n/);
+assert.match(previewRuntimeGrid, /"rdkitWasmPath": "\.\.\/assets\/rdkit\/RDKit_minimal\.wasm"/);
+assert.match(previewRuntimeGrid, /runtime\.join\("preview-rdkit-wasm\.js"\)/);
+assert.match(previewRuntimeGrid, /<script src="\{rdkit_wasm_js\}"><\/script>/);
 assert.match(previewRuntimeViewer, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
 assert.match(viewerRuntimeCSS, /--buret-toolbar-safe-top: 12px/);
 assert.match(viewerRuntimeCSS, /--buret-viewport-controls-top: 64px/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -613,5 +613,7 @@ assert.match(browserDevDocuments, /documentId: stableId\(path\)/);
 assert.match(browserDevDocuments, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
 assert.match(browserDevDocuments, /rdkitWasmPath: `\$\{WEB_ASSETS_BASE\}rdkit\/RDKit_minimal\.wasm`/);
 assert.doesNotMatch(browserDevDocuments, /BurreteRDKitWasmBase64/);
+assert.match(gridViewer, /if \(kind === 'error' && status && !window\.BurreteDebug && cfg\.appViewer === true\) status\.classList\.add\('hidden'\);/);
+assert.doesNotMatch(gridViewer, /post\('error', message\);/);
 
 console.log('ui shell contract tests passed');


### PR DESCRIPTION
## Summary
- fix RDKit grid runtime loading in the desktop app by embedding the wasm payload into the generated runtime and switching the runtime wasm path back to a relative asset path
- stop double-reporting the same grid error in the app-hosted viewer and force a fresh grid asset cache version
- extend runtime and UI shell contract tests to cover the new wasm bootstrap and app-hosted error dedup behavior

## Pre-PR
### Must-Fix Before PR
- none found in the final diff

### Cleanup / Simplification Suggestions
- optional only: `grid-viewer.js` still has a redundant `status &&` check inside an enclosing `if (status)` block
- optional only: the test around the exact error-hiding condition is intentionally strict and therefore somewhat brittle to harmless refactors

### Stress / Future Risks
- embedding `RDKit_minimal.wasm` into `preview-rdkit-wasm.js` increases per-runtime file size and I/O
- the desktop runtime now depends on the relative `../assets/rdkit/` layout remaining stable
- app-hosted errors are intentionally hidden in the inner grid status surface, so outer-shell error reporting becomes the main diagnostics path

### Security Notes
- no concrete vulnerability found in this diff
- the change does touch filesystem/webview asset loading boundaries, but only for bundled local runtime assets

## Verification
- `bun tests/test-tauri-structure.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `bun run check:js`
- `./scripts/build.sh`
- direct runtime verification from the current `build/Burrete.app` produced a grid runtime with `preview-rdkit-wasm.js` and relative `rdkitWasmPath`

## Caveats
- full security scan was not run
- installed app verification was temporarily polluted by a separate background release process from another worktree; the final runtime verification was done against the current build output directly
