### PR TITLE
Allow titlebar maximize toggle

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:event:allow-unlisten",
     "core:menu:allow-new",
     "core:menu:allow-popup",
+    "core:window:allow-internal-toggle-maximize",
     "core:window:allow-start-dragging",
     "dialog:allow-message",
     "dialog:allow-open",

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -172,6 +172,7 @@ assert.ok(defaultCapability.permissions.includes('dialog:allow-message'));
 assert.ok(defaultCapability.permissions.includes('dialog:allow-save'));
 assert.ok(defaultCapability.permissions.includes('core:menu:allow-new'));
 assert.ok(defaultCapability.permissions.includes('core:menu:allow-popup'));
+assert.ok(defaultCapability.permissions.includes('core:window:allow-internal-toggle-maximize'));
 assert.match(tauriConfig.app.security.csp, /script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' asset: http:\/\/asset\.localhost/);
 assert.match(previewEntitlements, /com\.apple\.security\.network\.client/);
 assert.match(docsReadmeSource, /Performance architecture/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -645,6 +645,7 @@ assert.doesNotMatch(appLayout, /<header\s+className="topbar"[^>]*data-tauri-drag
 assert.match(editorTabs, /className="tab-strip" data-tauri-drag-region/);
 assert.match(editorTabs, /className="tab-scroll-region"[\s\S]*role="tablist"[\s\S]*aria-label="Open structures"/);
 assert.match(editorTabs, /className="tab-strip-spacer"[\s\S]*data-tauri-drag-region/);
+assert.match(defaultCapability, /"core:window:allow-internal-toggle-maximize"/);
 assert.match(defaultCapability, /"core:window:allow-start-dragging"/);
 assert.match(pageKinds, /const kinds = \[fileKind, fepSetupKind, ketcherKind, launcherKind, poseReviewKind, settingsKind\] as const/);
 assert.match(pageKinds, /export function pageKind/);


### PR DESCRIPTION
## Summary
- allow Tauri internal titlebar maximize toggles in the desktop capability
- add structure and shell contract coverage for the required permission

## Validation
- vp run test:tauri-structure
- bun tests/test-ui-shell-contract.mjs
- pre-push ci-fast