### PR TITLE
Hide sidebar toggle tooltip

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -90,7 +90,6 @@ export function AppLayout({
               aria-label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"}
             >
               <HugeiconsIcon icon={SidebarLeftIcon} size={18} color="currentColor" strokeWidth={2} />
-              <ShortcutTooltip label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"} shortcut={"⌘\\"} />
             </button>
           </div>
           <div className="chrome-trailing-controls" data-tauri-drag-region>

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -726,7 +726,7 @@ assert.match(editorTabs, /import \{ CloseIcon \} from "\.\.\/close-icon"/);
 assert.match(editorTabs, /<CloseIcon size=\{13\} \/>/);
 assert.match(appLayout, /className="chrome-leading-controls"/);
 assert.match(appLayout, /from "\.\/shortcut-tooltip"/);
-assert.match(appLayout, /<ShortcutTooltip label=\{state\.sidebarOpen \? "Hide sidebar" : "Show sidebar"\} shortcut=\{"⌘\\\\"\} \/>/);
+assert.doesNotMatch(appLayout, /<ShortcutTooltip label=\{state\.sidebarOpen \? "Hide sidebar" : "Show sidebar"\} shortcut=\{"⌘\\\\"\} \/>/);
 assert.match(appLayout, /<ShortcutTooltip label=\{state\.bottomDockOpen \? "Hide bottom dock" : "Show bottom dock"\} shortcut="⌘J" \/>/);
 assert.match(appLayout, /<ShortcutTooltip label=\{state\.rightDockOpen \? "Hide right dock" : "Show right dock"\} shortcut="⌥⌘B" \/>/);
 assert.match(tauriConfig, /"trafficLightPosition":\s*\{\s*"x":\s*20,\s*"y":\s*29\s*\}/);


### PR DESCRIPTION
## Summary
- remove the hover shortcut tooltip from the sidebar toggle button
- keep the accessible aria-label for the sidebar toggle
- update the shell contract test to require the tooltip stays hidden

## Checks
- bun tests/test-ui-shell-contract.mjs
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: scripts/ci-fast.sh