### PR TITLE
Align theme colors

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,11 +2,11 @@
 name: Burrete
 description: Finder-native molecular structure previews for macOS.
 colors:
-  accent-blue: "#0A84FF"
-  shell-dark: "#171816"
-  shell-light: "#F5F3EF"
-  shell-dark-text: "#F5F5F2"
-  shell-light-text: "#171716"
+  accent-blue: "#0169CC"
+  shell-dark: "#111111"
+  shell-light: "#FFFFFF"
+  shell-dark-text: "#FCFCFC"
+  shell-light-text: "#0D0D0D"
   shell-dark-line: "#353630"
   shell-light-line: "#D7D1C8"
   shell-danger: "#D96A61"
@@ -81,13 +81,13 @@ Key Characteristics:
 The palette is restrained and utility-first. Most of the interface runs on neutrals, while the accent exists for state, primary actions, and active selection.
 
 ### Primary
-- **Command Blue** (`#0A84FF`): used for focus, primary actions, active accents, and the most important state changes. It should stay rare enough that it still reads as intent.
+- **Command Blue** (`#0169CC`): used for focus, primary actions, active accents, and the most important state changes. It should stay rare enough that it still reads as intent.
 
 ### Neutral
-- **Graphite Shell** (`#171816`): the default dark shell background for the desktop workspace.
-- **Warm Paper** (`#F5F3EF`): the light shell background for the desktop workspace.
-- **Porcelain Text** (`#F5F5F2`): primary text on dark shell surfaces.
-- **Carbon Text** (`#171716`): primary text on light shell surfaces.
+- **Graphite Shell** (`#111111`): the default dark shell background for the desktop workspace.
+- **Codex White** (`#FFFFFF`): the light shell background for the desktop workspace.
+- **Porcelain Text** (`#FCFCFC`): primary text on dark shell surfaces.
+- **Carbon Text** (`#0D0D0D`): primary text on light shell surfaces.
 - **Dark Line** (`#353630`): dark-theme separators, borders, and container definition.
 - **Light Line** (`#D7D1C8`): light-theme separators, borders, and container definition.
 

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -205,7 +205,7 @@
   }
 
   function canvasBackgroundCSS(background) {
-    if (background === 'white') return '#f7f7f2';
+    if (background === 'white') return '#ffffff';
     if (background === 'graphite') return '#111317';
     if (background === 'transparent') return 'transparent';
     return '#000000';

--- a/PreviewExtension/Web/grid.css
+++ b/PreviewExtension/Web/grid.css
@@ -7,12 +7,12 @@
   --buret-input: #333333;
   --buret-border: rgba(255, 255, 255, 0.09);
   --buret-border-strong: rgba(255, 255, 255, 0.14);
-  --buret-accent: #0a84ff;
+  --buret-accent: #0169cc;
   --buret-text: rgba(255, 255, 255, 0.94);
   --buret-muted: rgba(255, 255, 255, 0.62);
   --buret-faint: rgba(255, 255, 255, 0.38);
   --buret-shadow: rgba(0, 0, 0, 0.28);
-  --buret-picture-bg: #f6f5f2;
+  --buret-picture-bg: #ffffff;
   --buret-picture-bg-soft: #ffffff;
   --buret-card-min: 174px;
   --buret-card-gap: 12px;
@@ -23,17 +23,17 @@
 
 html[data-buret-theme="light"] {
   color-scheme: light;
-  --buret-bg: #f5f3ef;
+  --buret-bg: #ffffff;
   --buret-surface: rgba(255, 255, 255, 0.74);
   --buret-surface-raised: rgba(245, 245, 245, 0.88);
   --buret-input: rgba(238, 239, 242, 0.92);
   --buret-border: rgba(0, 0, 0, 0.08);
   --buret-border-strong: rgba(0, 0, 0, 0.14);
-  --buret-text: rgba(20, 20, 20, 0.92);
-  --buret-muted: rgba(20, 20, 20, 0.58);
-  --buret-faint: rgba(20, 20, 20, 0.34);
+  --buret-text: rgba(13, 13, 13, 0.92);
+  --buret-muted: rgba(13, 13, 13, 0.58);
+  --buret-faint: rgba(13, 13, 13, 0.34);
   --buret-shadow: rgba(0, 0, 0, 0.10);
-  --buret-picture-bg: #fbfaf8;
+  --buret-picture-bg: #ffffff;
   --buret-picture-bg-soft: #ffffff;
 }
 

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -33,7 +33,7 @@
   --buret-menu-divider: rgba(255, 255, 255, 0.06);
   --buret-menu-toggle-track: rgba(255, 255, 255, 0.20);
   --buret-menu-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
-  --buret-menu-accent: #0a84ff;
+  --buret-menu-accent: #0169cc;
   --buret-select-chevron: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='rgba(255,255,255,0.62)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M3 4.5l3 3 3-3'/></svg>");
 }
 html, body, #app { width: 100%; height: 100%; margin: 0; padding: 0; overflow: hidden; background: transparent; }
@@ -59,7 +59,7 @@ body.buret-theme-light {
   --buret-molstar-border: rgba(0, 0, 0, 0.13);
   --buret-molstar-text: rgba(32, 33, 35, 0.94);
   --buret-molstar-muted-text: rgba(86, 88, 92, 0.82);
-  --buret-molstar-accent: #006bd6;
+  --buret-molstar-accent: #0169cc;
   --buret-molstar-shadow: rgba(0, 0, 0, 0.18);
   --buret-menu-background: #f6f6f4;
   --buret-menu-section-background: #efefec;
@@ -69,7 +69,7 @@ body.buret-theme-light {
   --buret-menu-divider: rgba(0, 0, 0, 0.06);
   --buret-menu-toggle-track: rgba(0, 0, 0, 0.16);
   --buret-menu-shadow: 0 16px 36px rgba(0, 0, 0, 0.15);
-  --buret-menu-accent: #0a84ff;
+  --buret-menu-accent: #0169cc;
   --buret-select-chevron: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='rgba(51,54,59,0.66)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M3 4.5l3 3 3-3'/></svg>");
   color: #161719;
 }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -272,7 +272,7 @@
 
   function canvasBackgroundCSS() {
     const background = resolvedCanvasBackground();
-    if (background === 'white') return '#f7f7f2';
+    if (background === 'white') return '#ffffff';
     if (background === 'graphite') return '#111317';
     if (background === 'transparent') return 'transparent';
     return '#000000';
@@ -280,7 +280,7 @@
 
   function canvasBackgroundColor() {
     const background = resolvedCanvasBackground();
-    if (background === 'white') return 0xf7f7f2;
+    if (background === 'white') return 0xffffff;
     if (background === 'graphite') return 0x111317;
     return 0x000000;
   }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,11 +1,11 @@
 :root {
-  --accent: #0a84ff;
+  --accent: #0169cc;
   --bg-base: #111111;
   --fg-base: #fcfcfc;
   --ui-font: -apple-system-body, ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
   --editor-font: -apple-system-body, ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
   --bg-opacity: 0.715;
-  --contrast: 0.328;
+  --contrast: 0.55;
   --bg: rgba(17, 17, 17, 0.715);
   --text: var(--fg-base);
   --text-primary: var(--fg-base);
@@ -77,13 +77,13 @@ button, select, input, textarea, .tab, .new-tab, .chrome-button, .sidebar-search
 }
 
 .app-shell[data-theme="light"] {
-  --bg-base: #f5f3ef;
-  --fg-base: #171716;
-  --bg: #f5f3ef;
+  --bg-base: #ffffff;
+  --fg-base: #0d0d0d;
+  --bg: #ffffff;
   --bg-opacity: 1;
-  --contrast: 0.22;
-  --text: #171716;
-  --text-primary: #171716;
+  --contrast: 0.45;
+  --text: #0d0d0d;
+  --text-primary: #0d0d0d;
   --text-secondary: color-mix(in srgb, black 80%, transparent);
   --text-muted: color-mix(in srgb, black 54%, transparent);
   --text-faint: color-mix(in srgb, black 40%, transparent);
@@ -116,13 +116,13 @@ button, select, input, textarea, .tab, .new-tab, .chrome-button, .sidebar-search
 
 @media (prefers-color-scheme: light) {
   .app-shell[data-theme="auto"] {
-    --bg-base: #f5f3ef;
-    --fg-base: #171716;
-    --bg: #f5f3ef;
+    --bg-base: #ffffff;
+    --fg-base: #0d0d0d;
+    --bg: #ffffff;
     --bg-opacity: 1;
-    --contrast: 0.22;
-    --text: #171716;
-    --text-primary: #171716;
+    --contrast: 0.45;
+    --text: #0d0d0d;
+    --text-primary: #0d0d0d;
     --text-secondary: color-mix(in srgb, black 80%, transparent);
     --text-muted: color-mix(in srgb, black 54%, transparent);
     --text-faint: color-mix(in srgb, black 40%, transparent);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -560,7 +560,7 @@ assert.doesNotMatch(previewViewController, /viewerTheme == "auto" \? "dark" : vi
 assert.doesNotMatch(previewViewController, /canvasBackground == "auto" \? "black" : canvasBackground/);
 assert.match(gridViewer, /cfg\.transparentBackground === true \|\| canvasBackground === 'transparent'/);
 assert.match(gridViewer, /if \(background === 'graphite'\) return '#111317';/);
-assert.match(gridViewer, /if \(background === 'white'\) return '#f7f7f2';/);
+assert.match(gridViewer, /if \(background === 'white'\) return '#ffffff';/);
 assert.match(previewRuntimeCss, /--buret-canvas-background:/);
 assert.match(gridCss, /background: var\(--buret-grid-canvas-background, var\(--buret-bg\)\);/);
 assert.match(previewRuntimeViewer, /"defaultLayoutState": \{ "left": "hidden", "right": "hidden", "top": "hidden", "bottom": "hidden" \}/);


### PR DESCRIPTION
## Summary

- Align the desktop shell and Quick Look preview color tokens with the provided theme values.
- Replace warm light backgrounds with neutral white in Mol*, grid, and shell surfaces.
- Update the design document and UI shell contract test to match the new palette.

## Impact

Light mode no longer uses the previous warm paper/off-white canvas colors, so previews should stop reading as yellow. Dark mode keeps the same surface and ink values as the provided theme.

## Validation

- `node tests/test-ui-shell-contract.mjs`
- `node tests/test-tauri-structure.mjs`
- `bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js PreviewExtension/Web/grid-viewer.js tests/test-ui-shell-contract.mjs`
- Pre-commit hook: plist + JS syntax
