### PR TITLE
Require dev flavors for agent builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,11 @@ vp dev
 vp check
 vp test
 vp build
-./scripts/build.sh
-./scripts/install.sh
-./scripts/force-preview.sh samples/mini.pdb
-./scripts/force-preview.sh samples/mini.cif
-./scripts/force-preview.sh samples/mini.xyz
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/build.sh
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/install.sh
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/force-preview.sh samples/mini.pdb
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/force-preview.sh samples/mini.cif
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/force-preview.sh samples/mini.xyz
 ```
 
 Use Vite+ through the `vp` CLI for frontend development and JavaScript
@@ -49,6 +49,23 @@ through `vp run <script>` when they cover project-specific validation not yet
 folded into a Vite+ built-in. Direct Bun commands remain implementation details
 inside repository-owned build, release, and installer scripts until a separate
 toolchain migration replaces those paths.
+
+When an agent builds or installs a packaged app for local testing, always use a
+dev flavor with a unique slug, preferably the worktree suffix:
+
+```bash
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/build.sh
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/install.sh
+BURRETE_DEV_FLAVOR=<worktree-slug> ./scripts/force-preview.sh samples/mini.pdb
+```
+
+This keeps the app, Quick Look extension, thumbnail extension, content types,
+and Launch Services registrations isolated from other worktrees and from the
+release bundle. Do not run unflavored `./scripts/build.sh`,
+`./scripts/install.sh`, or packaged preview smoke commands unless the user
+explicitly asks for a release or final non-dev bundle. `scripts/build-dev.sh`
+does not support dev flavors; agents should prefer the flavored
+`./scripts/build.sh` path for packaged local builds.
 
 Rust validation runs from the Tauri crate:
 

--- a/docs/development-loops.md
+++ b/docs/development-loops.md
@@ -35,7 +35,8 @@ bun run build:tauri
 ## Parallel Dev App Identities
 
 Use a dev flavor when multiple local worktrees need to build and install Burrete
-without competing for the same Launch Services and Quick Look bundle IDs:
+without competing for the same Launch Services and Quick Look bundle IDs.
+Agents must treat this as the default for any packaged local build or install:
 
 ```bash
 BURRETE_DEV_FLAVOR=chat85b0 ./scripts/build.sh
@@ -73,20 +74,26 @@ app:
 - `build/Burrete.app/Contents/Resources/Web`
 - `build/Burrete.app/Contents/PlugIns/BurretePreview.appex/Contents/Resources/Web`
 
+For agent-driven work in a flavored build, set `BURRETE_APP_PATH` to the
+flavored app path before patching.
+
 Restart Burrete or reopen the preview after patching so the WebView reloads the
 updated files.
 
 ## Quick Look Native Extension
 
-Use the dev build when the Swift Quick Look extension or extension packaging
-changed:
+Use the flavored full build when the Swift Quick Look extension or extension
+packaging changed in an agent-managed worktree:
 
 ```bash
-./scripts/build-dev.sh
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/build.sh
 ```
 
-When Swift and extension packaging did not change, reuse the existing embedded
-preview extension:
+`scripts/build-dev.sh` remains available for a deliberately unflavored in-place
+debug loop, but agents should not use it unless the user explicitly asks for
+that path. When Swift and extension packaging did not change and an unflavored
+in-place build is explicitly desired, reuse the existing embedded preview
+extension:
 
 ```bash
 BURRETE_DEV_REUSE_QUICKLOOK=1 ./scripts/build-dev.sh
@@ -136,8 +143,11 @@ Use the full macOS build only for final bundle validation, release work, or
 changes that cross several native layers:
 
 ```bash
-./scripts/build.sh
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/build.sh
 ```
 
 The full build runs the JavaScript/Tauri build, Rust release build, Xcode Quick
 Look builds, bundle assembly, signing, and bundle validation.
+
+Run unflavored `./scripts/build.sh` only when explicitly producing a release or
+final non-dev bundle.

--- a/docs/quicklook-debugging.md
+++ b/docs/quicklook-debugging.md
@@ -33,21 +33,18 @@ com.local.burrete10.xyzrender-input
 
 ## Build And Install
 
-Build and install locally:
-
-```bash
-./scripts/build.sh
-./scripts/install.sh
-```
-
-For parallel local worktrees, use a dev flavor so the installed app, extension
-IDs, container paths, and forced content types do not collide with the release
-namespace or with another dev install:
+Build and install locally with a dev flavor:
 
 ```bash
 BURRETE_DEV_FLAVOR=chat85b0 ./scripts/build.sh
 BURRETE_DEV_FLAVOR=chat85b0 ./scripts/install.sh
 ```
+
+Agents should always use a dev flavor for local packaged builds and installs so
+the installed app, extension IDs, container paths, and forced content types do
+not collide with the release namespace or with another dev install. Run
+unflavored `./scripts/build.sh` and `./scripts/install.sh` only when explicitly
+producing a release or final non-dev bundle.
 
 The example above installs `~/Applications/Burrete-chat85b0.app` and registers
 `com.local.BurreteV10.Dev.chat85b0.Preview`. Normal Finder ownership for file
@@ -67,21 +64,18 @@ killall quicklookd 2>/dev/null || true
 Use forced previews to bypass Launch Services ambiguity while debugging:
 
 ```bash
-./scripts/force-preview.sh samples/mini.pdb
-./scripts/force-preview.sh samples/mini.cif
-./scripts/force-preview.sh samples/mini.xyz
-```
-
-For a dev flavor, keep the same environment variable on the smoke command:
-
-```bash
 BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.pdb
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.cif
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.xyz
 ```
+
+Keep the same `BURRETE_DEV_FLAVOR` value across build, install, diagnostics,
+and smoke commands.
 
 For a real desktop file:
 
 ```bash
-./scripts/force-preview.sh ~/Desktop/1HTB.pdb
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh ~/Desktop/1HTB.pdb
 ```
 
 ## Logs And Cache
@@ -137,11 +131,11 @@ Run these after changes to `PreviewExtension/`, `Burrete.xcodeproj`,
 assets:
 
 ```bash
-./scripts/build.sh
-codesign --verify --deep --strict build/Burrete.app
-test -d build/Burrete.app/Contents/PlugIns/BurretePreview.appex
-test -d build/Burrete.app/Contents/PlugIns/BurreteThumbnail.appex
-./scripts/force-preview.sh samples/mini.pdb
-./scripts/force-preview.sh samples/mini.cif
-./scripts/force-preview.sh samples/mini.xyz
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/build.sh
+codesign --verify --deep --strict build/Burrete-chat85b0.app
+test -d build/Burrete-chat85b0.app/Contents/PlugIns/BurretePreview.appex
+test -d build/Burrete-chat85b0.app/Contents/PlugIns/BurreteThumbnail.appex
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.pdb
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.cif
+BURRETE_DEV_FLAVOR=chat85b0 ./scripts/force-preview.sh samples/mini.xyz
 ```


### PR DESCRIPTION
## Summary
- Make dev-flavored packaged builds the default for agent-managed local work
- Update development-loop and Quick Look debugging docs to keep build/install/smoke commands on the same flavor
- Reserve unflavored builds for explicit release or final non-dev bundles

## Checks
- git diff --check
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: ci-fast