### PR TITLE
Add sidebar structure path copy action

### DIFF
--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -237,6 +237,14 @@ export function ProjectItem({
         text: "Open",
         action: openItem,
       },
+      {
+        kind: "item" as const,
+        id: "copy-structure-path",
+        text: "Copy Path",
+        action: () => {
+          void actions.copyPath(item.path, "structure");
+        },
+      },
       ...(isMoleculeCollectionPath(item.path)
         ? [
             { kind: "separator" as const },

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1820,6 +1820,9 @@ assert.match(sidebarSurface, /disabled: !project\.rootPath,\s*action: \(\) => \{
 assert.doesNotMatch(sidebarSurface, /!project\.rootPath \|\| !project\.isExplicit/);
 assert.match(sidebarSurface, /Pin structure/);
 assert.match(sidebarSurface, /Unpin structure/);
+assert.match(sidebarSurface, /id: "copy-structure-path"/);
+assert.match(sidebarSurface, /text: "Copy Path"/);
+assert.match(sidebarSurface, /actions\.copyPath\(item\.path, "structure"\)/);
 assert.match(sidebarSurface, /Pin project/);
 assert.match(sidebarSurface, /Unpin project/);
 assert.doesNotMatch(sidebarSurface, /projectCount/);


### PR DESCRIPTION
## Summary
- add a Copy Path action to sidebar structure context menus
- reuse the existing path-copy status handling
- pin the sidebar menu contract in the shell test

## Tests
- bun tests/test-ui-shell-contract.mjs
- bash scripts/ci-fast.sh