### PR TITLE
Keep structure viewers mounted across tabs

### DIFF
--- a/apps/desktop/src/components/editor-area/page-kinds/file.tsx
+++ b/apps/desktop/src/components/editor-area/page-kinds/file.tsx
@@ -21,7 +21,7 @@ export const fileKind = definePageKind<"file", FileLocation>({
     const document = findDocument(location, state.documents);
     return document ? <ViewerSurface document={document} actions={actions} /> : null;
   },
-  keepAlive: false,
+  keepAlive: true,
   fromPayload: (data) => (typeof data.path === "string" ? { kind: "file", documentId: typeof data.documentId === "string" ? data.documentId : undefined, path: data.path } : null),
   serialize: (location) => ({ documentId: location.documentId, path: location.path }),
 });

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -766,7 +766,7 @@ assert.match(pageKinds, /export function deserializeLocation/);
 assert.match(pageKindTypes, /export interface PageKindInput/);
 assert.match(pageKindTypes, /export function definePageKind/);
 assert.match(fileKind, /export const fileKind = definePageKind/);
-assert.match(fileKind, /keepAlive: false/);
+assert.match(fileKind, /keepAlive: true/);
 assert.match(fileKind, /kind: "file"/);
 assert.match(fileKind, /path: location\.path/);
 assert.match(fileKind, /const document = findDocument\(location, state\.documents\);\s*return document \? <ViewerSurface document=\{document\} actions=\{actions\} \/> : null;/);


### PR DESCRIPTION
## Summary
- Keep structure/file viewer pages mounted while they fit in the existing warm tab pool.
- Update the shell contract test to pin the new keep-alive behavior.

## Validation
- `vp run test:ui`
- pre-push `ci-fast` hook