### PR TITLE
Fix Ketcher icon backgrounds

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2028,8 +2028,9 @@ img.radix-menu-item-icon {
 .ketcher-editor-shell [class*="StructEditor-module_intermediateCanvas"],
 .ketcher-editor-shell [data-testid="canvas"],
 .ketcher-editor-shell [data-testid="drawn-structures"],
+.ketcher-editor-shell [data-testid="drawn-structures"] svg,
 .ketcher-editor-shell [data-testid="ketcher-canvas"],
-.ketcher-editor-shell svg {
+.ketcher-editor-shell [data-testid="ketcher-canvas"] svg {
   background-color: #f5f5f5;
 }
 .ketcher-editor-shell [data-testid="ketcher-canvas"] {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1065,6 +1065,8 @@ assert.match(styles, /\.ketcher-editor-shell \[class\*="App-module_app"\]\s*\{[^
 assert.match(styles, /\.ketcher-editor-shell \[data-testid="top-toolbar"\]\s*\{[^}]*width: min\(100%, calc\(100% \* var\(--ketcher-ui-scale, 1\)\)\) !important;[^}]*height: var\(--ketcher-top-toolbar-height\) !important;[^}]*min-height: var\(--ketcher-top-toolbar-height\) !important;/s);
 assert.match(styles, /\.ketcher-editor-shell \[data-testid="top-toolbar"\] button:has\(svg\)\s*\{[^}]*width: var\(--ketcher-top-toolbar-button-size\) !important;[^}]*min-width: var\(--ketcher-top-toolbar-button-size\) !important;/s);
 assert.match(styles, /\.ketcher-editor-shell \[data-testid="top-toolbar"\] button > svg\s*\{[^}]*width: var\(--ketcher-top-toolbar-icon-size\) !important;[^}]*height: var\(--ketcher-top-toolbar-icon-size\) !important;/s);
+assert.match(styles, /\.ketcher-editor-shell \[data-testid="ketcher-canvas"\] svg\s*\{[^}]*background-color: #f5f5f5;/s);
+assert.doesNotMatch(styles, /\.ketcher-editor-shell svg\s*\{[^}]*background-color: #f5f5f5;/s);
 assert.doesNotMatch(styles, /\.ketcher-editor-scale-frame\s*\{[^}]*transform: scale\(var\(--ketcher-ui-scale, 1\)\);/s);
 assert.doesNotMatch(styles, /\.ketcher-editor-scale-frame\s*\{[^}]*transform-origin: 0 0;/s);
 assert.doesNotMatch(styles, /\.ketcher-editor-scale-frame\s*\{[^}]*zoom: var\(--ketcher-ui-scale, 1\);/s);


### PR DESCRIPTION
## Summary
- keep Ketcher toolbar SVG icons transparent by limiting editor background styling to canvas SVGs
- add a shell contract regression for the scoped selector

## Tests
- bun tests/test-ui-shell-contract.mjs
- bash scripts/ci-fast.sh (via pre-push)