### PR TITLE
Fix settings scroll fade

### DIFF
--- a/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
+++ b/apps/desktop/src/components/editor-area/editor-scroll-container.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode, Ref } from "react";
 
 const SCROLLBAR_GUTTER = "18px";
-const FADE_MASK_VERTICAL = "linear-gradient(to bottom, transparent 5%, black 15%, black 85%, transparent)";
+const SCROLL_FADE_EDGE = "28px";
+const FADE_MASK_VERTICAL = `linear-gradient(to bottom, transparent 0, black ${SCROLL_FADE_EDGE}, black calc(100% - ${SCROLL_FADE_EDGE}), transparent 100%)`;
 const FADE_MASK_GUTTER = `linear-gradient(to right, black ${SCROLLBAR_GUTTER}, transparent ${SCROLLBAR_GUTTER}, transparent calc(100% - ${SCROLLBAR_GUTTER}), black calc(100% - ${SCROLLBAR_GUTTER}))`;
 const FADE_MASK = `${FADE_MASK_VERTICAL}, ${FADE_MASK_GUTTER}`;
 

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1912,6 +1912,8 @@ assert.match(settingsPanel, /className="settings-panel"/);
 assert.match(settingsPanel, /data-settings-section=\{section\}/);
 assert.match(settingsPanel, /EditorScrollContainer/);
 assert.doesNotMatch(settingsPanel, /className="settings-panel-scroll"/);
+assert.match(editorScrollContainer, /SCROLL_FADE_EDGE = "28px"/);
+assert.doesNotMatch(editorScrollContainer, /transparent 5%|black 15%|black 85%/);
 assert.match(editorScrollContainer, /WebkitMaskComposite:\s*"source-over"/);
 assert.match(editorScrollContainer, /maskComposite:\s*"add"/);
 assert.doesNotMatch(styles, /\.settings-panel-scroll \{/);


### PR DESCRIPTION
## Summary
- replace the percentage-based editor scroll fade with a fixed 28px edge
- keep the settings scroll mask while preventing large windows from dimming the settings content
- add a shell contract assertion so the percentage fade does not come back

## Validation
- node tests/test-ui-shell-contract.mjs
- pre-push ci-fast