### PR TITLE
Follow system theme changes

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -6,7 +6,7 @@ import { EditorTabs } from "./editor-area/editor-tabs";
 import { Sidebar } from "./sidebar";
 import type { ShellActions, ShellViewState, StatusNotice } from "./types";
 import { isTauriRuntime } from "../lib/tauri";
-import { buildThemeStyle, resolveThemeMode } from "../lib/theme";
+import { buildThemeStyle, resolveThemeMode, useSystemThemeMode } from "../lib/theme";
 
 function clampSidebarWidth(width: number, maxSidebarWidth: number) {
   return Math.max(220, Math.min(maxSidebarWidth, Math.round(width)));
@@ -40,11 +40,12 @@ export function AppLayout({
   const layoutState = sidebarWidth === state.sidebarWidth ? state : { ...state, sidebarWidth };
   const tabChromeLeft = state.sidebarOpen ? sidebarLayoutWidth + 12 : 132;
   const chromeTransition = state.sidebarDragging ? "none" : undefined;
+  const systemThemeMode = useSystemThemeMode();
   const shellStyle = {
-    ...buildThemeStyle(state.preferences),
+    ...buildThemeStyle(state.preferences, systemThemeMode),
     "--sidebar-layout-width": `${sidebarLayoutWidth}px`,
   } as CSSProperties;
-  const effectiveTheme = resolveThemeMode(state.preferences.theme);
+  const effectiveTheme = resolveThemeMode(state.preferences.theme, systemThemeMode);
   return (
     <main
       className="app-shell"

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -1,7 +1,7 @@
-import type { CSSProperties } from "react";
+import { useSyncExternalStore, type CSSProperties } from "react";
 import type { ViewerPreferences } from "../types";
 
-type ThemeMode = "light" | "dark";
+export type ThemeMode = "light" | "dark";
 
 type ThemeTokens = {
   accent: string;
@@ -13,10 +13,29 @@ type ThemeTokens = {
   contrast: number;
 };
 
-export function resolveThemeMode(theme: ViewerPreferences["theme"]): ThemeMode {
-  if (theme === "light" || theme === "dark") return theme;
-  if (typeof window === "undefined") return "dark";
+export function readSystemThemeMode(): ThemeMode {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return "dark";
   return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+export function subscribeSystemThemeMode(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => {};
+  const media = window.matchMedia("(prefers-color-scheme: light)");
+  if (typeof media.addEventListener === "function") {
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }
+  media.addListener(onChange);
+  return () => media.removeListener(onChange);
+}
+
+export function useSystemThemeMode(): ThemeMode {
+  return useSyncExternalStore(subscribeSystemThemeMode, readSystemThemeMode, () => "dark");
+}
+
+export function resolveThemeMode(theme: ViewerPreferences["theme"], systemThemeMode = readSystemThemeMode()): ThemeMode {
+  if (theme === "light" || theme === "dark") return theme;
+  return systemThemeMode;
 }
 
 export function readThemeTokens(preferences: ViewerPreferences, mode: ThemeMode): ThemeTokens {
@@ -42,8 +61,8 @@ export function readThemeTokens(preferences: ViewerPreferences, mode: ThemeMode)
   };
 }
 
-export function buildThemeStyle(preferences: ViewerPreferences): CSSProperties {
-  const mode = resolveThemeMode(preferences.theme);
+export function buildThemeStyle(preferences: ViewerPreferences, systemThemeMode?: ThemeMode): CSSProperties {
+  const mode = resolveThemeMode(preferences.theme, systemThemeMode);
   const tokens = readThemeTokens(preferences, mode);
   const bgOpacity = 1 - (clamp(tokens.translucent, 0, 100) / 100) * 0.95;
   const contrast = 0.2 + (clamp(tokens.contrast, 0, 100) / 100) * 0.8;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -18,6 +18,7 @@ const [
   settingsHook,
   shellStore,
   packageJson,
+  themeSource,
   appLayout,
   main,
   sidebar,
@@ -79,6 +80,7 @@ const [
   source('apps/desktop/src/hooks/use-settings.ts'),
   source('apps/desktop/src/stores/shell-store.ts'),
   source('package.json'),
+  source('apps/desktop/src/lib/theme.ts'),
   source('apps/desktop/src/components/app-layout.tsx'),
   source('apps/desktop/src/main.tsx'),
   source('apps/desktop/src/components/sidebar/index.tsx'),
@@ -517,6 +519,13 @@ assert.match(styles, /--accent: #af52de/);
 assert.match(styles, /--chrome-drag-height: 72px/);
 assert.match(styles, /\.app-shell\[data-theme="light"\] \{[^}]*--bg-base: #ffffff;[^}]*--fg-base: #0d0d0d;[^}]*--surface-card: transparent;/s);
 assert.match(styles, /@media \(prefers-color-scheme: light\) \{[\s\S]*\.app-shell\[data-theme="auto"\] \{[^}]*--bg-base: #ffffff;[^}]*--surface-card: transparent;/);
+assert.match(themeSource, /useSyncExternalStore/);
+assert.match(themeSource, /function subscribeSystemThemeMode\(onChange: \(\) => void\): \(\) => void/);
+assert.match(themeSource, /media\.addEventListener\("change", onChange\)/);
+assert.match(themeSource, /media\.removeEventListener\("change", onChange\)/);
+assert.match(appLayout, /const systemThemeMode = useSystemThemeMode\(\)/);
+assert.match(appLayout, /buildThemeStyle\(state\.preferences, systemThemeMode\)/);
+assert.match(appLayout, /resolveThemeMode\(state\.preferences\.theme, systemThemeMode\)/);
 assert.match(styles, /\*\[data-tauri-drag-region\] \{[^}]*app-region: drag;[^}]*-webkit-app-region: drag;[^}]*\}/s);
 assert.match(styles, /button, select, input, textarea, \.tab-shell, \.tab, \.new-tab, \.chrome-button, \.tab-history-button, \.sidebar-search-row, \.sidebar-tool-row, \.sidebar-section-title-button, \.sidebar-section-menu-button, \.project-group-row, \.project-group-menu-button, \.project, \.project-show-more, \.pin-hit, \.splitter \{[^}]*app-region: no-drag;[^}]*-webkit-app-region: no-drag;[^}]*\}/s);
 assert.match(styles, /\.drag-region \{[^}]*height: var\(--chrome-drag-height\);[^}]*z-index: 2/s);


### PR DESCRIPTION
Summary: Subscribe the desktop shell to system color-scheme changes, recompute inline theme tokens from the current system mode, and add UI contract coverage. Tests: bun tests/test-ui-shell-contract.mjs; bun run --cwd apps/desktop typecheck; bun run --cwd apps/desktop build; bun run test:ui; pre-push ci-fast.