### PR TITLE
Route file drops to dock panels

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1543,6 +1543,7 @@ export default function App() {
     openStructureRecords,
     openKetcherWithStructures,
     openFepSetupWorkspace,
+    openDockPayload,
     appendGridRecords,
     addXyzrenderSheetItems,
     addProjectRoots: addDroppedProjectRoots,

--- a/apps/desktop/src/components/dock-panel.tsx
+++ b/apps/desktop/src/components/dock-panel.tsx
@@ -7,7 +7,8 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { DOCK_TAB_LABELS, dockTabCatalog, type DockArea, type DockTabKind } from "../lib/dock";
-import { hasStructureDrag, readStructureDragPayload } from "../lib/structure-drag";
+import { hasStructureDrag, readStructureDragPayload, writeStructureDragPayload } from "../lib/structure-drag";
+import type { StructureDragPayload } from "../lib/structure-drag";
 import type { ShellActions, ShellViewState } from "./types";
 import { showNativeContextMenu } from "./native-context-menu";
 import { formatBytes } from "./format";
@@ -42,6 +43,11 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
   const size = area === "right" ? state.rightDockWidth : state.bottomDockHeight;
   const dragging = area === "right" ? state.rightDockDragging : state.bottomDockDragging;
   const activeTab = tabs.find((tab) => tab.kind === activeTabKind) ?? tabs[0];
+  const dockDocumentId = area === "right" ? state.rightDockDocumentId : state.bottomDockDocumentId;
+  const dockTool = area === "right" ? state.rightDockTool : state.bottomDockTool;
+  const dockDocument = dockDocumentId ? state.documents.find((document) => document.id === dockDocumentId) ?? null : null;
+  const dockTextDocument = dockDocumentId ? state.textDocuments.find((document) => document.id === dockDocumentId) ?? null : null;
+  const filesTabDragPayload = dockFilesDragPayload(dockDocument, dockTextDocument, dockTool);
   const dockDrops = useMemo(
     () => state.dockDroppedStructures.filter((item) => item.area === area && item.tabKind === activeTab.kind),
     [activeTab.kind, area, state.dockDroppedStructures],
@@ -90,6 +96,7 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
     <aside
       className="dock-panel"
       data-area={area}
+      data-active-tab={activeTab.kind}
       data-open={open ? "true" : "false"}
       data-dragging={dragging || undefined}
       data-drop-active={dropActive || undefined}
@@ -134,6 +141,13 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
                     type="button"
                     className="dock-tab"
                     data-active={active || undefined}
+                    draggable={tab.kind === "files" && Boolean(filesTabDragPayload)}
+                    onDragStart={(event) => {
+                      if (tab.kind !== "files" || !filesTabDragPayload) return;
+                      writeStructureDragPayload(event.dataTransfer, filesTabDragPayload);
+                      actions.setStructureDragActive(true);
+                    }}
+                    onDragEnd={() => actions.setStructureDragActive(false)}
                     onClick={() => actions.setDockActiveTab(area, tab.kind)}
                     role="tab"
                     aria-selected={active}
@@ -230,7 +244,7 @@ function DockPanelContent({
             Show metadata
           </button>
         ) : null}
-        <DockDropList items={dockDrops} emptyLabel="No inspected drops" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No inspected drops" />
       </div>
     );
   }
@@ -238,7 +252,7 @@ function DockPanelContent({
     return (
       <div className="dock-content">
         <Metric label="Basket" value={`${dockDrops.length} structure${dockDrops.length === 1 ? "" : "s"}`} />
-        <DockDropList items={dockDrops} emptyLabel="No structures" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No structures" />
       </div>
     );
   }
@@ -247,7 +261,7 @@ function DockPanelContent({
       <div className="dock-content">
         <Metric label="Compare set" value={`${dockDrops.length} structure${dockDrops.length === 1 ? "" : "s"}`} />
         <Metric label="Active source" value={activeDocument?.title ?? "None"} />
-        <DockDropList items={dockDrops} emptyLabel="No compare inputs" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No compare inputs" />
       </div>
     );
   }
@@ -256,7 +270,7 @@ function DockPanelContent({
       <div className="dock-content">
         <Metric label="Renderer jobs" value="Idle" />
         <Metric label="Open runtimes" value={String(state.documents.length)} />
-        <DockDropList items={dockDrops} emptyLabel="No job inputs" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No job inputs" />
       </div>
     );
   }
@@ -267,7 +281,7 @@ function DockPanelContent({
         <button type="button" className="dock-action" onClick={() => void actions.openLogs()}>
           Open logs folder
         </button>
-        <DockDropList items={dockDrops} emptyLabel="No log inputs" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No log inputs" />
       </div>
     );
   }
@@ -280,7 +294,7 @@ function DockPanelContent({
         <button type="button" className="dock-action" onClick={() => void actions.exportDiagnostics()}>
           Export diagnostics
         </button>
-        <DockDropList items={dockDrops} emptyLabel="No diagnostic inputs" />
+        <DockDropList items={dockDrops} actions={actions} emptyLabel="No diagnostic inputs" />
       </div>
     );
   }
@@ -288,9 +302,48 @@ function DockPanelContent({
     <div className="dock-content">
       <Metric label={area === "right" ? "Review context" : "Review queue"} value={activeDocument?.title ?? "None"} />
       <Metric label="Dropped inputs" value={String(dockDrops.length)} />
-      <DockDropList items={dockDrops} emptyLabel="No review inputs" />
+      <DockDropList items={dockDrops} actions={actions} emptyLabel="No review inputs" />
     </div>
   );
+}
+
+function dockFilesDragPayload(
+  dockDocument: ShellViewState["documents"][number] | null,
+  dockTextDocument: ShellViewState["textDocuments"][number] | null,
+  dockTool: ShellViewState["rightDockTool"],
+): StructureDragPayload | null {
+  if (dockDocument) {
+    return {
+      paths: [dockDocument.path],
+      records: [],
+      items: [{
+        kind: "file",
+        title: dockDocument.title,
+        detail: dockDocument.renderer,
+        path: dockDocument.path,
+      }],
+    };
+  }
+  if (dockTextDocument) {
+    return {
+      paths: [dockTextDocument.path],
+      records: [],
+      items: [{
+        kind: "writer",
+        title: dockTextDocument.title,
+        detail: dockTextDocument.extension,
+        path: dockTextDocument.path,
+      }],
+    };
+  }
+  if (dockTool === "ketcher") {
+    return {
+      paths: [],
+      records: [],
+      items: [{ kind: "ketcher", title: "Ketcher", detail: "Sketcher" }],
+    };
+  }
+  return null;
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
@@ -302,13 +355,30 @@ function Metric({ label, value }: { label: string; value: string }) {
   );
 }
 
-function DockDropList({ items, emptyLabel }: { items: ShellViewState["dockDroppedStructures"]; emptyLabel: string }) {
+function DockDropList({
+  items,
+  actions,
+  emptyLabel,
+}: {
+  items: ShellViewState["dockDroppedStructures"];
+  actions: ShellActions;
+  emptyLabel: string;
+}) {
   return (
     <div className="dock-drop-list">
       {items.length === 0 ? (
         <div className="dock-empty">{emptyLabel}</div>
       ) : items.map((item) => (
-        <div className="dock-drop-item" key={item.id}>
+        <div
+          className="dock-drop-item"
+          key={item.id}
+          draggable
+          onDragStart={(event) => {
+            writeStructureDragPayload(event.dataTransfer, item.payload);
+            actions.setStructureDragActive(true);
+          }}
+          onDragEnd={() => actions.setStructureDragActive(false)}
+        >
           <strong>{item.title}</strong>
           <span>{item.detail}</span>
         </div>

--- a/apps/desktop/src/hooks/use-open-drop.ts
+++ b/apps/desktop/src/hooks/use-open-drop.ts
@@ -6,6 +6,7 @@ import type { DockingDocumentRequest, FepSetupRequest, ViewerDocument } from "..
 import { resolveDropActionChoices } from "../lib/drop-actions";
 import type { DropSourceContext, DropTargetContext } from "../lib/drop-actions";
 import type { DropAction, DropActionChoice } from "../lib/drop-actions";
+import type { DockArea, DockDropInput, DockTabKind } from "../lib/dock";
 import { hasStructureDrag, readStructureDragPayload, structureDragPayloadFromText, structureDragRecordsToFragments } from "../lib/structure-drag";
 import type { StructureDragPayload, StructureDragRecord } from "../lib/structure-drag";
 import { isTauriRuntime } from "../lib/tauri";
@@ -20,12 +21,19 @@ type OpenDockingStructureRecords = (receptorPath: string, ligandPaths: string[],
 type OpenStructureRecords = (records: StructureDragRecord[]) => void | Promise<void>;
 type OpenKetcherWithStructures = (paths: string[], fragments?: Array<{ title: string; text: string }>) => void;
 type OpenFepSetupWorkspace = (request: FepSetupRequest) => void;
+type OpenDockPayload = (input: DockDropInput) => void | Promise<void>;
 type AppendGridRecords = (targetDocumentId: string, payload: StructureDragPayload) => boolean;
 type AddXyzrenderSheetItems = (payload: StructureDragPayload) => boolean;
 type MergeMoleculeCollections = (paths: string[]) => boolean;
 type AddProjectRoots = (paths: string[]) => void;
 type ReportStatus = (status: string, kind?: "info" | "error") => void;
 type DropPoint = { x: number; y: number };
+type DockDropTargetContext = {
+  kind: "dock";
+  area: DockArea;
+  tabKind: DockTabKind;
+};
+type OpenDropTargetContext = DropTargetContext | DockDropTargetContext;
 type ChooseDropAction = (
   choices: DropActionChoice[],
   at: DropPoint | null | undefined,
@@ -45,6 +53,7 @@ type OpenDropOptions = {
   openStructureRecords?: OpenStructureRecords;
   openKetcherWithStructures?: OpenKetcherWithStructures;
   openFepSetupWorkspace?: OpenFepSetupWorkspace;
+  openDockPayload?: OpenDockPayload;
   appendGridRecords?: AppendGridRecords;
   addXyzrenderSheetItems?: AddXyzrenderSheetItems;
   mergeMoleculeCollections?: MergeMoleculeCollections;
@@ -68,6 +77,16 @@ function tauriDropPoint(position: { x: number; y: number } | null | undefined) {
   return { x: position.x / scale, y: position.y / scale };
 }
 
+function elementFromTauriDropPosition(position: { x: number; y: number } | null | undefined) {
+  if (!position || typeof document === "undefined") return null;
+  const scaled = tauriDropPoint(position);
+  const candidates = [
+    scaled ? document.elementFromPoint(scaled.x, scaled.y) : null,
+    document.elementFromPoint(position.x, position.y),
+  ].filter((element): element is Element => Boolean(element));
+  return candidates.find((element) => element.closest(".dock-panel")) ?? candidates[0] ?? null;
+}
+
 export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStatus, options: OpenDropOptions = {}) {
   const [dropActive, setDropActive] = useState(false);
   const {
@@ -83,6 +102,7 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
     openStructureRecords,
     openKetcherWithStructures,
     openFepSetupWorkspace,
+    openDockPayload,
     appendGridRecords,
     addXyzrenderSheetItems,
     mergeMoleculeCollections,
@@ -101,7 +121,15 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
     };
   }, [activeDockingRequest, activeDocumentId, activeDocumentPath, activeDocumentRenderer]);
 
-  const dropTargetForElement = useCallback((element: Element | null): DropTargetContext => {
+  const dropTargetForElement = useCallback((element: Element | null): OpenDropTargetContext => {
+    const dockTarget = element?.closest<HTMLElement>(".dock-panel[data-area][data-active-tab]");
+    if (dockTarget) {
+      const area = dockTarget.dataset.area;
+      const tabKind = dockTarget.dataset.activeTab;
+      if ((area === "right" || area === "bottom") && tabKind) {
+        return { kind: "dock", area, tabKind: tabKind as DockTabKind };
+      }
+    }
     if (fepSetupRequest && element?.closest(".pose-review-workspace, .fep-setup-workspace")) {
       return { kind: "fep-setup", request: fepSetupRequest };
     }
@@ -129,11 +157,9 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
     return { kind: "workspace" };
   }, [activeTabKind, activeViewerTarget, documents, fepSetupRequest]);
 
-  const dropTargetForPosition = useCallback((position: { x: number; y: number } | null = null): DropTargetContext => {
+  const dropTargetForPosition = useCallback((position: { x: number; y: number } | null = null): OpenDropTargetContext => {
     if (typeof document === "undefined") return activeTabKind === "ketcher" ? { kind: "ketcher" } : { kind: "workspace" };
-    const element = position
-      ? document.elementFromPoint(position.x / window.devicePixelRatio, position.y / window.devicePixelRatio)
-      : document.activeElement;
+    const element = position ? elementFromTauriDropPosition(position) : document.activeElement;
     return dropTargetForElement(element);
   }, [activeTabKind, dropTargetForElement]);
 
@@ -228,9 +254,13 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
 
   const runDropAction = useCallback((
     payload: StructureDragPayload,
-    target: DropTargetContext,
+    target: OpenDropTargetContext,
     source: DropSourceContext = { kind: "unknown" },
   ) => {
+    if (target.kind === "dock") {
+      void openDockPayload?.({ area: target.area, tabKind: target.tabKind, payload });
+      return;
+    }
     const choices = resolveDropActionChoices(
       payload,
       target,
@@ -250,11 +280,12 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
   }, [
     chooseDropAction,
     executeDropAction,
+    openDockPayload,
   ]);
 
   const runFinderDropAction = useCallback(async (
     payload: StructureDragPayload,
-    target: DropTargetContext,
+    target: OpenDropTargetContext,
   ) => {
     if (payload.paths.length === 0 || !isTauriRuntime()) {
       runDropAction(payload, target, { kind: "finder" });

--- a/apps/desktop/src/lib/dock.ts
+++ b/apps/desktop/src/lib/dock.ts
@@ -25,6 +25,7 @@ export type DockDroppedStructure = {
   title: string;
   detail: string;
   addedAt: number;
+  payload: StructureDragPayload;
 };
 
 export type DockDropInput = {

--- a/apps/desktop/src/stores/shell-store.ts
+++ b/apps/desktop/src/stores/shell-store.ts
@@ -117,6 +117,7 @@ function dockDropItems(input: DockDropInput): DockDroppedStructure[] {
     title: path.split(/[\\/]/u).pop() || path,
     detail: path,
     addedAt: now + index,
+    payload: { paths: [path], records: [] },
   }));
   const records = input.payload.records.map((record, index) => ({
     id: `${now}-${input.area}-${input.tabKind}-record-${index}-${record.path}`,
@@ -125,6 +126,7 @@ function dockDropItems(input: DockDropInput): DockDroppedStructure[] {
     title: record.path,
     detail: `${record.inputExtension.toUpperCase()} inline structure`,
     addedAt: now + paths.length + index,
+    payload: { paths: [], records: [record] },
   }));
   const items = (input.payload.items ?? []).map((item, index) => ({
     id: `${now}-${input.area}-${input.tabKind}-item-${index}-${item.kind}-${item.title}`,
@@ -133,6 +135,7 @@ function dockDropItems(input: DockDropInput): DockDroppedStructure[] {
     title: item.title,
     detail: item.detail ?? item.path ?? item.kind,
     addedAt: now + paths.length + records.length + index,
+    payload: { paths: item.path ? [item.path] : [], records: [], items: [item] },
   }));
   return [...paths, ...records, ...items];
 }

--- a/tests/test-open-drop-contract.mjs
+++ b/tests/test-open-drop-contract.mjs
@@ -7,12 +7,18 @@ const source = await readFile(new URL("../apps/desktop/src/hooks/use-open-drop.t
 assert.match(source, /const fileDrop = Array\.from\(event\.dataTransfer\.types\)\.includes\("Files"\);/);
 assert.match(source, /const structureDrop = hasStructureDrag\(event\.dataTransfer\);/);
 assert.match(source, /if \(!fileDrop && !structureDrop\) return;/);
+assert.match(source, /type DockDropTargetContext = \{[\s\S]*kind: "dock";[\s\S]*area: DockArea;[\s\S]*tabKind: DockTabKind;[\s\S]*\};/);
+assert.match(source, /elementFromTauriDropPosition\(position\)/);
+assert.match(source, /candidates\.find\(\(element\) => element\.closest\("\.dock-panel"\)\) \?\? candidates\[0\]/);
+assert.match(source, /const dockTarget = element\?\.closest<HTMLElement>\("\.dock-panel\[data-area\]\[data-active-tab\]"\);/);
+assert.match(source, /return \{ kind: "dock", area, tabKind: tabKind as DockTabKind \};/);
 assert.match(source, /const payload = structureDrop\s*\?\s*readStructureDragPayload\(event\.dataTransfer\)/);
 assert.match(source, /invoke<ClassifiedOpenPaths>\("classify_open_paths", \{ paths: payload\.paths \}\)/);
 assert.match(source, /addProjectRoots\?\.\(classified\.directories\);/);
 assert.match(source, /if \(classified\.directories\.length > 0\) \{\s*addProjectRoots\?\.\(classified\.directories\);\s*\}/);
 assert.doesNotMatch(source, /if \(classified\.directories\.length > 0\) \{\s*addProjectRoots\?\.\(classified\.directories\);\s*return;\s*\}/);
 assert.match(source, /paths: classified\.files/);
+assert.match(source, /if \(target\.kind === "dock"\) \{\s*void openDockPayload\?\.\(\{ area: target\.area, tabKind: target\.tabKind, payload \}\);\s*return;\s*\}/);
 assert.match(source, /void runFinderDropAction\(payload, dropTargetForElement\(target\)\);/);
 assert.match(source, /runDropAction\(payload, dropTargetForElement\(target\), \{ kind: "unknown" \}\);/);
 

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -18,6 +18,7 @@ const [
   settingsStore,
   settingsHook,
   shellStore,
+  dock,
   packageJson,
   themeSource,
   appLayout,
@@ -102,6 +103,7 @@ const [
   source('apps/desktop/src/stores/settings-store.ts'),
   source('apps/desktop/src/hooks/use-settings.ts'),
   source('apps/desktop/src/stores/shell-store.ts'),
+  source('apps/desktop/src/lib/dock.ts'),
   source('package.json'),
   source('apps/desktop/src/lib/theme.ts'),
   source('apps/desktop/src/components/app-layout.tsx'),
@@ -1027,8 +1029,15 @@ assert.match(app, /setDockOpen\("bottom", false\)/);
 assert.match(app, /\[rightDockWidth, setDockOpen, setDockSize\]/);
 assert.match(app, /\[bottomDockHeight, setDockOpen, setDockSize\]/);
 assert.match(dockPanel, /data-open=\{open \? "true" : "false"\}/);
+assert.match(dockPanel, /data-active-tab=\{activeTab\.kind\}/);
 assert.match(dockPanel, /data-dragging=\{dragging \|\| undefined\}/);
 assert.doesNotMatch(dockPanel, /if \(!open\) return null/);
+assert.match(dockPanel, /function dockFilesDragPayload/);
+assert.match(dockPanel, /writeStructureDragPayload\(event\.dataTransfer, filesTabDragPayload\)/);
+assert.match(dockPanel, /writeStructureDragPayload\(event\.dataTransfer, item\.payload\)/);
+assert.match(dock, /payload: StructureDragPayload/);
+assert.match(shellStore, /payload: \{ paths: \[path\], records: \[\] \}/);
+assert.match(shellStore, /payload: \{ paths: \[\], records: \[record\] \}/);
 assert.match(dockPanel, /className="dock-panel-inner"/);
 assert.match(dockPanel, /style=\{area === "right" \? \{ width: size \} : \{ height: size \}\}/);
 assert.match(styles, /--dock-divider-color: color-mix\(in srgb, var\(--text-primary\) 52%, var\(--bg-base\)\)/);
@@ -1682,7 +1691,12 @@ assert.match(openDropHook, /if \(!handled\) runChoice\(choices\[0\]\)/);
 assert.match(openDropHook, /documentPath: activeDocumentPath/);
 assert.match(openDropHook, /renderer: activeDocumentRenderer/);
 assert.match(openDropHook, /void openDockingDocument\(action\.request\.receptorPath, action\.request\.ligandPaths\)/);
-assert.match(openDropHook, /document\.elementFromPoint\(position\.x \/ window\.devicePixelRatio, position\.y \/ window\.devicePixelRatio\)/);
+assert.match(openDropHook, /function elementFromTauriDropPosition/);
+assert.match(openDropHook, /scaled \? document\.elementFromPoint\(scaled\.x, scaled\.y\) : null/);
+assert.match(openDropHook, /document\.elementFromPoint\(position\.x, position\.y\)/);
+assert.match(openDropHook, /candidates\.find\(\(element\) => element\.closest\("\.dock-panel"\)\) \?\? candidates\[0\]/);
+assert.match(openDropHook, /const dockTarget = element\?\.closest<HTMLElement>\("\.dock-panel\[data-area\]\[data-active-tab\]"\)/);
+assert.match(openDropHook, /void openDockPayload\?\.\(\{ area: target\.area, tabKind: target\.tabKind, payload \}\)/);
 assert.match(openDropHook, /element\?\.closest\("\.molecule-stage, \.main-stage"\)/);
 assert.match(openDropHook, /void runFinderDropAction\(payload, dropTargetForPosition\(event\.position\)\)/);
 assert.match(openDropHook, /const structureDrop = hasStructureDrag\(event\.dataTransfer\)/);


### PR DESCRIPTION
## Summary

- route native Finder drops to the right or bottom dock when the pointer is over a dock panel
- let dock entries and the active Files dock tab write the shared structure drag payload so files can move between main, right, and bottom surfaces
- add contract coverage for dock drop targets and draggable dock payloads

## Validation

- vp run test:ui
- bun run --cwd apps/desktop typecheck
- git diff --check
- pre-push ci-fast
