### PR TITLE
Add Open as text file drop action

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1894,6 +1894,7 @@ export default function App() {
     openDockingDocument,
     openDockingStructureRecords,
     openStructureRecords,
+    openTextDocuments,
     openKetcherWithStructures,
     openFepSetupWorkspace,
     openDockPayload,
@@ -3279,6 +3280,9 @@ export default function App() {
     openStructurePaths: async (paths: string[]) => {
       await openDocuments(paths);
     },
+    openTextPaths: async (paths: string[]) => {
+      await openTextDocuments(paths);
+    },
     openPaths,
     openStructureRecords,
     openRecentStructure,
@@ -3465,7 +3469,7 @@ export default function App() {
     },
     setPreference,
     setUpdatePreferences,
-  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyKetcherToGridRow, backToApp, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openWorkspaceFolder, pushErrorStatus, pushStatus, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showTextFileMetadata, tabs, toggleDock, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
+  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyKetcherToGridRow, backToApp, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openTextDocuments, openWorkspaceFolder, pushErrorStatus, pushStatus, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showTextFileMetadata, tabs, toggleDock, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
 
   const page = activeTab?.location.kind === "settings" ? "settings" : "viewer";
 

--- a/apps/desktop/src/components/drop-action-executor.ts
+++ b/apps/desktop/src/components/drop-action-executor.ts
@@ -89,6 +89,10 @@ function runShellDropAction(
     void actions.openStructurePaths(action.paths);
     return;
   }
+  if (action.kind === "open-text-files") {
+    void actions.openTextPaths(action.paths);
+    return;
+  }
   if (action.kind === "open-structure-records") {
     if (action.paths.length > 0) void actions.openStructurePaths(action.paths);
     if (action.records.length > 0) void actions.openStructureRecords(action.records);

--- a/apps/desktop/src/components/types.ts
+++ b/apps/desktop/src/components/types.ts
@@ -70,6 +70,7 @@ export type ChemicalEditorTarget = {
 export type ShellActions = {
   chooseFiles: () => void | Promise<void>;
   openStructurePaths: (paths: string[]) => void | Promise<void>;
+  openTextPaths: (paths: string[]) => void | Promise<void>;
   openPaths: (paths: string[]) => void | Promise<void>;
   openStructureRecords: (records: StructureDragPayload["records"]) => void | Promise<void>;
   openRecentStructure: (structure: RecentStructure) => void | Promise<void>;

--- a/apps/desktop/src/hooks/use-open-drop.ts
+++ b/apps/desktop/src/hooks/use-open-drop.ts
@@ -12,6 +12,7 @@ import type { StructureDragPayload, StructureDragRecord } from "../lib/structure
 import { isTauriRuntime, trackTauriListener } from "../lib/tauri";
 
 type OpenDocuments = (paths: string[]) => void | Promise<void>;
+type OpenTextDocuments = (paths: string[]) => unknown;
 type OpenDockingDocument = (
   receptorPath: string,
   ligandPaths: string[],
@@ -51,6 +52,7 @@ type OpenDropOptions = {
   openDockingDocument?: OpenDockingDocument;
   openDockingStructureRecords?: OpenDockingStructureRecords;
   openStructureRecords?: OpenStructureRecords;
+  openTextDocuments?: OpenTextDocuments;
   openKetcherWithStructures?: OpenKetcherWithStructures;
   openFepSetupWorkspace?: OpenFepSetupWorkspace;
   openDockPayload?: OpenDockPayload;
@@ -100,6 +102,7 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
     openDockingDocument,
     openDockingStructureRecords,
     openStructureRecords,
+    openTextDocuments = openDocuments,
     openKetcherWithStructures,
     openFepSetupWorkspace,
     openDockPayload,
@@ -229,6 +232,10 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
       void openDocuments(action.paths);
       return;
     }
+    if (action.kind === "open-text-files") {
+      void openTextDocuments(action.paths);
+      return;
+    }
     if (action.kind === "open-structure-records") {
       if (action.paths.length > 0) void openDocuments(action.paths);
       if (action.records.length > 0 && openStructureRecords) {
@@ -246,6 +253,7 @@ export function useOpenDrop(openDocuments: OpenDocuments, pushStatus: ReportStat
     openDockingDocument,
     openDockingStructureRecords,
     openDocuments,
+    openTextDocuments,
     openFepSetupWorkspace,
     openKetcherWithStructures,
     openStructureRecords,

--- a/apps/desktop/src/lib/drop-actions.ts
+++ b/apps/desktop/src/lib/drop-actions.ts
@@ -69,6 +69,10 @@ export type DropAction =
       paths: string[];
     }
   | {
+      kind: "open-text-files";
+      paths: string[];
+    }
+  | {
       kind: "open-structure-records";
       paths: string[];
       records: StructureDragRecord[];
@@ -223,6 +227,13 @@ function withOpenSeparatelyChoices(
   const openSeparately = workspaceDropAction(payload);
   if (openSeparately.kind === "open-documents" || openSeparately.kind === "open-structure-records") {
     choices.push(choice(openSeparately.kind, "Open separately", "alternative", openSeparately, source));
+  }
+  const textPaths = uniquePaths(payload.paths);
+  if (textPaths.length > 0) {
+    choices.push(choice("open-text-files", "Open as text file", "alternative", {
+      kind: "open-text-files",
+      paths: textPaths,
+    }, source));
   }
   return choices;
 }

--- a/tests/test-drop-actions.mjs
+++ b/tests/test-drop-actions.mjs
@@ -82,8 +82,18 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/a.sdf"]), { kind: "ketc
       paths: ["/tmp/a.sdf"],
     },
   },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
+      paths: ["/tmp/a.sdf"],
+    },
+  },
 ]);
 assert.deepEqual(resolveDropActionChoices(payload(["/tmp/a.sdf"]), { kind: "ketcher" }, { kind: "tab" }).map((choice) => choice.source), [
+  { kind: "tab" },
   { kind: "tab" },
   { kind: "tab" },
 ]);
@@ -113,6 +123,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/receptor.pdb", "/tmp/a.
     confidence: "alternative",
     action: {
       kind: "open-documents",
+      paths: ["/tmp/receptor.pdb", "/tmp/a.sdf"],
+    },
+  },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
       paths: ["/tmp/receptor.pdb", "/tmp/a.sdf"],
     },
   },
@@ -169,6 +188,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/analogs.sdf"]), {
       paths: ["/tmp/analogs.sdf"],
     },
   },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
+      paths: ["/tmp/analogs.sdf"],
+    },
+  },
 ]);
 
 assert.deepEqual(resolveDropAction(payload(["/tmp/a.pdb"], [{ path: "structure.smi", inputExtension: "smi", text: "CCO\n" }]), {
@@ -215,6 +243,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/a.sdf"]), {
       paths: ["/tmp/a.sdf"],
     },
   },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
+      paths: ["/tmp/a.sdf"],
+    },
+  },
 ]);
 
 assert.deepEqual(resolveDropAction(payload(["/tmp/a.sdf"]), {
@@ -247,6 +284,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/a.sdf"]), {
     confidence: "alternative",
     action: {
       kind: "open-documents",
+      paths: ["/tmp/a.sdf"],
+    },
+  },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
       paths: ["/tmp/a.sdf"],
     },
   },
@@ -313,6 +359,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/ligand.sdf"]), {
     confidence: "alternative",
     action: {
       kind: "open-documents",
+      paths: ["/tmp/ligand.sdf"],
+    },
+  },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
       paths: ["/tmp/ligand.sdf"],
     },
   },
@@ -428,6 +483,15 @@ assert.deepEqual(resolveDropActionChoices(payload(["/tmp/receptor-a.pdb", "/tmp/
     confidence: "alternative",
     action: {
       kind: "open-documents",
+      paths: ["/tmp/receptor-a.pdb", "/tmp/receptor-b.cif", "/tmp/ligand.sdf"],
+    },
+  },
+  {
+    id: "open-text-files",
+    label: "Open as text file",
+    confidence: "alternative",
+    action: {
+      kind: "open-text-files",
       paths: ["/tmp/receptor-a.pdb", "/tmp/receptor-b.cif", "/tmp/ligand.sdf"],
     },
   },


### PR DESCRIPTION
## Summary
- add an Open as text file alternative to ambiguous structure drop menus when real file paths are present
- route the action through the existing text-file document opener in both browser drop and shell drop execution paths
- cover the new menu choice in drop-action contract expectations

## Tests
- bun tests/test-drop-actions.mjs
- bun tests/test-open-drop-contract.mjs
- bun tests/test-ui-shell-contract.mjs
- bun run --cwd apps/desktop typecheck
- git diff --check
- pre-push ci-fast