### PR TITLE
Open right dock drops as text by default

### DIFF
--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -385,6 +385,7 @@
 				<string>fdf</string>
 				<string>in</string>
 				<string>inp</string>
+				<string>log</string>
 				<string>nw</string>
 				<string>out</string>
 				<string>psi4</string>

--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -280,7 +280,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
     }
 
     private static let supportedStructureExtensions: Set<String> = [
-        "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "graphml", "gro", "in", "inp", "lammpstrj", "mae", "maegz", "mcif", "mmcif", "mol", "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin", "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz"
+        "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "graphml", "gro", "in", "inp", "lammpstrj", "log", "mae", "maegz", "mcif", "mmcif", "mol", "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin", "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz"
     ]
 
     private static func buildInlinePreviewHTML(
@@ -1434,7 +1434,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
             return 40 * mib
         case "bcif":
             return 50 * mib
-        case "abi", "com", "csv", "fdf", "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles", "tsv", "cub", "cube", "in", "inp", "nw", "out", "psi4", "qcin", "vasp", "lammpstrj", "top", "psf", "prmtop", "graphml":
+        case "abi", "com", "csv", "fdf", "sdf", "sd", "mol", "mol2", "xyz", "gro", "smi", "smiles", "tsv", "cub", "cube", "in", "inp", "log", "nw", "out", "psi4", "qcin", "vasp", "lammpstrj", "top", "psf", "prmtop", "graphml":
             return 25 * mib
         case "mae", "maegz", "cms":
             return 64 * mib
@@ -2216,7 +2216,7 @@ private enum PreviewStructureTextConverter {
             return parseQuantumEspressoInput(lines) ?? parseQSiteGeometry(lines) ?? parseBestCoordinateBlock(lines)
         case "nw", "psi4", "qcin":
             return parseBestCoordinateBlock(lines)
-        case "out":
+        case "log", "out":
             return parseOrcaOutput(lines) ?? parseGaussianOutput(lines) ?? parseBestCoordinateBlock(lines)
         case "cms", "mae", "maegz":
             return parseMaestroAtoms(lines, atomLimit: 20_000)
@@ -2341,7 +2341,7 @@ private enum PreviewStructureTextConverter {
     }
 
     private static func usesPDBTextFallback(_ fileExtension: String) -> Bool {
-        ["abi", "cub", "cube", "fdf", "in", "inp", "nw", "out", "psi4", "qcin"].contains(fileExtension.lowercased())
+        ["abi", "cub", "cube", "fdf", "in", "inp", "log", "nw", "out", "psi4", "qcin"].contains(fileExtension.lowercased())
     }
 
     private static func isGROExtension(_ fileExtension: String) -> Bool {
@@ -3402,7 +3402,7 @@ private struct StructureFormat {
             self = Self(molstarFormat: ext, isBinary: false)
         case "mae", "maegz", "cms":
             self = Self(molstarFormat: "xyzrender", isBinary: false, isExternalXyzrenderOnly: true)
-        case "abi", "com", "cub", "cube", "fdf", "in", "inp", "nw", "out", "psi4", "qcin", "vasp":
+        case "abi", "com", "cub", "cube", "fdf", "in", "inp", "log", "nw", "out", "psi4", "qcin", "vasp":
             self = Self(molstarFormat: "xyzrender", isBinary: false, isExternalXyzrenderOnly: true)
         default:
             self = Self(molstarFormat: "mmcif", isBinary: false)

--- a/apps/desktop/src-tauri/AppMetadata.plist
+++ b/apps/desktop/src-tauri/AppMetadata.plist
@@ -47,6 +47,7 @@
 				<string>in</string>
 				<string>inp</string>
 				<string>lammpstrj</string>
+				<string>log</string>
 				<string>mae</string>
 				<string>mae.gz</string>
 				<string>maegz</string>
@@ -154,6 +155,7 @@
 					<string>fdf</string>
 					<string>in</string>
 					<string>inp</string>
+					<string>log</string>
 					<string>nw</string>
 					<string>out</string>
 					<string>psi4</string>

--- a/apps/desktop/src-tauri/src/preview/runtime.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime.rs
@@ -1107,8 +1107,8 @@ mod document_open_tests {
 
     fn expected_real_renderer(path: &Path) -> &'static str {
         match super::structure_path_extension(path).as_str() {
-            "abi" | "com" | "cub" | "cube" | "fdf" | "in" | "inp" | "nw" | "out" | "psi4"
-            | "qcin" | "vasp" => "xyzrender-external",
+            "abi" | "com" | "cub" | "cube" | "fdf" | "in" | "inp" | "log" | "nw" | "out"
+            | "psi4" | "qcin" | "vasp" => "xyzrender-external",
             "cms" | "mae" | "maegz" => "xyzrender-external",
             "cif" | "mol2" | "pdb" => "molstar",
             "sdf" => {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -89,6 +89,7 @@
           "dcd",
           "inp",
           "lammpstrj",
+          "log",
           "nctraj",
           "nw",
           "top",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -113,7 +113,26 @@ const preferredTextExtensions = new Set([
   "html",
   "css",
 ]);
-const structureFirstTextExtensions = new Set(["out"]);
+const structureAndTextExtensions = new Set([
+  "abi",
+  "cms",
+  "com",
+  "csv",
+  "cub",
+  "cube",
+  "fdf",
+  "graphml",
+  "in",
+  "inp",
+  "log",
+  "mae",
+  "nw",
+  "out",
+  "psi4",
+  "qcin",
+  "tsv",
+  "vasp",
+]);
 
 const GRID_PERF_REPORT_PATH = "/private/tmp/burrete-grid-real-app-perf.jsonl";
 const SIDEBAR_DRAG_CLOSE_WIDTH = 180;
@@ -666,12 +685,12 @@ export default function App() {
 
     const structurePaths: string[] = [];
     const textPaths: string[] = [];
-    const structureFirstTextPaths: string[] = [];
+    const structureAndTextPaths: string[] = [];
 
     for (const path of cleanPaths) {
       const extension = pathExtension(path);
-      if (structureFirstTextExtensions.has(extension)) {
-        structureFirstTextPaths.push(path);
+      if (structureAndTextExtensions.has(extension)) {
+        structureAndTextPaths.push(path);
       } else if (structureExtensions.has(extension)) {
         structurePaths.push(path);
       } else if (preferredTextExtensions.has(extension) || extension.length > 0) {
@@ -685,13 +704,11 @@ export default function App() {
       await openDocuments(structurePaths);
     }
 
-    const fallbackTextPaths: string[] = [];
-    for (const path of structureFirstTextPaths) {
-      const result = await openDocuments([path]);
-      if (!result || result.documents.length === 0) fallbackTextPaths.push(path);
+    if (structureAndTextPaths.length > 0) {
+      await openDocuments(structureAndTextPaths);
     }
 
-    const textOpenPaths = [...textPaths, ...fallbackTextPaths];
+    const textOpenPaths = [...textPaths, ...structureAndTextPaths];
     if (textOpenPaths.length > 0) {
       await openTextDocuments(textOpenPaths);
     }
@@ -823,13 +840,31 @@ export default function App() {
 
     pushStatus(`Opening in ${input.area === "right" ? "right dock" : "bottom dock"}...`);
     try {
+      if (input.area === "right" && cleanPaths.length > 0) {
+        const textResult = isTauriRuntime()
+          ? await invoke<OpenTextFilesResult>("open_text_files", { paths: cleanPaths })
+          : await openBrowserDevTextFiles(cleanPaths);
+        if (textResult.documents.length > 0) {
+          addBackgroundTextDocuments(textResult.documents);
+          setDockDocument(input.area, textResult.documents[0].id);
+          addDockDrop(input);
+        }
+        const openedText = `Opened ${textResult.documents.length} text file${textResult.documents.length === 1 ? "" : "s"} in right dock`;
+        if (textResult.errors.length > 0) {
+          pushStatus(textResult.documents.length > 0 ? `${openedText}. ${summarizeErrors(textResult.errors)}` : summarizeErrors(textResult.errors), "error", textResult.errors);
+          return;
+        }
+        pushStatus(openedText);
+        return;
+      }
+
       const structurePaths: string[] = [];
       const textPaths: string[] = [];
-      const structureFirstTextPaths: string[] = [];
+      const structureAndTextPaths: string[] = [];
       for (const path of cleanPaths) {
         const extension = pathExtension(path);
-        if (structureFirstTextExtensions.has(extension)) {
-          structureFirstTextPaths.push(path);
+        if (structureAndTextExtensions.has(extension)) {
+          structureAndTextPaths.push(path);
         } else if (structureExtensions.has(extension)) {
           structurePaths.push(path);
         } else if (preferredTextExtensions.has(extension) || extension.length > 0) {
@@ -844,23 +879,18 @@ export default function App() {
           ? await invoke<OpenDocumentsResult>("open_documents", { paths: structurePaths, preferences, reloadOptions: undefined })
           : await openBrowserDevDocuments(structurePaths, preferences, undefined)
         : { documents: [], errors: [] };
-      const fallbackTextPaths: string[] = [];
-      const structureFirstResults: OpenDocumentsResult[] = [];
-      for (const path of structureFirstTextPaths) {
+      const structureAndTextResults: OpenDocumentsResult[] = [];
+      for (const path of structureAndTextPaths) {
         try {
           const result = isTauriRuntime()
             ? await invoke<OpenDocumentsResult>("open_documents", { paths: [path], preferences, reloadOptions: undefined })
             : await openBrowserDevDocuments([path], preferences, undefined);
           if (result.documents.length > 0) {
-            structureFirstResults.push(result);
-          } else {
-            fallbackTextPaths.push(path);
+            structureAndTextResults.push(result);
           }
-        } catch {
-          fallbackTextPaths.push(path);
-        }
+        } catch {}
       }
-      const textOpenPaths = [...textPaths, ...fallbackTextPaths];
+      const textOpenPaths = [...textPaths, ...structureAndTextPaths];
       const textResult = textOpenPaths.length > 0
         ? isTauriRuntime()
           ? await invoke<OpenTextFilesResult>("open_text_files", { paths: textOpenPaths })
@@ -871,13 +901,13 @@ export default function App() {
         : { opened: [], errors: [] };
       const openedStructures = [
         ...structurePathResult.documents,
-        ...structureFirstResults.flatMap((result) => result.documents),
+        ...structureAndTextResults.flatMap((result) => result.documents),
         ...recordResult.opened,
       ];
       const openedTextDocuments = textResult.documents;
       const errors = [
         ...structurePathResult.errors,
-        ...structureFirstResults.flatMap((result) => result.errors),
+        ...structureAndTextResults.flatMap((result) => result.errors),
         ...textResult.errors,
         ...recordResult.errors,
       ];

--- a/apps/desktop/src/lib/structure-drag.ts
+++ b/apps/desktop/src/lib/structure-drag.ts
@@ -243,5 +243,5 @@ function structureDragPathsFromPlainText(text: string) {
 function looksLikeStructurePathLine(line: string) {
   if (!line || /\s/u.test(line)) return false;
   if (/^(?:file:\/\/|\/|~\/|\.{1,2}\/|[A-Za-z]:[\\/])/u.test(line)) return true;
-  return /\.(?:abi|bcif|cif|cms|com|cub|cube|csv|ent|fdf|in|inp|mae|maegz|mmcif|mol|mol2|nw|out|pdb|psi4|qcin|sd|sdf|smi|smiles|tsv|vasp|xyz)$/iu.test(line);
+  return /\.(?:abi|bcif|cif|cms|com|cub|cube|csv|ent|fdf|in|inp|log|mae|maegz|mmcif|mol|mol2|nw|out|pdb|psi4|qcin|sd|sdf|smi|smiles|tsv|vasp|xyz)$/iu.test(line);
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -54,7 +54,7 @@ type StructureFileBundle = {
 };
 const DEV_FILE_EXTENSIONS = new Set([
   "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "gro",
-  "in", "inp", "lammpstrj", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
+  "in", "inp", "lammpstrj", "log", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
   "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
   "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz",
   "dtr",

--- a/config/preview-formats.json
+++ b/config/preview-formats.json
@@ -118,7 +118,7 @@
       "id": "xyzrender-input",
       "contentType": "com.local.burrete10.xyzrender-input",
       "contentTypeAliases": ["com.adobe.fdf", "com.apple.videoapps.cube", "com.gaussian.cube"],
-      "extensions": ["abi", "com", "cub", "cube", "fdf", "in", "inp", "nw", "out", "psi4", "qcin", "vasp"],
+      "extensions": ["abi", "com", "cub", "cube", "fdf", "in", "inp", "log", "nw", "out", "psi4", "qcin", "vasp"],
       "conformsTo": ["public.plain-text", "public.data"],
       "description": "xyzrender-compatible molecular structure file",
       "viewer": { "molstarFormat": "xyz", "binary": false, "externalOnly": true },
@@ -154,7 +154,7 @@
     "name": "Molecular structure files",
     "extensions": [
       "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "graphml", "gro",
-      "in", "inp", "lammpstrj", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
+      "in", "inp", "lammpstrj", "log", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
       "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
       "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz"
     ]

--- a/crates/burrete-core/src/lib.rs
+++ b/crates/burrete-core/src/lib.rs
@@ -124,8 +124,8 @@ pub fn quick_look_size_limit_for_extension(extension: &str) -> i64 {
         "cif" | "mmcif" | "mcif" => 40 * mib,
         "bcif" => 50 * mib,
         "abi" | "com" | "csv" | "fdf" | "sdf" | "sd" | "mol" | "mol2" | "xyz" | "gro" | "smi"
-        | "smiles" | "tsv" | "cub" | "cube" | "in" | "inp" | "nw" | "out" | "psi4" | "qcin"
-        | "vasp" | "lammpstrj" | "top" | "psf" | "prmtop" | "graphml" => 25 * mib,
+        | "smiles" | "tsv" | "cub" | "cube" | "in" | "inp" | "log" | "nw" | "out" | "psi4"
+        | "qcin" | "vasp" | "lammpstrj" | "top" | "psf" | "prmtop" | "graphml" => 25 * mib,
         "mae" | "maegz" | "cms" => 64 * mib,
         "xtc" | "trr" | "dcd" | "nctraj" => 75 * mib,
         _ => 20 * mib,
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn supports_quantum_chemistry_input_extensions_via_xyzrender() {
-        for extension in ["abi", "com", "fdf", "inp", "nw", "out", "psi4", "qcin"] {
+        for extension in ["abi", "com", "fdf", "inp", "log", "nw", "out", "psi4", "qcin"] {
             let format = format_for_extension(extension)
                 .unwrap_or_else(|_| panic!("{extension} should be supported"));
             assert_eq!(format.molstar_format, "xyz");
@@ -343,7 +343,7 @@ mod tests {
     fn rejects_unknown_extensions() {
         let error = format_for_extension("txt").expect_err("txt should not be supported");
         assert!(error.contains("Unsupported structure extension: txt"));
-        let error = format_for_extension("log").expect_err("log should not be supported");
-        assert!(error.contains("Unsupported structure extension: log"));
+        let error = format_for_extension("dat").expect_err("dat should not be supported");
+        assert!(error.contains("Unsupported structure extension: dat"));
     }
 }

--- a/tests/test-text-file-viewer-contract.mjs
+++ b/tests/test-text-file-viewer-contract.mjs
@@ -121,7 +121,17 @@ assert.match(app, /import \{ openBrowserDevTextFiles \} from "\.\/lib\/browser-d
 assert.match(app, /: await openBrowserDevTextFiles\(cleanPaths\)/);
 assert.doesNotMatch(app, /Text file viewer is available in the desktop app only/);
 assert.match(app, /const openPaths = useCallback/);
-assert.match(app, /structureFirstTextExtensions = new Set\(\["out"\]\)/);
+assert.match(app, /structureAndTextExtensions = new Set\(\[[\s\S]*"out"[\s\S]*"vasp"[\s\S]*\]\)/);
+for (const extension of ["abi", "cms", "com", "csv", "cub", "cube", "fdf", "graphml", "in", "inp", "log", "mae", "nw", "out", "psi4", "qcin", "tsv", "vasp"]) {
+  assert.match(app, new RegExp(`"${extension}"`), `${extension} should be a structure-and-text open extension`);
+}
+assert.match(app, /if \(structureAndTextExtensions\.has\(extension\)\) \{\s*structureAndTextPaths\.push\(path\);/);
+assert.match(app, /if \(structureAndTextPaths\.length > 0\) \{\s*await openDocuments\(structureAndTextPaths\);\s*\}/);
+assert.match(app, /const textOpenPaths = \[\.\.\.textPaths, \.\.\.structureAndTextPaths\];/);
+assert.match(app, /if \(input\.area === "right" && cleanPaths\.length > 0\) \{[\s\S]*open_text_files", \{ paths: cleanPaths \}[\s\S]*setDockDocument\(input\.area, textResult\.documents\[0\]\.id\);[\s\S]*return;/);
+const rightDockTextOpenBlock = app.match(/if \(input\.area === "right" && cleanPaths\.length > 0\) \{[\s\S]*?return;\s*\}/)?.[0] ?? "";
+assert.match(rightDockTextOpenBlock, /open_text_files", \{ paths: cleanPaths \}/);
+assert.doesNotMatch(rightDockTextOpenBlock, /pathExtension|structureExtensions|structureAndTextExtensions|preferredTextExtensions/);
 assert.match(app, /useOpenEvents\(openPaths, pushErrorStatus\)/);
 assert.match(app, /useOpenDrop\(openPaths, pushStatus/);
 assert.match(app, /showTextFileMetadata/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2437,7 +2437,7 @@ assert.match(previewViewController, /if PreviewStructureTextConverter\.shouldPre
 assert.match(previewViewController, /if isGROExtension\(fileExtension\),\s*let pdb = groPDBData\(from: data, label: label\) \{\s*return ConvertedStructure\(data: pdb, format: \.convertedPDB,/);
 assert.match(previewViewController, /let residueName = normalizeGROResidueName\(fixedGROField\(line, start: 5, length: 5\)\)/);
 assert.match(previewViewController, /x: x \* 10\.0,\s*y: y \* 10\.0,\s*z: z \* 10\.0/s);
-assert.match(previewViewController, /\["abi", "cub", "cube", "fdf", "in", "inp", "nw", "out", "psi4", "qcin"\]\.contains\(fileExtension\.lowercased\(\)\)/);
+assert.match(previewViewController, /\["abi", "cub", "cube", "fdf", "in", "inp", "log", "nw", "out", "psi4", "qcin"\]\.contains\(fileExtension\.lowercased\(\)\)/);
 assert.match(previewViewController, /case "znucl":\s*atomicNumbers \+= parts\.dropFirst\(\)\.compactMap\(Int\.init\)/);
 assert.match(previewViewController, /case "typat":\s*typeIndices \+= parts\.dropFirst\(\)\.compactMap\(Int\.init\)/);
 assert.match(previewViewController, /case "xangst":\s*coordinateStart = index \+ 1/);
@@ -2449,7 +2449,7 @@ assert.match(previewViewController, /pdb \+= String\(format: "CONECT%5d"/);
 assert.match(previewViewController, /pushPDBConectLines\(&pdb, bonds: bonds, serialByID: serialByID\)/);
 assert.match(previewViewController, /case "in", "inp":\s*return parseQuantumEspressoInput\(lines\) \?\? parseQSiteGeometry\(lines\) \?\? parseBestCoordinateBlock\(lines\)/);
 assert.match(previewViewController, /case "nw", "psi4", "qcin":\s*return parseBestCoordinateBlock\(lines\)/);
-assert.match(previewViewController, /case "out":\s*return parseOrcaOutput\(lines\) \?\? parseGaussianOutput\(lines\) \?\? parseBestCoordinateBlock\(lines\)/);
+assert.match(previewViewController, /case "log", "out":\s*return parseOrcaOutput\(lines\) \?\? parseGaussianOutput\(lines\) \?\? parseBestCoordinateBlock\(lines\)/);
 assert.match(previewViewController, /let coordinateScale = axisCounts\.allSatisfy \{ \$0 > 0 \} \? 0\.529177210903 : 1\.0/);
 assert.match(previewViewController, /catch \{\s*if format\.isExternalXyzrenderOnly,\s*rendererOverride == nil,\s*let convertedStructure = PreviewStructureTextConverter\.convertedData/s);
 assert.match(previewViewController, /private struct PreviewXyzrenderLaunch/);


### PR DESCRIPTION
Summary: open files dropped into the right dock as text by default; open mixed structure/text formats in both viewers; register .log as xyzrender-compatible text structure input. Verification: pre-push ci-fast passed.