### PR TITLE
Set trajectory loop default to 20 FPS

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2906,7 +2906,7 @@
     return Math.max(0, Math.min(poseCount - 1, Math.trunc(value)));
   }
 
-  const DEFAULT_TRAJECTORY_LOOP_FPS = 2;
+  const DEFAULT_TRAJECTORY_LOOP_FPS = 20;
 
   function trajectoryLoopFpsStorageKey(config, prepared) {
     return `${trajectoryControlStorageKey(config, prepared)}.fps.v1`;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2971,7 +2971,7 @@ assert.match(previewViewer, /function minimumTrajectoryLoopDelay\(prepared\)/);
 assert.match(previewViewer, /return prepared\?\.nativeTrajectoryControls \? 40 : 300/);
 assert.match(previewViewer, /function minimumTrajectoryLoopTimerDelay\(prepared\)/);
 assert.match(previewViewer, /return prepared\?\.nativeTrajectoryControls \? 8 : 60/);
-assert.match(previewViewer, /const DEFAULT_TRAJECTORY_LOOP_FPS = 2/);
+assert.match(previewViewer, /const DEFAULT_TRAJECTORY_LOOP_FPS = 20/);
 assert.match(previewViewer, /\.fps\.v1`/);
 assert.match(previewViewer, /function maximumTrajectoryLoopFps\(prepared\)/);
 assert.match(previewViewer, /function trajectoryFpsToDelay\(value, prepared\)/);


### PR DESCRIPTION
## Summary
- Set the trajectory loop FPS default from 2 to 20.
- Update the UI shell contract to pin the new default.

## Validation
- bun tests/test-ui-shell-contract.mjs
- bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js
- bash scripts/ci-fast.sh (via pre-push hook)