### PR TITLE
Keep all recent structures in sidebar

### DIFF
--- a/apps/desktop/src/stores/molecule-store.ts
+++ b/apps/desktop/src/stores/molecule-store.ts
@@ -15,8 +15,6 @@ import {
   isTemporaryDocumentPath,
 } from "../lib/temporary-documents";
 
-const MAX_RECENT_STRUCTURES = 12;
-
 export type MoleculeTab = {
   id: string;
   location: Location;
@@ -365,8 +363,7 @@ export const useMoleculeStore = create<MoleculeState>()(
           }
           return {
             recentStructures: Array.from(byPath.values())
-              .sort((a, b) => b.openedAt - a.openedAt)
-              .slice(0, MAX_RECENT_STRUCTURES),
+              .sort((a, b) => b.openedAt - a.openedAt),
           };
         }),
       clearRecentStructures: () => set({ recentStructures: [] }),

--- a/tests/test-molecule-store-behavior.mjs
+++ b/tests/test-molecule-store-behavior.mjs
@@ -123,4 +123,17 @@ assert.equal(restored.tabs.length, 2);
 assert.equal(restored.tabs.find((tab) => tab.id === restored.activeTabId)?.location.kind, "ketcher");
 assert.equal(restored.activeDocumentId, null);
 
+resetStore();
+const manyDocuments = Array.from({ length: 14 }, (_, index) => (
+  document(`recent-${index}`, `/tmp/project/file-${String(index).padStart(2, "0")}.pdb`)
+));
+useMoleculeStore.getState().rememberRecentStructures(manyDocuments);
+
+const recent = useMoleculeStore.getState().recentStructures;
+assert.equal(recent.length, manyDocuments.length);
+assert.deepEqual(
+  recent.map((structure) => structure.path).sort(),
+  manyDocuments.map((structure) => structure.path).sort(),
+);
+
 console.log("molecule store behavior tests passed");


### PR DESCRIPTION
## Summary
- Remove the 12-item cap from persisted recent structures.
- Add a regression test that records 14 structures and verifies none are dropped.

## Root cause
The sidebar project tree is built from open documents plus remembered recent structures. `rememberRecentStructures` kept only the latest 12 entries, so `Show more` could only reveal that truncated set.

## Validation
- `bun tests/test-molecule-store-behavior.mjs`
- `vp run test:ui`
- `bun run --cwd apps/desktop typecheck`
- pre-commit: plist, js-syntax, rust-fmt
- pre-push: `bash scripts/ci-fast.sh`