### PR TITLE
Add shortcut hover tooltips

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -6,6 +6,7 @@ import { ViewerArea } from "./editor-area";
 import { EditorTabs } from "./editor-area/editor-tabs";
 import { NotificationPopup } from "./notification-popup";
 import { Sidebar } from "./sidebar";
+import { ShortcutTooltip } from "./shortcut-tooltip";
 import type { ShellActions, ShellViewState } from "./types";
 import { isTauriRuntime } from "../lib/tauri";
 import { buildThemeStyle, resolveThemeMode, useSystemThemeMode } from "../lib/theme";
@@ -82,10 +83,10 @@ export function AppLayout({
           className="chrome-button sidebar-toggle-root"
           onMouseDown={(event) => event.preventDefault()}
           onClick={onToggleSidebar}
-          title={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"}
           aria-label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"}
         >
           <HugeiconsIcon icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
+          <ShortcutTooltip label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"} shortcut={"⌘\\"} />
         </button>
       </div>
       <div className="chrome-trailing-controls" data-tauri-drag-region>
@@ -95,10 +96,10 @@ export function AppLayout({
           data-active={state.bottomDockOpen || undefined}
           onMouseDown={(event) => event.preventDefault()}
           onClick={() => actions.toggleDock("bottom")}
-          title={state.bottomDockOpen ? "Hide bottom dock" : "Show bottom dock"}
           aria-label={state.bottomDockOpen ? "Hide bottom dock" : "Show bottom dock"}
         >
           <HugeiconsIcon className="dock-toggle-icon-bottom" icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
+          <ShortcutTooltip label={state.bottomDockOpen ? "Hide bottom dock" : "Show bottom dock"} shortcut="⌘J" />
         </button>
         <button
           type="button"
@@ -106,10 +107,10 @@ export function AppLayout({
           data-active={state.rightDockOpen || undefined}
           onMouseDown={(event) => event.preventDefault()}
           onClick={() => actions.toggleDock("right")}
-          title={state.rightDockOpen ? "Hide right dock" : "Show right dock"}
           aria-label={state.rightDockOpen ? "Hide right dock" : "Show right dock"}
         >
           <HugeiconsIcon className="dock-toggle-icon-right" icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
+          <ShortcutTooltip label={state.rightDockOpen ? "Hide right dock" : "Show right dock"} shortcut="⌥⌘B" />
         </button>
       </div>
       <header

--- a/apps/desktop/src/components/shortcut-tooltip.tsx
+++ b/apps/desktop/src/components/shortcut-tooltip.tsx
@@ -1,0 +1,14 @@
+type ShortcutTooltipProps = {
+  label: string;
+  shortcut: string;
+  side?: "top" | "bottom";
+};
+
+export function ShortcutTooltip({ label, shortcut, side = "bottom" }: ShortcutTooltipProps) {
+  return (
+    <span className="shortcut-tooltip" data-side={side} role="tooltip" aria-hidden="true">
+      <span className="shortcut-tooltip-label">{label}</span>
+      <kbd className="shortcut-tooltip-key">{shortcut}</kbd>
+    </span>
+  );
+}

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -6,6 +6,7 @@ import { hasStructureDrag, readStructureDragPayload, writeStructureDragItems } f
 import { runShellDropActionChoices, shellDropActionChoices } from "../drop-action-executor";
 import { RadixDropdownMenu } from "../radix-menu";
 import { ScrollFade } from "../scroll-fade";
+import { ShortcutTooltip } from "../shortcut-tooltip";
 import type { ShellActions, ShellViewState } from "../types";
 import { ProjectGroup, ProjectItem } from "./file-tree-node";
 
@@ -82,6 +83,7 @@ export function FileBrowser({
         </span>
         <span className="sidebar-search-label">Search</span>
         <kbd>⌘<span>P</span></kbd>
+        <ShortcutTooltip label="Search projects and structures" shortcut="⌘P" />
       </button>
       <button
         type="button"

--- a/apps/desktop/src/components/welcome/index.tsx
+++ b/apps/desktop/src/components/welcome/index.tsx
@@ -1,4 +1,5 @@
 import type { BuildInfo, ShellActions } from "../types";
+import { ShortcutTooltip } from "../shortcut-tooltip";
 
 function buildLabel(info: BuildInfo) {
   if (info.isBrowserDev) return `Browser dev · v${info.version}`;
@@ -33,9 +34,16 @@ export function WelcomeScreen({ actions, buildInfo }: { actions: ShellActions; b
       <div className="new-tab-actions">
         <button type="button" className="welcome-primary" onClick={() => void actions.chooseFiles()}>
           Open Structure <kbd>⌘O</kbd>
+          <ShortcutTooltip label="Open Structure" shortcut="⌘O" />
         </button>
-        <button type="button" onClick={actions.openCommandPalette}>Command Palette <kbd>⌘P</kbd> <kbd>/</kbd></button>
-        <button type="button" onClick={actions.openSettings}>Settings <kbd>⌘,</kbd></button>
+        <button type="button" onClick={actions.openCommandPalette}>
+          Command Palette <kbd>⌘P</kbd> <kbd>/</kbd>
+          <ShortcutTooltip label="Command Palette" shortcut="⌘P /" />
+        </button>
+        <button type="button" onClick={actions.openSettings}>
+          Settings <kbd>⌘,</kbd>
+          <ShortcutTooltip label="Settings" shortcut="⌘," />
+        </button>
       </div>
     </div>
   );

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -242,6 +242,7 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 }
 .chrome-button,
 .new-tab {
+  position: relative;
   height: var(--chrome-control-height);
   border: 0;
   border-radius: 8px;
@@ -259,6 +260,75 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 .chrome-button[data-active] { background: var(--tab-active-bg); color: var(--text-secondary); }
 .chrome-button:active,
 .new-tab:active { transform: scale(0.94); }
+.shortcut-tooltip {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 8px);
+  z-index: 1200;
+  min-height: 38px;
+  max-width: min(360px, calc(100vw - 24px));
+  padding: 8px 10px 8px 14px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+  color: var(--text-primary);
+  box-shadow: 0 16px 44px rgb(0 0 0 / 0.28);
+  backdrop-filter: blur(30px) saturate(1.35);
+  -webkit-backdrop-filter: blur(30px) saturate(1.35);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  transform: translate(-50%, -4px) scale(0.98);
+  transform-origin: top center;
+  transition: opacity 110ms ease-out, transform 130ms ease-out;
+}
+.shortcut-tooltip[data-side="top"] {
+  top: auto;
+  bottom: calc(100% + 8px);
+  transform: translate(-50%, 4px) scale(0.98);
+  transform-origin: bottom center;
+}
+.chrome-trailing-controls .shortcut-tooltip {
+  left: auto;
+  right: 0;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top right;
+}
+button:hover > .shortcut-tooltip,
+button:focus-visible > .shortcut-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+.chrome-trailing-controls button:hover > .shortcut-tooltip,
+.chrome-trailing-controls button:focus-visible > .shortcut-tooltip {
+  transform: translateY(0) scale(1);
+}
+.shortcut-tooltip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 13px;
+  font-weight: 560;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+.shortcut-tooltip-key {
+  flex: 0 0 auto;
+  min-height: 24px;
+  border-radius: 999px;
+  padding: 4px 9px;
+  background: color-mix(in srgb, var(--fg-base) calc(var(--contrast) * 32%), transparent);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1;
+}
 .dock-toggle-icon-right { transform: scaleX(-1); }
 .dock-toggle-icon-bottom { transform: rotate(-90deg); }
 .tab-strip {
@@ -2532,9 +2602,10 @@ kbd span { margin-left: 2px; }
 .new-tab-build-badge { min-height: 22px; max-width: 260px; border-radius: 6px; padding: 3px 8px; display: inline-flex; align-items: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; background: var(--surface-subtle); color: var(--text-secondary); font-size: 11px; font-weight: 650; letter-spacing: 0; text-transform: uppercase; }
 .new-tab-build-detail { max-width: 760px; margin: 10px 0 0; color: var(--text-muted); font-size: 13px; line-height: 1.35; }
 .new-tab-actions { display: flex; flex-direction: column; align-items: center; gap: 12px; }
-.new-tab-page button { border: 0; border-radius: 8px; background: transparent; color: var(--text-secondary); font-size: 13px; font-weight: 500; height: 28px; padding: 0 8px; display: inline-flex; align-items: center; gap: 6px; transition: color 120ms ease, background 120ms ease; }
+.new-tab-page button { position: relative; border: 0; border-radius: 8px; background: transparent; color: var(--text-secondary); font-size: 13px; font-weight: 500; height: 28px; padding: 0 8px; display: inline-flex; align-items: center; gap: 6px; transition: color 120ms ease, background 120ms ease; }
 .new-tab-page button:hover { color: var(--text-primary); background: transparent; }
 .new-tab-page kbd { font-size: 11px; letter-spacing: 0.16em; color: var(--text-icon-muted); }
+.new-tab-page .shortcut-tooltip-key { color: var(--text-secondary); font-size: 13px; letter-spacing: 0; }
 .error-boundary {
   width: 100vw;
   height: 100vh;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -46,6 +46,7 @@ const [
   settingControl,
   dockPanel,
   closeIcon,
+  shortcutTooltip,
   pageKinds,
   pageKindTypes,
   fileKind,
@@ -131,6 +132,7 @@ const [
   source('apps/desktop/src/components/settings-panel/setting-control.tsx'),
   source('apps/desktop/src/components/dock-panel.tsx'),
   source('apps/desktop/src/components/close-icon.tsx'),
+  source('apps/desktop/src/components/shortcut-tooltip.tsx'),
   source('apps/desktop/src/components/editor-area/page-kinds/index.ts'),
   source('apps/desktop/src/components/editor-area/page-kinds/types.ts'),
   source('apps/desktop/src/components/editor-area/page-kinds/file.tsx'),
@@ -684,6 +686,10 @@ assert.match(editorTabs, /→/);
 assert.match(editorTabs, /import \{ CloseIcon \} from "\.\.\/close-icon"/);
 assert.match(editorTabs, /<CloseIcon size=\{13\} \/>/);
 assert.match(appLayout, /className="chrome-leading-controls"/);
+assert.match(appLayout, /from "\.\/shortcut-tooltip"/);
+assert.match(appLayout, /<ShortcutTooltip label=\{state\.sidebarOpen \? "Hide sidebar" : "Show sidebar"\} shortcut=\{"⌘\\\\"\} \/>/);
+assert.match(appLayout, /<ShortcutTooltip label=\{state\.bottomDockOpen \? "Hide bottom dock" : "Show bottom dock"\} shortcut="⌘J" \/>/);
+assert.match(appLayout, /<ShortcutTooltip label=\{state\.rightDockOpen \? "Hide right dock" : "Show right dock"\} shortcut="⌥⌘B" \/>/);
 assert.match(tauriConfig, /"trafficLightPosition":\s*\{\s*"x":\s*20,\s*"y":\s*29\s*\}/);
 assert.match(appLayout, /className="chrome-leading-controls" data-tauri-drag-region/);
 assert.match(editorTabs, /actions\.navigateBack/);
@@ -1001,6 +1007,11 @@ assert.match(appLayout, /resolveThemeMode\(state\.preferences\.theme, systemThem
 assert.match(styles, /\*\[data-tauri-drag-region\] \{[^}]*app-region: drag;[^}]*-webkit-app-region: drag;[^}]*\}/s);
 assert.match(styles, /button, select, input, textarea, \.tab-shell, \.tab, \.new-tab, \.chrome-button, \.tab-history-button, \.sidebar-search-row, \.sidebar-tool-row, \.sidebar-section-title-button, \.sidebar-section-menu-button, \.project-group-row, \.project-group-menu-button, \.project, \.project-show-more, \.pin-hit, \.splitter \{[^}]*app-region: no-drag;[^}]*-webkit-app-region: no-drag;[^}]*\}/s);
 assert.match(styles, /\.drag-region \{[^}]*height: var\(--chrome-drag-height\);[^}]*z-index: 2/s);
+assert.match(shortcutTooltip, /export function ShortcutTooltip/);
+assert.match(shortcutTooltip, /className="shortcut-tooltip"/);
+assert.match(styles, /\.shortcut-tooltip \{[^}]*position: absolute;[^}]*backdrop-filter: blur\(30px\) saturate\(1\.35\);[^}]*transform: translate\(-50%, -4px\) scale\(0\.98\);/s);
+assert.match(styles, /button:hover > \.shortcut-tooltip,\s*button:focus-visible > \.shortcut-tooltip \{[^}]*opacity: 1;[^}]*transform: translate\(-50%, 0\) scale\(1\);/s);
+assert.match(styles, /\.shortcut-tooltip-key \{[^}]*border-radius: 999px;[^}]*letter-spacing: 0;/s);
 assert.doesNotMatch(styles, /\.workspace \{[^}]*z-index:/s);
 assert.match(styles, /\.splitter \{[^}]*z-index: 3;/s);
 assert.match(styles, /--sidebar-divider-right: transparent/);
@@ -1391,6 +1402,10 @@ assert.match(welcome, /buildInfo\.isDevBuild/);
 assert.match(welcome, /Open Structure/);
 assert.match(welcome, /Command Palette/);
 assert.match(welcome, /Settings/);
+assert.match(welcome, /from "\.\.\/shortcut-tooltip"/);
+assert.match(welcome, /<ShortcutTooltip label="Open Structure" shortcut="⌘O" \/>/);
+assert.match(welcome, /<ShortcutTooltip label="Command Palette" shortcut="⌘P \/" \/>/);
+assert.match(welcome, /<ShortcutTooltip label="Settings" shortcut="⌘," \/>/);
 assert.doesNotMatch(welcome, /Open molecular structures/);
 assert.match(errorBoundary, /export class ErrorBoundary/);
 assert.match(errorBoundary, /\[ErrorBoundary\]/);
@@ -1413,6 +1428,8 @@ assert.match(sidebarSurface, /actions\.openRecentStructure/);
 assert.match(sidebarSurface, /from "@hugeicons\/core-free-icons"/);
 assert.match(sidebarSurface, /from "@hugeicons\/react"/);
 assert.match(sidebarSurface, /actions\.openCommandPalette/);
+assert.match(sidebarSurface, /from "\.\.\/shortcut-tooltip"/);
+assert.match(sidebarSurface, /<ShortcutTooltip label="Search projects and structures" shortcut="⌘P" \/>/);
 assert.match(sidebarSurface, /function PinIcon/);
 assert.match(sidebarSurface, /function MoreIcon/);
 assert.doesNotMatch(sidebarSurface, /Cancel01Icon/);


### PR DESCRIPTION
## Summary
- add a reusable shortcut tooltip surface with Mac-style shortcut badges
- show shortcut hover/focus tooltips on chrome, sidebar search, and welcome actions
- pin the behavior in the UI shell contract test

## Tests
- node tests/test-ui-shell-contract.mjs
- git diff --check origin/main...HEAD
- pre-push ci-fast