### PR TITLE
Add Finder icon to open destination menus

### DIFF
--- a/apps/desktop/src/components/open-in-editor-menu.tsx
+++ b/apps/desktop/src/components/open-in-editor-menu.tsx
@@ -11,6 +11,8 @@ type ActiveFile = {
   label: string;
 };
 
+const FINDER_ICON_PATH = "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns";
+
 export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; actions: ShellActions }) {
   const activeFile = useMemo(() => activeFileFromState(state), [state]);
   const [targets, setTargets] = useState<ChemicalEditorTarget[]>([]);
@@ -179,6 +181,7 @@ function editorIconUrl(target: ChemicalEditorTarget) {
 }
 
 function finderIconUrl() {
+  if (isTauriRuntime()) return convertFileSrc(FINDER_ICON_PATH);
   if (!isTauriRuntime() && import.meta.env.DEV) return "/__burette/app-icon/finder.png";
   return null;
 }

--- a/apps/desktop/src/components/settings-panel/index.tsx
+++ b/apps/desktop/src/components/settings-panel/index.tsx
@@ -31,6 +31,8 @@ type OpenDestinationOption = {
   iconUrl?: string;
 };
 
+const FINDER_ICON_PATH = "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns";
+
 function preferenceRow<K extends Extract<keyof ViewerPreferences, string>>(
   label: string,
   description: string,
@@ -272,6 +274,7 @@ function editorIconUrl(target: ChemicalEditorTarget) {
 }
 
 function finderIconUrl() {
+  if (isTauriRuntime()) return convertFileSrc(FINDER_ICON_PATH);
   if (!isTauriRuntime() && import.meta.env.DEV) return "/__burette/app-icon/finder.png";
   return null;
 }

--- a/tests/test-chemical-editor-handoff-contract.mjs
+++ b/tests/test-chemical-editor-handoff-contract.mjs
@@ -93,12 +93,15 @@ assert.match(openInEditorMenu, /preferredTargetForDestination\(state\.preference
 assert.match(openInEditorMenu, /destination === "default-app"/);
 assert.match(openInEditorMenu, /destination === "finder"/);
 assert.match(openInEditorMenu, /function finderIconUrl/);
+assert.match(openInEditorMenu, /const FINDER_ICON_PATH = "\/System\/Library\/CoreServices\/CoreTypes\.bundle\/Contents\/Resources\/FinderIcon\.icns"/);
+assert.match(openInEditorMenu, /if \(isTauriRuntime\(\)\) return convertFileSrc\(FINDER_ICON_PATH\)/);
 assert.match(settingsPanel, /Default open destination/);
 assert.match(settingsPanel, /OpenDestinationControl/);
 assert.match(settingsPanel, /actions\.setPreference\("openInDefaultDestination"/);
 assert.match(settingsPanel, /actions\.listChemicalEditorTargets\(openDestinationProbePath\)/);
 assert.doesNotMatch(settingsPanel, /label: "Auto"/);
 assert.match(settingsPanel, /\/__burette\/app-icon\/finder\.png/);
+assert.match(settingsPanel, /if \(isTauriRuntime\(\)\) return convertFileSrc\(FINDER_ICON_PATH\)/);
 
 assert.match(menuTypes, /iconText\?: string/);
 assert.match(menuTypes, /iconUrl\?: string/);


### PR DESCRIPTION
## Summary
- use the system Finder icon for Reveal in Finder in the Tauri runtime
- apply the same icon path in the settings default destination control
- pin the Finder icon contract in the chemical editor handoff test

## Tests
- bun tests/test-chemical-editor-handoff-contract.mjs
- bun run --cwd apps/desktop typecheck
- git diff --check
- pre-push ci-fast