### PR TITLE
Fix CMS fallback opening

### DIFF
--- a/apps/desktop/src-tauri/src/preview/runtime.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime.rs
@@ -351,30 +351,35 @@ pub(crate) fn open_document_with_grid_options<R: Runtime>(
         return Err(format!("{} is not a file", canonical.display()));
     }
     let extension = structure_path_extension(&canonical);
-    if let Some(desmond_preview) = create_desmond_trajectory_preview(app, &canonical, &extension)? {
-        let format = format_for_extension("pdb")?;
-        let runtime = create_runtime(
-            app,
-            &canonical,
-            "pdb",
-            &format,
-            "molstar",
-            &desmond_preview,
-            preferences,
-            reload_options,
-        )?;
-        return Ok(ViewerDocument {
-            id: stable_id(&canonical),
-            path: canonical.to_string_lossy().to_string(),
-            title: file_title(&canonical),
-            extension,
-            renderer: runtime.renderer,
-            runtime_path: runtime.path.to_string_lossy().to_string(),
-            byte_count: metadata.len(),
-            is_virtual: false,
-            docking_request: None,
-        });
-    }
+    let desmond_preview_error = match create_desmond_trajectory_preview(app, &canonical, &extension)
+    {
+        Ok(Some(desmond_preview)) => {
+            let format = format_for_extension("pdb")?;
+            let runtime = create_runtime(
+                app,
+                &canonical,
+                "pdb",
+                &format,
+                "molstar",
+                &desmond_preview,
+                preferences,
+                reload_options,
+            )?;
+            return Ok(ViewerDocument {
+                id: stable_id(&canonical),
+                path: canonical.to_string_lossy().to_string(),
+                title: file_title(&canonical),
+                extension,
+                renderer: runtime.renderer,
+                runtime_path: runtime.path.to_string_lossy().to_string(),
+                byte_count: metadata.len(),
+                is_virtual: false,
+                docking_request: None,
+            });
+        }
+        Ok(None) => None,
+        Err(error) => Some(error),
+    };
     let uses_bounded_maestro_preview =
         is_maestro_preview_extension(&extension) && metadata.len() > MAX_STRUCTURE_FILE_SIZE;
     if metadata.len() > MAX_STRUCTURE_FILE_SIZE && !uses_bounded_maestro_preview {
@@ -400,10 +405,16 @@ pub(crate) fn open_document_with_grid_options<R: Runtime>(
         None
     };
     if uses_bounded_maestro_preview && maestro_preview_data.is_none() {
-        return Err(format!(
+        let mut message = format!(
             "{} is larger than the normal preview limit and no Maestro atom table could be extracted from the first 64 MB",
             canonical.display()
-        ));
+        );
+        if let Some(error) = desmond_preview_error {
+            message.push_str(&format!(
+                "; Desmond trajectory preview also failed: {error}"
+            ));
+        }
+        return Err(message);
     }
     let requested_renderer = normalize_renderer_mode(&preferences.renderer_mode);
     let should_use_viewer_for_sdf = matches!(extension.as_str(), "sd" | "sdf")

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3457,6 +3457,7 @@ function isFepGraphmlPath(path: string) {
 
 function pathExtension(path: string) {
   const fileName = path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+  if (fileName.toLowerCase().endsWith(".mae.gz")) return "maegz";
   const index = fileName.lastIndexOf(".");
   if (index <= 0 || index === fileName.length - 1) return "";
   return fileName.slice(index + 1).toLowerCase();

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -493,6 +493,9 @@ assert.match(viteConfig, /casebookCmsCandidates\(trjDirectory, base\)/);
 assert.match(viteConfig, /"dtr"/);
 assert.match(tauriConfig, /"[^"]*scripts\/desmond_preview_extract\.py": "desmond_preview_extract\.py"/);
 assert.match(previewRuntimeSource, /fn create_desmond_trajectory_preview/);
+assert.match(previewRuntimeSource, /let desmond_preview_error\s*=\s*match create_desmond_trajectory_preview/);
+assert.match(previewRuntimeSource, /Ok\(None\) => None,\s*Err\(error\) => Some\(error\),/);
+assert.match(previewRuntimeSource, /Desmond trajectory preview also failed: \{error\}/);
 assert.match(previewRuntimeSource, /const DESMOND_PREVIEW_TARGET_MB: &str = "24"/);
 assert.match(previewRuntimeSource, /\.arg\("--frames"\)\s*\.arg\("0"\)\s*\.arg\("--atoms"\)\s*\.arg\("0"\)\s*\.arg\("--target-mb"\)\s*\.arg\(DESMOND_PREVIEW_TARGET_MB\)/s);
 assert.match(previewRuntimeSource, /fn is_desmond_preview_candidate/);
@@ -2372,6 +2375,7 @@ assert.match(browserDevDocuments, /function maestroPdbDataFromText\(text: string
 assert.match(browserDevDocuments, /const score = maestroCtScore\(currentCtType\)/);
 assert.match(browserDevDocuments, /if \(ctType === "solute"\) return 4/);
 assert.match(browserDevDocuments, /function parseOrcaAtoms\(lines: string\[\]\)/);
+assert.match(app, /if \(fileName\.toLowerCase\(\)\.endsWith\("\.mae\.gz"\)\) return "maegz";/);
 assert.match(browserDevDocuments, /if \(name\.toLowerCase\(\)\.endsWith\("\.mae\.gz"\)\) return "maegz";/);
 assert.match(browserDevDocuments, /isMaestroPreviewExtension\(extension\) && extension !== "maegz"/);
 assert.match(browserDevDocuments, /function browserDevReadUrl\(path: string, extension: string\)/);


### PR DESCRIPTION
## Summary

- Keep CMS files openable when Desmond trajectory extraction fails by falling back to the normal Maestro/CMS preview path.
- Treat `.mae.gz` as `maegz` in the real app frontend path classifier so it routes through structure opening instead of text fallback.
- Pin both behaviors in the UI shell contract test.

## Root Cause

The Tauri runtime treated any Desmond preview extraction error as fatal before the regular CMS fallback could run. The frontend path classifier also handled only simple suffixes, so compound `.mae.gz` paths were classified as `gz`.

## Validation

- `node tests/test-ui-shell-contract.mjs`
- `cargo fmt --check`
- `cargo test -p burrete opens_supported_formats_with_expected_renderers`
- pre-push `ci-fast`