### PR TITLE
Add native update progress window

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod preview_cache;
 pub(crate) mod quicklook;
 pub(crate) mod shell;
 pub(crate) mod startup;
+pub(crate) mod update_progress;
 pub(crate) mod updater;

--- a/apps/desktop/src-tauri/src/commands/update_progress.rs
+++ b/apps/desktop/src-tauri/src/commands/update_progress.rs
@@ -1,0 +1,203 @@
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::{LazyLock, Mutex};
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+struct NativeUpdateProgressWindow {
+    window: usize,
+    message_label: usize,
+    progress_indicator: usize,
+}
+
+#[cfg(target_os = "macos")]
+static PROGRESS_WINDOW: LazyLock<Mutex<Option<NativeUpdateProgressWindow>>> =
+    LazyLock::new(|| Mutex::new(None));
+#[cfg(target_os = "macos")]
+static PROGRESS_WINDOW_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn show(app: &tauri::AppHandle, message: impl Into<String>, progress: Option<f64>) {
+    show_platform(app, message.into(), progress);
+}
+
+pub(crate) fn close(app: &tauri::AppHandle) {
+    close_platform(app);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn show_platform(_app: &tauri::AppHandle, _message: String, _progress: Option<f64>) {}
+
+#[cfg(not(target_os = "macos"))]
+fn close_platform(_app: &tauri::AppHandle) {}
+
+#[cfg(target_os = "macos")]
+fn show_platform(app: &tauri::AppHandle, message: String, progress: Option<f64>) {
+    PROGRESS_WINDOW_ACTIVE.store(true, Ordering::SeqCst);
+    let _ = app.run_on_main_thread(move || unsafe {
+        if !PROGRESS_WINDOW_ACTIVE.load(Ordering::SeqCst) {
+            return;
+        }
+        let window = ensure_progress_window();
+        update_progress_window(window, &message, progress);
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn close_platform(app: &tauri::AppHandle) {
+    PROGRESS_WINDOW_ACTIVE.store(false, Ordering::SeqCst);
+    let _ = app.run_on_main_thread(move || unsafe {
+        use objc::{msg_send, sel, sel_impl};
+
+        if let Ok(mut state) = PROGRESS_WINDOW.lock() {
+            if let Some(window) = state.take() {
+                let ns_window = window.window as cocoa::base::id;
+                let _: () = msg_send![ns_window, close];
+                let _: () = msg_send![ns_window, release];
+            }
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ensure_progress_window() -> NativeUpdateProgressWindow {
+    if let Ok(state) = PROGRESS_WINDOW.lock() {
+        if let Some(window) = *state {
+            return window;
+        }
+    }
+
+    let window = create_progress_window();
+    if let Ok(mut state) = PROGRESS_WINDOW.lock() {
+        *state = Some(window);
+    }
+    window
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn create_progress_window() -> NativeUpdateProgressWindow {
+    use cocoa::appkit::{NSApp, NSBackingStoreType, NSWindow, NSWindowStyleMask};
+    use cocoa::base::{id, nil, NO, YES};
+    use cocoa::foundation::{NSPoint, NSRect, NSSize};
+    use objc::{class, msg_send, sel, sel_impl};
+    use std::os::raw::c_void;
+
+    let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(620.0, 214.0));
+    let window: id = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
+        frame,
+        NSWindowStyleMask::NSTitledWindowMask,
+        NSBackingStoreType::NSBackingStoreBuffered,
+        NO,
+    );
+    window.setTitle_(nsstring("Updating Burrete"));
+    let _: () = msg_send![window, setReleasedWhenClosed: NO];
+    let _: () = msg_send![window, setMovableByWindowBackground: YES];
+    let _: () = msg_send![window, setTitleVisibility: 0u64];
+    let _: () = msg_send![window, setTitlebarAppearsTransparent: NO];
+    hide_standard_button(window, 0);
+    hide_standard_button(window, 1);
+    hide_standard_button(window, 2);
+
+    let content: id = msg_send![class!(NSView), alloc];
+    let content: id = msg_send![content, initWithFrame: frame];
+    let _: () = msg_send![window, setContentView: content];
+    let _: () = msg_send![content, release];
+
+    let icon: id = msg_send![NSApp(), applicationIconImage];
+    let icon_view: id = msg_send![class!(NSImageView), imageViewWithImage: icon];
+    let _: () = msg_send![icon_view, setFrame: rect(34.0, 78.0, 78.0, 78.0)];
+    let _: () = msg_send![content, addSubview: icon_view];
+
+    let message_label: id = msg_send![
+        class!(NSTextField),
+        labelWithString: nsstring("Preparing update...")
+    ];
+    let _: () = msg_send![message_label, setFrame: rect(134.0, 130.0, 430.0, 30.0)];
+    let font: id = msg_send![class!(NSFont), boldSystemFontOfSize: 17.0f64];
+    let _: () = msg_send![message_label, setFont: font];
+    let _: () = msg_send![message_label, setLineBreakMode: 4u64];
+    let _: () = msg_send![content, addSubview: message_label];
+
+    let progress_indicator: id = msg_send![class!(NSProgressIndicator), alloc];
+    let progress_indicator: id =
+        msg_send![progress_indicator, initWithFrame: rect(134.0, 90.0, 430.0, 14.0)];
+    let _: () = msg_send![progress_indicator, setStyle: 0u64];
+    let _: () = msg_send![progress_indicator, setMinValue: 0.0f64];
+    let _: () = msg_send![progress_indicator, setMaxValue: 100.0f64];
+    let _: () = msg_send![progress_indicator, setUsesThreadedAnimation: YES];
+    let _: () = msg_send![content, addSubview: progress_indicator];
+    let _: () = msg_send![progress_indicator, release];
+
+    let cancel_button: id = msg_send![
+        class!(NSButton),
+        buttonWithTitle: nsstring("Cancel")
+        target: nil
+        action: std::ptr::null::<c_void>()
+    ];
+    let _: () = msg_send![cancel_button, setFrame: rect(450.0, 28.0, 114.0, 32.0)];
+    let _: () = msg_send![cancel_button, setEnabled: NO];
+    let _: () = msg_send![content, addSubview: cancel_button];
+
+    let _: () = msg_send![window, center];
+    let _: () = msg_send![window, makeKeyAndOrderFront: nil];
+    let _: () = msg_send![NSApp(), activateIgnoringOtherApps: YES];
+
+    NativeUpdateProgressWindow {
+        window: window as usize,
+        message_label: message_label as usize,
+        progress_indicator: progress_indicator as usize,
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn update_progress_window(
+    window: NativeUpdateProgressWindow,
+    message: &str,
+    progress: Option<f64>,
+) {
+    use cocoa::base::{id, nil, NO, YES};
+    use objc::{msg_send, sel, sel_impl};
+
+    let message_label = window.message_label as id;
+    let progress_indicator = window.progress_indicator as id;
+    let ns_window = window.window as id;
+    let _: () = msg_send![message_label, setStringValue: nsstring(message)];
+    if let Some(progress) = progress {
+        let value = progress.clamp(0.0, 1.0) * 100.0;
+        let _: () = msg_send![progress_indicator, setIndeterminate: NO];
+        let _: () = msg_send![progress_indicator, stopAnimation: nil];
+        let _: () = msg_send![progress_indicator, setDoubleValue: value];
+    } else {
+        let _: () = msg_send![progress_indicator, setIndeterminate: YES];
+        let _: () = msg_send![progress_indicator, startAnimation: nil];
+    }
+    let _: () = msg_send![ns_window, orderFrontRegardless];
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn hide_standard_button(window: cocoa::base::id, button: u64) {
+    use cocoa::base::{id, YES};
+    use objc::{msg_send, sel, sel_impl};
+
+    let standard_button: id = msg_send![window, standardWindowButton: button];
+    if !standard_button.is_null() {
+        let _: () = msg_send![standard_button, setHidden: YES];
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn rect(x: f64, y: f64, width: f64, height: f64) -> cocoa::foundation::NSRect {
+    use cocoa::foundation::{NSPoint, NSRect, NSSize};
+
+    NSRect::new(NSPoint::new(x, y), NSSize::new(width, height))
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn nsstring(value: &str) -> cocoa::base::id {
+    use cocoa::base::nil;
+    use cocoa::foundation::NSString;
+    use objc::{msg_send, sel, sel_impl};
+
+    let string = NSString::alloc(nil).init_str(value);
+    msg_send![string, autorelease]
+}

--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tauri::Manager;
 
+use super::update_progress;
+
 const APP_ID: &str = "com.local.BurreteV10";
 const EXTENSION_ID: &str = "com.local.BurreteV10.Preview";
 const RELEASE_DOWNLOAD_PREFIX: &str =
@@ -51,21 +53,40 @@ pub(crate) async fn install_update(
     let package_version = app.package_info().version.to_string();
     let app_data_dir = app.path().app_data_dir().map_err(|err| err.to_string())?;
     let app_bundle = current_app_bundle()?;
+    let progress_app = app.clone();
 
-    tauri::async_runtime::spawn_blocking(move || {
-        let archive = download_update(&app_data_dir, &package_version, &request)?;
-        let staged_app =
-            unpack_and_validate_update(&app_data_dir, &archive, &package_version, &request)?;
+    update_progress::show(&app, "Preparing update...", Some(0.04));
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let archive = download_update(&progress_app, &app_data_dir, &package_version, &request)?;
+        let staged_app = unpack_and_validate_update(
+            &progress_app,
+            &app_data_dir,
+            &archive,
+            &package_version,
+            &request,
+        )?;
+        update_progress::show(&progress_app, "Preparing installer...", Some(0.92));
         launch_installer(&app_data_dir, &staged_app, &app_bundle, &request.tag_name)
     })
     .await
-    .map_err(|err| err.to_string())??;
+    .map_err(|err| err.to_string())
+    .and_then(|result| result);
 
-    app.exit(0);
-    Ok(())
+    match result {
+        Ok(()) => {
+            update_progress::show(&app, "Restarting Burrete...", Some(1.0));
+            app.exit(0);
+            Ok(())
+        }
+        Err(error) => {
+            update_progress::close(&app);
+            Err(error)
+        }
+    }
 }
 
 fn download_update(
+    app: &tauri::AppHandle,
     app_data_dir: &Path,
     package_version: &str,
     request: &UpdateInstallRequest,
@@ -81,7 +102,9 @@ fn download_update(
     remove_path_if_exists(&temporary)?;
     remove_path_if_exists(&archive)?;
 
+    update_progress::show(app, "Downloading update...", Some(0.10));
     download_asset(package_version, &request.browser_download_url, &temporary)?;
+    update_progress::show(app, "Checking downloaded update...", Some(0.34));
 
     let downloaded_size = fs::metadata(&temporary)
         .map_err(|err| err.to_string())?
@@ -144,6 +167,7 @@ fn download_update(
         remove_path_if_exists(&manifest)?;
         remove_path_if_exists(&manifest_signature)?;
 
+        update_progress::show(app, "Downloading update metadata...", Some(0.40));
         download_asset(package_version, digest_url, &temporary_digest)?;
         download_asset(package_version, manifest_url, &temporary_manifest)?;
         download_asset(
@@ -152,6 +176,7 @@ fn download_update(
             &temporary_manifest_signature,
         )?;
 
+        update_progress::show(app, "Verifying update metadata...", Some(0.50));
         let downloaded_digest_size = fs::metadata(&temporary_digest)
             .map_err(|err| err.to_string())?
             .len();
@@ -228,6 +253,7 @@ fn download_update(
     }
 
     fs::rename(&temporary, &archive).map_err(|err| err.to_string())?;
+    update_progress::show(app, "Download complete...", Some(0.58));
     Ok(archive)
 }
 
@@ -251,6 +277,7 @@ fn download_asset(package_version: &str, url: &str, target: &Path) -> Result<(),
 }
 
 fn unpack_and_validate_update(
+    app: &tauri::AppHandle,
     app_data_dir: &Path,
     archive: &Path,
     current_version: &str,
@@ -260,11 +287,13 @@ fn unpack_and_validate_update(
     let staging_dir = updates_dir.join(format!("Install-{}", safe_path_component(&uuid())));
     fs::create_dir_all(&staging_dir).map_err(|err| err.to_string())?;
 
+    update_progress::show(app, "Extracting update...", Some(0.64));
     run_status(
         "/usr/bin/ditto",
         &["-x", "-k", path_str(archive)?, path_str(&staging_dir)?],
     )?;
 
+    update_progress::show(app, "Validating update...", Some(0.78));
     let app = find_downloaded_app(&staging_dir)?;
     validate_downloaded_app(&app, current_version, &request.tag_name)?;
     Ok(app)


### PR DESCRIPTION
## Summary
- add a macOS AppKit progress window for update installation
- report updater stages from the Rust install flow
- close the progress window on install errors

## Tests
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml updater::tests --quiet
- git diff --check
- bun run typecheck (fails: frontend dependencies are not installed in this checkout)