### PR TITLE
Add keyboard shortcuts settings section

### DIFF
--- a/apps/desktop/src/components/settings-panel/index.tsx
+++ b/apps/desktop/src/components/settings-panel/index.tsx
@@ -13,6 +13,7 @@ import {
   selectPreferenceRow,
   type SettingRow,
 } from "./setting-control";
+import { KeyboardShortcutsSection } from "./keyboard-shortcuts-section";
 import { ThemesSection } from "./themes-section";
 
 const defaultRendererModeOptions: Array<ViewerPreferences["rendererMode"]> = ["auto", "molstar", "xyzrender-external"];
@@ -113,6 +114,7 @@ export function SettingsPanel({ location, state, actions }: { location: Settings
                   <ThemesSection preferences={preferences} actions={actions} />
                 </>
               ) : null}
+              {section === "keyboard" ? <KeyboardShortcutsSection /> : null}
               {section === "structure" ? (
                 <SettingsSection
                   title="Structure Rendering"

--- a/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
+++ b/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from "react";
+
+type ShortcutRow = {
+  command: string;
+  description: string;
+  keybindings: string[];
+};
+
+const keyboardShortcutRows: ShortcutRow[] = [
+  {
+    command: "Open command palette",
+    description: "Search commands, settings, projects, and structures.",
+    keybindings: ["⌘P", "/"],
+  },
+  {
+    command: "Open structures",
+    description: "Choose molecular structure files.",
+    keybindings: ["⌘O"],
+  },
+  {
+    command: "Open most recent structure",
+    description: "Open the latest structure from recent files.",
+    keybindings: ["⇧⌘O"],
+  },
+  {
+    command: "Toggle sidebar",
+    description: "Show or hide the project and structure browser.",
+    keybindings: ["⌘\\"],
+  },
+  {
+    command: "Toggle bottom dock",
+    description: "Show or hide the bottom workspace dock.",
+    keybindings: ["⌘J"],
+  },
+  {
+    command: "Toggle right dock",
+    description: "Show or hide the right workspace dock.",
+    keybindings: ["⌥⌘B"],
+  },
+  {
+    command: "Open Settings",
+    description: "Open the settings workspace.",
+    keybindings: ["⌘,"],
+  },
+  {
+    command: "Close active structure",
+    description: "Close the selected structure tab.",
+    keybindings: ["⌘W"],
+  },
+  {
+    command: "Reveal in Finder",
+    description: "Show the active structure file in Finder.",
+    keybindings: ["⇧⌘R"],
+  },
+  {
+    command: "Copy active path",
+    description: "Copy the active structure file path.",
+    keybindings: ["⇧⌘C"],
+  },
+  {
+    command: "Show metadata",
+    description: "Show renderer, format, path, and file size for the active structure.",
+    keybindings: ["⌘I"],
+  },
+  {
+    command: "Export preview as PNG",
+    description: "Save the active external preview as a PNG file.",
+    keybindings: ["⇧⌘E"],
+  },
+  {
+    command: "Export preview as SVG",
+    description: "Save the active external preview as an SVG file.",
+    keybindings: ["⌥⌘E"],
+  },
+  {
+    command: "Jump to tab",
+    description: "Switch to the matching tab position.",
+    keybindings: ["⌘1", "⌘2", "…", "⌘9"],
+  },
+];
+
+export function KeyboardShortcutsSection() {
+  const [query, setQuery] = useState("");
+  const visibleRows = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return keyboardShortcutRows;
+    return keyboardShortcutRows.filter((row) => (
+      row.command.toLowerCase().includes(normalized) ||
+      row.description.toLowerCase().includes(normalized) ||
+      row.keybindings.join(" ").toLowerCase().includes(normalized)
+    ));
+  }, [query]);
+
+  return (
+    <section className="keyboard-shortcuts-section" aria-label="Keyboard shortcuts">
+      <label className="keyboard-shortcuts-search">
+        <SearchIcon />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search shortcuts"
+          aria-label="Search shortcuts"
+        />
+      </label>
+      <div className="keyboard-shortcuts-card">
+        <div className="keyboard-shortcuts-header" aria-hidden="true">
+          <span>Command</span>
+          <span>Keybinding</span>
+        </div>
+        <div className="keyboard-shortcuts-list">
+          {visibleRows.length > 0 ? (
+            visibleRows.map((row) => (
+              <div className="keyboard-shortcuts-row" key={row.command}>
+                <div className="keyboard-shortcuts-copy">
+                  <div className="keyboard-shortcuts-command">{row.command}</div>
+                  <div className="keyboard-shortcuts-description">{row.description}</div>
+                </div>
+                <div className="keyboard-shortcuts-keys" aria-label={`${row.command} keybindings`}>
+                  {row.keybindings.map((keybinding) => (
+                    <kbd key={keybinding}>{keybinding}</kbd>
+                  ))}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="keyboard-shortcuts-empty">No matching shortcuts</div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M7.25 12.5C10.1495 12.5 12.5 10.1495 12.5 7.25C12.5 4.35051 10.1495 2 7.25 2C4.35051 2 2 4.35051 2 7.25C2 10.1495 4.35051 12.5 7.25 12.5Z" stroke="currentColor" strokeWidth="1.35" />
+      <path d="M11 11L14 14" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -6,7 +6,6 @@ import { hasStructureDrag, readStructureDragPayload, writeStructureDragItems } f
 import { runShellDropActionChoices, shellDropActionChoices } from "../drop-action-executor";
 import { RadixDropdownMenu } from "../radix-menu";
 import { ScrollFade } from "../scroll-fade";
-import { ShortcutTooltip } from "../shortcut-tooltip";
 import type { ShellActions, ShellViewState } from "../types";
 import { ProjectGroup, ProjectItem } from "./file-tree-node";
 
@@ -83,7 +82,6 @@ export function FileBrowser({
         </span>
         <span className="sidebar-search-label">Search</span>
         <kbd>⌘<span>P</span></kbd>
-        <ShortcutTooltip label="Search projects and structures" shortcut="⌘P" />
       </button>
       <button
         type="button"

--- a/apps/desktop/src/components/sidebar/settings-sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/settings-sidebar.tsx
@@ -138,6 +138,14 @@ function SettingsItemIcon({ id }: { id: SettingsSectionId }) {
       </svg>
     );
   }
+  if (id === "keyboard") {
+    return (
+      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
+        <rect x="2.4" y="4.2" width="12.2" height="9.2" rx="1.6" stroke="currentColor" strokeWidth="1.35" />
+        <path d="M4.6 6.8H4.61M6.9 6.8H6.91M9.2 6.8H9.21M11.5 6.8H11.51M4.6 9.1H4.61M6.9 9.1H6.91M9.2 9.1H9.21M11.5 9.1H11.51M5.4 11.3H11.6" stroke="currentColor" strokeWidth="1.45" strokeLinecap="round" />
+      </svg>
+    );
+  }
   if (id === "updates") {
     return (
       <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">

--- a/apps/desktop/src/lib/settings-sections.ts
+++ b/apps/desktop/src/lib/settings-sections.ts
@@ -1,6 +1,7 @@
 export type SettingsSectionId =
   | "general"
   | "appearance"
+  | "keyboard"
   | "structure"
   | "updates"
   | "workspace"
@@ -26,6 +27,7 @@ export const settingsNavGroups: SettingsNavGroup[] = [
     items: [
       { id: "general", label: "General", description: "Workspace defaults and open documents" },
       { id: "appearance", label: "Appearance", description: "Theme, colors, and shell presentation" },
+      { id: "keyboard", label: "Keyboard shortcuts", description: "Global app shortcuts and navigation keys" },
       { id: "structure", label: "Structure rendering", description: "Mol* and renderer defaults" },
       { id: "updates", label: "Updates", description: "Release checks and install channel" },
     ],

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -263,30 +263,31 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 .shortcut-tooltip {
   position: absolute;
   left: 50%;
-  top: calc(100% + 8px);
+  top: calc(100% + 4px);
   z-index: 1200;
-  min-height: 38px;
-  max-width: min(360px, calc(100vw - 24px));
-  padding: 8px 10px 8px 14px;
-  border-radius: 12px;
+  min-height: 19px;
+  max-width: min(180px, calc(100vw - 12px));
+  padding: 4px 5px 4px 7px;
+  border-radius: 6px;
   background: color-mix(in srgb, var(--bg-base) 82%, transparent);
   color: var(--text-primary);
-  box-shadow: 0 16px 44px rgb(0 0 0 / 0.28);
-  backdrop-filter: blur(30px) saturate(1.35);
-  -webkit-backdrop-filter: blur(30px) saturate(1.35);
+  box-shadow: 0 8px 22px rgb(0 0 0 / 0.28);
+  backdrop-filter: blur(15px) saturate(1.35);
+  -webkit-backdrop-filter: blur(15px) saturate(1.35);
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 6px;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   white-space: nowrap;
   transform: translate(-50%, -4px) scale(0.98);
   transform-origin: top center;
-  transition: opacity 110ms ease-out, transform 130ms ease-out;
+  transition: opacity 110ms ease-out, transform 130ms ease-out, visibility 0s linear 110ms;
 }
 .shortcut-tooltip[data-side="top"] {
   top: auto;
-  bottom: calc(100% + 8px);
+  bottom: calc(100% + 4px);
   transform: translate(-50%, 4px) scale(0.98);
   transform-origin: bottom center;
 }
@@ -299,7 +300,9 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 button:hover > .shortcut-tooltip,
 button:focus-visible > .shortcut-tooltip {
   opacity: 1;
+  visibility: visible;
   transform: translate(-50%, 0) scale(1);
+  transition-delay: 180ms, 180ms, 0s;
 }
 .chrome-trailing-controls button:hover > .shortcut-tooltip,
 .chrome-trailing-controls button:focus-visible > .shortcut-tooltip {
@@ -309,22 +312,22 @@ button:focus-visible > .shortcut-tooltip {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 13px;
+  font-size: 7px;
   font-weight: 560;
   letter-spacing: 0;
   line-height: 1.2;
 }
 .shortcut-tooltip-key {
   flex: 0 0 auto;
-  min-height: 24px;
+  min-height: 12px;
   border-radius: 999px;
-  padding: 4px 9px;
+  padding: 2px 5px;
   background: color-mix(in srgb, var(--fg-base) calc(var(--contrast) * 32%), transparent);
   color: var(--text-secondary);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 7px;
   font-weight: 650;
   letter-spacing: 0;
   line-height: 1;
@@ -3135,7 +3138,7 @@ kbd span { margin-left: 2px; }
 .new-tab-page button { position: relative; border: 0; border-radius: 8px; background: transparent; color: var(--text-secondary); font-size: 13px; font-weight: 500; height: 28px; padding: 0 8px; display: inline-flex; align-items: center; gap: 6px; transition: color 120ms ease, background 120ms ease; }
 .new-tab-page button:hover { color: var(--text-primary); background: transparent; }
 .new-tab-page kbd { font-size: 11px; letter-spacing: 0.16em; color: var(--text-icon-muted); }
-.new-tab-page .shortcut-tooltip-key { color: var(--text-secondary); font-size: 13px; letter-spacing: 0; }
+.new-tab-page .shortcut-tooltip-key { color: var(--text-secondary); font-size: 7px; letter-spacing: 0; }
 .error-boundary {
   width: 100vw;
   height: 100vh;
@@ -3250,6 +3253,104 @@ kbd span { margin-left: 2px; }
 .settings-control-label { color: var(--text-primary); font-size: 13px; font-weight: 500; }
 .settings-control-description { margin-top: 2px; color: var(--text-muted); font-size: 13px; line-height: 1.35; overflow-wrap: anywhere; }
 .settings-control-actions { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; }
+.keyboard-shortcuts-section { margin: 0 0 40px; }
+.keyboard-shortcuts-search {
+  height: 40px;
+  margin: 0 -16px 10px;
+  border: 1px solid var(--line-subtler);
+  border-radius: 10px;
+  background: var(--surface-input);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+}
+.keyboard-shortcuts-search:focus-within {
+  border-color: var(--focus-border);
+  color: var(--text-secondary);
+}
+.keyboard-shortcuts-search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.keyboard-shortcuts-search input::placeholder { color: var(--text-faint); }
+.keyboard-shortcuts-card {
+  margin: 0 -16px;
+  overflow: hidden;
+  border: 1px solid var(--line-subtler);
+  border-radius: 10px;
+  background: var(--surface-card);
+}
+.keyboard-shortcuts-header,
+.keyboard-shortcuts-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(148px, 188px);
+  gap: 20px;
+}
+.keyboard-shortcuts-header {
+  min-height: 40px;
+  align-items: center;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--line-subtler);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+}
+.keyboard-shortcuts-row {
+  min-height: 62px;
+  align-items: center;
+  padding: 12px 16px;
+}
+.keyboard-shortcuts-row + .keyboard-shortcuts-row { border-top: 1px solid var(--line-subtler); }
+.keyboard-shortcuts-copy { min-width: 0; }
+.keyboard-shortcuts-command {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+.keyboard-shortcuts-description {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.keyboard-shortcuts-keys {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.keyboard-shortcuts-keys kbd {
+  min-height: 22px;
+  border-radius: 999px;
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  padding: 3px 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 1;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+.keyboard-shortcuts-empty {
+  padding: 18px 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
 .settings-reset-button {
   height: 22px;
   border: 0;
@@ -3406,6 +3507,14 @@ kbd span { margin-left: 2px; }
   .agent-integration-actions { justify-content: flex-start; }
   .agent-status-row { display: grid; gap: 10px; }
   .agent-status-badge { justify-self: start; }
+  .keyboard-shortcuts-search,
+  .keyboard-shortcuts-card { margin-left: 0; margin-right: 0; }
+  .keyboard-shortcuts-header { display: none; }
+  .keyboard-shortcuts-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+    align-items: start;
+  }
   .settings-control-actions { width: 100%; justify-content: flex-start; }
   .settings-select,
   .settings-action-button,

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -44,6 +44,7 @@ const [
   editorScrollContainer,
   agentIntegrationPanel,
   settingsPanel,
+  keyboardShortcutsSection,
   themesSection,
   settingControl,
   dockPanel,
@@ -136,6 +137,7 @@ const [
   source('apps/desktop/src/components/editor-area/editor-scroll-container.tsx'),
   source('apps/desktop/src/components/agent-integration-panel/index.tsx'),
   source('apps/desktop/src/components/settings-panel/index.tsx'),
+  source('apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx'),
   source('apps/desktop/src/components/settings-panel/themes-section.tsx'),
   source('apps/desktop/src/components/settings-panel/setting-control.tsx'),
   source('apps/desktop/src/components/dock-panel.tsx'),
@@ -1062,8 +1064,8 @@ assert.match(styles, /button, select, input, textarea, \.tab-shell, \.tab, \.new
 assert.match(styles, /\.drag-region \{[^}]*height: var\(--chrome-drag-height\);[^}]*z-index: 2/s);
 assert.match(shortcutTooltip, /export function ShortcutTooltip/);
 assert.match(shortcutTooltip, /className="shortcut-tooltip"/);
-assert.match(styles, /\.shortcut-tooltip \{[^}]*position: absolute;[^}]*backdrop-filter: blur\(30px\) saturate\(1\.35\);[^}]*transform: translate\(-50%, -4px\) scale\(0\.98\);/s);
-assert.match(styles, /button:hover > \.shortcut-tooltip,\s*button:focus-visible > \.shortcut-tooltip \{[^}]*opacity: 1;[^}]*transform: translate\(-50%, 0\) scale\(1\);/s);
+assert.match(styles, /\.shortcut-tooltip \{[^}]*position: absolute;[^}]*min-height: 19px;[^}]*backdrop-filter: blur\(15px\) saturate\(1\.35\);[^}]*visibility: hidden;[^}]*transform: translate\(-50%, -4px\) scale\(0\.98\);/s);
+assert.match(styles, /button:hover > \.shortcut-tooltip,\s*button:focus-visible > \.shortcut-tooltip \{[^}]*opacity: 1;[^}]*visibility: visible;[^}]*transform: translate\(-50%, 0\) scale\(1\);[^}]*transition-delay: 180ms, 180ms, 0s;/s);
 assert.match(styles, /\.shortcut-tooltip-key \{[^}]*border-radius: 999px;[^}]*letter-spacing: 0;/s);
 assert.doesNotMatch(styles, /\.workspace \{[^}]*z-index:/s);
 assert.match(styles, /\.splitter \{[^}]*z-index: 3;/s);
@@ -1710,8 +1712,8 @@ assert.match(sidebarSurface, /actions\.openRecentStructure/);
 assert.match(sidebarSurface, /from "@hugeicons\/core-free-icons"/);
 assert.match(sidebarSurface, /from "@hugeicons\/react"/);
 assert.match(sidebarSurface, /actions\.openCommandPalette/);
-assert.match(sidebarSurface, /from "\.\.\/shortcut-tooltip"/);
-assert.match(sidebarSurface, /<ShortcutTooltip label="Search projects and structures" shortcut="⌘P" \/>/);
+assert.doesNotMatch(sidebarFileBrowser, /from "\.\.\/shortcut-tooltip"/);
+assert.doesNotMatch(sidebarFileBrowser, /<ShortcutTooltip label="Search projects and structures" shortcut="⌘P" \/>/);
 assert.match(sidebarSurface, /function PinIcon/);
 assert.match(sidebarSurface, /function MoreIcon/);
 assert.doesNotMatch(sidebarSurface, /Cancel01Icon/);
@@ -1835,12 +1837,19 @@ assert.match(settingsPanel, /title="Structure Rendering"/);
 assert.match(settingsPanel, /title="System"/);
 assert.match(settingsPanel, /<AgentIntegrationPanel embedded \/>/);
 assert.match(settingsSections, /id: "agent", label: "Burrete"/);
+assert.match(settingsSections, /id: "keyboard", label: "Keyboard shortcuts"/);
 assert.match(settingsPanel, /from "\.\/setting-control"/);
+assert.match(settingsPanel, /from "\.\/keyboard-shortcuts-section"/);
+assert.match(settingsPanel, /section === "keyboard" \? <KeyboardShortcutsSection \/> : null/);
 assert.match(settingsPanel, /SettingsSection/);
 assert.match(settingsPanel, /ToggleControl/);
 assert.match(settingsPanel, /from "\.\/themes-section"/);
 assert.match(settingsPanel, /<ThemesSection preferences=\{preferences\} actions=\{actions\} \/>/);
 assert.doesNotMatch(settingsPanel, /function ThemeCard/);
+assert.match(keyboardShortcutsSection, /export function KeyboardShortcutsSection/);
+assert.match(keyboardShortcutsSection, /placeholder="Search shortcuts"/);
+assert.match(keyboardShortcutsSection, /command: "Toggle bottom dock"[\s\S]*?keybindings: \["⌘J"\]/);
+assert.match(keyboardShortcutsSection, /command: "Toggle right dock"[\s\S]*?keybindings: \["⌥⌘B"\]/);
 assert.match(themesSection, /export function ThemesSection/);
 assert.match(themesSection, /<ThemeCard mode="light" preferences=\{preferences\} actions=\{actions\} \/>/);
 assert.match(themesSection, /<ThemeCard mode="dark" preferences=\{preferences\} actions=\{actions\} \/>/);


### PR DESCRIPTION
## Summary
- add a Keyboard shortcuts settings section with searchable read-only shortcut reference
- remove the sidebar search tooltip and shrink/delay remaining shortcut tooltips
- update UI shell contract coverage for the settings shortcut surface

## Checks
- bun run --cwd apps/desktop typecheck
- bun tests/test-ui-shell-contract.mjs
- bun run build:web
- pre-push ci-fast