### PR TITLE
Make Burrete default for CSV previews

### DIFF
--- a/docs/specs/pro-audit-remediation-plan.md
+++ b/docs/specs/pro-audit-remediation-plan.md
@@ -223,11 +223,11 @@ Verification. Mock GitHub releases with `.zip`, `.dmg`, `.pkg`, mixed assets. As
 
 Evidence. `AppMetadata.plist` declares `LSHandlerRank` as Owner, includes public CSV/TSV content types and many molecular/legacy UTIs; `install-local.sh` calls `LSSetDefaultRoleHandlerForContentType` for every content type in the app’s document types.
 
-Impact. Burrete may become the default viewer for CSV/TSV or broad molecular types without a clear user opt-in. On macOS this feels invasive; users may blame Burrete when double-click behavior changes outside molecular workflows.
+Impact. Burrete intentionally becomes the default viewer for CSV/TSV so molecular tables open in the RDKit grid from Finder and Quick Look. Non-molecular tables rely on the Quick Look fallback path.
 
-Fix. Do not set defaults for public CSV/TSV automatically. Prefer `LSHandlerRank=Alternate` for broad types, or expose per-type association toggles with explicit confirmation. Keep Quick Look registration separate from double-click default ownership.
+Fix. Keep the default-handler behavior explicit in installer code and tests. If user-facing opt-in is added later, it must preserve molecular CSV/TSV Quick Look as the default path unless disabled by the user.
 
-Verification. After install, query default handlers for public CSV/TSV and molecular UTIs. Ensure defaults are not changed unless user opted in.
+Verification. After install, query default handlers for public CSV/TSV and molecular UTIs. Molecular tables should open through Burrete; non-molecular tables should fall back to the system preview.
 
 ### 10. [Medium | confirmed] Runtime model duplicates large data as base64 JS and inlines RDKit WASM per grid preview
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -309,12 +309,7 @@ LSRegisterURL(appURL as CFURL, true)
 let bundle = Bundle(url: appURL)
 let documentTypes = bundle?.object(forInfoDictionaryKey: "CFBundleDocumentTypes") as? [[String: Any]] ?? []
 let contentTypes = documentTypes.flatMap { $0["LSItemContentTypes"] as? [String] ?? [] }
-let broadPublicTypes: Set<String> = [
-    "public.delimited-values-text",
-    "public.comma-separated-values-text",
-    "public.tab-separated-values-text",
-]
-for contentType in Set(contentTypes).subtracting(broadPublicTypes) {
+for contentType in Set(contentTypes) {
     LSSetDefaultRoleHandlerForContentType(contentType as CFString, .viewer, bundleID)
 }
 ' >/dev/null 2>&1 || true

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -214,10 +214,9 @@ assert.match(appMetadata, /<key>LSHandlerRank<\/key>\s*<string>Owner<\/string>/)
 assert.match(previewExtensionInfoPlist, /public\.comma-separated-values-text/);
 assert.match(previewExtensionInfoPlist, /public\.tab-separated-values-text/);
 assert.match(previewExtensionInfoPlist, /com\.local\.burrete10\.smiles/);
-assert.match(installLocalScript, /broadPublicTypes/);
-assert.match(installLocalScript, /public\.comma-separated-values-text/);
-assert.match(installLocalScript, /public\.tab-separated-values-text/);
-assert.match(installLocalScript, /subtracting\(broadPublicTypes\)/);
+assert.doesNotMatch(installLocalScript, /broadPublicTypes/);
+assert.match(installLocalScript, /let contentTypes = documentTypes\.flatMap/);
+assert.match(installLocalScript, /for contentType in Set\(contentTypes\)/);
 assert.match(installLocalScript, /assert_bundled_xyzrender_runtime\(\)\s*\{/);
 assert.match(installLocalScript, /assert_bundled_xyzrender_runner\(\)\s*\{/);
 assert.match(installLocalScript, /sign_bundled_xyzrender_runtime\(\)\s*\{/);


### PR DESCRIPTION
## Summary
- set Burrete as the default viewer for all registered CSV/TSV content types during local install
- keep molecule-grid fallback expectations aligned in the structure contract test
- update the remediation note to reflect intentional CSV/TSV ownership with system fallback for non-molecular tables

## Verification
- bun tests/test-tauri-structure.mjs
- vp run check:formats
- pre-push ci-fast