### PR TITLE
Thin dock divider lines

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1320,7 +1320,7 @@ img.radix-menu-item-icon {
   overflow: hidden;
 }
 .dock-panel {
-  --dock-divider-color: color-mix(in srgb, var(--text-primary) 52%, var(--bg-base));
+  --dock-divider-color: var(--line-subtler);
   --dock-divider-active-color: color-mix(in srgb, var(--accent) 62%, var(--text-primary));
   position: relative;
   z-index: 1;
@@ -1336,7 +1336,6 @@ img.radix-menu-item-icon {
   will-change: width, height;
 }
 .app-shell[data-effective-theme="dark"] .dock-panel {
-  --dock-divider-color: color-mix(in srgb, var(--text-primary) 60%, var(--bg-base));
   --dock-divider-active-color: color-mix(in srgb, var(--accent) 70%, var(--text-primary));
 }
 .dock-panel[data-dragging] {
@@ -1416,7 +1415,7 @@ img.radix-menu-item-icon {
   content: "";
   position: absolute;
   background: var(--dock-divider-color);
-  transition: background 180ms ease-out, box-shadow 180ms ease-out, transform 180ms ease-out;
+  transition: background 180ms ease-out, transform 180ms ease-out;
 }
 .dock-panel[data-area="right"] .dock-resizer::after {
   top: var(--chrome-height);
@@ -1435,7 +1434,6 @@ img.radix-menu-item-icon {
 .dock-panel[data-area="bottom"] .dock-resizer:hover::after,
 .dock-panel[data-area="bottom"] .dock-resizer:active::after {
   background: var(--dock-divider-active-color);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 34%, transparent);
 }
 .dock-header {
   height: 44px;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1179,8 +1179,8 @@ assert.match(shellStore, /payload: \{ paths: \[path\], records: \[\] \}/);
 assert.match(shellStore, /payload: \{ paths: \[\], records: \[record\] \}/);
 assert.match(dockPanel, /className="dock-panel-inner"/);
 assert.match(dockPanel, /style=\{area === "right" \? \{ width: size \} : \{ height: size \}\}/);
-assert.match(styles, /--dock-divider-color: color-mix\(in srgb, var\(--text-primary\) 52%, var\(--bg-base\)\)/);
-assert.match(styles, /\.app-shell\[data-effective-theme="dark"\] \.dock-panel \{[\s\S]*--dock-divider-color: color-mix\(in srgb, var\(--text-primary\) 60%, var\(--bg-base\)\)/);
+assert.match(styles, /--dock-divider-color: var\(--line-subtler\)/);
+assert.doesNotMatch(styles, /\.app-shell\[data-effective-theme="dark"\] \.dock-panel \{[\s\S]*--dock-divider-color:/);
 assert.match(styles, /\.app-shell\[data-effective-theme="dark"\] \.dock-panel \{/);
 assert.match(styles, /\.dock-panel \{[\s\S]*transition: width 180ms cubic-bezier\(0\.2, 0, 0, 1\), height 180ms cubic-bezier\(0\.2, 0, 0, 1\), opacity 140ms ease-out;/);
 assert.match(styles, /\.dock-panel\[data-dragging\] \{[\s\S]*transition: width 90ms linear, height 90ms linear, opacity 90ms linear;/);
@@ -1196,6 +1196,7 @@ assert.doesNotMatch(styles, /\.dock-panel\[data-area="bottom"\] \{[^}]*box-shado
 assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer::after \{[\s\S]*top: var\(--chrome-height\);/);
 assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer::after \{[\s\S]*width: 1px;/);
 assert.match(styles, /\.dock-panel\[data-area="bottom"\] \.dock-resizer::after \{[\s\S]*height: 1px;/);
+assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer:hover::after,[\s\S]*?\.dock-panel\[data-area="bottom"\] \.dock-resizer:active::after \{\s*background: var\(--dock-divider-active-color\);\s*\}/);
 assert.match(styles, /\.dock-viewer \.ketcher-page \{[\s\S]*position: relative;[\s\S]*inset: auto;[\s\S]*overflow: hidden;/);
 assert.match(styles, /\.dock-viewer \.ketcher-page-header \{[\s\S]*grid-template-columns: minmax\(0, 1fr\);/);
 assert.match(styles, /\.dock-viewer \.ketcher-page-actions \{[\s\S]*overflow-x: auto;/);


### PR DESCRIPTION
## Summary
- make dock split dividers use the same subtle line token as other shell hairlines
- remove the hover/active halo that made resize dividers appear thicker
- update the shell contract test to pin the divider treatment

## Validation
- uv run vp run test:ui
- git diff --check
- pre-push ci-fast