### PR TITLE
Fix Molstar atom context gestures

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6939,6 +6939,9 @@
     let contextPointer = null;
     const menuIsOpen = () => !!document.querySelector('.buret-molecule-context-menu');
     const menuIsInAtomMode = () => menuIsOpen() && molstarContextMenuMode === 'atom';
+    const clearMolstarHoverHighlights = () => {
+      try { activeViewer?.plugin?.managers?.interactivity?.lociHighlights?.clearHighlights?.(); } catch (_) {}
+    };
     const selectAtomFromEvent = (event) => {
       const contextPick = molstarContextPickFromEvent(event);
       if (!contextPick) return false;
@@ -6968,9 +6971,15 @@
       return true;
     };
     const onContextMenu = (event) => {
-      if (contextPointer?.moved) {
+      if (menuIsOpen() && !contextPointer) {
         event.preventDefault();
         event.stopPropagation();
+        return;
+      }
+      if (contextPointer) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!contextPointer.moved) return;
         hideMolstarContextMenu();
         contextPointer = null;
         return;
@@ -6991,8 +7000,6 @@
           hideMolstarContextMenu();
           return;
         }
-        event.preventDefault();
-        event.stopPropagation();
         contextPointer = {
           pointerId: event.pointerId,
           startX: event.clientX,
@@ -7023,7 +7030,11 @@
     };
     const onPointerUp = (event) => {
       if (!contextPointer || event.pointerId !== contextPointer.pointerId) return;
-      if (contextPointer.moved) return;
+      if (contextPointer.moved) {
+        hideMolstarContextMenu();
+        contextPointer = null;
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       openFromEvent(event, contextPointer.pick);
@@ -7031,6 +7042,13 @@
     };
     const onPointerCancel = (event) => {
       if (contextPointer && event.pointerId === contextPointer.pointerId) contextPointer = null;
+    };
+    const suppressAtomModeHover = (event) => {
+      if (!menuIsInAtomMode()) return;
+      if (Number(event.buttons || 0) !== 0) return;
+      if (!isMolstarContextMenuTarget(event.target)) return;
+      event.stopPropagation();
+      clearMolstarHoverHighlights();
     };
     const onKeyDown = (event) => {
       if (event.key === 'Escape') hideMolstarContextMenu();
@@ -7041,6 +7059,8 @@
     document.addEventListener('pointermove', onPointerMove, true);
     document.addEventListener('pointerup', onPointerUp, true);
     document.addEventListener('pointercancel', onPointerCancel, true);
+    document.addEventListener('pointermove', suppressAtomModeHover, true);
+    document.addEventListener('mousemove', suppressAtomModeHover, true);
     document.addEventListener('keydown', onKeyDown);
     window.addEventListener('resize', onResize);
     molstarContextMenuCleanup = () => {
@@ -7049,6 +7069,8 @@
       document.removeEventListener('pointermove', onPointerMove, true);
       document.removeEventListener('pointerup', onPointerUp, true);
       document.removeEventListener('pointercancel', onPointerCancel, true);
+      document.removeEventListener('pointermove', suppressAtomModeHover, true);
+      document.removeEventListener('mousemove', suppressAtomModeHover, true);
       document.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('resize', onResize);
       hideMolstarContextMenu();

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2777,10 +2777,11 @@ assert.match(previewViewer, /if \(!viewer \|\| \(!picked && !isMolstarContextMen
 assert.match(previewViewer, /const MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX = 4;/);
 assert.match(previewViewer, /let contextPointer = null;/);
 assert.match(previewViewer, /if \(event\.button === 2\) \{[\s\S]*?contextPointer = \{/);
-assert.match(previewViewer, /const contextPick = molstarContextPickFromEvent\(event\);[\s\S]*?event\.preventDefault\(\);[\s\S]*?event\.stopPropagation\(\);[\s\S]*?pick: contextPick/);
-assert.match(previewViewer, /const onPointerUp = \(event\) => \{[\s\S]*?if \(contextPointer\.moved\) return;[\s\S]*?openFromEvent\(event, contextPointer\.pick\);[\s\S]*?contextPointer = null;/);
+assert.match(previewViewer, /const contextPick = molstarContextPickFromEvent\(event\);[\s\S]*?contextPointer = \{[\s\S]*?pick: contextPick/);
+assert.doesNotMatch(previewViewer, /if \(event\.button === 2\) \{[\s\S]*?event\.preventDefault\(\);[\s\S]*?event\.stopPropagation\(\);[\s\S]*?contextPointer = \{/);
+assert.match(previewViewer, /const onPointerUp = \(event\) => \{[\s\S]*?if \(contextPointer\.moved\) \{[\s\S]*?hideMolstarContextMenu\(\);[\s\S]*?contextPointer = null;[\s\S]*?return;[\s\S]*?\}[\s\S]*?openFromEvent\(event, contextPointer\.pick\);[\s\S]*?contextPointer = null;/);
 assert.match(previewViewer, /document\.addEventListener\('pointerup', onPointerUp, true\)/);
-assert.match(previewViewer, /if \(contextPointer\?\.moved\) \{\s*event\.preventDefault\(\);\s*event\.stopPropagation\(\);\s*hideMolstarContextMenu\(\);\s*contextPointer = null;\s*return;/);
+assert.match(previewViewer, /if \(contextPointer\) \{\s*event\.preventDefault\(\);\s*event\.stopPropagation\(\);\s*if \(!contextPointer\.moved\) return;\s*hideMolstarContextMenu\(\);\s*contextPointer = null;\s*return;/);
 assert.doesNotMatch(previewViewer, /if \(event\.button === 2\) \{\s*openFromEvent\(event\);\s*return;/);
 assert.match(previewViewer, /function isMolstarContextMenuTarget\(target\)/);
 assert.match(previewViewer, /function molstarContextPickFromEvent\(event\)/);
@@ -2893,6 +2894,10 @@ assert.match(previewViewer, /let mode = menuTarget\.scope === 'ligand' && menuTa
 assert.match(previewViewer, /molstarContextMenuMode = mode;/);
 assert.match(previewViewer, /molstarContextMenuActions\(menuTarget, mode\)/);
 assert.match(previewViewer, /const menuIsInAtomMode = \(\) => menuIsOpen\(\) && molstarContextMenuMode === 'atom';/);
+assert.match(previewViewer, /const clearMolstarHoverHighlights = \(\) => \{[\s\S]*?lociHighlights\?\.clearHighlights\?\.\(\)/);
+assert.match(previewViewer, /const suppressAtomModeHover = \(event\) => \{[\s\S]*?if \(!menuIsInAtomMode\(\)\) return;[\s\S]*?if \(Number\(event\.buttons \|\| 0\) !== 0\) return;[\s\S]*?clearMolstarHoverHighlights\(\);/);
+assert.match(previewViewer, /document\.addEventListener\('pointermove', suppressAtomModeHover, true\)/);
+assert.match(previewViewer, /document\.addEventListener\('mousemove', suppressAtomModeHover, true\)/);
 assert.match(previewViewer, /const selectAtomFromEvent = \(event\) => \{/);
 assert.match(previewViewer, /selectMolstarContextPick\(\{ \.\.\.target, loci: target\.atomLoci \}, \{ additive: true, applyGranularity: false \}\)/);
 assert.match(previewViewer, /if \(event\.button === 0 && menuIsInAtomMode\(\) && isMolstarContextMenuTarget\(target\)\) \{/);


### PR DESCRIPTION
## Summary
- keep Molstar right-drag gestures from opening the custom context menu
- suppress Molstar hover highlights while the ligand context menu is in Atom mode
- pin both interaction rules in the UI shell contract test

## Validation
- vp run test:ui
- vp run check:js
- git diff --check
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: ci-fast