### PR TITLE
Keep Ketcher shell transparent

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -173,7 +173,6 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 }
 
 .app-shell[data-runtime="tauri"][data-active-page-kind="ketcher"] {
-  background: var(--bg-base);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
 }

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -885,6 +885,7 @@ assert.match(gridViewer, /function initGridRail\(cfg\)/);
 assert.match(gridCss, /\.buret-grid-rail \{/);
 assert.match(styles, /\.app-shell\[data-runtime="browser"\]\s*\{[^}]*backdrop-filter: none;[^}]*-webkit-backdrop-filter: none;/s);
 assert.match(styles, /\.app-shell\[data-runtime="tauri"\]\[data-active-page-kind="ketcher"\]\s*\{[^}]*backdrop-filter: none;[^}]*-webkit-backdrop-filter: none;/s);
+assert.doesNotMatch(styles, /\.app-shell\[data-runtime="tauri"\]\[data-active-page-kind="ketcher"\]\s*\{[^}]*background: var\(--bg-base\);/s);
 assert.match(styles, /\.page-surface\[data-page-kind="file"\]:not\(\[data-active\]\),\s*\.page-surface\[data-page-kind="ketcher"\]:not\(\[data-active\]\) \{ display: block; \}/);
 assert.match(styles, /\.ketcher-editor-shell\s*\{[^}]*overflow: hidden;[^}]*isolation: isolate;/s);
 assert.doesNotMatch(styles, /\.ketcher-editor-shell\s*\{[^}]*contain: layout paint;/s);


### PR DESCRIPTION
## Summary
- keep the app shell background translucent while Ketcher is active
- preserve the Ketcher-specific backdrop-filter override
- add a shell contract guard against reintroducing the solid shell background

## Tests
- bun tests/test-ui-shell-contract.mjs
- pre-push ci-fast