### PR TITLE
Expand Molstar combine mode for trajectories

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -61,6 +61,9 @@
     customConfigPath: null,
     extraArguments: null
   };
+  const DOCKING_COORDINATE_TRAJECTORY_FORMATS = new Set(['xtc', 'trr', 'dcd', 'nctraj', 'lammpstrj']);
+  const DOCKING_MODEL_TRAJECTORY_FORMATS = new Set(['pdb', 'pdbqt', 'mmcif', 'gro']);
+  const DOCKING_TOPOLOGY_TRAJECTORY_FORMATS = new Set(['top', 'psf', 'prmtop']);
   const STRUCTURE_DRAG_MIME = 'application/x-burrete-structure-paths';
   const XYZRENDER_POPOVER_OPEN_KEY_PREFIX = 'buret.xyzrender.popover.open.v2';
   let xyzrenderControlsApplyTimer = 0;
@@ -2838,6 +2841,29 @@
     };
   }
 
+  function isDockingCoordinateTrajectoryEntry(entry) {
+    return DOCKING_COORDINATE_TRAJECTORY_FORMATS.has(normalizeFormat(entry?.format));
+  }
+
+  function dockingTrajectoryModelKind(entry) {
+    const format = normalizeFormat(entry?.format);
+    if (DOCKING_TOPOLOGY_TRAJECTORY_FORMATS.has(format)) return 'topology-data';
+    if (DOCKING_MODEL_TRAJECTORY_FORMATS.has(format)) return 'model-data';
+    return null;
+  }
+
+  function dockingTrajectoryPair(entries) {
+    const coordinateEntry = entries.find(isDockingCoordinateTrajectoryEntry);
+    if (!coordinateEntry) return null;
+    const modelEntry = entries.find(entry => entry !== coordinateEntry && dockingTrajectoryModelKind(entry));
+    if (!modelEntry) return null;
+    return {
+      modelEntry,
+      modelKind: dockingTrajectoryModelKind(modelEntry),
+      coordinateEntry
+    };
+  }
+
   function prepareDockingStructure(config) {
     const docking = config.docking || {};
     const payloads = window.BurreteDockingPayloads || {};
@@ -2896,6 +2922,22 @@
       });
     });
     if (poses.length === 0) throw new Error('Docking view has no ligand poses.');
+    const trajectoryPair = dockingTrajectoryPair(entries);
+    if (trajectoryPair) {
+      return {
+        kind: 'docking',
+        label: config.label || 'Docking trajectory',
+        activePose: readDockingPoseIndex(config, Number.MAX_SAFE_INTEGER),
+        poseCount: 1,
+        nativeTrajectoryControls: true,
+        ligandLabel: trajectoryPair.coordinateEntry.label || 'Mol* trajectory',
+        controlLabel: 'Frame',
+        receptorEntry,
+        poses,
+        entries,
+        trajectoryPair
+      };
+    }
     const activePose = readDockingPoseIndex(config, poses.length);
     if (nativeTrajectoryPoseCount > 1) {
       return {
@@ -4407,6 +4449,44 @@
     });
   }
 
+  function isDockingTrajectoryPairEntry(entry, pair) {
+    return !!pair && (entry === pair.modelEntry || entry === pair.coordinateEntry);
+  }
+
+  async function loadDockingTrajectoryPair(viewer, pair) {
+    if (typeof viewer.loadTrajectory !== 'function') {
+      throw new Error('Mol* trajectory pairing is unavailable in this viewer runtime.');
+    }
+    await viewer.loadTrajectory({
+      model: {
+        kind: pair.modelKind,
+        data: pair.modelEntry.data,
+        format: normalizeFormat(pair.modelEntry.format)
+      },
+      modelLabel: pair.modelEntry.label,
+      coordinates: {
+        kind: 'coordinates-data',
+        data: pair.coordinateEntry.data,
+        format: normalizeFormat(pair.coordinateEntry.format)
+      },
+      coordinatesLabel: pair.coordinateEntry.label,
+      preset: 'default'
+    });
+  }
+
+  async function applyDockingTrajectoryPairFrameCount(prepared) {
+    if (!prepared?.trajectoryPair) return;
+    await afterNativeTrajectoryPaint();
+    const position = readNativeTrajectoryPosition(0);
+    const frameCount = Number(position?.total || nativeTrajectoryModelTransform(0)?.frameCount || 0);
+    if (!Number.isFinite(frameCount) || frameCount <= 1) return;
+    prepared.poseCount = frameCount;
+    prepared.activePose = readDockingPoseIndex(activeConfig, frameCount);
+    prepared.nativeTrajectoryControls = true;
+    prepared.controlLabel = 'Frame';
+    prepared.ligandLabel = prepared.trajectoryPair.coordinateEntry.label || prepared.ligandLabel || 'Mol* trajectory';
+  }
+
   async function loadStagedMolstarEntry(viewer, entry, cb) {
     const data = await loadStagedEntryData(entry, cb);
     const prepared = {
@@ -4474,7 +4554,12 @@
     if (typeof plugin.clear === 'function') {
       await plugin.clear();
     }
+    if (prepared.trajectoryPair) {
+      await loadDockingTrajectoryPair(viewer, prepared.trajectoryPair);
+      await applyDockingTrajectoryPairFrameCount(prepared);
+    }
     for (const entry of prepared.entries) {
+      if (isDockingTrajectoryPairEntry(entry, prepared.trajectoryPair)) continue;
       await loadMolstarEntry(viewer, entry);
     }
     await applyMolstarStyle(viewer, configuredMolstarStyle(activeConfig));

--- a/apps/desktop/src/lib/docking-documents.ts
+++ b/apps/desktop/src/lib/docking-documents.ts
@@ -1,6 +1,16 @@
 import type { DockingDocumentRequest } from "../types";
+import previewFormatRegistry from "../../../../config/preview-formats.json";
 
 export type DockingDropCandidate = DockingDocumentRequest;
+
+const MOLSTAR_COORDINATE_TRAJECTORY_EXTENSIONS = new Set(["xtc", "trr", "dcd", "nctraj", "lammpstrj"]);
+const MOLSTAR_TRAJECTORY_EXTENSIONS = new Set([...MOLSTAR_COORDINATE_TRAJECTORY_EXTENSIONS, "top", "psf", "prmtop"]);
+const MOLSTAR_VIEWER_EXTENSIONS = new Set([
+  ...previewFormatRegistry.formats
+    .filter((format) => Boolean(format.viewer))
+    .flatMap((format) => format.extensions.map((extension) => extension === "mae.gz" ? "maegz" : extension)),
+  ...MOLSTAR_TRAJECTORY_EXTENSIONS,
+]);
 
 export function extensionForDocking(path: string) {
   const name = path.replace(/\\/g, "/").split("/").filter(Boolean).pop()?.toLowerCase() ?? "";
@@ -13,12 +23,20 @@ export function isProteinLikeDockingSource(path: string) {
   return ["bcif", "cif", "cms", "ent", "mae", "maegz", "mcif", "mmcif", "pdb", "pdbqt", "pqr"].includes(extensionForDocking(path));
 }
 
+export function isMolstarCombineSource(path: string) {
+  return MOLSTAR_VIEWER_EXTENSIONS.has(extensionForDocking(path));
+}
+
+export function isMolstarCoordinateTrajectorySource(path: string) {
+  return MOLSTAR_COORDINATE_TRAJECTORY_EXTENSIONS.has(extensionForDocking(path));
+}
+
 function uniqueDockingPaths(paths: string[]) {
   return Array.from(new Set(paths.filter((path) => path && path.trim().length > 0)));
 }
 
-function ligandLikeDockingPaths(paths: string[]) {
-  return uniqueDockingPaths(paths).filter((path) => !isProteinLikeDockingSource(path));
+function combineDockingPaths(paths: string[]) {
+  return uniqueDockingPaths(paths).filter(isMolstarCombineSource);
 }
 
 export function ligandDropPathsForTarget(targetPath: string, droppedPaths: string[]) {
@@ -40,21 +58,25 @@ export function dockingCandidatesForDrop(
 ): DockingDropCandidate[] {
   if (existingDockingRequest) {
     const existingLigands = new Set(existingDockingRequest.ligandPaths);
-    const addedLigands = ligandLikeDockingPaths(droppedPaths)
+    const addedLigands = combineDockingPaths(droppedPaths)
       .filter((path) => path !== existingDockingRequest.receptorPath && !existingLigands.has(path));
     if (addedLigands.length === 0) return [];
     return [{
       receptorPath: existingDockingRequest.receptorPath,
-      ligandPaths: ligandLikeDockingPaths([...existingDockingRequest.ligandPaths, ...addedLigands])
+      ligandPaths: combineDockingPaths([...existingDockingRequest.ligandPaths, ...addedLigands])
         .filter((path) => path !== existingDockingRequest.receptorPath),
     }];
   }
-  const paths = uniqueDockingPaths([targetPath, ...droppedPaths]);
+  const paths = combineDockingPaths([targetPath, ...droppedPaths]);
   const receptorPaths = paths.filter(isProteinLikeDockingSource);
-  return receptorPaths
+  const modelOrTopologyPaths = paths.filter((path) => !isMolstarCoordinateTrajectorySource(path));
+  const anchorPaths = receptorPaths.length > 0
+    ? receptorPaths
+    : (modelOrTopologyPaths.length > 0 ? modelOrTopologyPaths : paths);
+  return anchorPaths
     .map((receptorPath) => ({
       receptorPath,
-      ligandPaths: ligandLikeDockingPaths(paths.filter((path) => path !== receptorPath)),
+      ligandPaths: paths.filter((path) => path !== receptorPath),
     }))
     .filter((candidate) => candidate.ligandPaths.length > 0);
 }

--- a/apps/desktop/src/lib/drop-actions.ts
+++ b/apps/desktop/src/lib/drop-actions.ts
@@ -1,6 +1,6 @@
 import type { DockingDocumentRequest, FepSetupRequest } from "../types";
 import { isMoleculeCollectionPath } from "./collection-documents";
-import { dockingCandidatesForDrop, isProteinLikeDockingSource } from "./docking-documents";
+import { dockingCandidatesForDrop, isMolstarCombineSource, isMolstarCoordinateTrajectorySource, isProteinLikeDockingSource } from "./docking-documents";
 import type { StructureDragPayload, StructureDragRecord } from "./structure-drag";
 
 export type DropTargetContext =
@@ -282,8 +282,13 @@ function dockingRecordCandidates(
     }];
   }
   const allPaths = uniquePaths([targetPath, ...paths]);
-  return allPaths
-    .filter(isProteinLikeDockingSource)
+  const receptorPaths = allPaths.filter(isProteinLikeDockingSource);
+  const combinePaths = allPaths.filter(isMolstarCombineSource);
+  const modelOrTopologyPaths = combinePaths.filter((path) => !isMolstarCoordinateTrajectorySource(path));
+  const anchorPaths = receptorPaths.length > 0
+    ? receptorPaths
+    : (modelOrTopologyPaths.length > 0 ? modelOrTopologyPaths : combinePaths);
+  return anchorPaths
     .map((receptorPath) => ({
       receptorPath,
       ligandPaths: uniqueLigandPaths(allPaths, receptorPath),
@@ -292,7 +297,7 @@ function dockingRecordCandidates(
 }
 
 function uniqueLigandPaths(paths: string[], receptorPath: string) {
-  return uniquePaths(paths).filter((path) => path !== receptorPath && !isProteinLikeDockingSource(path));
+  return uniquePaths(paths).filter((path) => path !== receptorPath && isMolstarCombineSource(path));
 }
 
 function uniquePaths(paths: string[]) {

--- a/tests/test-docking-documents.mjs
+++ b/tests/test-docking-documents.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 
-const { dockingCandidatesForDrop, dockingRequestForDrop, extensionForDocking, isProteinLikeDockingSource, ligandDropPathsForTarget } =
+const { dockingCandidatesForDrop, dockingRequestForDrop, extensionForDocking, isMolstarCombineSource, isMolstarCoordinateTrajectorySource, isProteinLikeDockingSource, ligandDropPathsForTarget } =
   await import("../apps/desktop/src/lib/docking-documents.ts");
 
 assert.equal(extensionForDocking("/tmp/protein.mae.gz"), "maegz");
@@ -15,8 +15,16 @@ assert.equal(isProteinLikeDockingSource("/tmp/receptor.mae.gz"), true);
 assert.equal(isProteinLikeDockingSource("/tmp/receptor.maegz"), true);
 assert.equal(isProteinLikeDockingSource("/tmp/receptor.pdbqt"), true);
 assert.equal(isProteinLikeDockingSource("/tmp/poses.sdf"), false);
+assert.equal(isProteinLikeDockingSource("/tmp/frame.gro"), false);
 assert.equal(isProteinLikeDockingSource("/tmp/field.cube"), false);
 assert.equal(isProteinLikeDockingSource("/tmp/field.cub"), false);
+assert.equal(isMolstarCombineSource("/tmp/receptor.pdb"), true);
+assert.equal(isMolstarCombineSource("/tmp/poses.sdf"), true);
+assert.equal(isMolstarCombineSource("/tmp/frame.gro"), true);
+assert.equal(isMolstarCombineSource("/tmp/traj.xtc"), true);
+assert.equal(isMolstarCombineSource("/tmp/network.graphml"), false);
+assert.equal(isMolstarCoordinateTrajectorySource("/tmp/traj.xtc"), true);
+assert.equal(isMolstarCoordinateTrajectorySource("/tmp/frame.gro"), false);
 
 assert.deepEqual(
   ligandDropPathsForTarget("/tmp/receptor.pdb", ["/tmp/poses.sdf", "/tmp/poses.sdf", "/tmp/receptor.pdb", "", "  "]),
@@ -55,21 +63,27 @@ assert.deepEqual(
   },
 );
 
-assert.equal(
+assert.deepEqual(
   dockingRequestForDrop("/tmp/pose-a.sdf", ["/tmp/pose-b.sdf"]),
-  null,
+  {
+    receptorPath: "/tmp/pose-a.sdf",
+    ligandPaths: ["/tmp/pose-b.sdf"],
+  },
 );
 
-assert.equal(
+assert.deepEqual(
   dockingRequestForDrop("/tmp/receptor-a.pdb", ["/tmp/receptor-b.cif"]),
-  null,
+  {
+    receptorPath: "/tmp/receptor-a.pdb",
+    ligandPaths: ["/tmp/receptor-b.cif"],
+  },
 );
 
 assert.deepEqual(
   dockingRequestForDrop("/tmp/receptor-a.pdb", ["/tmp/receptor-b.cif", "/tmp/pose-a.sdf"]),
   {
     receptorPath: "/tmp/receptor-a.pdb",
-    ligandPaths: ["/tmp/pose-a.sdf"],
+    ligandPaths: ["/tmp/receptor-b.cif", "/tmp/pose-a.sdf"],
   },
 );
 
@@ -77,7 +91,7 @@ assert.deepEqual(
   dockingRequestForDrop("/tmp/pose-a.sdf", ["/tmp/receptor-a.pdb", "/tmp/receptor-b.cif", "/tmp/pose-b.sdf"]),
   {
     receptorPath: "/tmp/receptor-a.pdb",
-    ligandPaths: ["/tmp/pose-a.sdf", "/tmp/pose-b.sdf"],
+    ligandPaths: ["/tmp/pose-a.sdf", "/tmp/receptor-b.cif", "/tmp/pose-b.sdf"],
   },
 );
 
@@ -86,11 +100,11 @@ assert.deepEqual(
   [
     {
       receptorPath: "/tmp/receptor-a.pdb",
-      ligandPaths: ["/tmp/pose-a.sdf", "/tmp/pose-b.sdf"],
+      ligandPaths: ["/tmp/pose-a.sdf", "/tmp/receptor-b.cif", "/tmp/pose-b.sdf"],
     },
     {
       receptorPath: "/tmp/receptor-b.cif",
-      ligandPaths: ["/tmp/pose-a.sdf", "/tmp/pose-b.sdf"],
+      ligandPaths: ["/tmp/pose-a.sdf", "/tmp/receptor-a.pdb", "/tmp/pose-b.sdf"],
     },
   ],
 );
@@ -100,11 +114,11 @@ assert.deepEqual(
   [
     {
       receptorPath: "/tmp/receptor-a.pdb",
-      ligandPaths: ["/tmp/pose-a.sdf"],
+      ligandPaths: ["/tmp/receptor-b.cif", "/tmp/pose-a.sdf"],
     },
     {
       receptorPath: "/tmp/receptor-b.cif",
-      ligandPaths: ["/tmp/pose-a.sdf"],
+      ligandPaths: ["/tmp/receptor-a.pdb", "/tmp/pose-a.sdf"],
     },
   ],
 );
@@ -120,11 +134,11 @@ assert.deepEqual(
   ),
   {
     receptorPath: "/tmp/receptor.pdb",
-    ligandPaths: ["/tmp/old-pose.sdf", "/tmp/new-pose.sdf"],
+    ligandPaths: ["/tmp/old-pose.sdf", "/tmp/new-pose.sdf", "/tmp/alternate-receptor.cif"],
   },
 );
 
-assert.equal(
+assert.deepEqual(
   dockingRequestForDrop(
     "burrete-docking://active-view",
     ["/tmp/alternate-receptor.cif"],
@@ -133,7 +147,10 @@ assert.equal(
       ligandPaths: ["/tmp/old-pose.sdf"],
     },
   ),
-  null,
+  {
+    receptorPath: "/tmp/receptor.pdb",
+    ligandPaths: ["/tmp/old-pose.sdf", "/tmp/alternate-receptor.cif"],
+  },
 );
 
 assert.deepEqual(
@@ -147,7 +164,23 @@ assert.deepEqual(
   ),
   {
     receptorPath: "/tmp/receptor.pdb",
-    ligandPaths: ["/tmp/old-pose.sdf", "/tmp/new-pose.sdf", "/tmp/new-pose-2.mol2"],
+    ligandPaths: ["/tmp/old-pose.sdf", "/tmp/new-pose.sdf", "/tmp/new-protein.pdb", "/tmp/new-pose-2.mol2"],
+  },
+);
+
+assert.deepEqual(
+  dockingRequestForDrop("/tmp/frame.gro", ["/tmp/trajectory.xtc"]),
+  {
+    receptorPath: "/tmp/frame.gro",
+    ligandPaths: ["/tmp/trajectory.xtc"],
+  },
+);
+
+assert.deepEqual(
+  dockingRequestForDrop("/tmp/trajectory.xtc", ["/tmp/frame.gro"]),
+  {
+    receptorPath: "/tmp/frame.gro",
+    ligandPaths: ["/tmp/trajectory.xtc"],
   },
 );
 

--- a/tests/test-docking-viewer-contract.mjs
+++ b/tests/test-docking-viewer-contract.mjs
@@ -66,8 +66,10 @@ assert.match(app, /void openDocuments\(\[targetPath\], \{\}, \{ rendererMode: "m
 assert.match(burretePermission, /"open_docking_document"/);
 
 assert.match(dockingDocuments, /export function dockingRequestForDrop/);
+assert.match(dockingDocuments, /export function isMolstarCombineSource/);
+assert.match(dockingDocuments, /export function isMolstarCoordinateTrajectorySource/);
 assert.match(dockingDocuments, /existingDockingRequest/);
-assert.match(dockingDocuments, /ligandLikeDockingPaths\(\[\.\.\.existingDockingRequest\.ligandPaths, \.\.\.addedLigands\]\)/);
+assert.match(dockingDocuments, /combineDockingPaths\(\[\.\.\.existingDockingRequest\.ligandPaths, \.\.\.addedLigands\]\)/);
 assert.match(dropActions, /export type DropAction/);
 assert.match(dropActions, /export type DropActionChoice/);
 assert.match(dropActions, /export type DropSourceContext/);
@@ -78,6 +80,11 @@ assert.match(dropActions, /kind: "add-xyzrender-sheet-items"/);
 assert.match(dropActions, /kind: "open-docking"/);
 
 assert.match(viewer, /function prepareDockingStructure\(config\)/);
+assert.match(viewer, /const DOCKING_COORDINATE_TRAJECTORY_FORMATS = new Set\(\['xtc', 'trr', 'dcd', 'nctraj', 'lammpstrj'\]\)/);
+assert.match(viewer, /const DOCKING_MODEL_TRAJECTORY_FORMATS = new Set\(\['pdb', 'pdbqt', 'mmcif', 'gro'\]\)/);
+assert.match(viewer, /const DOCKING_TOPOLOGY_TRAJECTORY_FORMATS = new Set\(\['top', 'psf', 'prmtop'\]\)/);
+assert.match(viewer, /function dockingTrajectoryPair\(entries\)/);
+assert.match(viewer, /trajectoryPair: dockingTrajectoryPair\(entries\)|const trajectoryPair = dockingTrajectoryPair\(entries\)/);
 assert.match(viewer, /ligandSources\.forEach\(\(source, ligandIndex\) =>/);
 assert.match(viewer, /records\.forEach\(\(record, poseIndex\) =>/);
 assert.match(viewer, /label: `\$\{source\.label \|\| `Ligand \$\{ligandIndex \+ 1\}`\} pose \$\{poseIndex \+ 1\}`/);
@@ -86,6 +93,13 @@ assert.match(viewer, /const activePose = readDockingPoseIndex\(config, poses\.le
 assert.match(viewer, /nativeTrajectoryControls: true/);
 assert.match(viewer, /activePose,\s*poseCount: nativeTrajectoryPoseCount/s);
 assert.match(viewer, /entries:\s*\[\s*entries\[0\],\s*poses\[activePose\]\s*\]/);
+assert.match(viewer, /async function loadDockingTrajectoryPair\(viewer, pair\)/);
+assert.match(viewer, /viewer\.loadTrajectory\(\{/);
+assert.match(viewer, /kind: pair\.modelKind/);
+assert.match(viewer, /kind: 'coordinates-data'/);
+assert.match(viewer, /async function applyDockingTrajectoryPairFrameCount\(prepared\)/);
+assert.match(viewer, /if \(prepared\.trajectoryPair\) \{/);
+assert.match(viewer, /if \(isDockingTrajectoryPairEntry\(entry, prepared\.trajectoryPair\)\) continue/);
 assert.match(viewer, /function notifyDockingPoseChanged\(activePose, prepared\)/);
 assert.match(viewer, /type: 'dockingPoseChanged'/);
 assert.match(viewer, /const initialPose = activePose/);

--- a/tests/test-drop-actions.mjs
+++ b/tests/test-drop-actions.mjs
@@ -374,7 +374,7 @@ assert.deepEqual(ligandOnDocking, {
   kind: "open-docking",
   request: {
     receptorPath: "/tmp/receptor.pdb",
-    ligandPaths: ["/tmp/old-ligand.sdf", "/tmp/new-ligand.sdf"],
+    ligandPaths: ["/tmp/old-ligand.sdf", "/tmp/new-ligand.sdf", "/tmp/receptor-2.pdb"],
   },
 });
 
@@ -406,7 +406,7 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/receptor-a.pdb", "/tmp/
       kind: "open-docking",
       request: {
         receptorPath: "/tmp/receptor-a.pdb",
-        ligandPaths: ["/tmp/current-ligand.sdf", "/tmp/ligand.sdf"],
+        ligandPaths: ["/tmp/current-ligand.sdf", "/tmp/receptor-b.cif", "/tmp/ligand.sdf"],
       },
     },
   },
@@ -418,7 +418,7 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/receptor-a.pdb", "/tmp/
       kind: "open-docking",
       request: {
         receptorPath: "/tmp/receptor-b.cif",
-        ligandPaths: ["/tmp/current-ligand.sdf", "/tmp/ligand.sdf"],
+        ligandPaths: ["/tmp/current-ligand.sdf", "/tmp/receptor-a.pdb", "/tmp/ligand.sdf"],
       },
     },
   },
@@ -445,7 +445,7 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/receptor-b.cif", "/tmp/
     kind: "open-docking",
     request: {
       receptorPath: "/tmp/receptor-a.pdb",
-      ligandPaths: ["/tmp/ligand.sdf"],
+      ligandPaths: ["/tmp/receptor-b.cif", "/tmp/ligand.sdf"],
     },
   },
 });
@@ -454,8 +454,11 @@ assert.deepEqual(resolveDropAction(payload(["/tmp/receptor-b.cif"]), {
   documentPath: "/tmp/receptor-a.pdb",
   renderer: "molstar",
 }), {
-  kind: "open-documents",
-  paths: ["/tmp/receptor-b.cif"],
+  kind: "open-docking",
+  request: {
+    receptorPath: "/tmp/receptor-a.pdb",
+    ligandPaths: ["/tmp/receptor-b.cif"],
+  },
 });
 
 assert.deepEqual(resolveDropActionChoices(
@@ -465,16 +468,29 @@ assert.deepEqual(resolveDropActionChoices(
     documentPath: "/tmp/current-ligand.sdf",
     renderer: "molstar",
   },
-), [{
-  id: "open-structure-records",
-  label: "Open as document tabs",
-  confidence: "default",
-  action: {
-    kind: "open-structure-records",
-    paths: [],
-    records: [{ path: "grid-ligand.sdf", inputExtension: "sdf", text: "mol\nM  END\n$$$$\n" }],
+), [
+  {
+    id: "open-docking-with-records",
+    label: "Open docking view",
+    confidence: "default",
+    action: {
+      kind: "open-docking-with-records",
+      receptorPath: "/tmp/current-ligand.sdf",
+      ligandPaths: [],
+      records: [{ path: "grid-ligand.sdf", inputExtension: "sdf", text: "mol\nM  END\n$$$$\n" }],
+    },
   },
-}]);
+  {
+    id: "open-structure-records",
+    label: "Open separately",
+    confidence: "alternative",
+    action: {
+      kind: "open-structure-records",
+      paths: [],
+      records: [{ path: "grid-ligand.sdf", inputExtension: "sdf", text: "mol\nM  END\n$$$$\n" }],
+    },
+  },
+]);
 
 const ligandOnGenericLigand = resolveDropAction(payload(["/tmp/ligand-b.sdf"]), {
   kind: "active-viewer",
@@ -482,8 +498,37 @@ const ligandOnGenericLigand = resolveDropAction(payload(["/tmp/ligand-b.sdf"]), 
   renderer: "molstar",
 });
 assert.deepEqual(ligandOnGenericLigand, {
-  kind: "open-documents",
-  paths: ["/tmp/ligand-b.sdf"],
+  kind: "open-docking",
+  request: {
+    receptorPath: "/tmp/ligand-a.sdf",
+    ligandPaths: ["/tmp/ligand-b.sdf"],
+  },
+});
+
+const trajectoryOnGro = resolveDropAction(payload(["/tmp/frame.xtc"]), {
+  kind: "active-viewer",
+  documentPath: "/tmp/frame.gro",
+  renderer: "molstar",
+});
+assert.deepEqual(trajectoryOnGro, {
+  kind: "open-docking",
+  request: {
+    receptorPath: "/tmp/frame.gro",
+    ligandPaths: ["/tmp/frame.xtc"],
+  },
+});
+
+const groOnTrajectory = resolveDropAction(payload(["/tmp/frame.gro"]), {
+  kind: "active-viewer",
+  documentPath: "/tmp/frame.xtc",
+  renderer: "molstar",
+});
+assert.deepEqual(groOnTrajectory, {
+  kind: "open-docking",
+  request: {
+    receptorPath: "/tmp/frame.gro",
+    ligandPaths: ["/tmp/frame.xtc"],
+  },
 });
 
 const dragDropMatrix = [
@@ -517,27 +562,63 @@ const dragDropMatrix = [
     },
   },
   {
-    name: "protein target plus protein file opens separately",
+    name: "protein target plus protein file opens combined view",
     actual: resolveDropAction(payload(["/tmp/receptor-b.cif"]), {
       kind: "active-viewer",
       documentPath: "/tmp/receptor-a.pdb",
       renderer: "molstar",
     }),
     expected: {
-      kind: "open-documents",
-      paths: ["/tmp/receptor-b.cif"],
+      kind: "open-docking",
+      request: {
+        receptorPath: "/tmp/receptor-a.pdb",
+        ligandPaths: ["/tmp/receptor-b.cif"],
+      },
     },
   },
   {
-    name: "ligand target plus ligand file opens separately",
+    name: "ligand target plus ligand file opens combined view",
     actual: resolveDropAction(payload(["/tmp/ligand-b.sdf"]), {
       kind: "active-viewer",
       documentPath: "/tmp/ligand-a.sdf",
       renderer: "molstar",
     }),
     expected: {
-      kind: "open-documents",
-      paths: ["/tmp/ligand-b.sdf"],
+      kind: "open-docking",
+      request: {
+        receptorPath: "/tmp/ligand-a.sdf",
+        ligandPaths: ["/tmp/ligand-b.sdf"],
+      },
+    },
+  },
+  {
+    name: "gro target plus trajectory file opens combined view",
+    actual: resolveDropAction(payload(["/tmp/frame.xtc"]), {
+      kind: "active-viewer",
+      documentPath: "/tmp/frame.gro",
+      renderer: "molstar",
+    }),
+    expected: {
+      kind: "open-docking",
+      request: {
+        receptorPath: "/tmp/frame.gro",
+        ligandPaths: ["/tmp/frame.xtc"],
+      },
+    },
+  },
+  {
+    name: "trajectory target plus gro file opens combined view with gro anchor",
+    actual: resolveDropAction(payload(["/tmp/frame.gro"]), {
+      kind: "active-viewer",
+      documentPath: "/tmp/frame.xtc",
+      renderer: "molstar",
+    }),
+    expected: {
+      kind: "open-docking",
+      request: {
+        receptorPath: "/tmp/frame.gro",
+        ligandPaths: ["/tmp/frame.xtc"],
+      },
     },
   },
   {


### PR DESCRIPTION
## Summary
- allow docking/combined mode to use any Mol* viewer source, including GRO and MD trajectory/topology files
- prefer model/topology anchors over coordinate trajectory files for trajectory combinations
- load model/topology + coordinates through Mol* loadTrajectory so GRO+XTC opens as a native trajectory

## Tests
- bun tests/test-docking-documents.mjs
- bun tests/test-drop-actions.mjs
- bun tests/test-docking-viewer-contract.mjs
- bun tests/test-ui-shell-contract.mjs
- pre-push ci-fast