### PR TITLE
Fix Quick Look CSV handler registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "base64 0.22.1",
  "burrete-core",
  "cocoa",
+ "core-foundation",
  "ed25519-dalek",
  "flate2",
  "objc",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,4 +31,5 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"
+core-foundation = "0.10"
 objc = "0.2"

--- a/apps/desktop/src-tauri/src/commands/quicklook.rs
+++ b/apps/desktop/src-tauri/src/commands/quicklook.rs
@@ -1,9 +1,33 @@
 #[cfg(target_os = "macos")]
+use core_foundation::base::{Boolean, OSStatus, TCFType};
+#[cfg(target_os = "macos")]
+use core_foundation::string::{CFString, CFStringRef};
+#[cfg(target_os = "macos")]
+use core_foundation::url::{CFURLRef, CFURL};
+#[cfg(target_os = "macos")]
+use plist::Value;
+#[cfg(target_os = "macos")]
 use serde::Serialize;
+#[cfg(target_os = "macos")]
+use std::collections::BTreeSet;
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
+
+#[cfg(target_os = "macos")]
+const K_LS_ROLES_VIEWER: u32 = 0x00000002;
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreServices", kind = "framework")]
+extern "C" {
+    fn LSRegisterURL(in_url: CFURLRef, in_update: Boolean) -> OSStatus;
+    fn LSSetDefaultRoleHandlerForContentType(
+        in_content_type: CFStringRef,
+        in_role: u32,
+        in_handler_bundle_id: CFStringRef,
+    ) -> OSStatus;
+}
 
 #[cfg(target_os = "macos")]
 #[derive(Debug, Serialize)]
@@ -11,6 +35,7 @@ use std::process::Command;
 pub(crate) struct QuickLookResetReport {
     ok: bool,
     launch_services_registered: CommandReport,
+    default_handlers_registered: CommandReport,
     extension_registered: CommandReport,
     extension_enabled: CommandReport,
     qlmanage_reset: CommandReport,
@@ -32,18 +57,21 @@ struct CommandReport {
 #[tauri::command]
 pub(crate) fn reset_quick_look() -> Result<QuickLookResetReport, String> {
     let app_bundle = current_app_bundle()?;
+    let app_bundle_id =
+        bundle_id(&app_bundle).unwrap_or_else(|| "com.local.BurreteV10".to_string());
     let preview_extension = app_bundle
         .join("Contents")
         .join("PlugIns")
         .join("BurretePreview.appex");
-    let preview_extension_id = preview_extension_bundle_id(&preview_extension)
-        .unwrap_or_else(|| "com.local.BurreteV10.Preview".to_string());
+    let preview_extension_id =
+        bundle_id(&preview_extension).unwrap_or_else(|| "com.local.BurreteV10.Preview".to_string());
 
     let launch_services_registered = run_command(
         "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
         vec!["-f".into(), "-R".into(), app_bundle.to_string_lossy().to_string()],
         false,
     );
+    let default_handlers_registered = register_default_viewer_handlers(&app_bundle, &app_bundle_id);
     let extension_registered = run_command(
         "/usr/bin/pluginkit",
         vec!["-a".into(), preview_extension.to_string_lossy().to_string()],
@@ -62,6 +90,7 @@ pub(crate) fn reset_quick_look() -> Result<QuickLookResetReport, String> {
     );
     let quicklookd_killed = run_command("/usr/bin/killall", vec!["quicklookd".into()], true);
     let ok = launch_services_registered.success
+        && default_handlers_registered.success
         && extension_registered.success
         && extension_enabled.success
         && qlmanage_reset.success
@@ -70,12 +99,126 @@ pub(crate) fn reset_quick_look() -> Result<QuickLookResetReport, String> {
     Ok(QuickLookResetReport {
         ok,
         launch_services_registered,
+        default_handlers_registered,
         extension_registered,
         extension_enabled,
         qlmanage_reset,
         qlmanage_cache_reset,
         quicklookd_killed,
     })
+}
+
+#[cfg(target_os = "macos")]
+fn register_default_viewer_handlers(app_bundle: &Path, app_bundle_id: &str) -> CommandReport {
+    let command = "CoreServices.LSSetDefaultRoleHandlerForContentType";
+    let content_types = match document_content_types(app_bundle) {
+        Ok(content_types) => content_types,
+        Err(message) => {
+            return CommandReport {
+                command,
+                success: false,
+                status: None,
+                message,
+            };
+        }
+    };
+    if content_types.is_empty() {
+        return CommandReport {
+            command,
+            success: false,
+            status: None,
+            message: "No LSItemContentTypes found in app bundle.".to_string(),
+        };
+    }
+
+    let app_url = match CFURL::from_path(app_bundle, true) {
+        Some(app_url) => app_url,
+        None => {
+            return CommandReport {
+                command,
+                success: false,
+                status: None,
+                message: format!(
+                    "Could not create app bundle URL for {}.",
+                    app_bundle.display()
+                ),
+            };
+        }
+    };
+    let app_bundle_id = CFString::new(app_bundle_id);
+    let register_status = unsafe { LSRegisterURL(app_url.as_concrete_TypeRef(), true as Boolean) };
+    let mut failures = Vec::new();
+    for content_type in &content_types {
+        let content_type_ref = CFString::new(content_type);
+        let status = unsafe {
+            LSSetDefaultRoleHandlerForContentType(
+                content_type_ref.as_concrete_TypeRef(),
+                K_LS_ROLES_VIEWER,
+                app_bundle_id.as_concrete_TypeRef(),
+            )
+        };
+        if status != 0 {
+            failures.push(format!("{content_type}: {status}"));
+        }
+    }
+
+    let success = register_status == 0 && failures.is_empty();
+    let status = if register_status != 0 {
+        Some(register_status)
+    } else {
+        failures
+            .first()
+            .and_then(|failure| failure.rsplit_once(": "))
+            .and_then(|(_, status)| status.parse::<i32>().ok())
+    };
+    let message = if success {
+        format!("registered {} default viewer handlers", content_types.len())
+    } else {
+        let mut message = format!("LSRegisterURL status: {register_status}");
+        if !failures.is_empty() {
+            message.push_str("; handler failures: ");
+            message.push_str(&failures.join(", "));
+        }
+        message
+    };
+    CommandReport {
+        command,
+        success,
+        status,
+        message,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn document_content_types(app_bundle: &Path) -> Result<BTreeSet<String>, String> {
+    let plist = app_bundle.join("Contents").join("Info.plist");
+    let info = Value::from_file(&plist)
+        .map_err(|err| format!("Could not read {}: {err}", plist.display()))?;
+    let dictionary = info
+        .as_dictionary()
+        .ok_or_else(|| format!("{} is not a dictionary.", plist.display()))?;
+    let document_types = dictionary
+        .get("CFBundleDocumentTypes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "CFBundleDocumentTypes is missing or not an array.".to_string())?;
+    let mut content_types = BTreeSet::new();
+    for document_type in document_types {
+        let Some(document_type) = document_type.as_dictionary() else {
+            continue;
+        };
+        let Some(values) = document_type
+            .get("LSItemContentTypes")
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for value in values {
+            if let Some(content_type) = value.as_string() {
+                content_types.insert(content_type.to_string());
+            }
+        }
+    }
+    Ok(content_types)
 }
 
 #[cfg(target_os = "macos")]
@@ -126,8 +269,8 @@ fn current_app_bundle() -> Result<PathBuf, String> {
 }
 
 #[cfg(target_os = "macos")]
-fn preview_extension_bundle_id(preview_extension: &Path) -> Option<String> {
-    let plist = preview_extension.join("Contents").join("Info.plist");
+fn bundle_id(bundle: &Path) -> Option<String> {
+    let plist = bundle.join("Contents").join("Info.plist");
     let output = Command::new("/usr/libexec/PlistBuddy")
         .args(["-c", "Print :CFBundleIdentifier"])
         .arg(plist)

--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -798,6 +798,23 @@ rm -rf "$BACKUP_APP"
 APPEX="$DEST_APP/Contents/PlugIns/BurretePreview.appex"
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 [ -x "$LSREGISTER" ] && "$LSREGISTER" -f -R "$DEST_APP" || true
+if [ -x /usr/bin/swift ]; then
+  BURRETE_APP_PATH="$DEST_APP" BURRETE_APP_ID="$APP_ID" /usr/bin/swift - <<'SWIFT' >/dev/null 2>&1 || true
+import CoreServices
+import Foundation
+
+let appPath = ProcessInfo.processInfo.environment["BURRETE_APP_PATH"] ?? ""
+let bundleID = (ProcessInfo.processInfo.environment["BURRETE_APP_ID"] ?? "com.local.BurreteV10") as CFString
+let appURL = URL(fileURLWithPath: appPath)
+LSRegisterURL(appURL as CFURL, true)
+let bundle = Bundle(url: appURL)
+let documentTypes = bundle?.object(forInfoDictionaryKey: "CFBundleDocumentTypes") as? [[String: Any]] ?? []
+let contentTypes = Set(documentTypes.flatMap {{ $0["LSItemContentTypes"] as? [String] ?? [] }})
+for contentType in contentTypes {{
+    LSSetDefaultRoleHandlerForContentType(contentType as CFString, .viewer, bundleID)
+}}
+SWIFT
+fi
 [ -d "$APPEX" ] && /usr/bin/pluginkit -a "$APPEX" 2>/dev/null || true
 /usr/bin/pluginkit -e use -i "$EXT_ID" 2>/dev/null || true
 /usr/bin/qlmanage -r >/dev/null 2>&1 || true

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -330,12 +330,15 @@ assert.match(quickLookCommand, /#\[tauri::command\]\s+pub\(crate\) fn reset_quic
 assert.match(updaterCommand, /#\[tauri::command\]\s+pub\(crate\) async fn install_update/);
 assert.match(quickLookCommand, /QuickLookResetReport/);
 assert.match(quickLookCommand, /launch_services_registered: CommandReport/);
+assert.match(quickLookCommand, /default_handlers_registered: CommandReport/);
 assert.match(quickLookCommand, /extension_registered: CommandReport/);
 assert.match(quickLookCommand, /extension_enabled: CommandReport/);
 assert.match(quickLookCommand, /LaunchServices\.framework\/Support\/lsregister/);
+assert.match(quickLookCommand, /LSSetDefaultRoleHandlerForContentType/);
 assert.match(quickLookCommand, /"\/usr\/bin\/pluginkit"/);
-assert.match(quickLookCommand, /preview_extension_bundle_id\(&preview_extension\)/);
+assert.match(quickLookCommand, /bundle_id\(&preview_extension\)/);
 assert.match(quickLookCommand, /\.output\(\)/);
+assert.match(updaterCommand, /LSSetDefaultRoleHandlerForContentType/);
 assert.doesNotMatch(quickLookCommand, /\.spawn\(\)/);
 assert.match(buildScript, /does not accept positional arguments/);
 assert.match(buildScript, /BURRETE_BUILD_MODE/);


### PR DESCRIPTION
## Summary
- register Burrete as the default viewer handler for supported document types during Quick Look reset
- restore document type handler registration after updater installs a replacement app
- pin the registration path in structural tests

## Verification
- cargo fmt --check
- cargo check
- cargo test ingests_canonical_smiles_csv_fixture
- bun tests/test-tauri-structure.mjs
- bun scripts/check-preview-format-registry.mjs
- pre-push ci-fast