### PR TITLE
Fix SDF grid handoff whitespace

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -945,8 +945,8 @@
   function sdfRecordTextForMolstar(row) {
     const record = gridDragRecord(row);
     if (!record || record.inputExtension !== 'sdf') return null;
-    const text = String(record.text || '').trim();
-    if (!text) return null;
+    const text = String(record.text || '').trimEnd();
+    if (!text.trim()) return null;
     return `${text.replace(/\n?\$\$\$\$\s*$/u, '').trimEnd()}\n$$$$\n`;
   }
 
@@ -970,8 +970,9 @@
   }
 
   function ketcherFragmentText(record) {
-    const text = String(record?.text || '').trim();
+    const text = String(record?.text || '').trimEnd();
     const extension = String(record?.inputExtension || '').toLowerCase();
+    if (!text.trim()) return '';
     if (extension === 'sdf' || extension === 'sd') {
       return text.replace(/\n?\$\$\$\$\s*$/u, '').trimEnd() + '\n';
     }
@@ -2299,8 +2300,8 @@
   function gridDragRecord(row) {
     const label = String(row?.name || `Molecule ${Number(row?.index) + 1 || 1}`).trim() || 'Molecule';
     const baseName = safeStructureFileStem(label, Number(row?.index));
-    const molblock = String(row?.molblock || '').trim();
-    if (molblock) {
+    const molblock = String(row?.molblock || '').trimEnd();
+    if (molblock.trim()) {
       const text = molblock.includes('$$$$') ? molblock : `${molblock}\n$$$$`;
       return {
         path: `${baseName}.sdf`,

--- a/tests/test-docking-viewer-contract.mjs
+++ b/tests/test-docking-viewer-contract.mjs
@@ -42,6 +42,8 @@ assert.match(gridViewer, /body\.type === 'poseReviewSelection'/);
 assert.match(gridViewer, /function selectPoseReviewRow\(activePose, cfg\)/);
 assert.match(gridViewer, /function selectedMolstarRows\(\)/);
 assert.match(gridViewer, /function sdfRecordTextForMolstar\(row\)/);
+assert.match(gridViewer, /const text = String\(record\.text \|\| ''\)\.trimEnd\(\);[\s\S]*?if \(!text\.trim\(\)\) return null;/);
+assert.match(gridViewer, /const molblock = String\(row\?\.molblock \|\| ''\)\.trimEnd\(\);[\s\S]*?if \(molblock\.trim\(\)\) \{/);
 
 assert.match(app, /body\?\.type === "openSdfMolstarDocument"/);
 assert.match(app, /body\?\.type === "openSdfKetcherDocument"/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3534,6 +3534,8 @@ assert.match(gridViewer, /textBase64: textToBase64\(records\.join\('\\n'\)\)/);
 assert.match(gridViewer, /receptorPath: receptorPath \|\| null/);
 assert.match(gridViewer, /function selectedMolstarRows\(\)/);
 assert.match(gridViewer, /function sdfRecordTextForMolstar\(row\)/);
+assert.match(gridViewer, /const text = String\(record\.text \|\| ''\)\.trimEnd\(\);[\s\S]*?if \(!text\.trim\(\)\) return null;/);
+assert.match(gridViewer, /const molblock = String\(row\?\.molblock \|\| ''\)\.trimEnd\(\);[\s\S]*?if \(molblock\.trim\(\)\) \{/);
 assert.match(gridViewer, /function requestSingleMolstarDocument\(row, cfg\)/);
 assert.match(gridViewer, /\['molstar', 'Open in Mol\*'\]/);
 assert.match(gridViewer, /\['ketcher', 'Edit in Ketcher'\]/);


### PR DESCRIPTION
## Summary
- preserve leading molfile header whitespace when handing SDF grid rows to Molstar and Ketcher
- keep SDF emptiness checks without trimming required header lines
- add contract checks for the whitespace-preserving handoff path

## Tests
- node tests/test-ui-shell-contract.mjs
- node tests/test-docking-viewer-contract.mjs
- pre-push ci-fast