### PR TITLE
Support ChimeraX GRO Quick Look type

### DIFF
--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -424,6 +424,7 @@
 				<string>com.apple.videoapps.cube</string>
 				<string>com.gaussian.cube</string>
 				<string>com.local.burrete10.gro</string>
+				<string>gg.flew.unfold.gromacs-structure</string>
 				<string>com.local.burrete10.molecular-dynamics</string>
 				<string>com.schrodinger.mae</string>
 				<string>com.local.burrete10.schrodinger</string>

--- a/PreviewExtension/ThumbnailInfo.plist
+++ b/PreviewExtension/ThumbnailInfo.plist
@@ -39,6 +39,7 @@
 				<string>com.local.burrete10.xyz</string>
 				<string>net.sourceforge.openbabel.xyz</string>
 				<string>com.local.burrete10.gro</string>
+				<string>gg.flew.unfold.gromacs-structure</string>
 				<string>com.local.burrete10.xyzrender-input</string>
 				<string>com.adobe.fdf</string>
 				<string>com.apple.videoapps.cube</string>

--- a/apps/desktop/src-tauri/AppMetadata.plist
+++ b/apps/desktop/src-tauri/AppMetadata.plist
@@ -97,6 +97,7 @@
 				<string>com.apple.videoapps.cube</string>
 				<string>com.gaussian.cube</string>
 				<string>com.local.burrete10.gro</string>
+				<string>gg.flew.unfold.gromacs-structure</string>
 				<string>com.local.burrete10.molecular-dynamics</string>
 				<string>com.schrodinger.mae</string>
 				<string>com.local.burrete10.schrodinger</string>

--- a/config/preview-formats.json
+++ b/config/preview-formats.json
@@ -108,6 +108,7 @@
     {
       "id": "gro",
       "contentType": "com.local.burrete10.gro",
+      "contentTypeAliases": ["gg.flew.unfold.gromacs-structure"],
       "extensions": ["gro"],
       "conformsTo": ["public.plain-text", "public.data"],
       "description": "GROMACS structure file",
@@ -202,6 +203,7 @@
       "com.apple.videoapps.cube",
       "com.gaussian.cube",
       "com.local.burrete10.gro",
+      "gg.flew.unfold.gromacs-structure",
       "com.local.burrete10.molecular-dynamics",
       "com.schrodinger.mae",
       "com.local.burrete10.schrodinger",

--- a/scripts/check-preview-format-registry.mjs
+++ b/scripts/check-preview-format-registry.mjs
@@ -74,6 +74,7 @@ const allowedSystemQuickLookContentTypes = new Set([
   'com.schrodinger.mol',
   'com.schrodinger.pdb',
   'com.schrodinger.sdf',
+  'gg.flew.unfold.gromacs-structure',
   'net.sourceforge.openbabel.xyz',
   'public.cif',
   'public.delimited-values-text',

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -423,6 +423,7 @@ assert.match(thumbnailInfoPlist, /ThumbnailProvider/);
 assert.match(thumbnailInfoPlist, /com\.local\.burrete10\.pdb/);
 assert.match(thumbnailInfoPlist, /com\.local\.burrete10\.sdf/);
 assert.match(thumbnailInfoPlist, /com\.local\.burrete10\.xyz/);
+assert.match(thumbnailInfoPlist, /gg\.flew\.unfold\.gromacs-structure/);
 assert.match(thumbnailProviderSource, /final class ThumbnailProvider: QLThumbnailProvider/);
 assert.match(thumbnailProviderSource, /QLThumbnailReply\(contextSize: size\)/);
 assert.match(thumbnailProviderSource, /parsePDB/);


### PR DESCRIPTION
## Summary
- Add the ChimeraX GROMACS `.gro` UTI alias to Burrete app, Quick Look preview, and thumbnail metadata.
- Keep the preview format registry and metadata validation aligned.
- Pin the thumbnail metadata contract so the alias is not dropped later.

## Root cause
Finder can resolve `.gro` files through ChimeraX's `gg.flew.unfold.gromacs-structure` UTI. Burrete only advertised `com.local.burrete10.gro`, so normal Quick Look selection could fall back to the system text preview even though forced Burrete preview rendered the file successfully.

## Validation
- `bun scripts/check-preview-format-registry.mjs`
- `bun tests/test-tauri-structure.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `plutil -lint apps/desktop/src-tauri/AppMetadata.plist PreviewExtension/Info.plist PreviewExtension/ThumbnailInfo.plist`
- pre-push `bun run ci:fast`
