### PR TITLE
Unify notification popup surface

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -62,6 +62,7 @@
     contextMenuOutsideHandler: null,
     contextMenuKeyHandler: null,
     railOutsideHandler: null,
+    railKeyHandler: null,
     railCloseTimer: null,
     railHoverIndex: null,
     railDragging: false,
@@ -978,12 +979,21 @@
       window.removeEventListener('resize', state.railOutsideHandler, true);
       state.railOutsideHandler = null;
     }
+    if (state.railKeyHandler) {
+      document.removeEventListener('keydown', state.railKeyHandler);
+      state.railKeyHandler = null;
+    }
     state.railOutsideHandler = event => {
       const target = event.target instanceof Element ? event.target : null;
       if (target?.closest?.('[data-buret-grid-rail]')) return;
       setGridRailOpen(false);
     };
+    state.railKeyHandler = event => {
+      if (event.key !== 'Escape' || popover.dataset.state !== 'open') return;
+      setGridRailOpen(false);
+    };
     document.addEventListener('click', state.railOutsideHandler, true);
+    document.addEventListener('keydown', state.railKeyHandler);
     marker?.addEventListener('pointerdown', event => startGridRailDrag(event, cfg));
     hoverTarget?.addEventListener('click', () => setGridRailOpen(true));
     popover.addEventListener('click', event => {
@@ -1063,13 +1073,13 @@
       return `<button type="button" class="buret-grid-rail-tick${active ? ' is-active' : ''}" data-buret-grid-rail-position="${position}"${indexAttr} title="${title}" aria-label="${title}"></button>`;
     }).join('');
     popover.innerHTML = `
-      <div class="buret-grid-rail-popover-title">Molecules</div>
-      <div class="buret-grid-rail-popover-list">
+      <div class="buret-grid-rail-popover-title" id="buret-grid-rail-popover-title">Molecules</div>
+      <div class="buret-grid-rail-popover-list" role="listbox" aria-labelledby="buret-grid-rail-popover-title">
         ${rows.map(row => {
           const index = Number(row.index);
           const name = escapeHTML(row.name || `Molecule ${index + 1}`);
           const detail = escapeHTML(row.smiles || `#${index + 1}`);
-          return `<button type="button" class="buret-grid-rail-popover-row" data-buret-grid-rail-index="${index}"><span>${name}</span><small>${detail}</small></button>`;
+          return `<button type="button" class="buret-grid-rail-popover-row" role="option" aria-selected="false" data-buret-grid-rail-index="${index}"><span>${name}</span><small>${detail}</small></button>`;
         }).join('')}
       </div>`;
     if (wasOpen && list) {
@@ -1109,7 +1119,9 @@
     }
     updateGridRailActiveMarker(activeIndex);
     root.querySelectorAll('.buret-grid-rail-popover-row[data-buret-grid-rail-index]').forEach(item => {
-      item.classList.toggle('is-active', Number(item.getAttribute('data-buret-grid-rail-index')) === activeIndex);
+      const active = Number(item.getAttribute('data-buret-grid-rail-index')) === activeIndex;
+      item.classList.toggle('is-active', active);
+      item.setAttribute('aria-selected', active ? 'true' : 'false');
     });
     updateGridRailHoverHighlight();
   }

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -3,8 +3,9 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { CSSProperties } from "react";
 import { ViewerArea } from "./editor-area";
 import { EditorTabs } from "./editor-area/editor-tabs";
+import { NotificationPopup } from "./notification-popup";
 import { Sidebar } from "./sidebar";
-import type { ShellActions, ShellViewState, StatusNotice } from "./types";
+import type { ShellActions, ShellViewState } from "./types";
 import { isTauriRuntime } from "../lib/tauri";
 import { buildThemeStyle, resolveThemeMode, useSystemThemeMode } from "../lib/theme";
 
@@ -108,55 +109,8 @@ export function AppLayout({
         </div>
       )}
       {state.status && (
-        <StatusSurface status={state.status} onDismiss={onDismissStatus} />
+        <NotificationPopup notice={state.status} onDismiss={onDismissStatus} />
       )}
     </main>
   );
-}
-
-function StatusSurface({
-  status,
-  onDismiss,
-}: {
-  status: StatusNotice;
-  onDismiss: () => void;
-}) {
-  const message = compactStatusMessage(status.message);
-  const details = message === status.message ? status.details : [status.message, ...status.details];
-  const hasExtraDetails = details.length > 0;
-  return (
-    <section
-      className="status-surface"
-      data-kind={status.kind}
-      role={status.kind === "error" ? "alert" : "status"}
-      aria-live={status.kind === "error" ? "assertive" : "polite"}
-    >
-      <div className="status-surface-copy">
-        <strong>{status.kind === "error" ? "Issue" : "Status"}</strong>
-        <p>{message}</p>
-        {hasExtraDetails && (
-          <details className="status-surface-details">
-            <summary>Show details</summary>
-            <ul>
-              {details.map((detail, index) => (
-                <li key={`${index}:${detail}`}>{detail}</li>
-              ))}
-            </ul>
-          </details>
-        )}
-      </div>
-      <button
-        type="button"
-        className="status-surface-dismiss"
-        onClick={onDismiss}
-        aria-label="Dismiss status"
-      >
-        Dismiss
-      </button>
-    </section>
-  );
-}
-
-function compactStatusMessage(message: string) {
-  return message.trim().split(/\r?\n| Error:| at /)[0]?.trim() || message;
 }

--- a/apps/desktop/src/components/native-context-menu.ts
+++ b/apps/desktop/src/components/native-context-menu.ts
@@ -80,11 +80,36 @@ function showWebContextMenu(spec: MenuItemSpec[], at?: { x: number; y: number })
     document.removeEventListener("keydown", onKeyDown);
     menu.remove();
   };
+  const menuItems = () => Array.from(menu.querySelectorAll<HTMLButtonElement>(".native-context-menu-item:not(:disabled)"));
+  const focusMenuItem = (index: number) => {
+    const items = menuItems();
+    if (items.length === 0) {
+      menu.focus();
+      return;
+    }
+    items[(index + items.length) % items.length]?.focus();
+  };
   const onOutsidePointerDown = (event: PointerEvent) => {
     if (!menu.contains(event.target as Node | null)) cleanup();
   };
   const onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Escape") cleanup();
+    if (event.key === "Escape") {
+      cleanup();
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+
+    event.preventDefault();
+    const items = menuItems();
+    const activeIndex = items.findIndex((item) => item === document.activeElement);
+    if (event.key === "Home") {
+      focusMenuItem(0);
+    } else if (event.key === "End") {
+      focusMenuItem(items.length - 1);
+    } else {
+      const direction = event.key === "ArrowDown" ? 1 : -1;
+      focusMenuItem(activeIndex === -1 ? (direction === 1 ? 0 : items.length - 1) : activeIndex + direction);
+    }
   };
 
   const themeHost = document.querySelector(".app-shell") ?? document.body;
@@ -95,5 +120,5 @@ function showWebContextMenu(spec: MenuItemSpec[], at?: { x: number; y: number })
   menu.style.top = `${y}px`;
   document.addEventListener("pointerdown", onOutsidePointerDown);
   document.addEventListener("keydown", onKeyDown);
-  menu.focus();
+  focusMenuItem(0);
 }

--- a/apps/desktop/src/components/notification-popup.tsx
+++ b/apps/desktop/src/components/notification-popup.tsx
@@ -1,0 +1,49 @@
+import type { StatusNotice } from "./types";
+
+export function NotificationPopup({
+  notice,
+  onDismiss,
+}: {
+  notice: StatusNotice;
+  onDismiss: () => void;
+}) {
+  const message = compactNotificationMessage(notice.message);
+  const details = message === notice.message ? notice.details : [notice.message, ...notice.details];
+  const hasExtraDetails = details.length > 0;
+
+  return (
+    <section
+      className="notification-popup"
+      data-kind={notice.kind}
+      role={notice.kind === "error" ? "alert" : "status"}
+      aria-live={notice.kind === "error" ? "assertive" : "polite"}
+    >
+      <div className="notification-popup-copy">
+        <strong>{notice.kind === "error" ? "Issue" : "Status"}</strong>
+        <p>{message}</p>
+        {hasExtraDetails && (
+          <details className="notification-popup-details">
+            <summary>Show details</summary>
+            <ul>
+              {details.map((detail, index) => (
+                <li key={`${index}:${detail}`}>{detail}</li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </div>
+      <button
+        type="button"
+        className="notification-popup-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss notification"
+      >
+        Dismiss
+      </button>
+    </section>
+  );
+}
+
+function compactNotificationMessage(message: string) {
+  return message.trim().split(/\r?\n| Error:| at /)[0]?.trim() || message;
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1198,7 +1198,7 @@ kbd span { margin-left: 2px; }
   font-size: 13px;
   font-weight: 650;
 }
-.status-surface {
+.notification-popup {
   position: absolute;
   right: 16px;
   bottom: 16px;
@@ -1216,16 +1216,16 @@ kbd span { margin-left: 2px; }
   backdrop-filter: blur(28px) saturate(1.2);
   -webkit-backdrop-filter: blur(28px) saturate(1.2);
 }
-.status-surface[data-kind="error"] {
+.notification-popup[data-kind="error"] {
   border-color: color-mix(in srgb, #ff7b72 42%, var(--line-strong));
   background: color-mix(in srgb, var(--bg-base) 88%, transparent);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.24), inset 0 0 0 1px color-mix(in srgb, #ff7b72 12%, transparent);
 }
-.status-surface-copy {
+.notification-popup-copy {
   min-width: 0;
   flex: 1;
 }
-.status-surface-copy strong {
+.notification-popup-copy strong {
   display: block;
   margin: 0 0 4px;
   color: var(--text-primary);
@@ -1234,7 +1234,7 @@ kbd span { margin-left: 2px; }
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.status-surface-copy p {
+.notification-popup-copy p {
   margin: 0;
   color: var(--text-secondary);
   font-size: 13px;
@@ -1243,22 +1243,22 @@ kbd span { margin-left: 2px; }
   overflow: hidden;
   max-height: calc(1.35em * 2);
 }
-.status-surface-details {
+.notification-popup-details {
   margin-top: 8px;
 }
-.status-surface-details summary {
+.notification-popup-details summary {
   cursor: default;
   color: var(--text-muted);
   font-size: 12px;
 }
-.status-surface-details ul {
+.notification-popup-details ul {
   margin: 8px 0 0;
   padding-left: 18px;
   color: var(--text-muted);
   font-size: 12px;
   line-height: 1.4;
 }
-.status-surface-dismiss {
+.notification-popup-dismiss {
   flex: 0 0 auto;
   height: 28px;
   border: 0;
@@ -1270,7 +1270,7 @@ kbd span { margin-left: 2px; }
   font-weight: 600;
   transition: background 120ms ease, color 120ms ease;
 }
-.status-surface-dismiss:hover {
+.notification-popup-dismiss:hover {
   background: var(--surface-subtle-strong);
   color: var(--text-primary);
 }
@@ -1605,7 +1605,7 @@ kbd span { margin-left: 2px; }
   .tab-history-controls { display: none; }
   .sidebar-search-row { padding: 0 28px 0 32px; }
   .settings-panel-content { width: 100%; padding: 24px 16px 72px; }
-  .status-surface {
+  .notification-popup {
     left: 16px;
     width: auto;
   }

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -20,6 +20,7 @@ const [
   packageJson,
   themeSource,
   appLayout,
+  notificationPopup,
   main,
   sidebar,
   sidebarFileBrowser,
@@ -83,6 +84,7 @@ const [
   source('package.json'),
   source('apps/desktop/src/lib/theme.ts'),
   source('apps/desktop/src/components/app-layout.tsx'),
+  source('apps/desktop/src/components/notification-popup.tsx'),
   source('apps/desktop/src/main.tsx'),
   source('apps/desktop/src/components/sidebar/index.tsx'),
   source('apps/desktop/src/components/sidebar/file-browser.tsx'),
@@ -398,13 +400,16 @@ assert.match(app, /void openDocuments\(paths\)/);
 assert.match(appLayout, /from "\.\/editor-area"/);
 assert.match(appLayout, /from "\.\/editor-area\/editor-tabs"/);
 assert.match(appLayout, /from "\.\/sidebar"/);
+assert.match(appLayout, /from "\.\/notification-popup"/);
 assert.match(appLayout, /SidebarLeftIcon/);
 assert.match(appLayout, /HugeiconsIcon/);
 assert.match(appLayout, /onDismissStatus: \(\) => void;/);
-assert.match(appLayout, /<StatusSurface status=\{state\.status\} onDismiss=\{onDismissStatus\} \/>/);
-assert.match(appLayout, /className="status-surface"/);
-assert.match(appLayout, /aria-live=\{status\.kind === "error" \? "assertive" : "polite"\}/);
-assert.match(appLayout, /compactStatusMessage/);
+assert.match(appLayout, /<NotificationPopup notice=\{state\.status\} onDismiss=\{onDismissStatus\} \/>/);
+assert.doesNotMatch(appLayout, /StatusSurface/);
+assert.match(notificationPopup, /export function NotificationPopup/);
+assert.match(notificationPopup, /className="notification-popup"/);
+assert.match(notificationPopup, /aria-live=\{notice\.kind === "error" \? "assertive" : "polite"\}/);
+assert.match(notificationPopup, /compactNotificationMessage/);
 assert.match(appLayout, /const sidebarLayoutWidth = state\.sidebarOpen \? sidebarWidth : 0/);
 assert.match(appLayout, /const tabChromeLeft = state\.sidebarOpen \? sidebarLayoutWidth \+ 12 : 132/);
 assert.match(appLayout, /const activePageKind = state\.activeTab\?\.location\.kind \?\? null/);
@@ -611,10 +616,10 @@ assert.match(styles, /\.main-stage \{[^}]*overflow: hidden/s);
 assert.match(styles, /\.app-shell\[data-theme="auto"\] \{[^}]*color-scheme: light dark/s);
 assert.match(styles, /@media \(prefers-color-scheme: light\) \{[\s\S]*\.app-shell\[data-theme="auto"\]/);
 assert.match(styles, /@media \(prefers-color-scheme: dark\) \{[\s\S]*\.app-shell\[data-theme="auto"\]/);
-assert.match(styles, /\.status-surface \{/);
-assert.match(styles, /\.status-surface\[data-kind="error"\] \{/);
-assert.match(styles, /\.status-surface-copy p \{[^}]*max-height: calc\(1\.35em \* 2\)/s);
-assert.match(styles, /\.status-surface-dismiss \{/);
+assert.match(styles, /\.notification-popup \{/);
+assert.match(styles, /\.notification-popup\[data-kind="error"\] \{/);
+assert.match(styles, /\.notification-popup-copy p \{[^}]*max-height: calc\(1\.35em \* 2\)/s);
+assert.match(styles, /\.notification-popup-dismiss \{/);
 assert.match(styles, /\.sidebar-product:hover/);
 assert.match(styles, /\.sidebar-section-title-button/);
 assert.match(styles, /\.sidebar-section-menu-button/);
@@ -772,6 +777,10 @@ assert.match(sidebarSurface, /Close All Tabs/);
 assert.match(nativeContextMenu, /export async function showNativeContextMenu/);
 assert.match(nativeContextMenu, /showWebContextMenu\(spec, at\)/);
 assert.match(nativeContextMenu, /\.native-context-menu/);
+assert.match(nativeContextMenu, /ArrowDown/);
+assert.match(nativeContextMenu, /ArrowUp/);
+assert.match(nativeContextMenu, /Home/);
+assert.match(nativeContextMenu, /End/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/menu/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/menuItem/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/predefinedMenuItem/);
@@ -1469,6 +1478,10 @@ assert.match(gridViewer, /function selectRangeTo\(index, cfg\)/);
 assert.match(gridViewer, /function handleCardSelection\(event, row, cfg, cardElement\)/);
 assert.match(gridViewer, /event\.shiftKey/);
 assert.match(gridViewer, /aria-selected/);
+assert.match(gridViewer, /railKeyHandler: null/);
+assert.match(gridViewer, /event\.key !== 'Escape' \|\| popover\.dataset\.state !== 'open'/);
+assert.match(gridViewer, /role="listbox"/);
+assert.match(gridViewer, /role="option" aria-selected="false"/);
 assert.match(gridViewer, /event\.key\.toLowerCase\(\) === 'a'/);
 assert.match(gridViewer, /state\.selected\.clear\(\)/);
 assert.match(gridCss, /--buret-control-height: 36px;/);


### PR DESCRIPTION
## Summary
- extract the shell notification surface into a dedicated NotificationPopup component
- rename status-surface styling to notification-popup styling
- improve web context menu keyboard focus and grid rail popover dismissal/ARIA state

## Tests
- bun run test:ui
- bun run check:js
- bun run build:web
- pre-push ci-fast