### PR TITLE
Fix settings panel edge clipping

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -459,6 +459,10 @@ button:focus-visible > .shortcut-tooltip {
   border-radius: 20px 0 0 20px;
   box-shadow: -12px 0 28px var(--workspace-edge-shadow);
 }
+.app-shell[data-settings-mode="true"] .workbench {
+  border-radius: 0;
+  box-shadow: none;
+}
 .workbench-main {
   min-width: 0;
   min-height: 0;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1072,6 +1072,7 @@ assert.match(styles, /--workspace-edge-border: color-mix\(in srgb, var\(--fg-bas
 assert.match(styles, /\.sidebar::after \{[^}]*background: var\(--sidebar-divider-right\);/s);
 assert.doesNotMatch(styles, /\.splitter::after \{ background: var\(--sidebar-divider-right\); \}/);
 assert.match(styles, /\.workbench \{[^}]*background: var\(--bg-base\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;[^}]*box-shadow: -12px 0 28px var\(--workspace-edge-shadow\);/s);
+assert.match(styles, /\.app-shell\[data-settings-mode="true"\] \.workbench \{[^}]*border-radius: 0;[^}]*box-shadow: none;[^}]*\}/s);
 assert.doesNotMatch(styles, /\.main-stage \{[^}]*border-radius: 20px 0 0 20px;/s);
 assert.match(styles, /\.app-shell\[data-theme="auto"\] \{[^}]*color-scheme: light dark/s);
 assert.match(styles, /@media \(prefers-color-scheme: light\) \{[\s\S]*\.app-shell\[data-theme="auto"\]/);


### PR DESCRIPTION
## Summary
- remove the viewer-stage rounded edge and shadow in settings mode
- pin the settings-mode override in the UI shell contract test

## Validation
- node tests/test-ui-shell-contract.mjs
- git diff --check
- pre-commit: plist, js-syntax, rust-fmt
- pre-push: ci-fast