### PR TITLE
Document Vite+ native binding recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ folded into a Vite+ built-in. Direct Bun commands remain implementation details
 inside repository-owned build, release, and installer scripts until a separate
 toolchain migration replaces those paths.
 
+When running `vp` from the Codex desktop shell on macOS, the app-bundled Node
+binary can fail to load Vite+/Rolldown native bindings. If a Vite+ command
+reports `Cannot find native binding` for `rolldown-binding.darwin-arm64.node`,
+first run `vp install`, then retry with the first non-Codex Node executable in
+`PATH` before changing application code. Do not hard-code a Codex runtime path;
+find a normal Node installation from the environment.
+
 ## Browser Opening
 
 When the user asks to open something in a browser, or simply asks to open a

--- a/docs/vite-plus.md
+++ b/docs/vite-plus.md
@@ -37,6 +37,47 @@ vp run ready
 temporarily disabled for the legacy source tree to avoid a repository-wide
 format-only diff during the toolchain migration.
 
+## Native Binding Troubleshooting
+
+If `vp dev`, `vp check`, or another Vite+ command fails on macOS with
+`Cannot find native binding` and mentions
+`rolldown-binding.darwin-arm64.node`, treat it as a local toolchain issue
+before investigating application code.
+
+First make sure the workspace dependencies are installed:
+
+```bash
+vp install
+```
+
+When running inside the Codex desktop shell, also check which Node executable
+is first in `PATH`:
+
+```bash
+which node
+```
+
+If it resolves to the Node binary inside `Codex.app`, macOS library validation
+can prevent Vite+ native packages from loading even when the optional
+dependencies are installed. Run Vite+ with the first non-Codex Node executable
+first in `PATH`:
+
+```bash
+node_bin="$(
+  printf '%s' "$PATH" | tr ':' '\n' | while IFS= read -r dir; do
+    case "$dir" in *Codex.app*|'') continue ;; esac
+    if [ -x "$dir/node" ]; then
+      printf '%s\n' "$dir/node"
+      break
+    fi
+  done
+)"
+PATH="$(dirname "$node_bin"):$PATH" vp dev
+```
+
+This keeps `vp` as the development entrypoint while avoiding false regressions
+from Codex's app-bundled Node binary.
+
 ## Native Validation
 
 Rust and native macOS validation still run from the Tauri crate or the existing


### PR DESCRIPTION
## Summary
- document Vite+ native binding recovery for macOS/Codex shell
- tell agents to find a normal non-Codex Node from the environment instead of hard-coding runtime paths

## Verification
- Not run manually; documentation-only change.