### PR TITLE
Simplify preview and startup helpers

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -719,7 +719,9 @@
   }
 
   function triStateBoolean(value) {
-    return value === true ? true : value === false ? false : null;
+    if (value === true) return true;
+    if (value === false) return false;
+    return null;
   }
 
   function nonEmptyText(value) {

--- a/PreviewExtension/Web/xyz-fast.js
+++ b/PreviewExtension/Web/xyz-fast.js
@@ -148,12 +148,17 @@
     return bonds;
   }
 
+  const DEFAULT_STYLE_OPTIONS = { atomScale: 0.62, minAtomRadius: 7.5, maxAtomRadius: 18.0, bondWidth: 4.2, showBonds: true };
+  const STYLE_OPTIONS = {
+    wire: { atomScale: 0.22, minAtomRadius: 3.4, maxAtomRadius: 8.5, bondWidth: 2.2, showBonds: true },
+    tube: { atomScale: 0.42, minAtomRadius: 6.0, maxAtomRadius: 13.0, bondWidth: 7.5, showBonds: true },
+    spacefill: { atomScale: 1.0, minAtomRadius: 11.0, maxAtomRadius: 28.0, bondWidth: 0, showBonds: false },
+    vdw: { atomScale: 1.0, minAtomRadius: 11.0, maxAtomRadius: 28.0, bondWidth: 0, showBonds: false }
+  };
+
   function styleOptions(styleName) {
     const name = String(styleName || 'default').toLowerCase();
-    if (name === 'wire') return { atomScale: 0.22, minAtomRadius: 3.4, maxAtomRadius: 8.5, bondWidth: 2.2, showBonds: true };
-    if (name === 'tube') return { atomScale: 0.42, minAtomRadius: 6.0, maxAtomRadius: 13.0, bondWidth: 7.5, showBonds: true };
-    if (name === 'spacefill' || name === 'vdw') return { atomScale: 1.0, minAtomRadius: 11.0, maxAtomRadius: 28.0, bondWidth: 0, showBonds: false };
-    return { atomScale: 0.62, minAtomRadius: 7.5, maxAtomRadius: 18.0, bondWidth: 4.2, showBonds: true };
+    return STYLE_OPTIONS[name] || DEFAULT_STYLE_OPTIONS;
   }
 
   function cellCorners(cell) {

--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -69,8 +69,7 @@ pub(crate) async fn install_update(
         launch_installer(&app_data_dir, &staged_app, &app_bundle, &request.tag_name)
     })
     .await
-    .map_err(|err| err.to_string())
-    .and_then(|result| result);
+    .map_err(|err| err.to_string())?;
 
     match result {
         Ok(()) => {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -19,10 +19,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             let paths = startup::file_args_from_argv(argv, Some(PathBuf::from(cwd)));
-            if !paths.is_empty() {
-                tray::show_main_window(app);
-            }
-            startup::emit_open_documents(app, paths);
+            show_and_emit_open_documents(app, paths);
         }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -36,9 +33,7 @@ pub fn run() {
                 std::env::args().collect(),
                 std::env::current_dir().ok(),
             );
-            if !startup_paths.is_empty() {
-                tray::show_main_window(app.handle());
-            }
+            show_and_emit_open_documents(app.handle(), startup_paths);
             let app_handle = app.handle().clone();
             app.on_menu_event(move |app, event| match event.id().0.as_str() {
                 "settings.open" => {
@@ -85,12 +80,16 @@ pub fn run() {
                     .filter(|path| path.exists())
                     .map(|path| path.to_string_lossy().to_string())
                     .collect();
-                if !paths.is_empty() {
-                    tray::show_main_window(app);
-                }
-                startup::emit_open_documents(app, paths);
+                show_and_emit_open_documents(app, paths);
             }
         });
+}
+
+fn show_and_emit_open_documents<R: tauri::Runtime>(app: &tauri::AppHandle<R>, paths: Vec<String>) {
+    if !paths.is_empty() {
+        tray::show_main_window(app);
+    }
+    startup::emit_open_documents(app, paths);
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -17,10 +17,12 @@ export function FileBrowser({
 }) {
   const [pinnedOpen, setPinnedOpen] = useState(true);
   const [ketcherDropActive, setKetcherDropActive] = useState(false);
+  const sidebarQuery = state.sidebarQuery.trim();
+  const hasSidebarQuery = sidebarQuery.length > 0;
   const visibleProjects = filterSidebarProjects(state.sidebarProjects, state.sidebarQuery);
   const pinnedItems = visibleProjects.flatMap((project) => project.items.filter((item) => item.isPinned));
-  const pinnedExpanded = pinnedOpen || state.sidebarQuery.trim().length > 0;
-  const projectsExpanded = state.projectsOpen || state.sidebarQuery.trim().length > 0;
+  const pinnedExpanded = pinnedOpen || hasSidebarQuery;
+  const projectsExpanded = state.projectsOpen || hasSidebarQuery;
   const visibleProjectIds = visibleProjects.map((project) => project.id);
   const allVisibleProjectsExpanded = visibleProjectIds.length > 0
     && visibleProjectIds.every((projectId) => state.expandedProjectIds.includes(projectId));
@@ -172,7 +174,7 @@ export function FileBrowser({
         {projectsExpanded && (
           visibleProjects.length === 0 ? (
             <div className="empty-sidebar">
-              {state.sidebarQuery.trim() ? "No matching projects or structures" : "No project structures yet"}
+              {hasSidebarQuery ? "No matching projects or structures" : "No project structures yet"}
             </div>
           ) : (
             <div className="project-tree" role="list" id="sidebar-projects-tree">

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -25,9 +25,10 @@ export function ProjectGroup({
   actions: ShellActions;
 }) {
   const [showAllItems, setShowAllItems] = useState(false);
-  const expanded = state.sidebarQuery.trim().length > 0
-    || state.expandedProjectIds.includes(project.id);
-  const shouldLimitItems = state.sidebarQuery.trim().length === 0
+  const sidebarQuery = state.sidebarQuery.trim();
+  const hasSidebarQuery = sidebarQuery.length > 0;
+  const expanded = hasSidebarQuery || state.expandedProjectIds.includes(project.id);
+  const shouldLimitItems = !hasSidebarQuery
     && project.items.length > COLLAPSED_PROJECT_ITEM_LIMIT
     && !showAllItems;
   const visibleItems = shouldLimitItems
@@ -97,7 +98,7 @@ export function ProjectGroup({
           {visibleItems.map((item) => (
             <ProjectItem key={item.key} item={item} actions={actions} />
           ))}
-          {project.items.length > COLLAPSED_PROJECT_ITEM_LIMIT && state.sidebarQuery.trim().length === 0 && (
+          {project.items.length > COLLAPSED_PROJECT_ITEM_LIMIT && !hasSidebarQuery && (
             <button
               type="button"
               className="project-show-more"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:update": "bun tests/test-update-versioning.mjs && bun tests/test-bun-installer-structure.mjs && bun tests/test-bun-installer-behavior.mjs",
     "test:ui": "bun tests/test-sidebar-projects.mjs && bun tests/test-docking-documents.mjs && bun tests/test-docking-viewer-contract.mjs && bun tests/test-ui-shell-contract.mjs && bun tests/test-collection-documents.mjs",
     "test:tauri-structure": "bun tests/test-tauri-structure.mjs",
-    "check:js": "bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js PreviewExtension/Web/viewer-shell.js PreviewExtension/Web/burette-agent.js PreviewExtension/Web/grid-viewer.js PreviewExtension/Web/xyz-fast.js scripts/vendor-molstar.mjs scripts/vendor-rdkit.mjs scripts/check-vendor-assets.mjs scripts/check-format-manifest.mjs scripts/check-preview-format-registry.mjs scripts/sign-update-manifest.mjs scripts/agent-preview.mjs scripts/check-release-version.mjs packages/burrete/bin/burrete.mjs",
+    "check:js": "bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js PreviewExtension/Web/viewer-shell.js PreviewExtension/Web/burette-agent.js PreviewExtension/Web/grid-viewer.js PreviewExtension/Web/xyz-fast.js scripts/vendor-molstar.mjs scripts/vendor-rdkit.mjs scripts/check-vendor-assets.mjs scripts/check-format-manifest.mjs scripts/check-preview-format-registry.mjs scripts/sign-update-manifest.mjs scripts/preview-content-type.mjs scripts/agent-preview.mjs scripts/check-release-version.mjs packages/burrete/bin/burrete.mjs",
     "check:vendor-assets": "bun scripts/check-vendor-assets.mjs",
     "check:formats": "bun scripts/check-preview-format-registry.mjs && bun scripts/check-format-manifest.mjs",
     "check:release": "bun scripts/check-release-version.mjs",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -125,7 +125,8 @@ esac
 # Prevent accidentally running old v5/v6/v7/v8 folders.
 grep -Eq '"version": "0\.10\.[0-9]+(-[0-9A-Za-z.-]+)?"' package.json || { echo "error: this is not a v10 release package; package.json version is:" >&2; grep '"version"' package.json >&2 || true; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj || { echo "error: this Xcode project is not v10." >&2; exit 1; }
-grep -q 'config/preview-formats.json' scripts/force-preview.sh || { echo "error: force-preview.sh is not using the preview format registry." >&2; exit 1; }
+grep -q 'preview-content-type.mjs' scripts/force-preview.sh || { echo "error: force-preview.sh is not using the preview format registry helper." >&2; exit 1; }
+grep -q 'config.*preview-formats.json' scripts/preview-content-type.mjs || { echo "error: preview content type helper is not using the preview format registry." >&2; exit 1; }
 bun --eval "import { readFileSync } from 'node:fs'; const registry = JSON.parse(readFileSync('config/preview-formats.json', 'utf8')); if (!registry.formats?.some((format) => format.contentType === 'com.local.burrete10.pdb')) process.exit(1);" || { echo "error: preview format registry is not v10." >&2; exit 1; }
 
 require_asset PreviewExtension/Web/molstar.js

--- a/scripts/check-preview-format-registry.mjs
+++ b/scripts/check-preview-format-registry.mjs
@@ -150,9 +150,15 @@ assert.match(browserDevDocuments, /preview-formats\.json/);
 assert.doesNotMatch(browserDevDocuments, /\["pdb", "ent", "pdbqt", "pqr"\]/);
 
 const forcePreview = readFileSync('scripts/force-preview.sh', 'utf8');
-assert.match(forcePreview, /config\/preview-formats\.json/);
+assert.match(forcePreview, /preview-content-type\.mjs/);
 assert.doesNotMatch(forcePreview, /pdb\|PDB\|ent\|ENT/);
 assert.match(forcePreview, /com\.local\.burrete10\.xyz/);
 assert.match(forcePreview, /Normal Quick Look resolves XYZ/);
+
+const previewContentType = readFileSync('scripts/preview-content-type.mjs', 'utf8');
+assert.match(previewContentType, /config['"], ['"]preview-formats\.json/);
+assert.match(previewContentType, /mae\.gz/);
+assert.match(previewContentType, /format\?\.contentType/);
+assert.doesNotMatch(previewContentType, /pdb\|PDB\|ent\|ENT/);
 
 console.log('preview format registry check passed');

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -10,18 +10,7 @@ APP="$HOME/Applications/Burrete.app"
 BUILT_APP="$ROOT/build/Burrete.app"
 EXT_ID="com.local.BurreteV10.Preview"
 CONTAINER_LOG="$HOME/Library/Containers/com.local.BurreteV10.Preview/Data/Library/Caches/Burrete/Burrete.log"
-CUSTOM_TYPE="$(
-  node --input-type=module - "$ROOT/config/preview-formats.json" "$FILE" <<'NODE'
-import { readFileSync } from 'node:fs';
-import { basename, extname } from 'node:path';
-
-const registry = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-const fileName = basename(process.argv[3]).toLowerCase();
-const extension = fileName.endsWith('.mae.gz') ? 'mae.gz' : extname(fileName).slice(1);
-const format = registry.formats.find((candidate) => candidate.extensions.includes(extension));
-if (format?.contentType) process.stdout.write(format.contentType);
-NODE
-)"
+CUSTOM_TYPE="$("$ROOT/scripts/preview-content-type.mjs" "$FILE")"
 
 printf '\n== File ==\n%s\n' "$FILE"
 if [ -f "$FILE" ]; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -9,9 +9,10 @@ echo "bundle IDs in project:"
 grep -n 'PRODUCT_BUNDLE_IDENTIFIER' Burrete.xcodeproj/project.pbxproj || true
 echo "force-preview UTI:"
 grep -n 'burrete' scripts/force-preview.sh || true
+grep -n 'burrete' scripts/preview-content-type.mjs || true
 echo "Trash check:"
 case "$ROOT" in *"/.Trash/"*|*"/Library/Mobile Documents/.Trash/"*) echo "ERROR: project is inside Trash"; exit 1;; *) echo "OK: not in Trash";; esac
 echo "Expected v10 markers:"
 grep -Eq '"version": "0\.10\.[0-9]+"' package.json && echo "OK package v10" || { echo "ERROR package is not v10"; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj && echo "OK project v10" || { echo "ERROR project is not v10"; exit 1; }
-grep -q 'com.local.burrete10.pdb' scripts/force-preview.sh && echo "OK force-preview v10" || { echo "ERROR force-preview is not v10"; exit 1; }
+grep -q 'preview-content-type.mjs' scripts/force-preview.sh && grep -q 'com.local.burrete10.pdb' config/preview-formats.json && echo "OK force-preview v10" || { echo "ERROR force-preview is not v10"; exit 1; }

--- a/scripts/force-preview.sh
+++ b/scripts/force-preview.sh
@@ -6,22 +6,7 @@ if [[ -z "$FILE" || ! -f "$FILE" ]]; then
   echo "usage: $0 /path/to/structure-file" >&2
   exit 1
 fi
-TYPE="$(
-  node --input-type=module - "$ROOT/config/preview-formats.json" "$FILE" <<'NODE'
-import { readFileSync } from 'node:fs';
-import { basename, extname } from 'node:path';
-
-const registry = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-const fileName = basename(process.argv[3]).toLowerCase();
-const extension = fileName.endsWith('.mae.gz') ? 'mae.gz' : extname(fileName).slice(1);
-const format = registry.formats.find((candidate) => candidate.extensions.includes(extension));
-if (format?.id === 'csv' || format?.id === 'tsv') {
-  console.error('CSV/TSV table previews must be tested with normal Quick Look selection; qlmanage aborts when forcing custom table UTIs.');
-  process.exit(2);
-}
-if (format?.contentType) process.stdout.write(format.contentType);
-NODE
-)"
+TYPE="$("$ROOT/scripts/preview-content-type.mjs" --reject-table "$FILE")"
 if [[ -z "$TYPE" ]]; then
   TYPE="$(mdls -raw -name kMDItemContentType "$FILE" 2>/dev/null || true)"
 fi

--- a/scripts/measure-quicklook-cold-open.sh
+++ b/scripts/measure-quicklook-cold-open.sh
@@ -24,18 +24,7 @@ if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [[ "$TIMEOUT_SECONDS" -lt 1 ]]; the
   exit 1
 fi
 
-TYPE="$(
-  node --input-type=module - "$ROOT/config/preview-formats.json" "$FILE" <<'NODE'
-import { readFileSync } from 'node:fs';
-import { basename, extname } from 'node:path';
-
-const registry = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-const fileName = basename(process.argv[3]).toLowerCase();
-const extension = fileName.endsWith('.mae.gz') ? 'mae.gz' : extname(fileName).slice(1);
-const format = registry.formats.find((candidate) => candidate.extensions.includes(extension));
-if (format?.contentType) process.stdout.write(format.contentType);
-NODE
-)"
+TYPE="$("$ROOT/scripts/preview-content-type.mjs" "$FILE")"
 if [[ -z "$TYPE" ]]; then
   TYPE="$(mdls -raw -name kMDItemContentType "$FILE" 2>/dev/null || true)"
 fi

--- a/scripts/preview-content-type.mjs
+++ b/scripts/preview-content-type.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { basename, extname, resolve } from 'node:path';
+
+function usage() {
+  console.error('usage: preview-content-type.mjs [--reject-table] /path/to/structure-file');
+}
+
+const args = process.argv.slice(2);
+const rejectTable = args[0] === '--reject-table';
+const filePath = rejectTable ? args[1] : args[0];
+
+if (!filePath) {
+  usage();
+  process.exit(1);
+}
+
+const registryPath = resolve(import.meta.dirname, '..', 'config', 'preview-formats.json');
+const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+const fileName = basename(filePath).toLowerCase();
+const extension = fileName.endsWith('.mae.gz') ? 'mae.gz' : extname(fileName).slice(1);
+const format = registry.formats.find((candidate) => candidate.extensions.includes(extension));
+
+if (rejectTable && (format?.id === 'csv' || format?.id === 'tsv')) {
+  console.error('CSV/TSV table previews must be tested with normal Quick Look selection; qlmanage aborts when forcing custom table UTIs.');
+  process.exit(2);
+}
+
+if (format?.contentType) {
+  process.stdout.write(format.contentType);
+}


### PR DESCRIPTION
## Summary
- centralize preview content type lookup for Quick Look helper scripts
- simplify small web runtime, sidebar, Tauri startup, and updater helper paths
- keep preview format registry checks covering the new helper

## Tests
- bun run check
- bun run test
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
- pre-push ci-fast