### PR TITLE
Keep xyzrender controls closed by default

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -61,7 +61,7 @@
     extraArguments: null
   };
   const STRUCTURE_DRAG_MIME = 'application/x-burrete-structure-paths';
-  const XYZRENDER_POPOVER_OPEN_KEY_PREFIX = 'buret.xyzrender.popover.open';
+  const XYZRENDER_POPOVER_OPEN_KEY_PREFIX = 'buret.xyzrender.popover.open.v2';
   let xyzrenderControlsApplyTimer = 0;
   let xyzrenderInlineRequestSerial = 0;
   let xyzrenderSheetRequestSerial = 0;
@@ -577,7 +577,7 @@
       if (renderer === 'xyzrender-external') {
         populateXyzrenderControlsForm(toolbar, normalizeXyzrenderControls(config.xyzrenderControls || DEFAULT_XYZRENDER_CONTROLS, config));
         updateXyzrenderFormVisibility(toolbar);
-        if (popoverWasOpen || shouldRestoreXyzrenderPopoverOpen() || (!hasXyzrenderPopoverPreference() && shouldOpenXyzrenderPopoverByDefault(config))) {
+        if (popoverWasOpen || shouldRestoreXyzrenderPopoverOpen()) {
           setXyzrenderPopoverVisibility(toolbar, true, { resetScroll: false });
           if (popover) popover.scrollTop = popoverScrollTop;
         }
@@ -665,30 +665,6 @@
     } catch (_) {
       return false;
     }
-  }
-
-  function hasXyzrenderPopoverPreference() {
-    try {
-      return window.localStorage?.getItem(xyzrenderPopoverStorageKey()) != null;
-    } catch (_) {
-      return false;
-    }
-  }
-
-  function shouldOpenXyzrenderPopoverByDefault(config) {
-    const controls = normalizeXyzrenderControls(config?.xyzrenderControls || DEFAULT_XYZRENDER_CONTROLS, config || {});
-    return !!(
-      controls.fieldMode ||
-      controls.fieldIso != null ||
-      controls.fieldOpacity != null ||
-      controls.fieldSurfaceStyle ||
-      controls.fieldMoPositiveColor ||
-      controls.fieldMoNegativeColor ||
-      controls.fieldDensityColor ||
-      controls.fieldCmapPalette ||
-      controls.fieldCmapMin != null ||
-      controls.fieldCmapMax != null
-    );
   }
 
   function normalizeXyzrenderControls(value, config = {}) {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -219,10 +219,12 @@ assert.match(viewer, /updateXyzrenderFormVisibility\(toolbar\);\s*scheduleXyzren
 assert.match(viewer, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
 assert.match(viewer, /function bindXyzrenderControls\(toolbar\)/);
 assert.match(viewer, /XYZRENDER_POPOVER_OPEN_KEY_PREFIX/);
+assert.match(viewer, /buret\.xyzrender\.popover\.open\.v2/);
+assert.doesNotMatch(viewer, /buret\.xyzrender\.popover\.open';/);
 assert.match(viewer, /function setXyzrenderPopoverVisibility\(toolbar, open, options = \{\}\)/);
 assert.match(viewer, /toolbar\?\.classList\.toggle\('buret-popover-open', open\)/);
 assert.match(viewer, /function shouldRestoreXyzrenderPopoverOpen\(\)/);
-assert.match(viewer, /function shouldOpenXyzrenderPopoverByDefault\(config\)/);
+assert.doesNotMatch(viewer, /shouldOpenXyzrenderPopoverByDefault/);
 assert.match(viewer, /function syncXyzrenderSliders\(toolbar\)/);
 assert.match(viewer, /function requestBrowserDevXyzrenderUpdate\(options = \{\}\)/);
 assert.match(viewer, /fetch\(endpoint, \{/);


### PR DESCRIPTION
## Summary
- keep the xyzrender controls popover closed on initial render instead of auto-opening when field controls are present
- version the popover localStorage key so stale auto-open state from previous builds does not reopen the menu
- update the UI shell contract test to cover the default-closed behavior

## Validation
- bun tests/test-ui-shell-contract.mjs
- bun run check:js
- bun run test:ui
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: ci-fast