### PR TITLE
Keep recent projects visible after opening file

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -201,7 +201,7 @@ export default function App() {
 
   const allSidebarProjects = useMemo(() => buildSidebarProjects({
     documents,
-    recentStructures: documents.length === 0 ? recentStructures : [],
+    recentStructures,
     projectRoots,
     activeDocumentId: activeDocument?.id ?? null,
     pinnedStructurePaths,

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -369,6 +369,8 @@ assert.match(app, /openedBrowserDevDockingRef/);
 assert.match(app, /browserDevRuntimeNeedsRefresh/);
 assert.match(app, /openedPersistedTabsRef/);
 assert.match(app, /buildSidebarProjects/);
+assert.match(app, /buildSidebarProjects\(\{\s*documents,\s*recentStructures,/);
+assert.doesNotMatch(app, /recentStructures:\s*documents\.length === 0 \? recentStructures : \[\]/);
 assert.match(app, /pinnedStructurePaths,/);
 assert.match(app, /sidebarProjects/);
 assert.match(app, /isTauriRuntime\(\) \|\| documents\.length === 0/);


### PR DESCRIPTION
## Summary
- keep recent structures in the sidebar project model after a file is opened
- add a UI shell contract check that rejects the old documents-length gate

## Validation
- bun run test:ui
- git diff --check
- pre-push ci-fast