### PR TITLE
Trim redundant CI and release runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
           native=false
           while IFS= read -r path; do
             case "$path" in
-              App/*|PreviewExtension/*|Burrete.xcodeproj/*|apps/desktop/src-tauri/*|scripts/build*.sh|scripts/install*.sh|scripts/ci.sh|package.json|bun.lock|.github/workflows/ci.yml)
+              PreviewExtension/Web/*)
+                ;;
+              App/*|PreviewExtension/*|Burrete.xcodeproj/*|apps/desktop/src-tauri/*|scripts/build*.sh|scripts/install*.sh|scripts/ci.sh|package.json|bun.lock)
                 native=true
                 ;;
             esac
@@ -67,7 +69,7 @@ jobs:
     needs:
       - changes
       - validate
-    if: needs.changes.outputs.native == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.native == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- stop running the Release workflow on every push to main; releases now run manually or from version tags
- stop repeating Native Bundle Build on post-merge pushes to main
- keep Native Bundle Build for pull requests with native/package changes
- exclude PreviewExtension/Web-only and CI workflow-only changes from native bundle scope
- cancelled the redundant in-progress push-main CI run from PR #103

## Validation

- ruby YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- git diff --cached --check
- pre-push ci-fast hook
