### PR TITLE
Render Desmond trajectories and GRO solvent lines

### DIFF
--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -782,6 +782,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             "themeTokens": preferences.themeTokens,
             "canvasBackground": preferences.runtimeCanvasBackground,
             "molstarStyle": resolvedMolstarStyle,
+            "waterRepresentation": "line",
             "uiScale": 0.9,
             "overlayOpacity": preferences.overlayOpacity,
             "transparentBackground": preferences.resolvedTransparentBackground,

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -608,6 +608,8 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
 }
 .buret-renderer-control.visible { display: flex; }
 .buret-renderer-choice { min-width: 38px; }
+.buret-molstar-style-slot { display: none; align-items: center; }
+.buret-molstar-style-slot.visible { display: flex; }
 .buret-xyzrender-preset-slot { display: none; align-items: center; }
 .buret-xyzrender-preset-slot.visible { display: flex; }
 .buret-xyzrender-tune.hidden { display: none; }

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -12,6 +12,9 @@
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="log" aria-label="Toggle log panel" title="Toggle log panel">Log</button>
+          <div class="buret-molstar-style-slot" data-buret-molstar-style-slot>
+            <select class="buret-select" data-buret-molstar-style aria-label="Mol* preview style" title="Mol* preview style"></select>
+          </div>
           <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light</button>
           <button class="buret-button hidden" type="button" data-buret-action="ketcher" aria-label="Open in Ketcher" title="Open in Ketcher">Ketcher</button>
           <div class="buret-xyzrender-preset-slot" data-buret-xyzrender-preset-slot>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -14,6 +14,16 @@
   const PANEL_CLOSE_HIT_WIDTH = 38;
   const VIEWER_THEME_STORAGE_KEY = 'buret.viewer.theme';
   const DEFAULT_MOLSTAR_STYLE = 'illustrative';
+  const MOLSTAR_STYLE_OPTIONS = [
+    { value: 'default', label: 'Default' },
+    { value: 'illustrative', label: 'Illustrative' },
+    { value: 'polymer-ligand', label: 'Polymer+Ligand' },
+    { value: 'cartoon', label: 'Cartoon' },
+    { value: 'ball-and-stick', label: 'Ball+Stick' },
+    { value: 'spacefill', label: 'Spacefill' },
+    { value: 'line', label: 'Line' },
+    { value: 'molecular-surface', label: 'Surface' }
+  ];
   const DEFAULT_XYZRENDER_PRESETS = [
     { value: 'default', label: 'Default' },
     { value: 'flat', label: 'Flat' },
@@ -175,6 +185,9 @@
   let viewerUIScale = DEFAULT_VIEWER_UI_SCALE;
   let activeViewer = null;
   let activeConfig = null;
+  let activeMolstarPrepared = null;
+  let activeMolstarCacheBuster = null;
+  let molstarStyleApplySerial = 0;
   let latestXyzrenderOrientationRef = null;
   let orientationTrackingCleanup = null;
   let externalArtifactInteractionsCleanup = null;
@@ -234,7 +247,8 @@
   }
 
   function normalizeMolstarStyle(value) {
-    return value === 'default' || value === 'illustrative' ? value : DEFAULT_MOLSTAR_STYLE;
+    const normalized = String(value || '').trim().toLowerCase();
+    return MOLSTAR_STYLE_OPTIONS.some(option => option.value === normalized) ? normalized : DEFAULT_MOLSTAR_STYLE;
   }
 
   function configuredMolstarStyle(config) {
@@ -513,6 +527,14 @@
     const ketcherButton = toolbar.querySelector('[data-buret-action="ketcher"]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
     control.classList.toggle('visible', canSwitchRenderer);
+    const molstarStyleSlot = toolbar.querySelector('[data-buret-molstar-style-slot]');
+    const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
+    molstarStyleSlot?.classList.toggle('visible', renderer === 'molstar');
+    if (molstarStyleSelect) {
+      populateMolstarStyleSelect(molstarStyleSelect);
+      molstarStyleSelect.value = configuredMolstarStyle(config);
+      molstarStyleSelect.disabled = renderer !== 'molstar';
+    }
     const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
     presetSlot?.classList.remove('visible');
     const canOpenSdfGrid = canOpenSdfGridFromConfig(config);
@@ -865,9 +887,13 @@
     });
     const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
     const preset = toolbar.querySelector('[data-buret-xyzrender-preset]');
+    const molstarStyleSlot = toolbar.querySelector('[data-buret-molstar-style-slot]');
+    const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
     const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
     const external = normalized === 'xyzrender-external';
+    molstarStyleSlot?.classList.toggle('visible', !external);
+    if (molstarStyleSelect) molstarStyleSelect.disabled = external;
     presetSlot?.classList.toggle('visible', external);
     if (preset) preset.disabled = !external;
     tuneButton?.classList.toggle('hidden', !external);
@@ -877,6 +903,70 @@
       popover?.classList.add('hidden');
       setXyzrenderPopoverOpenPersisted(false);
     }
+  }
+
+  function populateMolstarStyleSelect(select) {
+    if (!select || select.dataset.populated === '1') return;
+    select.innerHTML = MOLSTAR_STYLE_OPTIONS
+      .map(option => `<option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>`)
+      .join('');
+    select.dataset.populated = '1';
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function requestMolstarStyle(style) {
+    const value = normalizeMolstarStyle(style);
+    activeConfig = {
+      ...(activeConfig || window.BurreteConfig || {}),
+      molstarStyle: value
+    };
+    window.BurreteConfig = { ...(window.BurreteConfig || {}), ...activeConfig };
+    const toolbar = document.getElementById('buret-toolbar');
+    const select = toolbar?.querySelector('[data-buret-molstar-style]');
+    if (select) select.value = value;
+    if (!activeViewer) {
+      setStatus('Mol* style can be changed after the viewer loads.', 'error');
+      return;
+    }
+    const serial = ++molstarStyleApplySerial;
+    setStatus(`[web] Applying Mol* ${molstarStyleLabel(value)} style…`);
+    void reloadMolstarStyle(activeViewer, value, serial).catch(error => {
+      if (serial !== molstarStyleApplySerial) return;
+      setStatus(`Mol* style switch failed.\n\n${error?.message || String(error)}`, 'error');
+    });
+  }
+
+  function molstarStyleLabel(value) {
+    return MOLSTAR_STYLE_OPTIONS.find(option => option.value === value)?.label || value;
+  }
+
+  async function reloadMolstarStyle(viewer, style, serial) {
+    const prepared = activeMolstarPrepared;
+    if (!prepared) {
+      await applyMolstarStyle(viewer, style);
+      return;
+    }
+    const plugin = viewer?.plugin;
+    if (typeof plugin?.clear === 'function') {
+      await plugin.clear();
+    }
+    await loadPreparedStructure(viewer, prepared);
+    if (serial !== molstarStyleApplySerial) return;
+    if (Array.isArray(activeConfig?.stagedEntries) && activeConfig.stagedEntries.length > 0) {
+      await loadStagedMolstarEntries(viewer, activeConfig, activeMolstarCacheBuster || String(Date.now()));
+    }
+    applyLayoutState(viewer);
+    scheduleLayoutStateReapply(viewer);
+    try { viewer.handleResize(); } catch (_) {}
+    setStatus(`[web] Applied Mol* ${molstarStyleLabel(style)} style`);
+    setTimeout(hideStatus, isQuickLookHost() ? 0 : 700);
   }
 
   function requestXyzrenderPreset(preset) {
@@ -1445,6 +1535,7 @@
       toolbar.dataset.panelTogglesBound = '1';
     }
     bindThemeButton(toolbar, viewer);
+    bindMolstarStyleControls(toolbar);
     bindXyzrenderControls(toolbar);
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
@@ -1495,6 +1586,17 @@
 
     requestAnimationFrame(handleSizeChange);
     setTimeout(handleSizeChange, 120);
+  }
+
+  function bindMolstarStyleControls(toolbar) {
+    if (!toolbar || toolbar.dataset.molstarStyleBound === '1') return;
+    const select = toolbar.querySelector('[data-buret-molstar-style]');
+    populateMolstarStyleSelect(select);
+    if (select) {
+      select.value = configuredMolstarStyle(activeConfig || window.BurreteConfig || {});
+      select.addEventListener('change', () => requestMolstarStyle(select.value));
+    }
+    toolbar.dataset.molstarStyleBound = '1';
   }
 
   function bindXyzrenderControls(toolbar) {
@@ -2342,6 +2444,7 @@
       theme: 'dark',
       canvasBackground: 'black',
       molstarStyle: DEFAULT_MOLSTAR_STYLE,
+      waterRepresentation: 'line',
       overlayOpacity: 0.9,
       defaultLayoutState: {
         left: 'hidden',
@@ -3810,11 +3913,153 @@
     return String(value).padStart(3, ' ');
   }
 
+  function molstarCurrentStructures(viewer) {
+    return viewer?.plugin?.managers?.structure?.hierarchy?.current?.structures || [];
+  }
+
+  function isMolstarBoxComponent(component) {
+    const key = String(component?.key || '').toLowerCase();
+    const label = String(component?.cell?.obj?.label || '').trim().toLowerCase();
+    return key.includes('box') || label === 'box' || label.includes(' box');
+  }
+
+  async function tryCreateMolstarComponent(plugin, structure, kind) {
+    for (const target of [structure?.cell, structure]) {
+      if (!target) continue;
+      try {
+        const component = await plugin.builders.structure.tryCreateComponentStatic(target, kind);
+        if (component) return component;
+      } catch (error) {
+        debug(`Mol* static ${kind} component creation failed: ` + (error && error.message || String(error)));
+      }
+    }
+    return null;
+  }
+
+  async function clearMolstarMainRepresentations(viewer) {
+    const plugin = viewer?.plugin;
+    const components = [];
+    for (const structure of molstarCurrentStructures(viewer)) {
+      for (const component of structure.components || []) {
+        if (isMolstarWaterComponent(component) || isMolstarBoxComponent(component)) continue;
+        components.push(component);
+      }
+    }
+    if (components.length) {
+      await plugin.managers.structure.component.removeRepresentations(components);
+    }
+  }
+
+  async function addMolstarRepresentation(plugin, component, representation) {
+    if (!component) return false;
+    try {
+      await plugin.builders.structure.representation.addRepresentation(component.cell || component, representation);
+      return true;
+    } catch (error) {
+      debug('Mol* representation failed: ' + (error && error.message || String(error)));
+      return false;
+    }
+  }
+
+  async function applyMolstarUniformRepresentation(viewer, representation) {
+    const plugin = viewer?.plugin;
+    if (!plugin) return;
+    await clearMolstarMainRepresentations(viewer);
+    let created = 0;
+    for (const structure of molstarCurrentStructures(viewer)) {
+      const component = await tryCreateMolstarComponent(plugin, structure, 'all');
+      if (await addMolstarRepresentation(plugin, component, representation)) created += 1;
+    }
+    if (created === 0) throw new Error('Mol* could not create a component for this style.');
+  }
+
+  async function applyMolstarPolymerLigandRepresentation(viewer, polymerRepresentation, ligandRepresentation) {
+    const plugin = viewer?.plugin;
+    if (!plugin) return;
+    await clearMolstarMainRepresentations(viewer);
+    let created = 0;
+    for (const structure of molstarCurrentStructures(viewer)) {
+      const polymer = await tryCreateMolstarComponent(plugin, structure, 'polymer');
+      if (await addMolstarRepresentation(plugin, polymer, polymerRepresentation)) created += 1;
+      for (const kind of ['ligand', 'ion']) {
+        const component = await tryCreateMolstarComponent(plugin, structure, kind);
+        if (await addMolstarRepresentation(plugin, component, ligandRepresentation)) created += 1;
+      }
+    }
+    if (created === 0) await applyMolstarUniformRepresentation(viewer, ligandRepresentation);
+  }
+
+  function resetMolstarPostprocessing(viewer) {
+    const canvas = viewer?.plugin?.canvas3d;
+    if (!canvas) return;
+    canvas.setProps({
+      postprocessing: {
+        outline: { name: 'off', params: {} },
+        occlusion: { name: 'off', params: {} },
+        shadow: { name: 'off', params: {} }
+      }
+    });
+  }
+
   async function applyMolstarStyle(viewer, style) {
     const plugin = viewer?.plugin;
     if (!plugin) return;
+    const normalized = normalizeMolstarStyle(style);
 
-    if (style === 'illustrative') {
+    if (normalized !== 'illustrative') {
+      await plugin.managers.structure.component.setOptions({
+        ...plugin.managers.structure.component.state.options,
+        ignoreLight: false
+      });
+      resetMolstarPostprocessing(viewer);
+    }
+
+    if (normalized === 'line') {
+      await applyMolstarUniformRepresentation(viewer, {
+        type: 'line',
+        typeParams: { sizeFactor: 0.08 },
+        color: 'element-symbol'
+      });
+      return;
+    }
+    if (normalized === 'ball-and-stick') {
+      await applyMolstarUniformRepresentation(viewer, {
+        type: 'ball-and-stick',
+        typeParams: { sizeFactor: 0.16 },
+        color: 'element-symbol'
+      });
+      return;
+    }
+    if (normalized === 'spacefill') {
+      await applyMolstarUniformRepresentation(viewer, {
+        type: 'spacefill',
+        typeParams: { sizeFactor: 0.45 },
+        color: 'element-symbol'
+      });
+      return;
+    }
+    if (normalized === 'molecular-surface') {
+      await applyMolstarUniformRepresentation(viewer, {
+        type: 'molecular-surface',
+        typeParams: { alpha: 0.72 },
+        color: 'element-symbol'
+      });
+      return;
+    }
+    if (normalized === 'cartoon' || normalized === 'polymer-ligand') {
+      await applyMolstarPolymerLigandRepresentation(
+        viewer,
+        { type: 'cartoon', color: 'chain-id' },
+        {
+          type: normalized === 'cartoon' ? 'line' : 'ball-and-stick',
+          typeParams: normalized === 'cartoon' ? { sizeFactor: 0.08 } : { sizeFactor: 0.16 },
+          color: 'element-symbol'
+        }
+      );
+      return;
+    }
+
+    if (normalized === 'illustrative') {
       await plugin.managers.structure.component.setOptions({
         ...plugin.managers.structure.component.state.options,
         ignoreLight: true
@@ -3859,37 +4104,93 @@
 
   function isMolstarWaterComponent(component) {
     if (!component) return false;
+    const format = normalizeFormat(activeConfig?.molstarFormat || activeConfig?.format || '');
+    const isGroDocument = format === 'gro';
     const key = String(component.key || '');
-    if (key.split(',').includes('water')) return true;
+    const keyParts = key.split(',').map(part => part.trim().toLowerCase());
+    if (keyParts.includes('water') || keyParts.includes('solvent')) return true;
+    if (keyParts.some(part => part.includes('water') || part.includes('solvent'))) return true;
     const label = String(component.cell?.obj?.label || '');
-    return label.toLowerCase() === 'water';
+    const normalizedLabel = label.trim().toLowerCase();
+    if (isGroDocument && normalizedLabel.includes('non-standard')) return true;
+    return ['water', 'solvent', 'hoh', 'wat', 'sol', 'tip3', 'tip3p', 'spc', 'tip4p'].some(name => (
+      normalizedLabel === name || normalizedLabel.includes(name)
+    ));
+  }
+
+  async function tryCreateMolstarWaterComponent(plugin, structure) {
+    for (const target of [structure?.cell, structure]) {
+      if (!target) continue;
+      try {
+        const component = await plugin.builders.structure.tryCreateComponentStatic(target, 'water');
+        if (component) return component;
+      } catch (error) {
+        debug('Mol* static water component creation failed: ' + (error && error.message || String(error)));
+      }
+    }
+    return null;
+  }
+
+  function shouldUseMolstarWaterLines(config) {
+    const value = String(config?.waterRepresentation || 'line').trim().toLowerCase();
+    return value === 'line' || value === 'lines' || value === 'solvent-lines';
   }
 
   async function applyMolstarWaterLineRepresentation(viewer) {
+    if (!shouldUseMolstarWaterLines(activeConfig)) return;
     const plugin = viewer?.plugin;
     const structures = plugin?.managers?.structure?.hierarchy?.current?.structures || [];
     const waterComponents = [];
+    const createdWaterComponents = [];
     for (const structure of structures) {
+      let structureWaterCount = 0;
       for (const component of structure.components || []) {
-        if (isMolstarWaterComponent(component)) waterComponents.push(component);
+        if (!isMolstarWaterComponent(component)) continue;
+        waterComponents.push(component);
+        structureWaterCount += 1;
+      }
+      if (structureWaterCount === 0) {
+        const component = await tryCreateMolstarWaterComponent(plugin, structure);
+        if (component) createdWaterComponents.push(component);
       }
     }
-    if (!waterComponents.length) return;
+    if (!waterComponents.length && !createdWaterComponents.length) return;
 
-    await plugin.managers.structure.component.removeRepresentations(waterComponents);
+    if (waterComponents.length) {
+      await plugin.managers.structure.component.removeRepresentations(waterComponents);
+    }
     for (const component of waterComponents) {
       await plugin.builders.structure.representation.addRepresentation(component.cell, {
         type: 'line',
         typeParams: {
-          alpha: 0.6,
-          visuals: ['intra-bond', 'element-point']
+          alpha: 0.32,
+          sizeFactor: 0.035,
+          visuals: ['intra-bond']
         },
-        color: 'element-symbol'
+        color: 'uniform',
+        colorParams: { value: 0x8aa4b8 },
+        size: 'uniform',
+        sizeParams: { value: 0.03 }
+      }, { tag: 'water' });
+    }
+    for (const component of createdWaterComponents) {
+      await plugin.builders.structure.representation.addRepresentation(component.cell || component, {
+        type: 'line',
+        typeParams: {
+          alpha: 0.32,
+          sizeFactor: 0.035,
+          visuals: ['intra-bond']
+        },
+        color: 'uniform',
+        colorParams: { value: 0x8aa4b8 },
+        size: 'uniform',
+        sizeParams: { value: 0.03 }
       }, { tag: 'water' });
     }
   }
 
   async function loadPreparedStructure(viewer, prepared) {
+    activeMolstarPrepared = prepared;
     if (prepared.kind === 'docking') {
       await loadDockingPreparedStructure(viewer, prepared);
       return;
@@ -3958,6 +4259,32 @@
     });
   }
 
+  async function loadMolstarEntryAsBoxLines(viewer, entry) {
+    const plugin = viewer.plugin;
+    const normalized = normalizeFormat(entry.format);
+    const payload = normalized === 'cifCore'
+      ? { data: coreCifToPdb(entry.data), format: 'pdb' }
+      : { data: entry.data, format: normalized };
+    const data = await plugin.builders.data.rawData({ data: payload.data, label: entry.label });
+    const trajectory = await plugin.builders.structure.parseTrajectory(data, payload.format);
+    const model = await plugin.builders.structure.createModel(trajectory);
+    const structure = await plugin.builders.structure.createStructure(model, { name: 'model', params: {} });
+    const component = await plugin.builders.structure.tryCreateComponentStatic(structure, 'all');
+    if (!component) throw new Error('Mol* could not create staged box component.');
+    await plugin.builders.structure.representation.addRepresentation(component, {
+      type: 'line',
+      typeParams: {
+        alpha: 0.72,
+        sizeFactor: 0.02,
+        visuals: ['intra-bond']
+      },
+      color: 'uniform',
+      colorParams: { value: 0x2f6f66 },
+      size: 'uniform',
+      sizeParams: { value: 0.018 }
+    });
+  }
+
   async function loadStagedMolstarEntry(viewer, entry, cb) {
     const data = await loadStagedEntryData(entry, cb);
     const prepared = {
@@ -3972,6 +4299,14 @@
         return;
       } catch (error) {
         debug('staged solvent line representation failed, falling back to default preset: ' + (error && error.message || String(error)));
+      }
+    }
+    if (entry.representation === 'box-lines') {
+      try {
+        await loadMolstarEntryAsBoxLines(viewer, prepared);
+        return;
+      } catch (error) {
+        debug('staged box line representation failed, falling back to default preset: ' + (error && error.message || String(error)));
       }
     }
     await loadMolstarEntry(viewer, prepared);
@@ -5355,6 +5690,8 @@
       molstarWindowResizeHandler = null;
     }
     activeViewer = null;
+    activeMolstarPrepared = null;
+    activeMolstarCacheBuster = null;
     window.BurreteViewer = null;
     window.BuretteViewer = null;
   }
@@ -5407,6 +5744,7 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
 
     debug('before structureDataForMolstar: bytes=' + (window.BurreteDataBytes ? window.BurreteDataBytes.length : -1) + '; base64 chars=' + (window.BurreteDataBase64 ? window.BurreteDataBase64.length : -1));
     const prepared = structureDataForMolstar(config);
+    activeMolstarCacheBuster = cb;
     debug('prepared format=' + prepared.format + '; data type=' + (prepared.data && prepared.data.constructor ? prepared.data.constructor.name : typeof prepared.data) + '; data length=' + (prepared.data ? prepared.data.length : -1));
     setStatus(`[web] Parsing structure…\n${prepared.label} (${describeFormat(prepared.format, config.binary)})`);
 

--- a/apps/desktop/src-tauri/src/preview/runtime.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs::{self, File};
 use std::io::Read;
-use std::path::PathBuf;
-use tauri::Runtime;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tauri::{Manager, Runtime};
 
 use super::formats::{
     format_for_extension, normalize_renderer_mode, resolve_renderer, structure_path_extension,
@@ -16,6 +17,36 @@ use super::text_xyz::converted_data_from_text;
 
 const MAX_STRUCTURE_FILE_SIZE: u64 = 75 * 1024 * 1024;
 const MAESTRO_PREVIEW_READ_LIMIT: u64 = 64 * 1024 * 1024;
+const DESMOND_PREVIEW_TARGET_MB: &str = "24";
+const SCHRODINGER_RUN: &str = "/opt/schrodinger/suites2026-1/run";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StructureAttachmentRole {
+    Topology,
+    Trajectory,
+    TrajectoryPointer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructureAttachment {
+    role: StructureAttachmentRole,
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StructureBundleKind {
+    Desmond,
+    Md,
+    Single,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructureFileBundle {
+    kind: StructureBundleKind,
+    primary_path: PathBuf,
+    input_path: PathBuf,
+    attachments: Vec<StructureAttachment>,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -320,6 +351,30 @@ pub(crate) fn open_document_with_grid_options<R: Runtime>(
         return Err(format!("{} is not a file", canonical.display()));
     }
     let extension = structure_path_extension(&canonical);
+    if let Some(desmond_preview) = create_desmond_trajectory_preview(app, &canonical, &extension)? {
+        let format = format_for_extension("pdb")?;
+        let runtime = create_runtime(
+            app,
+            &canonical,
+            "pdb",
+            &format,
+            "molstar",
+            &desmond_preview,
+            preferences,
+            reload_options,
+        )?;
+        return Ok(ViewerDocument {
+            id: stable_id(&canonical),
+            path: canonical.to_string_lossy().to_string(),
+            title: file_title(&canonical),
+            extension,
+            renderer: runtime.renderer,
+            runtime_path: runtime.path.to_string_lossy().to_string(),
+            byte_count: metadata.len(),
+            is_virtual: false,
+            docking_request: None,
+        });
+    }
     let uses_bounded_maestro_preview =
         is_maestro_preview_extension(&extension) && metadata.len() > MAX_STRUCTURE_FILE_SIZE;
     if metadata.len() > MAX_STRUCTURE_FILE_SIZE && !uses_bounded_maestro_preview {
@@ -424,6 +479,298 @@ pub(crate) fn open_document_with_grid_options<R: Runtime>(
 
 fn is_maestro_preview_extension(extension: &str) -> bool {
     matches!(extension, "cms" | "mae" | "maegz")
+}
+
+fn create_desmond_trajectory_preview<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    path: &Path,
+    extension: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    let bundle = resolve_structure_file_bundle(path, extension);
+    if bundle.kind != StructureBundleKind::Desmond || !is_desmond_preview_candidate(path, extension)
+    {
+        return Ok(None);
+    }
+    let extractor = desmond_preview_extractor_path(app)?;
+    if !Path::new(SCHRODINGER_RUN).exists() {
+        return Err("Schrodinger Desmond preview extractor is unavailable.".to_string());
+    }
+    let temp_dir =
+        std::env::temp_dir().join(format!("burrete-desmond-preview-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&temp_dir).map_err(|err| err.to_string())?;
+    let output_path = temp_dir.join("desmond-preview.pdb");
+    let output = Command::new(SCHRODINGER_RUN)
+        .arg("python3")
+        .arg(&extractor)
+        .arg(&bundle.input_path)
+        .arg("--frames")
+        .arg("0")
+        .arg("--atoms")
+        .arg("0")
+        .arg("--target-mb")
+        .arg(DESMOND_PREVIEW_TARGET_MB)
+        .arg("--output")
+        .arg(&output_path)
+        .output()
+        .map_err(|err| format!("Could not start Schrodinger Desmond preview extractor: {err}"));
+    let result = match output {
+        Ok(output) if output.status.success() => fs::read(&output_path)
+            .map_err(|err| format!("Could not read Desmond trajectory preview: {err}"))
+            .and_then(|data| {
+                if data.is_empty() {
+                    Err("Desmond preview extractor produced an empty PDB file.".to_string())
+                } else {
+                    Ok(data)
+                }
+            }),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let details = if stderr.is_empty() { stdout } else { stderr };
+            Err(format!(
+                "Desmond preview extractor failed with exit status {}. {}",
+                output.status, details
+            ))
+        }
+        Err(error) => Err(error),
+    };
+    let _ = fs::remove_dir_all(&temp_dir);
+    result.map(Some)
+}
+
+fn desmond_preview_extractor_path<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<PathBuf, String> {
+    if let Ok(resource) = app.path().resolve(
+        "desmond_preview_extract.py",
+        tauri::path::BaseDirectory::Resource,
+    ) {
+        if resource.exists() {
+            return Ok(resource);
+        }
+    }
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .unwrap_or(&manifest_dir);
+    let source = repo_root.join("scripts").join("desmond_preview_extract.py");
+    if source.exists() {
+        return Ok(source);
+    }
+    Err("Schrodinger Desmond preview extractor is unavailable.".to_string())
+}
+
+fn is_desmond_preview_candidate(path: &Path, extension: &str) -> bool {
+    resolve_desmond_file_bundle(path, extension).is_some()
+}
+
+fn resolve_structure_file_bundle(path: &Path, extension: &str) -> StructureFileBundle {
+    resolve_desmond_file_bundle(path, extension)
+        .or_else(|| resolve_md_file_bundle(path, extension))
+        .unwrap_or_else(|| StructureFileBundle {
+            kind: StructureBundleKind::Single,
+            primary_path: path.to_path_buf(),
+            input_path: path.to_path_buf(),
+            attachments: Vec::new(),
+        })
+}
+
+fn resolve_desmond_file_bundle(path: &Path, extension: &str) -> Option<StructureFileBundle> {
+    match extension {
+        "cms" => {
+            let parent = path.parent()?;
+            for base in candidate_desmond_bases(path) {
+                let mut candidates = vec![parent.join(format!("{base}_trj"))];
+                candidates.extend(casebook_trj_candidates(path, &base));
+                let Some(trj_dir) = candidates.into_iter().find(|candidate| candidate.is_dir())
+                else {
+                    continue;
+                };
+                let clickme = trj_dir.join("clickme.dtr");
+                let mut attachments = vec![
+                    StructureAttachment {
+                        role: StructureAttachmentRole::Topology,
+                        path: path.to_path_buf(),
+                    },
+                    StructureAttachment {
+                        role: StructureAttachmentRole::Trajectory,
+                        path: trj_dir,
+                    },
+                ];
+                if clickme.is_file() {
+                    attachments.push(StructureAttachment {
+                        role: StructureAttachmentRole::TrajectoryPointer,
+                        path: clickme,
+                    });
+                }
+                return Some(StructureFileBundle {
+                    kind: StructureBundleKind::Desmond,
+                    primary_path: path.to_path_buf(),
+                    input_path: path.to_path_buf(),
+                    attachments,
+                });
+            }
+            None
+        }
+        "dtr" => {
+            let trj_dir = path.parent()?;
+            let base = trj_dir
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(|value| value.strip_suffix("_trj").unwrap_or(value).to_string())?;
+            if !trj_dir.is_dir() {
+                return None;
+            }
+            let mut candidates = trj_dir
+                .parent()
+                .map(|parent| {
+                    vec![
+                        parent.join(format!("{base}-out.cms")),
+                        parent.join(format!("{base}.cms")),
+                    ]
+                })
+                .unwrap_or_default();
+            candidates.extend(casebook_cms_candidates(trj_dir, &base));
+            let cms_path = candidates
+                .into_iter()
+                .find(|candidate| candidate.is_file())?;
+            Some(StructureFileBundle {
+                kind: StructureBundleKind::Desmond,
+                primary_path: cms_path.clone(),
+                input_path: path.to_path_buf(),
+                attachments: vec![
+                    StructureAttachment {
+                        role: StructureAttachmentRole::Topology,
+                        path: cms_path,
+                    },
+                    StructureAttachment {
+                        role: StructureAttachmentRole::Trajectory,
+                        path: trj_dir.to_path_buf(),
+                    },
+                    StructureAttachment {
+                        role: StructureAttachmentRole::TrajectoryPointer,
+                        path: path.to_path_buf(),
+                    },
+                ],
+            })
+        }
+        _ => None,
+    }
+}
+
+fn resolve_md_file_bundle(path: &Path, extension: &str) -> Option<StructureFileBundle> {
+    let base = path.with_extension("");
+    if matches!(extension, "xtc" | "trr" | "dcd" | "nctraj") {
+        let topology = ["pdb", "gro", "cif", "mmcif", "bcif", "psf", "prmtop", "top"]
+            .into_iter()
+            .map(|candidate| base.with_extension(candidate))
+            .find(|candidate| candidate.is_file())?;
+        return Some(StructureFileBundle {
+            kind: StructureBundleKind::Md,
+            primary_path: topology.clone(),
+            input_path: path.to_path_buf(),
+            attachments: vec![
+                StructureAttachment {
+                    role: StructureAttachmentRole::Topology,
+                    path: topology,
+                },
+                StructureAttachment {
+                    role: StructureAttachmentRole::Trajectory,
+                    path: path.to_path_buf(),
+                },
+            ],
+        });
+    }
+    if matches!(
+        extension,
+        "pdb" | "gro" | "cif" | "mmcif" | "bcif" | "psf" | "prmtop" | "top"
+    ) {
+        let trajectory = ["xtc", "trr", "dcd", "nctraj"]
+            .into_iter()
+            .map(|candidate| base.with_extension(candidate))
+            .find(|candidate| candidate.is_file())?;
+        return Some(StructureFileBundle {
+            kind: StructureBundleKind::Md,
+            primary_path: path.to_path_buf(),
+            input_path: path.to_path_buf(),
+            attachments: vec![
+                StructureAttachment {
+                    role: StructureAttachmentRole::Topology,
+                    path: path.to_path_buf(),
+                },
+                StructureAttachment {
+                    role: StructureAttachmentRole::Trajectory,
+                    path: trajectory,
+                },
+            ],
+        });
+    }
+    None
+}
+
+fn candidate_desmond_bases(path: &Path) -> Vec<String> {
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return Vec::new();
+    };
+    let mut bases = vec![stem.to_string()];
+    for suffix in ["-out", "_out"] {
+        if let Some(base) = stem.strip_suffix(suffix) {
+            if !base.is_empty() && !bases.iter().any(|value| value == base) {
+                bases.push(base.to_string());
+            }
+        }
+    }
+    bases
+}
+
+fn casebook_source_files_parts(path: &Path) -> Option<(PathBuf, Vec<String>)> {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    let marker = "/source_files/";
+    let index = normalized.find(marker)?;
+    let root = PathBuf::from(&normalized[..index + marker.len() - 1]);
+    let rest = normalized[index + marker.len()..]
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    Some((root, rest))
+}
+
+fn casebook_trj_candidates(cms_path: &Path, base: &str) -> Vec<PathBuf> {
+    let Some((root, rest)) = casebook_source_files_parts(cms_path) else {
+        return Vec::new();
+    };
+    let Some(first) = rest.first() else {
+        return Vec::new();
+    };
+    if !first.starts_with("mnt__") {
+        return Vec::new();
+    }
+    let mut path = root;
+    for part in first.split("__") {
+        path.push(part);
+    }
+    for part in rest.iter().skip(1).take(rest.len().saturating_sub(2)) {
+        path.push(part);
+    }
+    path.push(format!("{base}_trj"));
+    vec![path]
+}
+
+fn casebook_cms_candidates(trj_dir: &Path, base: &str) -> Vec<PathBuf> {
+    let Some((root, rest)) = casebook_source_files_parts(trj_dir) else {
+        return Vec::new();
+    };
+    if rest.len() < 4 || rest[0] != "mnt" || rest[1] != "ligandpro" || rest[2] != "crim3s" {
+        return Vec::new();
+    }
+    let mapped_dir = root.join(rest[0..4].join("__"));
+    vec![
+        mapped_dir.join(format!("{base}-out.cms")),
+        mapped_dir.join(format!("{base}.cms")),
+    ]
 }
 
 fn read_file_prefix(path: &PathBuf, max_bytes: u64) -> Result<Vec<u8>, String> {

--- a/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
@@ -79,11 +79,17 @@ pub(crate) fn create_runtime<R: Runtime>(
         .as_ref()
         .and_then(|payload| payload.frame_count)
         .unwrap_or(0);
-    let is_xyz_trajectory = xyz_frame_count > 1;
+    let pdb_model_count = if format.molstar_format == "pdb" && !format.is_binary {
+        count_pdb_models(data)
+    } else {
+        0
+    };
+    let trajectory_frame_count = xyz_frame_count.max(pdb_model_count);
+    let is_trajectory = trajectory_frame_count > 1;
     let xyzrender_available = xyzrender_available_for_document(format, data);
     let mut renderer = renderer.to_string();
     let requested_renderer = normalize_renderer_mode(&preferences.renderer_mode);
-    if is_xyz_trajectory && requested_renderer == "auto" && renderer != "molstar" {
+    if is_trajectory && requested_renderer == "auto" && renderer != "molstar" {
         renderer = "molstar".to_string();
     }
     if renderer == "xyzrender-external" && !xyzrender_available {
@@ -190,11 +196,12 @@ pub(crate) fn create_runtime<R: Runtime>(
         "transparentBackground": preferences.resolved_transparent_background(),
         "sdfGrid": true,
         "sdfPosePager": renderer == "molstar" && molstar_format == "sdf" && !format.is_binary,
-        "trajectoryControls": renderer == "molstar" && is_xyz_trajectory,
-        "trajectoryFrameCount": xyz_frame_count,
+        "trajectoryControls": renderer == "molstar" && is_trajectory,
+        "trajectoryFrameCount": trajectory_frame_count,
         "appViewer": true,
         "tauriViewer": true,
         "molstarStyle": preferences.resolved_molstar_style(),
+        "waterRepresentation": "line",
         "xyzrenderViewer": false,
         "xyzrenderAvailable": xyzrender_available,
         "molstarAvailable": !format.external_only || external_molstar_data.is_some(),
@@ -243,6 +250,21 @@ pub(crate) fn create_runtime<R: Runtime>(
     if let Some(status) = external_status {
         config["externalRendererStatus"] = status;
     }
+    if let Some(converted) = external_molstar_data.as_ref() {
+        if !converted.staged_entries.is_empty() {
+            config["stagedEntries"] = json!(converted
+                .staged_entries
+                .iter()
+                .map(|entry| json!({
+                    "label": entry.label,
+                    "format": entry.extension,
+                    "binary": false,
+                    "representation": entry.representation,
+                    "dataBase64": base64::engine::general_purpose::STANDARD.encode(&entry.data)
+                }))
+                .collect::<Vec<_>>());
+        }
+    }
 
     let config_text = serde_json::to_string(&config).map_err(|err| err.to_string())?;
     fs::write(
@@ -262,6 +284,13 @@ pub(crate) fn create_runtime<R: Runtime>(
         path: runtime.join("index.html"),
         renderer,
     })
+}
+
+fn count_pdb_models(data: &[u8]) -> usize {
+    let text = String::from_utf8_lossy(data);
+    text.lines()
+        .filter(|line| line.trim_start().starts_with("MODEL"))
+        .count()
 }
 
 pub(crate) fn create_docking_runtime<R: Runtime>(
@@ -336,6 +365,7 @@ pub(crate) fn create_docking_runtime<R: Runtime>(
         "appViewer": true,
         "tauriViewer": true,
         "molstarStyle": preferences.resolved_molstar_style(),
+        "waterRepresentation": "line",
         "xyzrenderViewer": false,
         "xyzrenderAvailable": false,
         "molstarAvailable": true,
@@ -446,7 +476,7 @@ fn should_use_converted_molstar_data(
 ) -> bool {
     data.is_some()
         && !format.is_binary
-        && matches!(format.molstar_format.as_str(), "mmcif" | "cifCore")
+        && matches!(format.molstar_format.as_str(), "gro" | "mmcif" | "cifCore")
 }
 
 fn xyzrender_available_for_document(format: &FormatInfo, data: &[u8]) -> bool {

--- a/apps/desktop/src-tauri/src/preview/text_xyz.rs
+++ b/apps/desktop/src-tauri/src/preview/text_xyz.rs
@@ -15,6 +15,15 @@ struct Atom {
 pub(crate) struct ConvertedStructureData {
     pub(crate) data: Vec<u8>,
     pub(crate) extension: &'static str,
+    pub(crate) staged_entries: Vec<ConvertedStagedEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ConvertedStagedEntry {
+    pub(crate) label: String,
+    pub(crate) data: Vec<u8>,
+    pub(crate) extension: &'static str,
+    pub(crate) representation: &'static str,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -29,6 +38,8 @@ struct MaestroAtom {
     z: f64,
 }
 
+type BoxVectors = [[f64; 3]; 3];
+
 pub(crate) fn converted_data_from_text(
     data: &[u8],
     extension: &str,
@@ -37,9 +48,13 @@ pub(crate) fn converted_data_from_text(
     if matches!(extension, "cms" | "mae" | "maegz") {
         return maestro_pdb_data_from_text(data, extension);
     }
+    if extension == "gro" {
+        return gro_pdb_data_from_text(data, label);
+    }
     pdb_data_from_text(data, extension, label).map(|data| ConvertedStructureData {
         data,
         extension: "pdb",
+        staged_entries: Vec::new(),
     })
 }
 
@@ -289,7 +304,225 @@ fn maestro_pdb_data_from_text(data: &[u8], extension: &str) -> Option<ConvertedS
     Some(ConvertedStructureData {
         data: maestro_atoms_to_pdb(&atoms).into_bytes(),
         extension: "pdb",
+        staged_entries: Vec::new(),
     })
+}
+
+fn gro_pdb_data_from_text(data: &[u8], label: &str) -> Option<ConvertedStructureData> {
+    let decoded = decode_structure_text(data, "gro")?;
+    let text = decoded.replace("\r\n", "\n").replace('\r', "\n");
+    let lines: Vec<&str> = text.lines().collect();
+    let atoms = parse_gro_pdb_atoms(&lines)?;
+    if atoms.is_empty() {
+        return None;
+    }
+    let box_vectors = parse_gro_box(&lines);
+    let (water_atoms, main_atoms): (Vec<_>, Vec<_>) = atoms
+        .into_iter()
+        .partition(|atom| atom.residue_name == "HOH");
+    let mut pdb = String::new();
+    if let Some(box_vectors) = box_vectors {
+        pdb.push_str(&pdb_cryst1_line(&box_vectors));
+        pdb.push('\n');
+    }
+    pdb.push_str(&format!("REMARK Converted from {label}\n"));
+    for (index, atom) in main_atoms.iter().take(99_999).enumerate() {
+        pdb.push_str(&maestro_pdb_atom_line(index + 1, atom));
+        pdb.push('\n');
+    }
+    pdb.push_str("END\n");
+    let mut staged_entries = Vec::new();
+    if let Some(box_vectors) = box_vectors {
+        staged_entries.push(ConvertedStagedEntry {
+            label: "Box".to_string(),
+            data: box_pdb_from_vectors(&box_vectors, label).into_bytes(),
+            extension: "pdb",
+            representation: "box-lines",
+        });
+    }
+    if !water_atoms.is_empty() {
+        let mut water_pdb = format!("REMARK Water split from {label}\n");
+        for (index, atom) in water_atoms.iter().take(99_999).enumerate() {
+            water_pdb.push_str(&maestro_pdb_atom_line(index + 1, atom));
+            water_pdb.push('\n');
+        }
+        water_pdb.push_str("END\n");
+        staged_entries.push(ConvertedStagedEntry {
+            label: "Water".to_string(),
+            data: water_pdb.into_bytes(),
+            extension: "pdb",
+            representation: "solvent-lines",
+        });
+    }
+    Some(ConvertedStructureData {
+        data: pdb.into_bytes(),
+        extension: "pdb",
+        staged_entries,
+    })
+}
+
+fn parse_gro_pdb_atoms(lines: &[&str]) -> Option<Vec<MaestroAtom>> {
+    if lines.len() < 3 {
+        return None;
+    }
+    let atom_count = lines[1].trim().parse::<usize>().ok()?;
+    if atom_count == 0 || lines.len() < atom_count + 2 {
+        return None;
+    }
+    let mut atoms = Vec::with_capacity(atom_count);
+    for line in &lines[2..2 + atom_count] {
+        let Some(atom) =
+            parse_gro_fixed_atom_line(line).or_else(|| parse_gro_loose_atom_line(line))
+        else {
+            continue;
+        };
+        atoms.push(atom);
+    }
+    (!atoms.is_empty()).then_some(atoms)
+}
+
+fn parse_gro_box(lines: &[&str]) -> Option<BoxVectors> {
+    if lines.len() < 3 {
+        return None;
+    }
+    let atom_count = lines[1].trim().parse::<usize>().ok()?;
+    let values: Vec<f64> = lines
+        .get(atom_count + 2)?
+        .split_whitespace()
+        .map(|value| value.parse::<f64>())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?
+        .into_iter()
+        .map(|value| value * 10.0)
+        .collect();
+    match values.as_slice() {
+        [x, y, z] => Some([[*x, 0.0, 0.0], [0.0, *y, 0.0], [0.0, 0.0, *z]]),
+        [v1x, v2y, v3z, v1y, v1z, v2x, v2z, v3x, v3y] => {
+            Some([[*v1x, *v1y, *v1z], [*v2x, *v2y, *v2z], [*v3x, *v3y, *v3z]])
+        }
+        _ => None,
+    }
+}
+
+fn parse_gro_fixed_atom_line(line: &str) -> Option<MaestroAtom> {
+    if line.len() < 44 {
+        return None;
+    }
+    let residue_number = line.get(0..5)?.trim().parse::<i32>().ok()?;
+    let residue_name = line.get(5..10)?.trim();
+    let atom_name = line.get(10..15)?.trim();
+    let x = line.get(20..28)?.trim().parse::<f64>().ok()?;
+    let y = line.get(28..36)?.trim().parse::<f64>().ok()?;
+    let z = line.get(36..44)?.trim().parse::<f64>().ok()?;
+    gro_atom_to_maestro(residue_number, residue_name, atom_name, x, y, z)
+}
+
+fn parse_gro_loose_atom_line(line: &str) -> Option<MaestroAtom> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    let (residue_number, residue_name, atom_name, offset) =
+        if let Some((number, name)) = split_gro_residue_token(parts[0]) {
+            (number, name, parts[1], 3)
+        } else {
+            (parts[0].parse::<i32>().ok()?, parts[1], parts[2], 4)
+        };
+    let x = parts.get(offset)?.parse::<f64>().ok()?;
+    let y = parts.get(offset + 1)?.parse::<f64>().ok()?;
+    let z = parts.get(offset + 2)?.parse::<f64>().ok()?;
+    gro_atom_to_maestro(residue_number, residue_name, atom_name, x, y, z)
+}
+
+fn split_gro_residue_token(token: &str) -> Option<(i32, &str)> {
+    let split_at = token
+        .char_indices()
+        .find(|(_, ch)| !ch.is_ascii_digit())
+        .map(|(index, _)| index)?;
+    if split_at == 0 {
+        return None;
+    }
+    Some((token[..split_at].parse::<i32>().ok()?, &token[split_at..]))
+}
+
+fn gro_atom_to_maestro(
+    residue_number: i32,
+    residue_name: &str,
+    atom_name: &str,
+    x: f64,
+    y: f64,
+    z: f64,
+) -> Option<MaestroAtom> {
+    let symbol = gro_element_symbol(atom_name, residue_name)?;
+    let residue_name = if is_gro_water_residue(residue_name) {
+        "HOH".to_string()
+    } else {
+        normalize_pdb_residue_name(residue_name)
+    };
+    Some(MaestroAtom {
+        symbol,
+        atom_name: normalize_pdb_atom_name(atom_name),
+        residue_name: if residue_name.is_empty() {
+            "MOL".to_string()
+        } else {
+            residue_name
+        },
+        residue_number,
+        chain_name: "A".to_string(),
+        x: x * 10.0,
+        y: y * 10.0,
+        z: z * 10.0,
+    })
+}
+
+fn is_gro_water_residue(residue_name: &str) -> bool {
+    matches!(
+        residue_name.trim().to_ascii_uppercase().as_str(),
+        "SOL"
+            | "WAT"
+            | "HOH"
+            | "H2O"
+            | "TIP"
+            | "TIP3"
+            | "TIP3P"
+            | "TIP4"
+            | "TIP4P"
+            | "TP3"
+            | "TP4"
+            | "SPC"
+            | "SPCE"
+    )
+}
+
+fn gro_element_symbol(atom_name: &str, residue_name: &str) -> Option<String> {
+    let cleaned = atom_name
+        .trim_start_matches(|ch: char| ch.is_ascii_digit())
+        .chars()
+        .filter(|ch| ch.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_ascii_uppercase();
+    if cleaned.is_empty() {
+        return None;
+    }
+    if is_gro_water_residue(residue_name) {
+        return Some(if cleaned.starts_with('H') { "H" } else { "O" }.to_string());
+    }
+    for (prefix, symbol) in [
+        ("CL", "Cl"),
+        ("BR", "Br"),
+        ("NA", "Na"),
+        ("MG", "Mg"),
+        ("ZN", "Zn"),
+        ("FE", "Fe"),
+    ] {
+        if cleaned.starts_with(prefix) {
+            return Some(symbol.to_string());
+        }
+    }
+    if cleaned.starts_with("CA") && residue_name.trim().eq_ignore_ascii_case("CA") {
+        return Some("Ca".to_string());
+    }
+    Some(normalize_element_symbol(&cleaned[..1]))
 }
 
 fn parse_maestro_pdb_atoms(lines: &[&str], atom_limit: usize) -> Option<Vec<MaestroAtom>> {
@@ -661,6 +894,103 @@ fn format_pdb_atom_name(atom_name: &str, symbol: &str) -> String {
         cleaned = symbol.to_string();
     }
     cleaned
+}
+
+fn vector_length(vector: &[f64; 3]) -> f64 {
+    vector.iter().map(|value| value * value).sum::<f64>().sqrt()
+}
+
+fn vector_angle(first: &[f64; 3], second: &[f64; 3]) -> f64 {
+    let denominator = vector_length(first) * vector_length(second);
+    if denominator <= 0.0 {
+        return 90.0;
+    }
+    let cosine = first
+        .iter()
+        .zip(second.iter())
+        .map(|(left, right)| left * right)
+        .sum::<f64>()
+        / denominator;
+    cosine.clamp(-1.0, 1.0).acos().to_degrees()
+}
+
+fn pdb_cryst1_line(box_vectors: &BoxVectors) -> String {
+    let [a, b, c] = box_vectors;
+    format!(
+        "CRYST1{a_len:>9.3}{b_len:>9.3}{c_len:>9.3}{alpha:>7.2}{beta:>7.2}{gamma:>7.2} P 1           1",
+        a_len = vector_length(a),
+        b_len = vector_length(b),
+        c_len = vector_length(c),
+        alpha = vector_angle(b, c),
+        beta = vector_angle(a, c),
+        gamma = vector_angle(a, b),
+    )
+}
+
+fn add_vectors(first: &[f64; 3], second: &[f64; 3]) -> [f64; 3] {
+    [
+        first[0] + second[0],
+        first[1] + second[1],
+        first[2] + second[2],
+    ]
+}
+
+fn box_vertices(box_vectors: &BoxVectors) -> [[f64; 3]; 8] {
+    let [a, b, c] = box_vectors;
+    let origin = [0.0, 0.0, 0.0];
+    let ab = add_vectors(a, b);
+    let ac = add_vectors(a, c);
+    let bc = add_vectors(b, c);
+    [origin, *a, ab, *b, *c, ac, add_vectors(&ab, c), bc]
+}
+
+fn pdb_box_atom_line(serial: usize, name: &str, vertex: &[f64; 3]) -> String {
+    format!(
+        "HETATM{serial:>5} {name:<4} BOX Z9999    {x:>8.3}{y:>8.3}{z:>8.3}  1.00  0.00           C  ",
+        x = vertex[0],
+        y = vertex[1],
+        z = vertex[2],
+    )
+}
+
+fn push_pdb_box_lines(pdb: &mut String, box_vectors: &BoxVectors, serial_start: usize) {
+    for (index, vertex) in box_vertices(box_vectors).iter().enumerate() {
+        pdb.push_str(&pdb_box_atom_line(
+            serial_start + index,
+            &format!("B{}", index + 1),
+            vertex,
+        ));
+        pdb.push('\n');
+    }
+    for (first, second) in [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 4),
+        (0, 4),
+        (1, 5),
+        (2, 6),
+        (3, 7),
+    ] {
+        pdb.push_str(&format!(
+            "CONECT{:>5}{:>5}\n",
+            serial_start + first,
+            serial_start + second
+        ));
+    }
+}
+
+fn box_pdb_from_vectors(box_vectors: &BoxVectors, label: &str) -> String {
+    let mut pdb = pdb_cryst1_line(box_vectors);
+    pdb.push('\n');
+    pdb.push_str(&format!("REMARK Box split from {label}\n"));
+    push_pdb_box_lines(&mut pdb, box_vectors, 1);
+    pdb.push_str("END\n");
+    pdb
 }
 
 fn truncate_ascii(value: &str, max_len: usize) -> String {
@@ -1073,6 +1403,31 @@ generated
         assert!(pdb.contains("HETATM    2 H    MOL A   1       0.508   0.000   0.000"));
         assert!(pdb.contains("CONECT    1    2    3"));
         assert!(pdb.ends_with("END\n"));
+    }
+
+    #[test]
+    fn converts_gro_box_to_pdb_cryst1_and_frame_edges() {
+        let data = br#"GRO box fixture
+2
+    1MOL      C    1   1.000   2.000   3.000
+    2TP3      O    2   0.100   0.200   0.300
+   1.00000   2.00000   3.00000   0.10000   0.20000   0.30000   0.40000   0.50000   0.60000
+"#;
+
+        let converted = converted_data_from_text(data, "gro", "box.gro").unwrap();
+        let pdb = String::from_utf8(converted.data).unwrap();
+
+        assert!(pdb.starts_with("CRYST1   10.247   20.616   31.000"));
+        assert!(pdb.contains("REMARK Converted from box.gro\nHETATM    1 C    MOL A   1"));
+        assert!(!pdb.contains("BOX Z9999"));
+        assert_eq!(converted.staged_entries.len(), 2);
+        assert_eq!(converted.staged_entries[0].representation, "box-lines");
+        let box_pdb = String::from_utf8(converted.staged_entries[0].data.clone()).unwrap();
+        assert!(box_pdb.contains("HETATM    1 B1   BOX Z9999       0.000   0.000   0.000"));
+        assert!(box_pdb.contains("HETATM    2 B2   BOX Z9999      10.000   1.000   2.000"));
+        assert!(box_pdb.contains("HETATM    3 B3   BOX Z9999      13.000  21.000   6.000"));
+        assert!(box_pdb.contains("CONECT    1    2"));
+        assert_eq!(converted.staged_entries[1].representation, "solvent-lines");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,8 @@
     "active": true,
     "targets": "app",
     "resources": {
-      "../../../PreviewExtension/Web": "Web"
+      "../../../PreviewExtension/Web": "Web",
+      "../../../scripts/desmond_preview_extract.py": "desmond_preview_extract.py"
     },
     "macOS": {
       "minimumSystemVersion": "12.0",

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -27,6 +27,7 @@ type Atom = {
 type ConvertedStructureData = {
   bytes: Uint8Array;
   molstarFormat: string;
+  stagedEntries?: Array<Record<string, unknown>>;
 };
 
 type MaestroAtom = Atom & {
@@ -35,6 +36,8 @@ type MaestroAtom = Atom & {
   residueNumber: number;
   chainName: string;
 };
+
+type BoxVectors = [[number, number, number], [number, number, number], [number, number, number]];
 
 const MAX_STRUCTURE_FILE_SIZE = 75 * 1024 * 1024;
 const MAESTRO_PREVIEW_READ_LIMIT = 64 * 1024 * 1024;
@@ -226,6 +229,7 @@ export async function openBrowserDevDockingDocument(
     appViewer: true,
     tauriViewer: false,
     molstarStyle: preferences.molstarStyle,
+    waterRepresentation: "line",
     xyzrenderViewer: false,
     xyzrenderAvailable: false,
     molstarAvailable: true,
@@ -347,6 +351,7 @@ export async function openBrowserDevMolstarContextDocument(
     appViewer: true,
     tauriViewer: false,
     molstarStyle: preferences.molstarStyle,
+    waterRepresentation: "line",
     xyzrenderViewer: false,
     xyzrenderAvailable: false,
     molstarAvailable: true,
@@ -578,6 +583,7 @@ async function openBrowserDevDocumentFromBytes(
     undefined,
     Math.max(trajectoryFrameCount, sdfRecordCount),
     ketcherEditConfig(path, extension, text, sourceByteCount, sdfRecordCount),
+    convertedMolstarData?.stagedEntries,
   );
   return browserDocument(path, extension, renderer, html, sourceByteCount);
 }
@@ -707,6 +713,7 @@ function browserDevContextConfig(
     appViewer: true,
     tauriViewer: false,
     molstarStyle: preferences.molstarStyle,
+    waterRepresentation: "line",
     xyzrenderViewer: false,
     xyzrenderAvailable: false,
     molstarAvailable: true,
@@ -746,6 +753,7 @@ function viewerHtml(
   configOverride?: Record<string, unknown>,
   trajectoryFrameCount = 0,
   ketcherConfig: Record<string, unknown> | null = null,
+  stagedEntries?: Array<Record<string, unknown>>,
 ) {
   const label = fileTitle(path);
   const visuals = resolvePreviewVisuals(preferences);
@@ -778,6 +786,8 @@ function viewerHtml(
     appViewer: true,
     tauriViewer: false,
     molstarStyle,
+    waterRepresentation: "line",
+    ...(stagedEntries?.length ? { stagedEntries } : {}),
     xyzrenderViewer: renderer === "xyzrender-external",
     xyzrenderAvailable,
     xyzrenderEndpoint: "/__burette/xyzrender",
@@ -1249,7 +1259,7 @@ function proteinLikeAtomRecordCount(text: string) {
 }
 
 function shouldUseConvertedMolstarData(format: FormatInfo, xyzBytes: Uint8Array | null) {
-  return Boolean(xyzBytes) && !format.binary && ["mmcif", "cifCore"].includes(format.molstarFormat);
+  return Boolean(xyzBytes) && !format.binary && ["gro", "mmcif", "cifCore"].includes(format.molstarFormat);
 }
 
 function defaultRendererModeForDocument(extension: string, requestedMode: string, reloadOptions?: ViewerReloadOptions) {
@@ -1495,6 +1505,10 @@ function convertedDataFromText(text: string, extension: string, label: string): 
     const bytes = maestroPdbDataFromText(text);
     return bytes ? { bytes, molstarFormat: "pdb" } : null;
   }
+  if (extension === "gro") {
+    const converted = groPdbDataFromText(text, label);
+    return converted ? { molstarFormat: "pdb", ...converted } : null;
+  }
   const bytes = pdbDataFromText(text, extension, label);
   return bytes ? { bytes, molstarFormat: "pdb" } : null;
 }
@@ -1555,6 +1569,150 @@ function maestroPdbDataFromText(text: string) {
     "",
   ].join("\n");
   return new TextEncoder().encode(pdb);
+}
+
+function groPdbDataFromText(text: string, label: string) {
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const atoms = parseGroPdbAtoms(lines);
+  if (!atoms?.length) return null;
+  const box = parseGroBox(lines);
+  const mainAtoms = atoms.filter((atom) => atom.residueName !== "HOH");
+  const waterAtoms = atoms.filter((atom) => atom.residueName === "HOH");
+  const pdb = [
+    ...(box ? [pdbCryst1Line(box)] : []),
+    `REMARK Converted from ${label}`,
+    ...mainAtoms.slice(0, 99999).map((atom, index) => maestroPdbAtomLine(index + 1, atom)),
+    "END",
+    "",
+  ].join("\n");
+  const bytes = new TextEncoder().encode(pdb);
+  const stagedEntries: Array<Record<string, unknown>> = [];
+  if (box) {
+    stagedEntries.push({
+      label: "Box",
+      format: "pdb",
+      binary: false,
+      representation: "box-lines",
+      dataBase64: bytesToBase64(new TextEncoder().encode(boxPdbFromVectors(box, label))),
+    });
+  }
+  if (waterAtoms.length) {
+    const waterPdb = [
+      `REMARK Water split from ${label}`,
+      ...waterAtoms.slice(0, 99999).map((atom, index) => maestroPdbAtomLine(index + 1, atom)),
+      "END",
+      "",
+    ].join("\n");
+    stagedEntries.push({
+      label: "Water",
+      format: "pdb",
+      binary: false,
+      representation: "solvent-lines",
+      dataBase64: bytesToBase64(new TextEncoder().encode(waterPdb)),
+    });
+  }
+  if (!stagedEntries.length) return { bytes };
+  return {
+    bytes,
+    stagedEntries,
+  };
+}
+
+function parseGroPdbAtoms(lines: string[]) {
+  if (lines.length < 3) return null;
+  const atomCount = Number.parseInt(lines[1].trim(), 10);
+  if (!Number.isFinite(atomCount) || atomCount <= 0 || lines.length < atomCount + 2) return null;
+  const atoms: MaestroAtom[] = [];
+  for (let index = 0; index < atomCount; index += 1) {
+    const line = lines[index + 2] || "";
+    const fixed = parseGroFixedAtomLine(line);
+    const parsed = fixed ?? parseGroLooseAtomLine(line);
+    if (!parsed) continue;
+    const residueName = isGroWaterResidue(parsed.residueName) ? "HOH" : normalizePdbResidueName(parsed.residueName);
+    const atomName = normalizePdbAtomName(parsed.atomName) || parsed.symbol;
+    atoms.push({
+      symbol: parsed.symbol,
+      atomName,
+      residueName: residueName || "MOL",
+      residueNumber: parsed.residueNumber,
+      chainName: "A",
+      x: parsed.x * 10,
+      y: parsed.y * 10,
+      z: parsed.z * 10,
+    });
+  }
+  return atoms.length ? atoms : null;
+}
+
+function parseGroBox(lines: string[]): BoxVectors | null {
+  if (lines.length < 3) return null;
+  const atomCount = Number.parseInt(lines[1].trim(), 10);
+  const boxLine = lines[atomCount + 2]?.trim();
+  if (!Number.isFinite(atomCount) || !boxLine) return null;
+  const values = fields(boxLine).map((value) => Number.parseFloat(value));
+  if (values.length !== 3 && values.length !== 9) return null;
+  if (values.some((value) => !Number.isFinite(value))) return null;
+  const angstrom = values.map((value) => value * 10);
+  if (angstrom.length === 3) {
+    return [
+      [angstrom[0], 0, 0],
+      [0, angstrom[1], 0],
+      [0, 0, angstrom[2]],
+    ];
+  }
+  return [
+    [angstrom[0], angstrom[3], angstrom[4]],
+    [angstrom[5], angstrom[1], angstrom[6]],
+    [angstrom[7], angstrom[8], angstrom[2]],
+  ];
+}
+
+function parseGroFixedAtomLine(line: string) {
+  if (line.length < 44) return null;
+  const residueNumber = Number.parseInt(line.slice(0, 5).trim(), 10);
+  const residueName = line.slice(5, 10).trim();
+  const atomName = line.slice(10, 15).trim();
+  const x = Number.parseFloat(line.slice(20, 28).trim());
+  const y = Number.parseFloat(line.slice(28, 36).trim());
+  const z = Number.parseFloat(line.slice(36, 44).trim());
+  const symbol = groElementSymbol(atomName, residueName);
+  if (!Number.isFinite(residueNumber) || !residueName || !atomName || !symbol || !Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+  return { residueNumber, residueName, atomName, symbol, x, y, z };
+}
+
+function parseGroLooseAtomLine(line: string) {
+  const parts = fields(line);
+  if (parts.length < 6) return null;
+  const residueToken = parts[0];
+  const residueMatch = residueToken.match(/^(\d+)([A-Za-z0-9]+)$/u);
+  const residueNumber = Number.parseInt(residueMatch?.[1] ?? residueToken, 10);
+  const residueName = residueMatch?.[2] ?? parts[1];
+  const atomName = residueMatch ? parts[1] : parts[2];
+  const offset = residueMatch ? 3 : 4;
+  const x = Number.parseFloat(parts[offset] || "");
+  const y = Number.parseFloat(parts[offset + 1] || "");
+  const z = Number.parseFloat(parts[offset + 2] || "");
+  const symbol = groElementSymbol(atomName, residueName);
+  if (!Number.isFinite(residueNumber) || !residueName || !atomName || !symbol || !Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+  return { residueNumber, residueName, atomName, symbol, x, y, z };
+}
+
+function isGroWaterResidue(residueName: string) {
+  return ["SOL", "WAT", "HOH", "H2O", "TIP", "TIP3", "TIP3P", "TIP4", "TIP4P", "TP3", "TP4", "SPC", "SPCE"].includes(residueName.trim().toUpperCase());
+}
+
+function groElementSymbol(atomName: string, residueName: string) {
+  const cleaned = atomName.replace(/^[0-9]+/u, "").replace(/[^A-Za-z]/gu, "").toUpperCase();
+  if (!cleaned) return null;
+  if (isGroWaterResidue(residueName)) return cleaned.startsWith("H") ? "H" : "O";
+  if (cleaned.startsWith("CL")) return "Cl";
+  if (cleaned.startsWith("BR")) return "Br";
+  if (cleaned.startsWith("NA")) return "Na";
+  if (cleaned.startsWith("MG")) return "Mg";
+  if (cleaned.startsWith("ZN")) return "Zn";
+  if (cleaned.startsWith("FE")) return "Fe";
+  if (cleaned.startsWith("CA") && residueName.trim().toUpperCase() === "CA") return "Ca";
+  return normalizeElementSymbol(cleaned[0]);
 }
 
 function parseMaestroAtoms(lines: string[], atomLimit: number) {
@@ -1774,6 +1932,58 @@ function formatPdbAtomName(atomName: string, symbol: string) {
 
 function formatPdbCoordinate(value: number) {
   return value.toFixed(3).padStart(8, " ");
+}
+
+function vectorLength(vector: [number, number, number]) {
+  return Math.hypot(...vector);
+}
+
+function vectorAngle(first: [number, number, number], second: [number, number, number]) {
+  const denominator = vectorLength(first) * vectorLength(second);
+  if (denominator <= 0) return 90;
+  const cosine = (first[0] * second[0] + first[1] * second[1] + first[2] * second[2]) / denominator;
+  return Math.acos(clamp(cosine, -1, 1)) * 180 / Math.PI;
+}
+
+function pdbCryst1Line(box: BoxVectors) {
+  const [a, b, c] = box;
+  return `CRYST1${vectorLength(a).toFixed(3).padStart(9, " ")}${vectorLength(b).toFixed(3).padStart(9, " ")}${vectorLength(c).toFixed(3).padStart(9, " ")}${vectorAngle(b, c).toFixed(2).padStart(7, " ")}${vectorAngle(a, c).toFixed(2).padStart(7, " ")}${vectorAngle(a, b).toFixed(2).padStart(7, " ")} P 1           1`;
+}
+
+function boxVertices(box: BoxVectors) {
+  const [a, b, c] = box;
+  const add = (first: [number, number, number], second: [number, number, number]): [number, number, number] => [
+    first[0] + second[0],
+    first[1] + second[1],
+    first[2] + second[2],
+  ];
+  const origin: [number, number, number] = [0, 0, 0];
+  const ab = add(a, b);
+  const ac = add(a, c);
+  const bc = add(b, c);
+  return [origin, a, ab, b, c, ac, add(ab, c), bc];
+}
+
+function pdbBoxAtomLine(serial: number, name: string, [x, y, z]: [number, number, number]) {
+  return `HETATM${String(serial).padStart(5, " ")} ${name.padEnd(4, " ")} BOX Z9999    ${formatPdbCoordinate(x)}${formatPdbCoordinate(y)}${formatPdbCoordinate(z)}  1.00  0.00           C  `;
+}
+
+function pdbBoxLines(box: BoxVectors, serialStart: number) {
+  const lines = boxVertices(box).map((vertex, index) => pdbBoxAtomLine(serialStart + index, `B${index + 1}`, vertex));
+  for (const [first, second] of [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]]) {
+    lines.push(`CONECT${String(serialStart + first).padStart(5, " ")}${String(serialStart + second).padStart(5, " ")}`);
+  }
+  return lines;
+}
+
+function boxPdbFromVectors(box: BoxVectors, label: string) {
+  return [
+    pdbCryst1Line(box),
+    `REMARK Box split from ${label}`,
+    ...pdbBoxLines(box, 1),
+    "END",
+    "",
+  ].join("\n");
 }
 
 function clamp(value: number, min: number, max: number) {

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -34,7 +34,15 @@ const devFsAllowRoots = [repoRoot, ...defaultFsAllow, ...extraFsAllow].map((path
 const execFileAsync = promisify(execFile);
 const DEV_FILE_SIZE_LIMIT = 75 * 1024 * 1024;
 const TEXT_FILE_READ_LIMIT = 12 * 1024 * 1024;
+const DESMOND_PREVIEW_TARGET_MB = 24;
 const RDKIT_WASM_PATH = join(repoRoot, "PreviewExtension", "Web", "rdkit", "RDKit_minimal.wasm");
+type StructureAttachmentRole = "topology" | "trajectory" | "trajectoryPointer" | "configuration";
+type StructureFileBundle = {
+  kind: "desmond" | "md" | "single";
+  primaryPath: string;
+  inputPath: string;
+  attachments: Array<{ role: StructureAttachmentRole; path: string }>;
+};
 const DEV_FILE_EXTENSIONS = new Set([
   "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "gro",
   "in", "inp", "lammpstrj", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
@@ -427,6 +435,40 @@ export function browserDevXyzrenderPlugin() {
           res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
         }
       });
+      server.middlewares.use("/__burette/file-bundle", async (req, res) => {
+        if ((req.method || "GET").toUpperCase() !== "GET") {
+          res.statusCode = 405;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: "Method not allowed" }));
+          return;
+        }
+        try {
+          const url = new URL(req.url || "", "http://127.0.0.1");
+          const path = url.searchParams.get("path");
+          if (!path) {
+            res.statusCode = 400;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ error: "Missing path" }));
+            return;
+          }
+          const filePath = resolve(path);
+          if (!isDevFileReadAllowed(filePath)) {
+            res.statusCode = 403;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ error: "Forbidden" }));
+            return;
+          }
+          const bundle = resolveStructureFileBundle(filePath);
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.setHeader("Cache-Control", "no-cache");
+          res.end(JSON.stringify(bundle));
+        } catch (error) {
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+        }
+      });
       server.middlewares.use("/__burette/desmond-preview", async (req, res) => {
         if ((req.method || "GET").toUpperCase() !== "GET") {
           res.statusCode = 405;
@@ -450,7 +492,8 @@ export function browserDevXyzrenderPlugin() {
             res.end(JSON.stringify({ error: "Forbidden" }));
             return;
           }
-          if (!isDesmondPreviewCandidate(filePath)) {
+          const bundle = resolveStructureFileBundle(filePath);
+          if (bundle.kind !== "desmond") {
             res.statusCode = 404;
             res.setHeader("Content-Type", "application/json; charset=utf-8");
             res.end(JSON.stringify({ error: "No Desmond trajectory candidate found." }));
@@ -467,8 +510,20 @@ export function browserDevXyzrenderPlugin() {
           try {
             await execFileAsync(
               SCHRODINGER_RUN,
-              ["python3", DESMOND_PREVIEW_EXTRACTOR, filePath, "--frames", "30", "--atoms", "6000", "--output", outputPath],
-              { timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
+              [
+                "python3",
+                DESMOND_PREVIEW_EXTRACTOR,
+                bundle.inputPath,
+                "--frames",
+                "0",
+                "--atoms",
+                "0",
+                "--target-mb",
+                String(DESMOND_PREVIEW_TARGET_MB),
+                "--output",
+                outputPath,
+              ],
+              { timeout: 0, maxBuffer: 16 * 1024 * 1024 },
             );
             const bytes = await readFile(outputPath);
             if (!bytes.length) {
@@ -682,21 +737,105 @@ function casebookCmsCandidates(trjDirectory: string, base: string) {
   return [join(mappedDirectory, `${base}-out.cms`), join(mappedDirectory, `${base}.cms`)];
 }
 
-function isDesmondPreviewCandidate(path: string) {
+function existingFileCandidate(candidates: string[]) {
+  return candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isFile()) || null;
+}
+
+function existingDirectoryCandidate(candidates: string[]) {
+  return candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isDirectory()) || null;
+}
+
+function resolveStructureFileBundle(path: string): StructureFileBundle {
+  return resolveDesmondFileBundle(path) ?? resolveMdFileBundle(path) ?? {
+    kind: "single",
+    primaryPath: path,
+    inputPath: path,
+    attachments: [],
+  };
+}
+
+function resolveDesmondFileBundle(path: string): StructureFileBundle | null {
   const extension = fileExtension(path);
   if (extension === "dtr") {
     const trjDirectory = dirname(path);
     const base = trjDirectory.replace(/\\/g, "/").split("/").pop()?.replace(/_trj$/u, "") || "";
-    return statSync(trjDirectory).isDirectory()
-      && [join(dirname(trjDirectory), `${base}-out.cms`), join(dirname(trjDirectory), `${base}.cms`), ...casebookCmsCandidates(trjDirectory, base)]
-        .some((candidate) => existsSync(candidate));
+    const cmsPath = existingFileCandidate([
+      join(dirname(trjDirectory), `${base}-out.cms`),
+      join(dirname(trjDirectory), `${base}.cms`),
+      ...casebookCmsCandidates(trjDirectory, base),
+    ]);
+    if (!cmsPath || !existsSync(trjDirectory) || !statSync(trjDirectory).isDirectory()) return null;
+    return {
+      kind: "desmond",
+      primaryPath: cmsPath,
+      inputPath: path,
+      attachments: [
+        { role: "topology", path: cmsPath },
+        { role: "trajectory", path: trjDirectory },
+        { role: "trajectoryPointer", path },
+      ],
+    };
   }
-  if (extension !== "cms") return false;
+  if (extension !== "cms") return null;
   for (const base of candidateDesmondBases(path)) {
-    const candidates = [join(dirname(path), `${base}_trj`), ...casebookTrjCandidates(path, base)];
-    if (candidates.some((candidate) => existsSync(candidate) && statSync(candidate).isDirectory())) return true;
+    const trjDirectory = existingDirectoryCandidate([join(dirname(path), `${base}_trj`), ...casebookTrjCandidates(path, base)]);
+    if (!trjDirectory) continue;
+    const clickme = join(trjDirectory, "clickme.dtr");
+    const attachments: StructureFileBundle["attachments"] = [
+      { role: "topology", path },
+      { role: "trajectory", path: trjDirectory },
+    ];
+    if (existsSync(clickme) && statSync(clickme).isFile()) {
+      attachments.push({ role: "trajectoryPointer", path: clickme });
+    }
+    return {
+      kind: "desmond",
+      primaryPath: path,
+      inputPath: path,
+      attachments,
+    };
   }
-  return false;
+  return null;
+}
+
+function resolveMdFileBundle(path: string): StructureFileBundle | null {
+  const extension = fileExtension(path);
+  const base = path.slice(0, Math.max(0, path.length - extension.length - 1));
+  if (["xtc", "trr", "dcd", "nctraj"].includes(extension)) {
+    const topology = existingFileCandidate(
+      ["pdb", "gro", "cif", "mmcif", "bcif", "psf", "prmtop", "top"].map((candidate) => `${base}.${candidate}`),
+    );
+    if (!topology) return null;
+    return {
+      kind: "md",
+      primaryPath: topology,
+      inputPath: path,
+      attachments: [
+        { role: "topology", path: topology },
+        { role: "trajectory", path },
+      ],
+    };
+  }
+  if (["pdb", "gro", "cif", "mmcif", "bcif", "psf", "prmtop", "top"].includes(extension)) {
+    const trajectory = existingFileCandidate(
+      ["xtc", "trr", "dcd", "nctraj"].map((candidate) => `${base}.${candidate}`),
+    );
+    if (!trajectory) return null;
+    return {
+      kind: "md",
+      primaryPath: path,
+      inputPath: path,
+      attachments: [
+        { role: "topology", path },
+        { role: "trajectory", path: trajectory },
+      ],
+    };
+  }
+  return null;
+}
+
+function isDesmondPreviewCandidate(path: string) {
+  return resolveDesmondFileBundle(path) !== null;
 }
 
 async function readJsonBody(req: import("node:http").IncomingMessage) {

--- a/scripts/desmond_preview_extract.py
+++ b/scripts/desmond_preview_extract.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import math
+import re
 import sys
 from pathlib import Path
 
@@ -37,6 +39,8 @@ STANDARD_RESIDUES = {
 }
 WATER_RESIDUES = {"HOH", "H2O", "SOL", "TIP", "T3P", "T4P", "WAT"}
 LIPID_RESIDUES = {"POPC", "POPE", "POPG", "POPS", "DPPC", "DOPC", "CHL", "CHOL"}
+ESTIMATED_PDB_ATOM_BYTES = 96
+BoxVectors = tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]
 
 
 def candidate_bases(stem: str) -> list[str]:
@@ -116,9 +120,43 @@ def resolve_inputs(input_path: Path) -> tuple[Path, Path]:
     return input_path, find_trj_for_cms(input_path)
 
 
-def frame_indices(frame_count: int, limit: int) -> list[int]:
+def candidate_cfg_paths(cms_path: Path) -> list[Path]:
+    candidates: list[Path] = []
+    for base in candidate_bases(cms_path.stem):
+        candidates.extend(
+            [
+                cms_path.with_name(f"{base}-out.cfg"),
+                cms_path.with_name(f"{base}.cfg"),
+                cms_path.with_name(f"{base}.cpt.cfg"),
+            ]
+        )
+    return list(dict.fromkeys(candidates))
+
+
+def desmond_box_from_cfg(cms_path: Path) -> BoxVectors | None:
+    for cfg_path in candidate_cfg_paths(cms_path):
+        if not cfg_path.is_file():
+            continue
+        text = cfg_path.read_text(encoding="utf-8", errors="ignore")
+        match = re.search(r"\bbox\s*=\s*\[([^\]]+)\]", text, re.DOTALL)
+        if not match:
+            continue
+        values = [float(value) for value in re.findall(r"[-+]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][-+]?\d+)?", match.group(1))]
+        if len(values) != 9:
+            continue
+        return (
+            (values[0], values[1], values[2]),
+            (values[3], values[4], values[5]),
+            (values[6], values[7], values[8]),
+        )
+    return None
+
+
+def frame_indices(frame_count: int, limit: int | None) -> list[int]:
     if frame_count <= 0:
         return []
+    if limit is None:
+        return list(range(frame_count))
     if frame_count <= limit:
         return list(range(frame_count))
     step = (frame_count - 1) / max(limit - 1, 1)
@@ -137,30 +175,26 @@ def is_hydrogen(atom) -> bool:
     return str(getattr(atom, "element", "")).strip().upper() == "H"
 
 
-def selected_atom_indices(structure, atom_limit: int) -> list[int]:
+def selected_atom_indices(structure, atom_limit: int | None) -> list[int]:
     atoms = list(structure.atom)
+    if atom_limit is None:
+        return [atom.index for atom in atoms]
     selected: list[int] = []
     selected_set: set[int] = set()
 
-    def append_indices(indices: list[int]) -> bool:
+    def append_indices(indices: list[int], limit: int | None = None) -> bool:
+        added = 0
         for index in indices:
             if index in selected_set:
                 continue
+            if limit is not None and added >= limit:
+                return len(selected) >= atom_limit
             if len(selected) >= atom_limit:
                 return True
             selected.append(index)
             selected_set.add(index)
+            added += 1
         return len(selected) >= atom_limit
-
-    backbone = [
-        atom.index
-        for atom in atoms
-        if residue_name(atom) in STANDARD_RESIDUES
-        and atom_pdb_name(atom) in BACKBONE_NAMES
-        and not is_hydrogen(atom)
-    ]
-    if append_indices(backbone):
-        return selected
 
     ligand_or_ion_heavy = [
         atom.index
@@ -170,8 +204,13 @@ def selected_atom_indices(structure, atom_limit: int) -> list[int]:
         and residue_name(atom) not in LIPID_RESIDUES
         and not is_hydrogen(atom)
     ]
-    if append_indices(ligand_or_ion_heavy):
-        return selected
+    backbone = [
+        atom.index
+        for atom in atoms
+        if residue_name(atom) in STANDARD_RESIDUES
+        and atom_pdb_name(atom) in BACKBONE_NAMES
+        and not is_hydrogen(atom)
+    ]
 
     lipid_heavy = [
         atom.index
@@ -179,8 +218,6 @@ def selected_atom_indices(structure, atom_limit: int) -> list[int]:
         if residue_name(atom) in LIPID_RESIDUES
         and not is_hydrogen(atom)
     ]
-    if append_indices(lipid_heavy):
-        return selected
 
     waters_by_residue: dict[tuple[str, int, str], list[int]] = {}
     for atom in atoms:
@@ -192,10 +229,24 @@ def selected_atom_indices(structure, atom_limit: int) -> list[int]:
             str(getattr(atom, "inscode", "") or " "),
         )
         waters_by_residue.setdefault(key, []).append(atom.index)
-    for water in waters_by_residue.values():
-        if append_indices(water):
-            break
+
+    ligand_quota = max(64, atom_limit // 5)
+    backbone_quota = max(128, atom_limit // 2)
+    lipid_quota = max(64, atom_limit // 5)
+    water_quota = max(0, atom_limit - ligand_quota - backbone_quota - lipid_quota)
+
+    if append_indices(ligand_or_ion_heavy, ligand_quota):
+        return selected
+    if append_indices(backbone, backbone_quota):
+        return selected
+    if append_indices(lipid_heavy, lipid_quota):
+        return selected
+    water_indices = [index for water in waters_by_residue.values() for index in water]
+    if append_indices(water_indices, water_quota):
+        return selected
     if selected:
+        if len(selected) < atom_limit:
+            append_indices([atom.index for atom in atoms if not is_hydrogen(atom)])
         return selected
 
     protein_heavy = [
@@ -210,6 +261,34 @@ def selected_atom_indices(structure, atom_limit: int) -> list[int]:
     if heavy:
         return heavy[:atom_limit]
     return [atom.index for atom in atoms[:atom_limit]]
+
+
+def adaptive_atom_limit(frame_count: int, atom_limit: int | None, target_mb: int | None) -> int | None:
+    if atom_limit is not None or target_mb is None or target_mb <= 0 or frame_count <= 0:
+        return atom_limit
+    target_bytes = target_mb * 1024 * 1024
+    per_frame = max(1, target_bytes // frame_count)
+    return max(250, int(per_frame // ESTIMATED_PDB_ATOM_BYTES))
+
+
+def vector_length(vector: tuple[float, float, float]) -> float:
+    return math.sqrt(sum(value * value for value in vector))
+
+
+def vector_angle(first: tuple[float, float, float], second: tuple[float, float, float]) -> float:
+    denominator = vector_length(first) * vector_length(second)
+    if denominator <= 0:
+        return 90.0
+    cosine = sum(a * b for a, b in zip(first, second)) / denominator
+    return math.degrees(math.acos(max(-1.0, min(1.0, cosine))))
+
+
+def pdb_cryst1_line(box: BoxVectors) -> str:
+    a, b, c = box
+    return (
+        f"CRYST1{vector_length(a):9.3f}{vector_length(b):9.3f}{vector_length(c):9.3f}"
+        f"{vector_angle(b, c):7.2f}{vector_angle(a, c):7.2f}{vector_angle(a, b):7.2f} P 1           1\n"
+    )
 
 
 def atom_symbol(atom) -> str:
@@ -256,17 +335,84 @@ def pdb_atom_line(serial: int, atom) -> str:
     )
 
 
-def write_pdb_frame(output, structure, selected_indices: list[int], frame_index: int, frame_count: int) -> None:
+def pdb_box_atom_line(serial: int, name: str, x: float, y: float, z: float) -> str:
+    return (
+        f"HETATM{serial:5d} {name:<4} BOX Z9999    "
+        f"{x:8.3f}{y:8.3f}{z:8.3f}{1.0:6.2f}{0.0:6.2f}"
+        f"           C  \n"
+    )
+
+
+def centered_box_vertices(box: BoxVectors) -> list[tuple[float, float, float]]:
+    a, b, c = box
+    vertices: list[tuple[float, float, float]] = []
+    for sa, sb, sc in (
+        (-0.5, -0.5, -0.5),
+        (0.5, -0.5, -0.5),
+        (0.5, 0.5, -0.5),
+        (-0.5, 0.5, -0.5),
+        (-0.5, -0.5, 0.5),
+        (0.5, -0.5, 0.5),
+        (0.5, 0.5, 0.5),
+        (-0.5, 0.5, 0.5),
+    ):
+        vertices.append(
+            (
+                sa * a[0] + sb * b[0] + sc * c[0],
+                sa * a[1] + sb * b[1] + sc * c[1],
+                sa * a[2] + sb * b[2] + sc * c[2],
+            )
+        )
+    return vertices
+
+
+def write_pdb_box(output, box: BoxVectors, serial_start: int) -> None:
+    vertices = centered_box_vertices(box)
+    for offset, (x, y, z) in enumerate(vertices):
+        output.write(pdb_box_atom_line(serial_start + offset, f"B{offset + 1}", x, y, z))
+    for first, second in (
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 4),
+        (0, 4),
+        (1, 5),
+        (2, 6),
+        (3, 7),
+    ):
+        output.write(f"CONECT{serial_start + first:5d}{serial_start + second:5d}\n")
+
+
+def write_pdb_frame(
+    output,
+    structure,
+    selected_indices: list[int],
+    frame_index: int,
+    frame_count: int,
+    box: BoxVectors | None,
+) -> None:
     atoms_by_index = {atom.index: atom for atom in structure.atom}
     selected = [atoms_by_index[index] for index in selected_indices if index in atoms_by_index]
     output.write(f"MODEL     {frame_index + 1:4d}\n")
     output.write(f"REMARK   Desmond preview frame {frame_index + 1} / {frame_count}\n")
     for serial, atom in enumerate(selected, start=1):
         output.write(pdb_atom_line(serial, atom))
+    if box is not None:
+        write_pdb_box(output, box, len(selected) + 1)
     output.write("ENDMDL\n")
 
 
-def extract(input_path: Path, frame_limit: int, atom_limit: int, output_path: Path | None) -> None:
+def extract(
+    input_path: Path,
+    frame_limit: int | None,
+    atom_limit: int | None,
+    target_mb: int | None,
+    output_path: Path | None,
+) -> None:
     cms_path, trj_dir = resolve_inputs(input_path)
     _, cms_model = topo.read_cms(str(cms_path))
     trajectory = traj.read_traj(str(trj_dir))
@@ -275,15 +421,18 @@ def extract(input_path: Path, frame_limit: int, atom_limit: int, output_path: Pa
         raise RuntimeError(f"No frames found in {trj_dir}")
 
     first_structure = topo.update_ct(cms_model.fsys_ct, cms_model, trajectory[indices[0]]).copy()
-    selected_indices = selected_atom_indices(first_structure, atom_limit)
+    selected_indices = selected_atom_indices(first_structure, adaptive_atom_limit(len(indices), atom_limit, target_mb))
     if not selected_indices:
         raise RuntimeError(f"No atoms selected from {cms_path}")
 
+    box = desmond_box_from_cfg(cms_path)
     output = output_path.open("w", encoding="utf-8") if output_path else sys.stdout
     try:
+        if box is not None:
+            output.write(pdb_cryst1_line(box))
         for index in indices:
             structure = topo.update_ct(cms_model.fsys_ct, cms_model, trajectory[index]).copy()
-            write_pdb_frame(output, structure, selected_indices, index, len(trajectory))
+            write_pdb_frame(output, structure, selected_indices, index, len(trajectory), box)
     finally:
         if output_path:
             output.close()
@@ -293,13 +442,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", help="Desmond .cms file or clickme.dtr pointer")
     parser.add_argument("--output", help="Output multi-frame XYZ path")
-    parser.add_argument("--frames", type=int, default=60)
-    parser.add_argument("--atoms", type=int, default=3000)
+    parser.add_argument("--frames", type=int, default=0, help="Maximum frames to include; 0 means all frames")
+    parser.add_argument("--atoms", type=int, default=0, help="Maximum atoms to include; 0 means all atoms unless --target-mb is set")
+    parser.add_argument("--target-mb", type=int, default=0, help="Approximate output size target for adaptive all-frame atom selection")
     args = parser.parse_args()
 
-    frame_limit = max(1, min(args.frames, 300))
-    atom_limit = max(1, min(args.atoms, 10000))
-    extract(Path(args.input).resolve(), frame_limit, atom_limit, Path(args.output).resolve() if args.output else None)
+    frame_limit = None if args.frames <= 0 else max(1, args.frames)
+    atom_limit = None if args.atoms <= 0 else max(1, args.atoms)
+    target_mb = None if args.target_mb <= 0 else max(1, args.target_mb)
+    extract(Path(args.input).resolve(), frame_limit, atom_limit, target_mb, Path(args.output).resolve() if args.output else None)
     return 0
 
 

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -71,6 +71,8 @@ const [
   viteConfig,
   bundleReportScript,
   previewRuntimeViewer,
+  previewRuntimeSource,
+  previewTextXyz,
   previewXyzrender,
   previewViewController,
   shortcutDocs,
@@ -152,6 +154,8 @@ const [
   source('apps/desktop/vite.config.ts'),
   source('scripts/bundle-report.mjs'),
   source('apps/desktop/src-tauri/src/preview/runtime_viewer.rs'),
+  source('apps/desktop/src-tauri/src/preview/runtime.rs'),
+  source('apps/desktop/src-tauri/src/preview/text_xyz.rs'),
   source('apps/desktop/src-tauri/src/preview/xyzrender.rs'),
   source('PreviewExtension/Platform/PreviewViewController.swift'),
   source('docs/keyboard-shortcuts.md'),
@@ -405,6 +409,17 @@ assert.match(desmondPreviewExtract, /LIPID_RESIDUES = \{"POPC", "POPE", "POPG", 
 assert.match(desmondPreviewExtract, /ligand_or_ion_heavy = \[/);
 assert.match(desmondPreviewExtract, /lipid_heavy = \[/);
 assert.match(desmondPreviewExtract, /parser\.add_argument\("--frames"/);
+assert.match(desmondPreviewExtract, /0 means all frames/);
+assert.match(desmondPreviewExtract, /def adaptive_atom_limit/);
+assert.match(desmondPreviewExtract, /def desmond_box_from_cfg/);
+assert.match(desmondPreviewExtract, /def pdb_cryst1_line/);
+assert.match(desmondPreviewExtract, /def write_pdb_box/);
+assert.match(desmondPreviewExtract, /CRYST1/);
+assert.match(desmondPreviewExtract, /CONECT/);
+assert.match(desmondPreviewExtract, /ligand_quota = max\(64, atom_limit \/\/ 5\)/);
+assert.match(desmondPreviewExtract, /backbone_quota = max\(128, atom_limit \/\/ 2\)/);
+assert.match(desmondPreviewExtract, /0 means all atoms unless --target-mb is set/);
+assert.match(desmondPreviewExtract, /parser\.add_argument\("--target-mb"/);
 assert.match(desmondPreviewExtract, /parser\.add_argument\("--output"/);
 assert.match(viteConfig, /plugins: \[react\(\), ketcherRaphaelImportShimPlugin\(\), deferKetcherCssPlugin\(\), browserDevXyzrenderPlugin\(\)\]/);
 assert.match(viteConfig, /join\(homedir\(\), "Desktop", "BurettePreviewSamples"\)/);
@@ -418,12 +433,28 @@ assert.match(viteConfig, /server\.middlewares\.use\("\/__burette\/read-file"/);
 assert.match(viteConfig, /server\.middlewares\.use\("\/__burette\/read-text-file"/);
 assert.match(viteConfig, /const TEXT_FILE_READ_LIMIT = 12 \* 1024 \* 1024/);
 assert.match(viteConfig, /function languageForTextExtension/);
+assert.match(viteConfig, /server\.middlewares\.use\("\/__burette\/file-bundle"/);
 assert.match(viteConfig, /const SCHRODINGER_RUN = "\/opt\/schrodinger\/suites2026-1\/run"/);
+assert.match(viteConfig, /const DESMOND_PREVIEW_TARGET_MB = 24/);
 assert.match(viteConfig, /desmond_preview_extract\.py/);
-assert.match(viteConfig, /"--frames", "30", "--atoms", "6000"/);
+assert.match(viteConfig, /"--frames",\s*"0",\s*"--atoms",\s*"0",\s*"--target-mb",\s*String\(DESMOND_PREVIEW_TARGET_MB\)/s);
+assert.match(viteConfig, /timeout: 0/);
 assert.match(viteConfig, /server\.middlewares\.use\("\/__burette\/desmond-preview"/);
 assert.match(viteConfig, /function isDesmondPreviewCandidate/);
+assert.match(viteConfig, /function resolveStructureFileBundle\(path: string\): StructureFileBundle/);
+assert.match(viteConfig, /function resolveDesmondFileBundle\(path: string\): StructureFileBundle \| null/);
+assert.match(viteConfig, /function resolveMdFileBundle\(path: string\): StructureFileBundle \| null/);
+assert.match(viteConfig, /casebookCmsCandidates\(trjDirectory, base\)/);
 assert.match(viteConfig, /"dtr"/);
+assert.match(tauriConfig, /"[^"]*scripts\/desmond_preview_extract\.py": "desmond_preview_extract\.py"/);
+assert.match(previewRuntimeSource, /fn create_desmond_trajectory_preview/);
+assert.match(previewRuntimeSource, /const DESMOND_PREVIEW_TARGET_MB: &str = "24"/);
+assert.match(previewRuntimeSource, /\.arg\("--frames"\)\s*\.arg\("0"\)\s*\.arg\("--atoms"\)\s*\.arg\("0"\)\s*\.arg\("--target-mb"\)\s*\.arg\(DESMOND_PREVIEW_TARGET_MB\)/s);
+assert.match(previewRuntimeSource, /fn is_desmond_preview_candidate/);
+assert.match(previewRuntimeSource, /fn resolve_structure_file_bundle\(path: &Path, extension: &str\) -> StructureFileBundle/);
+assert.match(previewRuntimeSource, /fn resolve_desmond_file_bundle\(path: &Path, extension: &str\) -> Option<StructureFileBundle>/);
+assert.match(previewRuntimeSource, /fn resolve_md_file_bundle\(path: &Path, extension: &str\) -> Option<StructureFileBundle>/);
+assert.match(previewRuntimeSource, /fn casebook_cms_candidates\(trj_dir: &Path, base: &str\) -> Vec<PathBuf>/);
 assert.match(viteConfig, /function isDevFileReadAllowed\(path: string\)/);
 assert.match(viteConfig, /async function collectDefaultDevFiles\(\)/);
 assert.match(viteConfig, /if \(path\.endsWith\("\/no-molecule-column\.csv"\)\) return;/);
@@ -1649,12 +1680,22 @@ assert.match(browserDevDocuments, /shouldOpenTrajectoryInMolstar[\s\S]*\? "molst
 assert.match(browserDevDocuments, /function defaultMolstarStyleForDocument\(/);
 assert.match(browserDevDocuments, /return trajectoryFrameCount > 1 \? "default" : preferences\.molstarStyle;/);
 assert.match(browserDevDocuments, /const molstarStyle = defaultMolstarStyleForDocument\(preferences, trajectoryFrameCount\);/);
+assert.match(browserDevDocuments, /waterRepresentation: "line"/);
+assert.match(browserDevDocuments, /function groPdbDataFromText\(text: string, label: string\)/);
+assert.match(browserDevDocuments, /representation: "solvent-lines"/);
+assert.match(browserDevDocuments, /"TP3", "TP4"/);
+assert.match(browserDevDocuments, /function parseGroBox\(lines: string\[\]\)/);
+assert.match(browserDevDocuments, /function pdbCryst1Line\(box: BoxVectors\)/);
+assert.match(browserDevDocuments, /function pdbBoxLines\(box: BoxVectors, serialStart: number\)/);
+assert.match(browserDevDocuments, /representation: "box-lines"/);
+assert.match(browserDevDocuments, /function boxPdbFromVectors\(box: BoxVectors, label: string\)/);
 assert.match(browserDevDocuments, /trajectoryControls: renderer === "molstar" && trajectoryFrameCount > 1/);
 assert.match(previewViewController, /let isXYZTrajectory = \(xyzPayload\?\.frameCount \?\? 0\) > 1/);
 assert.match(previewViewController, /requestedRendererMode == BurreteRendererMode\.auto/);
 assert.match(previewViewController, /renderer = BurreteRendererMode\.molstar/);
 assert.match(previewViewController, /"trajectoryControls": renderer == BurreteRendererMode\.molstar && resolvedTrajectoryFrameCount > 1/);
 assert.match(previewViewController, /"trajectoryFrameCount": resolvedTrajectoryFrameCount/);
+assert.match(previewViewController, /"waterRepresentation": "line"/);
 assert.match(previewViewController, /"quickLookViewer": true/);
 assert.match(previewViewController, /"sdfPosePager": renderer == BurreteRendererMode\.molstar && format\.molstarFormat == "sdf" && !format\.isBinary/);
 assert.match(previewViewController, /private static let maestroPreviewReadLimit = 64 \* 1024 \* 1024/);
@@ -1738,11 +1779,15 @@ assert.match(browserDevDocuments, /if \(!messageHandlers\.burrete\) \{/);
 assert.match(browserDevDocuments, /window\.__mqlAction = \(name\) => messageHandlers\.burrete\.postMessage/);
 assert.match(previewShell, /data-buret-toolbar-content/);
 assert.match(previewShell, /data-buret-action="ketcher"/);
+assert.match(previewShell, /data-buret-molstar-style-slot/);
+assert.match(previewShell, /data-buret-molstar-style aria-label="Mol\* preview style"/);
 assert.doesNotMatch(previewShell, /data-buret-renderer="xyz-fast"/);
 assert.doesNotMatch(previewShell, /id="buret-open-in-app"/);
 assert.doesNotMatch(previewShell, /data-buret-action="open-burrete"/);
 assert.match(previewRuntimeCss, /\.buret-xyzrender-preset-slot \{ display: none; align-items: center; \}/);
 assert.match(previewRuntimeCss, /\.buret-xyzrender-preset-slot\.visible \{ display: flex; \}/);
+assert.match(previewRuntimeCss, /\.buret-molstar-style-slot \{ display: none; align-items: center; \}/);
+assert.match(previewRuntimeCss, /\.buret-molstar-style-slot\.visible \{ display: flex; \}/);
 assert.match(previewRuntimeCss, /\.buret-corner-button \{/);
 assert.match(previewRuntimeCss, /body\.burette-quicklook-host \{\s*--buret-toolbar-safe-top: 56px;/s);
 assert.match(previewRuntimeCss, /body\.burette-quicklook-host \.buret-corner-button \{/);
@@ -1799,8 +1844,30 @@ assert.match(previewRuntimeViewer, /"defaultLayoutState": \{ "left": "hidden", "
 assert.match(previewRuntimeViewer, /preferences\.theme_for_runtime\(\)/);
 assert.match(previewRuntimeViewer, /preferences\.canvas_background_for_runtime\(\)/);
 assert.match(previewRuntimeViewer, /"molstarStyle": preferences\.resolved_molstar_style\(\)/);
+assert.match(previewRuntimeViewer, /"waterRepresentation": "line"/);
+assert.match(previewRuntimeViewer, /config\["stagedEntries"\]/);
+assert.match(previewTextXyz, /fn gro_pdb_data_from_text\(/);
+assert.match(previewTextXyz, /representation: "solvent-lines"/);
+assert.match(previewTextXyz, /"TP3"\s*\|\s*"TP4"/);
+assert.match(previewTextXyz, /fn parse_gro_box\(lines: &\[&str\]\) -> Option<BoxVectors>/);
+assert.match(previewTextXyz, /fn pdb_cryst1_line\(box_vectors: &BoxVectors\) -> String/);
+assert.match(previewTextXyz, /fn push_pdb_box_lines\(pdb: &mut String, box_vectors: &BoxVectors, serial_start: usize\)/);
+assert.match(previewTextXyz, /representation: "box-lines"/);
+assert.match(previewTextXyz, /fn box_pdb_from_vectors\(box_vectors: &BoxVectors, label: &str\) -> String/);
 assert.match(previewViewer, /const layoutState = \{\s*left: 'hidden',\s*right: 'hidden',\s*top: 'hidden',\s*bottom: 'hidden'\s*\}/);
 assert.match(previewViewer, /const DEFAULT_MOLSTAR_STYLE = 'illustrative'/);
+assert.match(previewViewer, /const MOLSTAR_STYLE_OPTIONS = \[/);
+assert.match(previewViewer, /\{ value: 'molecular-surface', label: 'Surface' \}/);
+assert.match(previewViewer, /function populateMolstarStyleSelect\(select\)/);
+assert.match(previewViewer, /function bindMolstarStyleControls\(toolbar\)/);
+assert.match(previewViewer, /function requestMolstarStyle\(style\)/);
+assert.match(previewViewer, /async function reloadMolstarStyle\(viewer, style, serial\)/);
+assert.match(previewViewer, /async function applyMolstarUniformRepresentation\(viewer, representation\)/);
+assert.match(previewViewer, /async function applyMolstarPolymerLigandRepresentation\(viewer, polymerRepresentation, ligandRepresentation\)/);
+assert.match(previewViewer, /type: 'molecular-surface'/);
+assert.match(previewViewer, /type: 'spacefill'/);
+assert.match(previewViewer, /type: 'ball-and-stick'/);
+assert.match(previewViewer, /type: 'cartoon'/);
 assert.match(previewViewer, /function normalizeMolstarStyle\(value\)/);
 assert.match(previewViewer, /function configuredMolstarStyle\(config\)/);
 assert.match(previewViewer, /if \(canvasBackground === 'auto'\) return resolveViewerTheme\(\) === 'light' \? 'white' : 'graphite';/);
@@ -1819,10 +1886,21 @@ assert.match(previewViewer, /if \(region === 'left'\) layoutState\.left = layout
 assert.match(previewViewer, /await plugin\.builders\.structure\.hierarchy\.applyPreset\(trajectory, 'default'\)/);
 assert.match(previewViewer, /await applyMolstarStyle\(viewer, configuredMolstarStyle\(activeConfig\)\)/);
 assert.match(previewViewer, /function isMolstarWaterComponent\(component\)/);
-assert.match(previewViewer, /key\.split\(','\)\.includes\('water'\)/);
+assert.match(previewViewer, /const isGroDocument = format === 'gro'/);
+assert.match(previewViewer, /isGroDocument && normalizedLabel\.includes\('non-standard'\)/);
+assert.match(previewViewer, /keyParts\.includes\('water'\) \|\| keyParts\.includes\('solvent'\)/);
+assert.match(previewViewer, /'hoh', 'wat', 'sol', 'tip3', 'tip3p', 'spc', 'tip4p'/);
+assert.match(previewViewer, /async function tryCreateMolstarWaterComponent\(plugin, structure\)/);
+assert.match(previewViewer, /tryCreateComponentStatic\(target, 'water'\)/);
+assert.match(previewViewer, /function shouldUseMolstarWaterLines\(config\)/);
+assert.match(previewViewer, /waterRepresentation \|\| 'line'/);
 assert.match(previewViewer, /async function applyMolstarWaterLineRepresentation\(viewer\)/);
 assert.match(previewViewer, /await plugin\.managers\.structure\.component\.removeRepresentations\(waterComponents\)/);
-assert.match(previewViewer, /type: 'line',\s*typeParams: \{\s*alpha: 0\.6,\s*visuals: \['intra-bond', 'element-point'\]\s*\},\s*color: 'element-symbol'/s);
+assert.match(previewViewer, /type: 'line',\s*typeParams: \{\s*alpha: 0\.32,\s*sizeFactor: 0\.035,\s*visuals: \['intra-bond'\]\s*\},\s*color: 'uniform',\s*colorParams: \{ value: 0x8aa4b8 \},\s*size: 'uniform',\s*sizeParams: \{ value: 0\.03 \}/s);
+assert.match(previewViewer, /async function loadMolstarEntryAsBoxLines\(viewer, entry\)/);
+assert.match(previewViewer, /entry\.representation === 'box-lines'/);
+assert.match(previewViewer, /colorParams: \{ value: 0x2f6f66 \}/);
+assert.doesNotMatch(previewViewer, /visuals: \['intra-bond', 'element-point'\]/);
 assert.match(previewViewer, /await applyMolstarStyle\(viewer, configuredMolstarStyle\(activeConfig\)\);\s*await applyMolstarWaterLineRepresentation\(viewer\);/);
 assert.match(previewViewer, /plugin\.managers\.structure\.component\.setOptions\(\{\s*\.\.\.plugin\.managers\.structure\.component\.state\.options,\s*ignoreLight: true\s*\}\)/s);
 assert.match(previewViewer, /postprocessing:\s*\{\s*outline:/s);


### PR DESCRIPTION
## Summary

- Add automatic file bundle resolution for Desmond CMS/DTR and paired MD topology/trajectory files.
- Extract bounded all-frame Desmond previews through the packaged Schrodinger helper, including trajectory frame controls and box metadata when available.
- Convert GRO files for Mol* with solvent split into thin line staging and box split into dedicated line staging.
- Add a Mol* preview style selector for common Mol* representations while preserving staged water and box overlays.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun run --cwd apps/desktop typecheck`
- `python3 -m py_compile scripts/desmond_preview_extract.py`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/burette-cargo-target-b066 cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `CARGO_TARGET_DIR=/private/tmp/burette-cargo-target-b066 cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml preview::text_xyz::tests::converts_gro_box_to_pdb_cryst1_and_frame_edges`
- `git push` pre-push hook: `ci-fast`
