### PR TITLE
Add agent Molstar scene controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,15 @@ When the user asks to open something in a browser, or simply asks to open a
 local web target, always use the built-in `@Browser` plugin
 (`plugin://browser@openai-bundled`). Do not use macOS `open`, Chrome, Safari,
 or another external browser unless the user explicitly asks for an external
-browser or the built-in Browser plugin is unavailable.
+browser. If the built-in Browser plugin is unavailable, crashed, or cannot
+attach to a tab, report that blocker and provide the local URL instead of
+falling back to an external browser.
+
+Do not open the Burrete desktop app as a substitute for a browser preview.
+Use `desktop-app` only when the user explicitly asks for the real packaged app,
+native app, Quick Look behavior, or another desktop-specific verification path.
+When the requested surface is ambiguous, keep the work in the built-in Browser
+or report the blocker; do not silently switch surfaces.
 
 When an agent builds or installs a packaged app for local testing, always use a
 dev flavor with a unique slug, preferably the worktree suffix:

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -98,6 +98,53 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
+				<string>public.json</string>
+				<string>public.text</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MolViewSpec JSON scene file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.mvsj</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mvsj</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/vnd.molstar.mvsj+json</string>
+					<string>application/json</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MolViewSpec archive scene file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.mvsx</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mvsx</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/vnd.molstar.mvsx</string>
+					<string>application/zip</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
 				<string>public.data</string>
 			</array>
 			<key>UTTypeDescription</key>
@@ -423,6 +470,8 @@
 				<string>com.gaussian.cube</string>
 				<string>com.local.burrete10.gro</string>
 				<string>gg.flew.unfold.gromacs-structure</string>
+				<string>com.local.burrete10.mvsj</string>
+				<string>com.local.burrete10.mvsx</string>
 				<string>com.local.burrete10.molecular-dynamics</string>
 				<string>com.schrodinger.mae</string>
 				<string>com.local.burrete10.schrodinger</string>

--- a/PreviewExtension/Web/burette-agent.js
+++ b/PreviewExtension/Web/burette-agent.js
@@ -67,6 +67,26 @@
     try { return JSON.parse(JSON.stringify(value)); } catch (_) { return value; }
   }
 
+  function base64ToBytes(base64) {
+    const raw = atob(String(base64 || ''));
+    const bytes = new Uint8Array(raw.length);
+    for (let index = 0; index < raw.length; index += 1) bytes[index] = raw.charCodeAt(index);
+    return bytes;
+  }
+
+  function mvsCommandPayload(args = {}) {
+    const format = args.format || (args.dataBase64 ? 'mvsx' : 'mvsj');
+    if (args.dataBase64) {
+      return { format, data: format === 'mvsx' ? base64ToBytes(args.dataBase64) : new TextDecoder('utf-8', { fatal: false }).decode(base64ToBytes(args.dataBase64)) };
+    }
+    if (args.json !== undefined) return { format: 'mvsj', data: JSON.stringify(args.json) };
+    if (args.data !== undefined) {
+      const data = typeof args.data === 'string' || args.data instanceof Uint8Array ? args.data : JSON.stringify(args.data);
+      return { format: args.format || (typeof data === 'string' && data.trim().startsWith('{') ? 'mvsj' : 'mvsx'), data };
+    }
+    throw coded('INVALID_ARGS', 'loadMVS requires args.data, args.json, or args.dataBase64.');
+  }
+
   function durationSince(start) {
     return Math.max(0, Math.round(now() - start));
   }
@@ -144,7 +164,7 @@
   function commands() {
     return [
       'capabilities', 'summary', 'select', 'selectResidues', 'focusSelection', 'colorSelection',
-      'showLigands', 'focusLigand', 'contacts', 'resetCamera', 'screenshot', 'loadMVS', 'exportMVS'
+      'labelSelection', 'showLigands', 'focusLigand', 'contacts', 'resetCamera', 'screenshot', 'loadMVS', 'exportMVS'
     ];
   }
 
@@ -258,6 +278,7 @@
     if (command === 'select' || command === 'selectResidues') return commandSelect(args, command, warnings);
     if (command === 'focusSelection') return commandFocus(args, warnings);
     if (command === 'colorSelection') return commandColor(args, warnings);
+    if (command === 'labelSelection') return commandLabelSelection(args, warnings);
     if (command === 'showLigands') return commandShowLigands(args, warnings);
     if (command === 'focusLigand') return commandFocusLigand(args, warnings);
     if (command === 'contacts') return commandContacts(args, warnings);
@@ -374,6 +395,98 @@
     };
   }
 
+  async function commandLabelSelection(args = {}, warnings) {
+    const selection = resolveSelection(args.selection || args.selector || 'last');
+    const counts = countSelectorMatches(selection.selector, Number(args.maxPreviewResidues) || 24);
+    if (!counts.atoms) throw coded('SELECTION_EMPTY', 'Label selector matched no atoms.', { selector: selection.selector });
+    applyMolstarInteractivity(selection.selector, 'select', {
+      mode: args.mode || 'replace',
+      granularity: args.granularity || 'residue',
+      warnings
+    });
+    const labels = await addMeasurementLabels(args, warnings);
+    if (!labels.length) throw coded('NOT_IMPLEMENTED', 'Mol* measurement label API did not create a label for the current selection.');
+    state.sceneVersion++;
+    return {
+      selectionId: selection.id,
+      label: labelSelectionText(args, selection, counts),
+      labels,
+      selectorEcho: selection.selector,
+      counts: counts.counts,
+      residuesPreview: counts.residuesPreview
+    };
+  }
+
+  async function addMeasurementLabels(args = {}, warnings = []) {
+    const manager = state.plugin?.managers?.structure?.measurement;
+    const selectionManager = state.plugin?.managers?.structure?.selection;
+    if (typeof manager?.addLabel !== 'function' || !selectionManager?.entries) {
+      throw coded('NOT_IMPLEMENTED', 'Mol* structure measurement labels are unavailable in this runtime.');
+    }
+    const text = String(args.text || args.label || '').trim();
+    const labelParams = {
+      customText: text,
+      textSize: Number(args.textSize) || 0.32,
+      background: args.background !== false,
+      backgroundOpacity: Number.isFinite(Number(args.backgroundOpacity)) ? Number(args.backgroundOpacity) : 0.72,
+      backgroundMargin: Number.isFinite(Number(args.backgroundMargin)) ? Number(args.backgroundMargin) : 0.22,
+      tether: args.tether !== false,
+      tetherLength: Number.isFinite(Number(args.tetherLength)) ? Number(args.tetherLength) : 1.6,
+      borderWidth: Number.isFinite(Number(args.borderWidth)) ? Number(args.borderWidth) : 0.08,
+      offsetY: Number.isFinite(Number(args.offsetY)) ? Number(args.offsetY) : 0.4,
+      ...(args.labelParams && typeof args.labelParams === 'object' ? args.labelParams : {})
+    };
+    const result = [];
+    for (const [ref, entry] of selectionManager.entries) {
+      const loci = entry?.selection;
+      if (!loci || isEmptySelectionLoci(loci)) continue;
+      const created = await manager.addLabel(loci, {
+        labelParams,
+        selectionTags: ['burrete-agent-label-selection'],
+        reprTags: ['burrete-agent-label']
+      });
+      if (created) {
+        result.push({
+          structureRef: String(ref),
+          selectionRef: created.selection?.ref,
+          representationRef: created.representation?.ref
+        });
+      }
+    }
+    if (!text) warnings.push('labelSelection used the Mol* default selection label because no custom text was provided.');
+    return result;
+  }
+
+  function isEmptySelectionLoci(loci) {
+    if (!loci) return true;
+    if (Array.isArray(loci.elements)) {
+      return loci.elements.every(entry => {
+        const indices = entry?.indices;
+        if (!indices) return true;
+        if (Number.isInteger(indices.size)) return indices.size <= 0;
+        if (typeof indices.length === 'number') return indices.length <= 0;
+        if (typeof indices.end === 'number' && typeof indices.start === 'number') return indices.end <= indices.start;
+        return false;
+      });
+    }
+    return false;
+  }
+
+  function labelSelectionText(args, selection, counts) {
+    const explicit = String(args.text || args.label || '').trim();
+    if (explicit) return explicit;
+    const saved = String(selection?.label || '').trim();
+    if (saved && saved !== 'ligand:undefined') return saved;
+    const residue = counts.residuesPreview?.[0];
+    if (residue) {
+      const comp = residue.auth_comp_id || residue.label_comp_id || residue.kind || 'Selection';
+      const chain = residue.auth_asym_id || residue.label_asym_id;
+      const seq = residue.auth_seq_id ?? residue.label_seq_id;
+      return [comp, chain, seq].filter(value => value != null && value !== '').join(' ');
+    }
+    return 'Selection';
+  }
+
   function commandShowLigands(args = {}, warnings) {
     const ligands = listLigands();
     if (!ligands.length) throw coded('SELECTION_EMPTY', 'No ligands were detected by the MVP ligand policy.');
@@ -410,13 +523,26 @@
     state.sceneVersion++;
     const result = { selectionId, ligand, counts: counts.counts, residuesPreview: counts.residuesPreview };
     if (args.showNeighborhood || args.contacts) {
-      result.neighborhood = computeContacts({
-        source: ligandSelector,
-        target: args.target || { kind: 'protein' },
-        radiusA: Number(args.radiusA) || DEFAULT_CONTACT_RADIUS_A,
-        maxSourceAtoms: args.maxSourceAtoms,
-        maxTargetAtoms: args.maxTargetAtoms
-      }, warnings);
+      try {
+        result.neighborhood = computeContacts({
+          source: ligandSelector,
+          target: args.target || { kind: 'protein' },
+          radiusA: Number(args.radiusA) || DEFAULT_CONTACT_RADIUS_A,
+          maxSourceAtoms: args.maxSourceAtoms,
+          maxTargetAtoms: args.maxTargetAtoms
+        }, warnings);
+      } catch (error) {
+        const partial = {
+          ok: false,
+          error: {
+            code: error?.code || inferErrorCode(error),
+            message: error?.message || String(error),
+            details: error?.details
+          }
+        };
+        result.neighborhood = partial;
+        warnings.push(`Ligand focus completed, but neighborhood failed: ${partial.error.code}.`);
+      }
     }
     return result;
   }
@@ -477,11 +603,10 @@
     if (typeof state.viewer?.loadMvsData !== 'function') {
       throw coded('NOT_IMPLEMENTED', 'viewer.loadMvsData is not available in this Mol* viewer build.');
     }
-    const format = args.format || (String(args.data || '').trim().startsWith('{') ? 'mvsj' : 'mvsx');
-    if (!args.data) throw coded('INVALID_ARGS', 'loadMVS requires args.data.');
-    await state.viewer.loadMvsData(args.data, format, args.options || {});
+    const { data, format } = mvsCommandPayload(args);
+    await state.viewer.loadMvsData(data, format, args.options || {});
     state.sceneVersion++;
-    warnings.push('MVS loading is delegated directly to Mol* viewer.loadMvsData; validate with a real mvsj/mvsx fixture.');
+    warnings.push('MVS loading is delegated directly to Mol* viewer.loadMvsData.');
     return { format, loaded: true };
   }
 
@@ -591,7 +716,9 @@
       return clean;
     }).sort(sortChain);
 
-    const ligands = Array.from(ligandMap.values()).sort(sortResidueLike);
+    const ligands = Array.from(ligandMap.values())
+      .map(ligand => ({ ...ligand, category: ligandCategory(ligand) }))
+      .sort(sortResidueLike);
     const summary = {
       id: String(entry.ref || `structure-${index}`),
       label: entry.entry?.cell?.obj?.label || state.prepared?.label || state.config?.label || undefined,
@@ -789,6 +916,10 @@
     delete selector.granularity;
     delete selector.maxPreviewResidues;
     delete selector.label;
+    if (selector.comp_id && !selector.label_comp_id && !selector.auth_comp_id) {
+      selector.label_comp_id = selector.comp_id;
+      delete selector.comp_id;
+    }
     if (selector.chain && !selector.auth_asym_id && !selector.label_asym_id) {
       selector.auth_asym_id = selector.chain;
       delete selector.chain;
@@ -988,7 +1119,16 @@
       }
       ligand.atomCount++;
     }
-    return Array.from(ligands.values()).sort(sortResidueLike);
+    return Array.from(ligands.values())
+      .map(ligand => ({ ...ligand, category: ligandCategory(ligand) }))
+      .sort(sortResidueLike);
+  }
+
+  function ligandCategory(ligand) {
+    const comp = String(ligand.label_comp_id || ligand.auth_comp_id || '').toUpperCase();
+    if (COMMON_IONS.has(comp) || ligand.kind === 'ion') return 'ion';
+    if (Number(ligand.atomCount) === 1) return 'single_atom';
+    return 'small_molecule';
   }
 
   function matchesLigand(ligand, selector) {

--- a/PreviewExtension/Web/index.html
+++ b/PreviewExtension/Web/index.html
@@ -33,7 +33,9 @@
   <script src="./viewer-shell.js"></script>
   <div id="buret-window-outline" aria-hidden="true"></div>
   <div id="status">[web] Loading Mol* preview shell…</div>
-  <script>window.BurreteCacheBuster = String(Date.now());</script>
+  <script>
+    window.BurreteCacheBuster = String(Date.now());
+  </script>
   <script src="./burette-agent.js"></script>
   <script src="./viewer.js"></script>
 </body>

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -634,6 +634,145 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
   display: none; align-items: center; gap: 4px; padding-left: 5px;
   border-left: 1px solid var(--buret-toolbar-border);
 }
+.buret-preview-dock-toggle {
+  width: 30px;
+  padding: 0;
+}
+body:not(.buret-preview-docks-enabled) .buret-preview-dock-toggle {
+  display: none;
+}
+.buret-preview-dock {
+  position: fixed;
+  z-index: 2147483644;
+  display: none;
+  box-sizing: border-box;
+  border: 1px solid var(--buret-toolbar-border);
+  color: var(--buret-toolbar-color);
+  background: var(--buret-menu-background);
+  -webkit-backdrop-filter: blur(22px) saturate(1.25);
+  backdrop-filter: blur(22px) saturate(1.25);
+  box-shadow: var(--buret-menu-shadow);
+  font: 400 12px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  overflow: hidden;
+}
+.buret-preview-dock.open {
+  display: flex;
+}
+.buret-preview-dock-right {
+  top: calc(var(--buret-toolbar-safe-top) + 48px);
+  right: 12px;
+  bottom: 12px;
+  width: min(332px, calc(100vw - 24px));
+  border-radius: 12px;
+  flex-direction: column;
+}
+.buret-preview-dock-bottom {
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  height: min(260px, calc(100vh - 96px));
+  border-radius: 12px;
+  flex-direction: column;
+}
+body.buret-preview-dock-right-open .buret-preview-dock-bottom {
+  right: min(356px, calc(100vw - 12px));
+}
+.buret-preview-dock-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 34px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--buret-toolbar-border);
+}
+.buret-preview-dock-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.buret-preview-dock-close {
+  min-width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 7px;
+}
+.buret-preview-dock-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 10px;
+}
+.buret-preview-dock-section {
+  display: grid;
+  gap: 8px;
+}
+.buret-preview-dock-section + .buret-preview-dock-section {
+  margin-top: 12px;
+}
+.buret-preview-dock-section-title {
+  color: var(--buret-toolbar-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.buret-preview-dock-card {
+  display: grid;
+  gap: 5px;
+  padding: 9px;
+  border: 1px solid var(--buret-toolbar-border);
+  border-radius: 8px;
+  background: var(--buret-menu-section-background);
+}
+.buret-preview-dock-label {
+  color: var(--buret-molstar-muted-text);
+  font-size: 11px;
+}
+.buret-preview-dock-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.buret-preview-dock-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.buret-preview-dock-list-item {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border: 1px solid var(--buret-toolbar-border);
+  border-radius: 8px;
+  background: var(--buret-menu-section-background);
+}
+.buret-preview-dock-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.buret-preview-dock-muted {
+  color: var(--buret-molstar-muted-text);
+}
+.buret-preview-dock-status-pill {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  color: var(--buret-molstar-muted-text);
+  background: var(--buret-menu-input-background);
+  font-size: 10px;
+}
+.buret-preview-dock-status-pill.ok {
+  color: #b8f7cf;
+}
+.buret-preview-dock-status-pill.failed {
+  color: #ffb8b8;
+}
 .buret-renderer-control.visible { display: flex; }
 .buret-renderer-choice { min-width: 38px; }
 .buret-molstar-style-slot { display: none; align-items: center; }

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -8,6 +8,12 @@
     app.insertAdjacentHTML('afterend', `
       <div id="buret-toolbar" role="toolbar" aria-label="Burrete preview controls">
         <div class="buret-toolbar-content" data-buret-toolbar-content>
+          <button class="buret-button buret-preview-dock-toggle" type="button" data-buret-dock-toggle="bottom" aria-label="Show bottom dock" title="Show bottom dock">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v13a2.5 2.5 0 0 1-2.5 2.5h-11A2.5 2.5 0 0 1 4 18.5v-13Zm2 0v10h12v-10a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5Zm0 13a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5V17H6v1.5Z" fill="currentColor"/></svg>
+          </button>
+          <button class="buret-button buret-preview-dock-toggle" type="button" data-buret-dock-toggle="right" aria-label="Show right dock" title="Show right dock">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.5 4A2.5 2.5 0 0 0 3 6.5v11A2.5 2.5 0 0 0 5.5 20h13a2.5 2.5 0 0 0 2.5-2.5v-11A2.5 2.5 0 0 0 18.5 4h-13ZM5 6.5a.5.5 0 0 1 .5-.5H15v12H5.5a.5.5 0 0 1-.5-.5v-11Zm12 11.5V6h1.5a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5H17Z" fill="currentColor"/></svg>
+          </button>
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="left" aria-label="Toggle left panel" title="Toggle left panel">L</button>
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="right" aria-label="Toggle right panel" title="Toggle right panel">R</button>
           <button class="buret-button buret-panel-toggle" type="button" data-buret-toggle="sequence" aria-label="Toggle sequence panel" title="Toggle sequence panel">Seq</button>
@@ -116,6 +122,8 @@
           </details>
         </div>
       </div>
+      <aside class="buret-preview-dock buret-preview-dock-right" data-buret-preview-dock="right" aria-label="Right dock" aria-hidden="true"></aside>
+      <section class="buret-preview-dock buret-preview-dock-bottom" data-buret-preview-dock="bottom" aria-label="Bottom dock" aria-hidden="true"></section>
     `);
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -349,8 +349,12 @@
         command: 'focusLigand',
         args: {
           selector: action.selector || action,
+          allowAmbiguous: action.allowAmbiguous === true,
+          index: Number.isInteger(action.index) ? action.index : undefined,
           showNeighborhood: !!action.showNeighborhood,
-          radiusA: action.radiusA
+          radiusA: action.radiusA,
+          durationMs: action.durationMs,
+          extraRadius: action.extraRadius
         }
       });
     }
@@ -362,6 +366,28 @@
     }
     if (type === 'focus_selection') {
       return window.BurreteAgent.run({ command: 'focusSelection', args: action.args || {} });
+    }
+    if (type === 'label_selection') {
+      return window.BurreteAgent.run({
+        command: 'labelSelection',
+        args: {
+          selection: action.selection,
+          selector: action.selector,
+          text: action.text || action.label,
+          label: action.label,
+          mode: action.mode,
+          granularity: action.granularity,
+          textSize: action.textSize,
+          background: action.background,
+          backgroundOpacity: action.backgroundOpacity,
+          backgroundMargin: action.backgroundMargin,
+          tether: action.tether,
+          tetherLength: action.tetherLength,
+          borderWidth: action.borderWidth,
+          offsetY: action.offsetY,
+          labelParams: action.labelParams
+        }
+      });
     }
     if (type === 'contacts') {
       return window.BurreteAgent.run({ command: 'contacts', args: action.args || action });
@@ -384,6 +410,21 @@
     if (type === 'render_panel') {
       return renderBurreteAgentPanel(action);
     }
+    if (type === 'apply_scene') {
+      return executeBurreteSceneSpec(action);
+    }
+    if (type === 'load_mvs') {
+      return window.BurreteAgent.run({
+        command: 'loadMVS',
+        args: {
+          data: action.data,
+          json: action.json,
+          dataBase64: action.dataBase64,
+          format: action.format,
+          options: action.options || {}
+        }
+      });
+    }
     if (type === 'screenshot' || type === 'export_image') {
       return window.BurreteAgent.run({ command: 'screenshot', args: action.args || {} });
     }
@@ -392,6 +433,84 @@
       return window.BurreteAgent.run({ command: action.command, args: action.args || {} });
     }
     return agentActionFailure(type, 'NOT_IMPLEMENTED', `Unsupported BurreteAgent action: ${type}`);
+  }
+
+  function burreteSceneSpecOperations(action) {
+    const raw = Array.isArray(action?.operations) ? action.operations : action?.components;
+    return Array.isArray(raw) ? raw : [];
+  }
+
+  function burreteSceneSpecTarget(operation) {
+    if (operation?.selector != null) return operation.selector;
+    if (operation?.target != null) return operation.target;
+    if (operation?.component != null) return operation.component;
+    return null;
+  }
+
+  function burreteSceneSpecLabel(operation, index) {
+    return operation?.label || operation?.name || operation?.id || `scene-component-${index + 1}`;
+  }
+
+  async function executeBurreteSceneSpec(action) {
+    const operations = burreteSceneSpecOperations(action);
+    if (!operations.length) return agentActionFailure('apply_scene', 'INVALID_ARGS', 'apply_scene requires components or operations.');
+
+    const results = [];
+    for (let index = 0; index < operations.length; index++) {
+      const operation = operations[index] || {};
+      const target = burreteSceneSpecTarget(operation);
+      if (target == null) {
+        results.push(agentActionFailure('apply_scene', 'INVALID_ARGS', `Scene operation ${index + 1} requires selector or target.`));
+        continue;
+      }
+      const label = burreteSceneSpecLabel(operation, index);
+      const kind = String(operation.kind || operation.action || '').toLowerCase();
+      const wantsSelect = operation.select === true || kind === 'select' || kind === 'selection';
+      const wantsFocus = operation.focus === true || kind === 'focus';
+      const wantsHighlight = operation.highlight === true || operation.color != null || operation.representation != null || kind === 'highlight' || kind === 'color';
+
+      if (wantsHighlight || (!wantsSelect && !wantsFocus)) {
+        results.push(await window.BurreteAgent.run({
+          command: 'colorSelection',
+          args: {
+            selector: target,
+            label,
+            color: operation.color || operation.hex,
+            highlight: operation.highlight !== false,
+            mode: operation.mode || 'add',
+            granularity: operation.granularity || 'residue'
+          }
+        }));
+      }
+      if (wantsSelect) {
+        results.push(await window.BurreteAgent.run({
+          command: 'selectResidues',
+          args: {
+            selector: target,
+            label,
+            mode: operation.mode || 'add',
+            granularity: operation.granularity || 'residue'
+          }
+        }));
+      }
+      if (wantsFocus) {
+        results.push(await window.BurreteAgent.run({
+          command: 'focusSelection',
+          args: {
+            selector: target,
+            durationMs: operation.durationMs,
+            extraRadius: operation.extraRadius
+          }
+        }));
+      }
+    }
+
+    return {
+      ok: results.every(result => result?.ok !== false),
+      action: 'apply_scene',
+      operationCount: operations.length,
+      results
+    };
   }
 
   window.addEventListener('message', event => {
@@ -630,6 +749,11 @@
   let floatingLayoutFrame = 0;
   let molstarViewportPanelOpen = false;
   let molstarSelectionControlsOpen = false;
+  const previewDockState = { right: false, bottom: false };
+  let previewDockObserve = null;
+  let previewDockObserveError = '';
+  let previewDockObserveLoading = false;
+  let previewDockObserveTimer = 0;
   const draggableViewportPanels = new WeakSet();
 
   function isQuickLookHost() {
@@ -1420,6 +1544,255 @@
       .replace(/"/g, '&quot;');
   }
 
+  function previewDockDocumentRows() {
+    const config = activeConfig || window.BurreteConfig || {};
+    const rows = [
+      ['Document', config.label || config.title || 'Burrete preview'],
+      ['Format', config.format || config.molstarFormat || 'unknown']
+    ];
+    if (config.byteCount !== undefined) rows.push(['Size', `${Number(config.byteCount || 0).toLocaleString()} bytes`]);
+    if (config.documentId) rows.push(['Document ID', config.documentId]);
+    if (config.path) rows.push(['Path', config.path]);
+    return rows.map(([label, value]) => `
+      <div class="buret-preview-dock-card">
+        <div class="buret-preview-dock-label">${escapeHtml(label)}</div>
+        <div class="buret-preview-dock-value">${escapeHtml(value)}</div>
+      </div>
+    `).join('');
+  }
+
+  function previewDockCard(label, value) {
+    return `
+      <div class="buret-preview-dock-card">
+        <div class="buret-preview-dock-label">${escapeHtml(label)}</div>
+        <div class="buret-preview-dock-value">${escapeHtml(value)}</div>
+      </div>
+    `;
+  }
+
+  function previewDockSection(title, body) {
+    return `
+      <div class="buret-preview-dock-section">
+        <div class="buret-preview-dock-section-title">${escapeHtml(title)}</div>
+        ${body}
+      </div>
+    `;
+  }
+
+  function previewDockSceneDescription(observe) {
+    const scene = observe?.scene || {};
+    if (!scene.known) return scene.note || 'Scene summary is waiting for the Mol* viewer agent.';
+    const counts = scene.counts || {};
+    const parts = [
+      `${counts.structures || scene.structures || 0} structure`,
+      `${counts.models || scene.models || 0} model`,
+      `${counts.chains || 0} chains`,
+      `${counts.residues || 0} residues`,
+      `${counts.atoms || 0} atoms`,
+      `${counts.ligands || 0} ligands`
+    ];
+    return `${scene.label || 'Active scene'} (${scene.format || 'unknown'}): ${parts.join(', ')}.`;
+  }
+
+  function previewDockLigandList(observe) {
+    const ligands = observe?.scene?.ligands || [];
+    if (!ligands.length) return previewDockCard('Ligands', 'No ligands reported yet.');
+    const items = ligands.slice(0, 8).map(ligand => {
+      const chain = ligand.auth_asym_id || ligand.label_asym_id || '?';
+      const seq = ligand.auth_seq_id || ligand.label_seq_id || '?';
+      const atoms = Number.isFinite(ligand.atomCount) ? `${ligand.atomCount} atoms` : 'atom count unknown';
+      return `<li class="buret-preview-dock-list-item">
+        <div class="buret-preview-dock-line">
+          <span>${escapeHtml(`${chain}:${seq}`)}</span>
+          <span class="buret-preview-dock-muted">${escapeHtml(atoms)}</span>
+        </div>
+      </li>`;
+    }).join('');
+    const suffix = ligands.length > 8 ? previewDockCard('More ligands', `${ligands.length - 8} additional ligands are hidden in this compact view.`) : '';
+    return `<ul class="buret-preview-dock-list">${items}</ul>${suffix}`;
+  }
+
+  function previewDockAgentRows(observe) {
+    if (!observe) {
+      return previewDockCard('Bridge', previewDockObserveLoading ? 'Loading agent observe state...' : 'No observe state loaded yet.');
+    }
+    const agent = observe.viewerAgent || {};
+    const commands = Array.isArray(agent.commands) ? agent.commands : [];
+    return [
+      previewDockCard('Workspace mode', `${observe.mode || 'unknown'} / ${observe.transport || 'unknown'}`),
+      previewDockCard('Viewer agent', agent.available ? 'available' : 'not ready'),
+      previewDockCard('Commands', commands.length ? commands.join(', ') : 'No commands reported yet.'),
+      agent.lastReportAt ? previewDockCard('Last report', agent.lastReportAt) : ''
+    ].join('');
+  }
+
+  function previewDockActionList(observe) {
+    const recent = observe?.actions?.recent || [];
+    if (!recent.length) return previewDockCard('Actions', 'No MCP/agent actions have been recorded yet.');
+    const items = recent.slice(-8).reverse().map(action => {
+      const result = action.result || {};
+      const statusClass = action.status === 'completed' ? 'ok' : action.status === 'failed' ? 'failed' : '';
+      const command = result.command || action.type || 'action';
+      const detail = result.error?.message || result.result?.selectionId || result.result?.counts
+        ? JSON.stringify(result.result?.counts || result.result?.selectionId || result.error?.message)
+        : '';
+      return `<li class="buret-preview-dock-list-item">
+        <div class="buret-preview-dock-line">
+          <span>${escapeHtml(`${action.id}: ${command}`)}</span>
+          <span class="buret-preview-dock-status-pill ${statusClass}">${escapeHtml(action.status || 'unknown')}</span>
+        </div>
+        ${detail ? `<div class="buret-preview-dock-muted">${escapeHtml(detail)}</div>` : ''}
+      </li>`;
+    }).join('');
+    return `<ul class="buret-preview-dock-list">${items}</ul>`;
+  }
+
+  function previewDockRightBody() {
+    const observe = previewDockObserve;
+    const error = previewDockObserveError ? previewDockCard('Observe error', previewDockObserveError) : '';
+    return [
+      previewDockSection('Document', previewDockDocumentRows()),
+      previewDockSection('Scene text', previewDockCard('Summary', previewDockSceneDescription(observe)) + previewDockLigandList(observe)),
+      previewDockSection('Agent bridge', previewDockAgentRows(observe)),
+      previewDockSection('MCP action log', previewDockActionList(observe)),
+      error
+    ].join('');
+  }
+
+  function renderPreviewDock(area) {
+    const panel = document.querySelector(`[data-buret-preview-dock="${area}"]`);
+    if (!panel) return;
+    const title = area === 'right' ? 'Agent scene log' : 'Preview dock';
+    const body = area === 'right'
+      ? previewDockRightBody()
+      : `<div class="buret-preview-dock-section">
+          <div class="buret-preview-dock-card">
+            <div class="buret-preview-dock-label">Active preview</div>
+            <div class="buret-preview-dock-value">${escapeHtml((activeConfig || window.BurreteConfig || {}).label || 'Burrete preview')}</div>
+          </div>
+          <div class="buret-preview-dock-card">
+            <div class="buret-preview-dock-label">Status</div>
+            <div class="buret-preview-dock-value">Standalone browser preview controls are available here.</div>
+          </div>
+        </div>`;
+    panel.innerHTML = `
+      <div class="buret-preview-dock-header">
+        <div class="buret-preview-dock-title">${escapeHtml(title)}</div>
+        <button class="buret-button buret-preview-dock-close" type="button" data-buret-dock-close="${area}" aria-label="Hide ${area} dock" title="Hide ${area} dock">×</button>
+      </div>
+      <div class="buret-preview-dock-body">${body}</div>
+    `;
+  }
+
+  function previewDockObserveUrl() {
+    return window.BurreteAgentControl?.observeUrl || '/__agent/observe';
+  }
+
+  async function refreshPreviewDockObserve() {
+    if (!previewDocksEnabled() || !previewDockState.right || previewDockObserveLoading) return;
+    previewDockObserveLoading = true;
+    try {
+      const response = await fetch(previewDockObserveUrl(), { cache: 'no-store', credentials: 'same-origin' });
+      if (!response.ok) throw new Error(`observe returned HTTP ${response.status}`);
+      previewDockObserve = await response.json();
+      previewDockObserveError = '';
+    } catch (error) {
+      previewDockObserveError = error?.message || String(error);
+    } finally {
+      previewDockObserveLoading = false;
+      if (previewDockState.right) renderPreviewDock('right');
+      schedulePreviewDockObserveRefresh();
+    }
+  }
+
+  function schedulePreviewDockObserveRefresh() {
+    window.clearTimeout(previewDockObserveTimer);
+    previewDockObserveTimer = 0;
+    if (!previewDocksEnabled() || !previewDockState.right) return;
+    previewDockObserveTimer = window.setTimeout(() => {
+      void refreshPreviewDockObserve();
+    }, previewDockObserve ? 2000 : 250);
+  }
+
+  function setPreviewDockOpen(area, open) {
+    if (area !== 'right' && area !== 'bottom') return;
+    previewDockState[area] = open === true;
+    const panel = document.querySelector(`[data-buret-preview-dock="${area}"]`);
+    if (panel) {
+      renderPreviewDock(area);
+      panel.classList.toggle('open', previewDockState[area]);
+      panel.setAttribute('aria-hidden', previewDockState[area] ? 'false' : 'true');
+    }
+    document.body?.classList.toggle(`buret-preview-dock-${area}-open`, previewDockState[area]);
+    if (area === 'right') {
+      if (previewDockState.right) void refreshPreviewDockObserve();
+      else window.clearTimeout(previewDockObserveTimer);
+    }
+    updatePreviewDockButtons();
+  }
+
+  function togglePreviewDock(area) {
+    setPreviewDockOpen(area, !previewDockState[area]);
+  }
+
+  function previewDocksEnabled() {
+    const config = activeConfig || window.BurreteConfig || {};
+    return config.enablePreviewDocks === true;
+  }
+
+  function updatePreviewDockAvailability() {
+    const enabled = previewDocksEnabled();
+    document.body?.classList.toggle('buret-preview-docks-enabled', enabled);
+    if (!enabled) {
+      setPreviewDockOpen('bottom', false);
+      setPreviewDockOpen('right', false);
+    }
+    return enabled;
+  }
+
+  function updatePreviewDockButtons() {
+    const toolbar = document.getElementById('buret-toolbar');
+    if (!toolbar) return;
+    for (const area of ['bottom', 'right']) {
+      const button = toolbar.querySelector(`[data-buret-dock-toggle="${area}"]`);
+      if (!button) continue;
+      const open = previewDockState[area] === true;
+      button.classList.toggle('active', open);
+      button.setAttribute('aria-label', `${open ? 'Hide' : 'Show'} ${area} dock`);
+      button.setAttribute('title', `${open ? 'Hide' : 'Show'} ${area} dock`);
+    }
+  }
+
+  function bindPreviewDockControls(toolbar) {
+    if (!toolbar || !previewDocksEnabled() || toolbar.dataset.previewDockTogglesBound === '1') return;
+    toolbar.addEventListener('click', event => {
+      const button = event.target?.closest?.('[data-buret-dock-toggle]');
+      if (!button || !toolbar.contains(button)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      togglePreviewDock(button.getAttribute('data-buret-dock-toggle'));
+    });
+    document.addEventListener('click', event => {
+      const close = event.target?.closest?.('[data-buret-dock-close]');
+      if (!close) return;
+      event.preventDefault();
+      event.stopPropagation();
+      setPreviewDockOpen(close.getAttribute('data-buret-dock-close'), false);
+    });
+    toolbar.dataset.previewDockTogglesBound = '1';
+    updatePreviewDockButtons();
+  }
+
+  function applyDefaultPreviewDocks(toolbar) {
+    if (!toolbar || !previewDocksEnabled() || toolbar.dataset.previewDocksDefaulted === '1') return;
+    const config = activeConfig || window.BurreteConfig || {};
+    const defaultDocks = Array.isArray(config.defaultPreviewDocks) ? config.defaultPreviewDocks : [];
+    toolbar.dataset.previewDocksDefaulted = '1';
+    for (const area of defaultDocks) {
+      if (area === 'bottom' || area === 'right') setPreviewDockOpen(area, true);
+    }
+  }
+
   function requestMolstarStyle(style) {
     const value = normalizeMolstarStyle(style);
     activeConfig = {
@@ -2042,12 +2415,16 @@
       sdfPoseButton.dataset.bound = '1';
       sdfPoseButton.addEventListener('click', toggleSdfPoseMode);
     }
+    updatePreviewDockAvailability();
+    bindPreviewDockControls(toolbar);
+    applyDefaultPreviewDocks(toolbar);
     initToolbarDrag(toolbar);
     restoreToolbarCollapsed(toolbar, viewer);
     installToolbarAutoLayoutTracking(toolbar);
     installMolstarFloatingPanelTracking();
     updateToolbarVisibility();
     updateSdfPoseButton();
+    updatePreviewDockButtons();
     updateThemeButton();
     applyLayoutState(viewer);
   }
@@ -2952,7 +3329,12 @@
     if (value === 'cif' || value === 'mmcif' || value === 'mcif') return 'mmcif';
     if (value === 'bcif' || value === 'binarycif') return 'mmcif';
     if (value === 'sd') return 'sdf';
+    if (value === 'molviewspec' || value === 'mol-view-spec') return 'mvsj';
     return value;
+  }
+
+  function isMolViewSpecFormat(format) {
+    return format === 'mvsj' || format === 'mvsx';
   }
 
   function requireConfig() {
@@ -3307,6 +3689,14 @@
       return prepareDockingStructure(config);
     }
     const normalized = normalizeFormat(config.format);
+    if (isMolViewSpecFormat(normalized)) {
+      return {
+        kind: 'mvs',
+        data: rawStructureData(config),
+        format: normalized,
+        label: config.label || 'MolViewSpec scene'
+      };
+    }
     if (normalized === 'cifCore') {
       const pdb = coreCifToPdb(rawStructureData({ ...config, binary: false }));
       return {
@@ -5035,6 +5425,15 @@
     updateSdfPoseButton(prepared);
     if (prepared.kind === 'docking') {
       await loadDockingPreparedStructure(viewer, prepared);
+      return;
+    }
+    if (prepared.kind === 'mvs') {
+      activeDockingPrepared = null;
+      if (typeof viewer.loadMvsData !== 'function') {
+        throw new Error('Mol* viewer.loadMvsData is not available in this runtime.');
+      }
+      await viewer.loadMvsData(prepared.data, prepared.format, { replaceExisting: true });
+      installDockingPoseControls(viewer, null);
       return;
     }
     activeDockingPrepared = null;
@@ -7365,7 +7764,6 @@
           molstarContextMenuMode = mode;
           modeGroup.querySelectorAll('button').forEach(item => item.setAttribute('aria-pressed', item.dataset.buretContextMode === mode ? 'true' : 'false'));
           renderActions();
-          actionContainer.querySelector('button')?.focus();
         });
         modeGroup.appendChild(button);
       });
@@ -7375,7 +7773,6 @@
     menu.appendChild(actionContainer);
     document.body.appendChild(menu);
     positionMolstarContextMenu(menu, event.clientX, event.clientY);
-    menu.querySelector('button')?.focus();
   }
 
   function installMolstarContextMenu(viewer) {
@@ -7447,6 +7844,8 @@
           hideMolstarContextMenu();
           return;
         }
+        event.preventDefault();
+        event.stopPropagation();
         contextPointer = {
           pointerId: event.pointerId,
           startX: event.clientX,

--- a/apps/desktop/src-tauri/AppMetadata.plist
+++ b/apps/desktop/src-tauri/AppMetadata.plist
@@ -41,6 +41,8 @@
 				<string>mmcif</string>
 				<string>mol</string>
 				<string>mol2</string>
+				<string>mvsj</string>
+				<string>mvsx</string>
 				<string>in</string>
 				<string>inp</string>
 				<string>lammpstrj</string>
@@ -96,6 +98,8 @@
 				<string>com.gaussian.cube</string>
 				<string>com.local.burrete10.gro</string>
 				<string>gg.flew.unfold.gromacs-structure</string>
+				<string>com.local.burrete10.mvsj</string>
+				<string>com.local.burrete10.mvsx</string>
 				<string>com.local.burrete10.molecular-dynamics</string>
 				<string>com.schrodinger.mae</string>
 				<string>com.local.burrete10.schrodinger</string>
@@ -205,6 +209,53 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>chemical/x-mmcif</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+				<string>public.text</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MolViewSpec JSON scene file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.mvsj</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mvsj</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/vnd.molstar.mvsj+json</string>
+					<string>application/json</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MolViewSpec archive scene file</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.local.burrete10.mvsx</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mvsx</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/vnd.molstar.mvsx</string>
+					<string>application/zip</string>
 				</array>
 			</dict>
 		</dict>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -82,6 +82,8 @@
           "graphml",
           "mol",
           "mol2",
+          "mvsj",
+          "mvsx",
           "xyz",
           "gro",
           "cub",

--- a/apps/desktop/src/components/dock-panel.tsx
+++ b/apps/desktop/src/components/dock-panel.tsx
@@ -320,7 +320,7 @@ function DockPanelContent({
   if (activeTabKind === "diagnostics") {
     return (
       <div className="dock-content dock-content-grid">
-        <Metric label="Runtime" value={state.buildInfo.isBrowserDev ? "Browser dev" : "Desktop"} />
+        <Metric label="Runtime" value={state.buildInfo.isAgentShell ? "Agent shell" : state.buildInfo.isBrowserDev ? "Browser dev" : "Desktop"} />
         <Metric label="Build" value={state.buildInfo.version} />
         <Metric label="Flavor" value={state.buildInfo.flavor ?? "Release"} />
         <button type="button" className="dock-action" onClick={() => void actions.exportDiagnostics()}>

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -18,9 +18,10 @@ export function FileBrowser({
 }) {
   const [pinnedOpen, setPinnedOpen] = useState(true);
   const [ketcherDropActive, setKetcherDropActive] = useState(false);
+  const hideProjectPreviews = state.buildInfo.isAgentShell;
   const sidebarQuery = state.sidebarQuery.trim();
   const hasSidebarQuery = sidebarQuery.length > 0;
-  const visibleProjects = filterSidebarProjects(state.sidebarProjects, state.sidebarQuery);
+  const visibleProjects = hideProjectPreviews ? [] : filterSidebarProjects(state.sidebarProjects, state.sidebarQuery);
   const pinnedItems = visibleProjects.flatMap((project) => project.items.filter((item) => item.isPinned));
   const pinnedExpanded = pinnedOpen || hasSidebarQuery;
   const projectsExpanded = state.projectsOpen || hasSidebarQuery;
@@ -126,6 +127,7 @@ export function FileBrowser({
           )}
         </section>
       )}
+      {!hideProjectPreviews && (
       <section className="sidebar-section" aria-label="Projects">
         <div className="sidebar-section-header">
           <button
@@ -197,6 +199,7 @@ export function FileBrowser({
           )
         )}
       </section>
+      )}
     </ScrollFade>
   );
 }

--- a/apps/desktop/src/components/sidebar/workspace-switcher.tsx
+++ b/apps/desktop/src/components/sidebar/workspace-switcher.tsx
@@ -3,6 +3,7 @@ import { RadixDropdownMenu } from "../radix-menu";
 import type { BuildInfo, ShellActions, ShellViewState } from "../types";
 
 function buildLabel(info: BuildInfo) {
+  if (info.isAgentShell) return `AGENT SHELL · v${info.version}`;
   if (info.isBrowserDev) return `BROWSER DEV · v${info.version}`;
   if (info.isDevBuild) return `DEV ${info.flavor ?? "local"} · v${info.version}`;
   return "";

--- a/apps/desktop/src/components/types.ts
+++ b/apps/desktop/src/components/types.ts
@@ -51,6 +51,7 @@ export type BuildInfo = {
   flavor: string | null;
   isDevBuild: boolean;
   isBrowserDev: boolean;
+  isAgentShell: boolean;
   notes: string[];
   limitations: string[];
 };

--- a/apps/desktop/src/components/welcome/index.tsx
+++ b/apps/desktop/src/components/welcome/index.tsx
@@ -2,6 +2,7 @@ import type { BuildInfo, ShellActions } from "../types";
 import { ShortcutTooltip } from "../shortcut-tooltip";
 
 function buildLabel(info: BuildInfo) {
+  if (info.isAgentShell) return `Agent shell · v${info.version}`;
   if (info.isBrowserDev) return `Browser dev · v${info.version}`;
   if (info.isDevBuild) return `Dev ${info.flavor ?? "local"} · v${info.version}`;
   return `Release · v${info.version}`;

--- a/apps/desktop/src/hooks/use-agent-session.ts
+++ b/apps/desktop/src/hooks/use-agent-session.ts
@@ -8,6 +8,8 @@ import type { DockArea } from "../lib/dock";
 
 const AGENT_API_VERSION = "burette-agent-control/v1";
 const ACTION_POLL_INTERVAL_MS = 500;
+const BROWSER_AGENT_SESSION_DIR = "__browser_agent_shell__";
+const isBrowserAgentShell = import.meta.env.VITE_BURRETE_AGENT_SHELL === "1";
 
 type OpenPaths = (paths: string[]) => void | Promise<void>;
 type OpenTextDocuments = (
@@ -49,7 +51,23 @@ type ViewerAgentState = {
   viewerReady: boolean;
   lastMessage: string | null;
   lastError: string | null;
+  lastAction: AgentSceneAction | null;
+  selection: AgentSceneSelection | null;
   updatedAt: string;
+};
+
+type AgentSceneAction = {
+  ok: boolean | null;
+  command: string | null;
+  errorCode: string | null;
+  completedAt: string;
+};
+
+type AgentSceneSelection = {
+  selectionId: string | null;
+  selector: unknown;
+  ligand: unknown;
+  counts: unknown;
 };
 
 type UseAgentSessionArgs = {
@@ -120,11 +138,32 @@ export function useAgentSession({
   }, [activateSession]);
 
   useEffect(() => {
-    if (!isTauriRuntime()) return undefined;
+    if (!isBrowserAgentShell) return undefined;
+    activateSession(BROWSER_AGENT_SESSION_DIR);
+    return undefined;
+  }, [activateSession]);
+
+  useEffect(() => {
+    if (!isTauriRuntime() && !isBrowserAgentShell) return undefined;
     const handler = (event: MessageEvent) => {
       if (event.data?.source === "burrete-agent-viewer") {
         const body = event.data.body;
         if (!body || body.type !== "agent-action-result" || typeof body.id !== "string") return;
+        const activeDocumentId = activeDocumentRef.current?.id;
+        if (activeDocumentId) {
+          viewerAgentStatesRef.current[activeDocumentId] = viewerAgentStateWithActionResult(
+            activeDocumentId,
+            viewerAgentStatesRef.current[activeDocumentId],
+            body.result,
+          );
+          void writeObserve(
+            sessionDirRef.current,
+            activeDocumentRef.current,
+            documentsRef.current,
+            workspacePanelsRef.current,
+            viewerAgentStatesRef.current,
+          );
+        }
         const resolve = pendingViewerActionsRef.current.get(body.id);
         if (!resolve) return;
         pendingViewerActionsRef.current.delete(body.id);
@@ -150,9 +189,9 @@ export function useAgentSession({
   }, []);
 
   useEffect(() => {
-    if (!isTauriRuntime()) return undefined;
+    if (!isTauriRuntime() && !isBrowserAgentShell) return undefined;
     let busy = false;
-    const timer = window.setInterval(() => {
+    const pollNow = () => {
       const sessionDir = sessionDirRef.current;
       if (!sessionDir || busy) return;
       busy = true;
@@ -171,8 +210,17 @@ export function useAgentSession({
         .finally(() => {
           busy = false;
         });
-    }, ACTION_POLL_INTERVAL_MS);
-    return () => window.clearInterval(timer);
+    };
+    const timer = window.setInterval(pollNow, ACTION_POLL_INTERVAL_MS);
+    const browserActionEvents = isBrowserAgentShell
+      ? new EventSource("/__burette/agent-session/events")
+      : null;
+    browserActionEvents?.addEventListener("actions", pollNow);
+    pollNow();
+    return () => {
+      window.clearInterval(timer);
+      browserActionEvents?.close();
+    };
   }, []);
 }
 
@@ -183,7 +231,7 @@ async function writeObserve(
   workspacePanels: AgentWorkspacePanel[],
   viewerAgentStates: Record<string, ViewerAgentState>,
 ) {
-  if (!sessionDir || !isTauriRuntime()) return;
+  if (!sessionDir || (!isTauriRuntime() && !isBrowserAgentSessionDir(sessionDir))) return;
   const activeAgentState = activeDocument ? viewerAgentStates[activeDocument.id] : undefined;
   const activeMolstar = !!activeDocument && activeDocument.renderer === "molstar";
   const activeReady = activeDocument
@@ -193,8 +241,8 @@ async function writeObserve(
     : false;
   const observe = {
     apiVersion: AGENT_API_VERSION,
-    mode: "desktop-app",
-    transport: "file-session-token",
+    mode: isBrowserAgentSessionDir(sessionDir) ? "browser-dev-shell" : "desktop-app",
+    transport: isBrowserAgentSessionDir(sessionDir) ? "browser-agent-http-session" : "file-session-token",
     reportedAt: new Date().toISOString(),
     activeDocument: activeDocument
       ? {
@@ -225,8 +273,13 @@ async function writeObserve(
       lastError: activeAgentState?.lastError ?? null,
       updatedAt: activeAgentState?.updatedAt ?? null,
       note: activeMolstar
-        ? "Desktop app actions are relayed to the active Mol* viewer iframe after the viewer reports BurreteAgent readiness."
-        : "Desktop app actions require an active Mol* viewer document.",
+        ? "Actions are relayed to the active Mol* viewer iframe after the viewer reports BurreteAgent readiness."
+        : "Agent actions require an active Mol* viewer document.",
+    },
+    scene: {
+      known: activeMolstar && !!activeAgentState?.agentReady,
+      selection: activeAgentState?.selection ?? null,
+      lastAction: activeAgentState?.lastAction ?? null,
     },
     panels: ["viewer", ...workspacePanels.map((panel) => panel.id)],
     workspacePanels,
@@ -394,6 +447,8 @@ function viewerAgentStateFromMessage(body: { type?: unknown; message?: unknown; 
     viewerReady: previous?.viewerReady ?? false,
     lastMessage: previous?.lastMessage ?? null,
     lastError: previous?.lastError ?? null,
+    lastAction: previous?.lastAction ?? null,
+    selection: previous?.selection ?? null,
     updatedAt: new Date().toISOString(),
   };
   if (type === "agentReady") {
@@ -416,6 +471,46 @@ function viewerAgentStateFromMessage(body: { type?: unknown; message?: unknown; 
   return null;
 }
 
+function viewerAgentStateWithActionResult(
+  documentId: string,
+  previous: ViewerAgentState | undefined,
+  result: unknown,
+): ViewerAgentState {
+  const object = typeof result === "object" && result !== null ? result as Record<string, unknown> : {};
+  const ok = typeof object.ok === "boolean" ? object.ok : null;
+  const command = typeof object.command === "string" ? object.command : null;
+  const error = typeof object.error === "object" && object.error !== null ? object.error as Record<string, unknown> : null;
+  const next: ViewerAgentState = {
+    documentId,
+    agentReady: previous?.agentReady ?? true,
+    viewerReady: previous?.viewerReady ?? true,
+    lastMessage: command ? `Action ${command} ${ok === false ? "failed" : "completed"}` : (previous?.lastMessage ?? null),
+    lastError: ok === false && typeof error?.message === "string" ? error.message : null,
+    lastAction: {
+      ok,
+      command,
+      errorCode: typeof error?.code === "string" ? error.code : null,
+      completedAt: new Date().toISOString(),
+    },
+    selection: sceneSelectionFromActionResult(result) ?? previous?.selection ?? null,
+    updatedAt: new Date().toISOString(),
+  };
+  return next;
+}
+
+function sceneSelectionFromActionResult(result: unknown): AgentSceneSelection | null {
+  if (typeof result !== "object" || result === null) return null;
+  const outer = result as Record<string, unknown>;
+  const payload = typeof outer.result === "object" && outer.result !== null ? outer.result as Record<string, unknown> : null;
+  if (!payload) return null;
+  const selectionId = typeof payload.selectionId === "string" ? payload.selectionId : null;
+  const selector = payload.selectorEcho ?? null;
+  const ligand = payload.ligand ?? null;
+  const counts = payload.counts ?? null;
+  if (!selectionId && !selector && !ligand && !counts) return null;
+  return { selectionId, selector, ligand, counts };
+}
+
 function isFailedResult(result: unknown) {
   return typeof result === "object" && result !== null && "ok" in result && (result as { ok?: unknown }).ok === false;
 }
@@ -429,6 +524,16 @@ function agentFailure(command: string, code: string, message: string) {
 }
 
 async function readJson<T>(path: string, fallback: T): Promise<T> {
+  const browserFile = browserAgentSessionFile(path);
+  if (browserFile) {
+    try {
+      const response = await fetch(`/__burette/agent-session/${browserFile}`, { cache: "no-store" });
+      if (!response.ok) return fallback;
+      return await response.json() as T;
+    } catch {
+      return fallback;
+    }
+  }
   try {
     const file = await invoke<ReadTextFileResult>("read_text_file", { path });
     return JSON.parse(file.content) as T;
@@ -438,6 +543,18 @@ async function readJson<T>(path: string, fallback: T): Promise<T> {
 }
 
 async function writeJson(path: string, value: unknown) {
+  const browserFile = browserAgentSessionFile(path);
+  if (browserFile) {
+    const response = await fetch(`/__burette/agent-session/${browserFile}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(value),
+    });
+    if (!response.ok) {
+      throw new Error(`Agent shell session write failed for ${browserFile}: HTTP ${response.status}`);
+    }
+    return;
+  }
   await invoke<string>("write_text_file", {
     request: {
       outputPath: path,
@@ -448,4 +565,15 @@ async function writeJson(path: string, value: unknown) {
 
 function joinSessionPath(sessionDir: string, fileName: string) {
   return `${sessionDir.replace(/\/+$/u, "")}/${fileName}`;
+}
+
+function isBrowserAgentSessionDir(sessionDir: string) {
+  return sessionDir === BROWSER_AGENT_SESSION_DIR;
+}
+
+function browserAgentSessionFile(path: string) {
+  const prefix = `${BROWSER_AGENT_SESSION_DIR}/`;
+  if (!path.startsWith(prefix)) return null;
+  const fileName = path.slice(prefix.length);
+  return ["actions.json", "observe.json"].includes(fileName) ? fileName : null;
 }

--- a/apps/desktop/src/lib/build-info.ts
+++ b/apps/desktop/src/lib/build-info.ts
@@ -6,6 +6,7 @@ const RELEASE_IDENTIFIER = "com.local.BurreteV10";
 const buildIdentifier = import.meta.env.VITE_BURRETE_BUILD_IDENTIFIER;
 const buildFlavor = import.meta.env.VITE_BURRETE_BUILD_FLAVOR;
 const buildChannel = import.meta.env.VITE_BURRETE_BUILD_CHANNEL;
+const isAgentShell = import.meta.env.VITE_BURRETE_AGENT_SHELL === "1";
 
 function devFlavorFromIdentifier(identifier: string) {
   return identifier.match(/\.Dev\.([A-Za-z][A-Za-z0-9-]*)$/u)?.[1] ?? null;
@@ -27,11 +28,14 @@ function buildInfoFromValues(
     flavor: isBrowserDev ? "browser" : flavor,
     isDevBuild,
     isBrowserDev,
+    isAgentShell: isBrowserDev && isAgentShell,
     notes: isDevBuild
-      ? ["Full desktop features", isBrowserDev ? "Vite browser runtime" : "Isolated app and Quick Look identifiers"]
+      ? ["Full desktop features", isAgentShell ? "Agent browser shell" : isBrowserDev ? "Vite browser runtime" : "Isolated app and Quick Look identifiers"]
       : [],
     limitations: isBrowserDev
-      ? ["Native app bundle, installer, and Quick Look registration are not active in browser dev."]
+      ? [isAgentShell
+        ? "Native app bundle, installer, and Quick Look registration are not active in the agent browser shell."
+        : "Native app bundle, installer, and Quick Look registration are not active in browser dev."]
       : [],
   };
 }

--- a/apps/desktop/src/lib/instance.ts
+++ b/apps/desktop/src/lib/instance.ts
@@ -1,5 +1,6 @@
 const devInstanceSuffix = import.meta.env.VITE_BURETTE_DEV_INSTANCE ?? "8a18";
+const agentShell = import.meta.env.VITE_BURRETE_AGENT_SHELL === "1";
 
 export const appInstanceLabel = import.meta.env.DEV
-  ? `Burette Dev ${devInstanceSuffix}`
+  ? agentShell ? "Burette Agent" : `Burette Dev ${devInstanceSuffix}`
   : "Burette";

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_BURRETE_BUILD_CHANNEL?: string;
   readonly VITE_BURRETE_BUILD_FLAVOR?: string;
   readonly VITE_BURRETE_BUILD_IDENTIFIER?: string;
+  readonly VITE_BURRETE_AGENT_SHELL?: string;
   readonly BURRETE_REPO_ROOT?: string;
 }
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, watch } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { delimiter, dirname, join, relative, resolve } from "node:path";
@@ -55,7 +55,7 @@ type StructureFileBundle = {
 const DEV_FILE_EXTENSIONS = new Set([
   "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "gro",
   "in", "inp", "lammpstrj", "log", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
-  "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
+  "mol2", "mvsj", "mvsx", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
   "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz",
   "dtr",
 ]);
@@ -336,6 +336,84 @@ export function browserDevXyzrenderPlugin() {
           res.setHeader("Content-Length", String(bytes.length));
           res.setHeader("Cache-Control", "no-cache");
           res.end(bytes);
+        } catch (error) {
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+        }
+      });
+      server.middlewares.use("/__burette/agent-session/", async (req, res) => {
+        const sessionDir = process.env.BURRETE_AGENT_SHELL_SESSION_DIR
+          ? resolve(process.env.BURRETE_AGENT_SHELL_SESSION_DIR)
+          : null;
+        const method = (req.method || "GET").toUpperCase();
+        const url = new URL(req.url || "", "http://127.0.0.1");
+        const fileName = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+        if (!sessionDir || !["actions.json", "observe.json", "session.json", "events"].includes(fileName)) {
+          res.statusCode = sessionDir ? 404 : 403;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: sessionDir ? "Not found" : "Agent shell session is not enabled" }));
+          return;
+        }
+        if (fileName === "events") {
+          if (method !== "GET") {
+            res.statusCode = 405;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ error: "Method not allowed" }));
+            return;
+          }
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+          res.setHeader("Cache-Control", "no-cache, no-transform");
+          res.setHeader("Connection", "keep-alive");
+          const sendActionsEvent = () => {
+            res.write(`event: actions\ndata: ${JSON.stringify({ file: "actions.json", at: new Date().toISOString() })}\n\n`);
+          };
+          sendActionsEvent();
+          const watcher = watch(sessionDir, (_eventType, changedFileName) => {
+            if (changedFileName === "actions.json") sendActionsEvent();
+          });
+          req.on("close", () => watcher.close());
+          return;
+        }
+        const filePath = resolve(sessionDir, fileName);
+        if (!filePath.startsWith(`${sessionDir}/`)) {
+          res.statusCode = 403;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: "Forbidden" }));
+          return;
+        }
+        try {
+          if (method === "GET") {
+            const fallback = fileName === "actions.json"
+              ? { apiVersion: "burette-agent-control/v1", actions: [] }
+              : {};
+            let value = fallback;
+            if (existsSync(filePath)) value = JSON.parse(await readFile(filePath, "utf8"));
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.setHeader("Cache-Control", "no-cache");
+            res.end(JSON.stringify(value));
+            return;
+          }
+          if (method === "PUT") {
+            if (fileName === "session.json") {
+              res.statusCode = 405;
+              res.setHeader("Content-Type", "application/json; charset=utf-8");
+              res.end(JSON.stringify({ error: "session.json is read-only" }));
+              return;
+            }
+            const body = await readJsonBody(req);
+            await mkdir(sessionDir, { recursive: true });
+            await writeFile(filePath, `${JSON.stringify(body, null, 2)}\n`);
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
+            res.end(JSON.stringify({ ok: true }));
+            return;
+          }
+          res.statusCode = 405;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: "Method not allowed" }));
         } catch (error) {
           res.statusCode = 500;
           res.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/config/preview-formats.json
+++ b/config/preview-formats.json
@@ -210,6 +210,26 @@
       "quickLook": { "sizeLimitMiB": 25 }
     },
     {
+      "id": "mol-view-spec-json",
+      "contentType": "com.local.burrete10.mvsj",
+      "extensions": ["mvsj"],
+      "mimeTypes": ["application/vnd.molstar.mvsj+json", "application/json"],
+      "conformsTo": ["public.json", "public.text", "public.data"],
+      "description": "MolViewSpec JSON scene file",
+      "viewer": { "molstarFormat": "mvsj", "binary": false, "externalOnly": false },
+      "quickLook": { "sizeLimitMiB": 25 }
+    },
+    {
+      "id": "mol-view-spec-archive",
+      "contentType": "com.local.burrete10.mvsx",
+      "extensions": ["mvsx"],
+      "mimeTypes": ["application/vnd.molstar.mvsx", "application/zip"],
+      "conformsTo": ["public.data", "public.archive"],
+      "description": "MolViewSpec archive scene file",
+      "viewer": { "molstarFormat": "mvsx", "binary": true, "externalOnly": false },
+      "quickLook": { "sizeLimitMiB": 25 }
+    },
+    {
       "id": "xyzrender-input",
       "contentType": "com.local.burrete10.xyzrender-input",
       "contentTypeAliases": ["com.adobe.fdf", "com.apple.videoapps.cube", "com.gaussian.cube"],
@@ -303,7 +323,7 @@
     "extensions": [
       "abi", "bcif", "cif", "cms", "com", "csv", "cub", "cube", "dcd", "ent", "fdf", "graphml", "gro",
       "in", "inp", "lammpstrj", "log", "mae", "mae.gz", "maegz", "mcif", "mmcif", "mol",
-      "mol2", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
+      "mol2", "mvsj", "mvsx", "nctraj", "nw", "out", "pdb", "pdbqt", "pqr", "prmtop", "psf", "psi4", "qcin",
       "sd", "sdf", "smi", "smiles", "top", "trr", "tsv", "vasp", "xtc", "xyz"
     ]
   },
@@ -321,6 +341,8 @@
       "com.local.burrete10.xyz",
       "com.local.burrete10.smiles",
       "com.local.burrete10.gro",
+      "com.local.burrete10.mvsj",
+      "com.local.burrete10.mvsx",
       "com.local.burrete10.molecular-dynamics",
       "com.local.burrete10.schrodinger",
       "com.local.burrete10.xyzrender-input",
@@ -349,6 +371,8 @@
       "com.gaussian.cube",
       "com.local.burrete10.gro",
       "gg.flew.unfold.gromacs-structure",
+      "com.local.burrete10.mvsj",
+      "com.local.burrete10.mvsx",
       "com.local.burrete10.molecular-dynamics",
       "com.schrodinger.mae",
       "com.local.burrete10.schrodinger",

--- a/crates/burrete-core/src/lib.rs
+++ b/crates/burrete-core/src/lib.rs
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn lists_supported_structure_extensions_from_registry() {
         let supported = supported_structure_extensions().expect("supported extensions should load");
-        for extension in ["pdb", "cif", "sdf", "xyz", "maegz"] {
+        for extension in ["pdb", "cif", "sdf", "xyz", "maegz", "mvsj", "mvsx"] {
             assert!(
                 supported.contains(extension),
                 "{extension} should be supported"
@@ -931,6 +931,8 @@ mod tests {
         assert_eq!(quick_look_size_limit_for_extension("mmcif"), 40 * mib);
         assert_eq!(quick_look_size_limit_for_extension("bcif"), 50 * mib);
         assert_eq!(quick_look_size_limit_for_extension("sdf"), 25 * mib);
+        assert_eq!(quick_look_size_limit_for_extension("mvsj"), 25 * mib);
+        assert_eq!(quick_look_size_limit_for_extension("mvsx"), 25 * mib);
         assert_eq!(quick_look_size_limit_for_extension("mae.gz"), 64 * mib);
         assert_eq!(quick_look_size_limit_for_extension("xtc"), 75 * mib);
         assert_eq!(quick_look_size_limit_for_extension("trr"), 75 * mib);

--- a/docs/renderer-support.md
+++ b/docs/renderer-support.md
@@ -20,6 +20,7 @@ Mol* interactive preview is used for:
 - SDF, SD
 - MOL, MOL2
 - XYZ and GRO when selected or resolved by policy
+- MolViewSpec scene files: MVSJ and MVSX
 
 External `xyzrender` is used for text XYZ input when selected or when `auto`
 resolves to the default preview path. It is also the required path for
@@ -30,6 +31,11 @@ external-renderer-only groups:
 - VASP
 
 SDF, SMILES, CSV, and TSV collection previews use the grid runtime.
+
+MolViewSpec files are loaded through the Mol* `loadMvsData` path instead of the
+coordinate trajectory parser. This keeps MVS usable as a declarative scene and
+agent-control format for camera, components, selections, annotations, and
+representation state.
 
 ## Ketcher Editing
 

--- a/plugins/burette-agent/README.md
+++ b/plugins/burette-agent/README.md
@@ -53,13 +53,36 @@ The source of truth is the repository CLI:
 
 ```bash
 bun scripts/burrete-agent.mjs open --mode browser-preview samples/mini.pdb
+bun scripts/burrete-agent.mjs open --mode browser-dev-shell samples/mini.pdb
 bun scripts/burrete-agent.mjs open --mode desktop-app samples/mini.pdb
 bun scripts/burrete-agent.mjs observe --session-dir /tmp/burrete-agent-session
 bun scripts/burrete-agent.mjs act --session-dir /tmp/burrete-agent-session '{"type":"reset_camera"}'
+bun scripts/burrete-agent.mjs act --session-dir /tmp/burrete-agent-session '{"type":"apply_scene","components":[{"selector":"protein","label":"Protein","highlight":true},{"selector":{"chain":"A","range":[45,58]},"label":"Active loop","select":true,"focus":true}]}'
 bun scripts/burrete-agent.mjs render-panel --session-dir /tmp/burrete-agent-session --kind markdown --file notes.md
 ```
 
 MCP tools wrap this CLI instead of reimplementing the app control layer.
+
+## MolViewSpec Scene Language
+
+The Mol* scene skill uses MolViewSpec as the vocabulary for agent requests:
+component selectors, representation, color, opacity, labels, tooltips, focus,
+camera, canvas, transforms, primitives, volumes, and animations.
+
+There are two execution paths:
+
+- `apply_scene` is the fast active-viewer action DSL. It maps MVS-like
+  component operations to allowlisted Burrete commands such as
+  `colorSelection`, `selectResidues`, `focusSelection`, `focus_ligand`,
+  `contacts`, and `reset_camera`.
+- `load_mvs` is for complete MolViewSpec scenes (`mvsj`/`mvsx`) that should be
+  loaded through Mol* `loadMvsData`. Use this for full representation graphs,
+  durable opacity/labels/tooltips/primitives, explicit camera/canvas settings,
+  transforms/instances, volumes, and animations.
+
+Use `apply_scene` for commands like "highlight the protein", "select and focus
+the active loop", or "show the ligand pocket". Use `load_mvs` when the user
+asks for a reproducible scene file or geometry-level scene changes.
 
 ## Artifact Contract
 

--- a/plugins/burette-agent/mcp/lib/plugin-root.mjs
+++ b/plugins/burette-agent/mcp/lib/plugin-root.mjs
@@ -1,9 +1,11 @@
 import path from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const libDir = path.dirname(fileURLToPath(import.meta.url));
 export const pluginRoot = path.resolve(libDir, "..", "..");
-export const repoRoot = path.resolve(pluginRoot, "..", "..");
+const defaultRepoRoot = path.resolve(pluginRoot, "..", "..");
+export const repoRoot = resolveRepoRoot();
 
 export function pluginPath(...parts) {
   return path.join(pluginRoot, ...parts);
@@ -11,4 +13,19 @@ export function pluginPath(...parts) {
 
 export function repoPath(...parts) {
   return path.join(repoRoot, ...parts);
+}
+
+function resolveRepoRoot() {
+  if (process.env.BURRETE_AGENT_REPO_ROOT) {
+    return path.resolve(process.env.BURRETE_AGENT_REPO_ROOT);
+  }
+  try {
+    const metadata = JSON.parse(readFileSync(path.join(pluginRoot, ".burette-agent-install.json"), "utf8"));
+    if (typeof metadata.repoRoot === "string" && metadata.repoRoot.trim()) {
+      return path.resolve(metadata.repoRoot);
+    }
+  } catch {
+    // Source checkouts do not have install metadata.
+  }
+  return defaultRepoRoot;
 }

--- a/plugins/burette-agent/mcp/registrations/molecular-workspace/register.mjs
+++ b/plugins/burette-agent/mcp/registrations/molecular-workspace/register.mjs
@@ -24,10 +24,10 @@ export function registerMolecularWorkspace(server) {
     "open_burrete_workspace",
     {
       title: "Open Burrete Workspace",
-      description: "Open a local molecular artifact in Browser preview or the real Burrete desktop app through the repository CLI.",
+      description: "Open a local molecular artifact in the full Browser shell, Browser preview, or the real Burrete desktop app through the repository CLI.",
       inputSchema: {
         file: z.string().trim(),
-        mode: z.enum(["browser-preview", "desktop-app"]).default("browser-preview"),
+        mode: z.enum(["browser-dev-shell", "browser-preview", "desktop-app"]).default("browser-dev-shell"),
         app: z.string().trim().optional(),
         sessionDir: z.string().trim().optional(),
         host: z.string().trim().optional(),
@@ -114,7 +114,7 @@ export function registerMolecularWorkspace(server) {
     "act_molstar_scene",
     {
       title: "Act On Molstar Scene",
-      description: "Queue an allowlisted high-level Mol* scene action through the Burrete agent contract.",
+      description: "Queue an allowlisted high-level or declarative Mol* scene action through the Burrete agent contract.",
       inputSchema: {
         action: actionSchema,
         url: z.string().trim().optional(),

--- a/plugins/burette-agent/scripts/burette_agent_preflight.mjs
+++ b/plugins/burette-agent/scripts/burette_agent_preflight.mjs
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
-const repoRoot = path.resolve(pluginRoot, "..", "..");
+const defaultRepoRoot = path.resolve(pluginRoot, "..", "..");
+const repoRoot = await resolveRepoRoot();
 
 async function exists(filePath) {
   try {
@@ -22,6 +23,17 @@ async function readJson(filePath, fallback = null) {
   } catch {
     return fallback;
   }
+}
+
+async function resolveRepoRoot() {
+  if (process.env.BURRETE_AGENT_REPO_ROOT) {
+    return path.resolve(process.env.BURRETE_AGENT_REPO_ROOT);
+  }
+  const metadata = await readJson(path.join(pluginRoot, ".burette-agent-install.json"), {});
+  if (typeof metadata.repoRoot === "string" && metadata.repoRoot.trim()) {
+    return path.resolve(metadata.repoRoot);
+  }
+  return defaultRepoRoot;
 }
 
 const pluginManifestPath = path.join(pluginRoot, ".codex-plugin", "plugin.json");
@@ -67,8 +79,13 @@ const payload = {
   },
   context: {
     scope: "burette_agent_capability_registry",
-    preferredMode: desktopApp ? "desktop-app" : "browser-preview",
+    preferredMode: "browser-dev-shell",
     transports: [
+      {
+        id: "browser-dev-shell",
+        status: hasCli ? "available" : "blocked",
+        note: "Agent-owned full Browser shell on a fresh local port with ?devFiles=...",
+      },
       {
         id: "browser-preview",
         status: hasCli && hasPreview ? "available" : "blocked",
@@ -93,8 +110,18 @@ const payload = {
       },
     ],
     workflowRoutes: {
-      openWorkspace: ["open local PDB/CIF/XYZ/SDF-like artifacts", "choose browser-preview or desktop-app"],
-      molstarScene: ["observe scene", "focus ligand", "hide waters", "surface", "color", "reset camera"],
+      openWorkspace: ["open local PDB/CIF/XYZ/SDF-like artifacts", "choose browser-dev-shell, browser-preview, or desktop-app"],
+      molstarScene: [
+        "observe scene",
+        "apply MolViewSpec-informed declarative scene schema",
+        "focus ligand",
+        "highlight/select/focus components",
+        "hide waters",
+        "surface",
+        "color",
+        "reset camera",
+        "load complete MolViewSpec scenes",
+      ],
       moleculeCollection: ["render SDF/property tables", "filter/sort externally", "link row selection to viewer"],
       trajectoryReview: ["load result bundles", "review frame metrics", "show trajectory controls when supported"],
       workflowResults: ["accept server-produced prep/docking/MD artifacts", "surface logs and run reports"],
@@ -110,6 +137,8 @@ const payload = {
       sdf: "partial",
     },
     molstarActions: {
+      apply_scene: "supported",
+      scene_language: "mvs_informed_active_viewer_dsl",
       reset_camera: "supported",
       focus_ligand: "supported_when_detectable",
       hide_waters: "supported",
@@ -117,6 +146,8 @@ const payload = {
       show_surface: "best_effort",
       color_by_chain: "best_effort",
       contacts: "supported_when_structure_available",
+      load_mvs: "supported_for_complete_mvs_payloads",
+      full_mvs_scene: "supported_via_load_mvs",
     },
     externalWorkflows: {
       proteinPreparation: "external_workflow",

--- a/plugins/burette-agent/skills/index/SKILL.md
+++ b/plugins/burette-agent/skills/index/SKILL.md
@@ -47,6 +47,26 @@ The CLI is the execution contract. MCP tools wrap it. Browser and Computer
 verify visual reality. Do not replace typed `observe` and `act` with screenshot
 interpretation.
 
+For Browser work, distinguish two local surfaces:
+
+- `browser-dev-shell`: the full Burrete Browser shell, started by
+  `scripts/burrete-agent.mjs open --mode browser-dev-shell ...` on a fresh
+  local port and opened as
+  `http://127.0.0.1:<fresh-port>/?devFiles=<encoded absolute path>`. Use it
+  when the user wants the normal app UI: sidebar, files/projects, tabs, right
+  dock, bottom dock, command palette, or behavior matching the browser shell.
+  Do not reuse another browser-dev port unless the user explicitly asks to
+  attach to that exact surface.
+- `browser-preview`: the tokenized agent preview opened through
+  `scripts/burrete-agent.mjs open --mode browser-preview ... --no-launch`.
+  Use it when typed MCP/CLI `observe` and `act` over a tokenized localhost
+  transport are required.
+
+Browser means the Codex in-app Browser plugin for both surfaces. Create or use
+local URLs without launching an external browser and navigate them in the
+in-app Browser. Do not use macOS `open`, Arc, Chrome, Safari, or another
+external browser unless the user explicitly asks for an external browser.
+
 ## Completion Gate
 
 A Burrete workflow is complete only when:

--- a/plugins/burette-agent/skills/molstar-scene/SKILL.md
+++ b/plugins/burette-agent/skills/molstar-scene/SKILL.md
@@ -8,6 +8,7 @@ description: "Operate the active Mol* scene through allowlisted Burrete agent ac
 Use this workflow for scene operations:
 
 - focus ligand;
+- label the active selection or a precise component;
 - show ligands;
 - select residues;
 - focus selection;
@@ -16,6 +17,12 @@ Use this workflow for scene operations:
 - show molecular surface;
 - color by chain;
 - reset camera;
+- apply a compact declarative scene schema for target/component requests such
+  as highlighting protein, selecting active-site loops, and focusing a named
+  selection;
+- load a complete MolViewSpec scene payload when the agent already has one;
+- translate user requests into MolViewSpec-informed selectors, components,
+  representations, color, opacity, labels, camera, focus, and canvas concepts;
 - export image or screenshot when supported.
 
 ## Contract
@@ -26,8 +33,159 @@ Use one typed action surface:
 bun scripts/burrete-agent.mjs act --session-dir <dir> '{"type":"hide_waters"}' --wait-ms 12000
 ```
 
+For `browser-dev-shell`, use the `sessionDir` returned by
+`open --mode browser-dev-shell`; the browser shell polls that session over its
+local dev-server endpoint and relays actions to the active Mol* iframe. Do not
+use Browser DOM clicks for scene edits when this session contract is available.
+If the user is already looking at a browser-dev-shell URL and the session
+directory is not in context, pass that URL directly with `--url`; the CLI will
+resolve the shell session through `/__burette/agent-session/session.json` when
+the shell is alive.
+
 Do not add one endpoint per Mol* command. The action body must be allowlisted
 and serializable.
+
+## MolViewSpec-informed scene language
+
+Use MolViewSpec as the mental model for agent scene requests, but keep two
+execution paths separate:
+
+- `apply_scene` edits the currently active Burrete/Mol* viewer by relaying
+  allowlisted commands. Use it for highlight, select, focus, contact
+  neighborhood, water/surface/theme toggles, screenshot, and reset camera.
+- `load_mvs` loads a complete MolViewSpec state (`mvsj` JSON or `mvsx` archive)
+  through Mol* `loadMvsData`. Use it when the request really needs a full
+  MVS tree: download/parse/structure/transform/component/representation/color/
+  opacity/label/tooltip/focus/camera/canvas/primitives/volume/animation.
+
+Map natural language to these MVS concepts:
+
+- component: what atoms/residues/chains are affected.
+- representation: how that component is drawn, e.g. `cartoon`,
+  `ball_and_stick`, `line`, `spacefill`, `surface`.
+- color/opacity: visual emphasis for the component or a sub-selection.
+- label/tooltip: textual annotation for a component.
+- focus: camera fit to a component.
+- camera: explicit root-level camera orientation (`target`, `position`, `up`).
+- canvas: global view settings such as background color.
+- transform/instance: coordinate movement or duplicated transformed instances;
+  only promise this through a full MVS scene, not through quick `apply_scene`.
+
+Selectors follow MolViewSpec vocabulary. Prefer these static selectors when
+they match the request:
+
+```json
+"all" | "polymer" | "protein" | "nucleic" | "branched" | "ligand" | "ion" | "water"
+```
+
+For precise requests, use an object selector. Prefer `label_*` identifiers when
+the file exposes them, but accept `auth_*` when the user names author/PDB
+numbering:
+
+```json
+{"label_asym_id":"A"}
+{"label_asym_id":"A","beg_label_seq_id":45,"end_label_seq_id":58}
+{"auth_asym_id":"A","beg_auth_seq_id":100,"end_auth_seq_id":112}
+{"label_comp_id":"PYZ"}
+{"comp_id":"PYZ"}
+{"label_asym_id":"A","label_seq_id":377,"label_atom_id":"CA"}
+```
+
+Use an array of selector objects as a union, e.g. multiple chains or separated
+loop ranges.
+
+`apply_scene` accepts MVS-like components or operations with `selector`/`target`,
+optional `label`, optional visual hints, and operation flags:
+
+```bash
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "apply_scene",
+  "components": [
+    {"selector": "protein", "label": "Protein", "highlight": true, "color": "#4f8cff"},
+    {"selector": {"chain": "A", "range": [45, 58]}, "label": "Active loop", "select": true, "focus": true}
+  ]
+}' --wait-ms 12000
+```
+
+Use these request patterns:
+
+```bash
+# Highlight the whole protein.
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "apply_scene",
+  "components": [
+    {"selector": "protein", "label": "Protein", "highlight": true, "color": "#4f8cff"}
+  ]
+}' --wait-ms 12000
+
+# Select and focus an active loop by residue range.
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "apply_scene",
+  "components": [
+    {"selector": {"label_asym_id": "A", "beg_label_seq_id": 45, "end_label_seq_id": 58}, "label": "Active loop", "select": true, "focus": true}
+  ]
+}' --wait-ms 12000
+
+# Focus a ligand and ask for a local protein neighborhood/contacts.
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "focus_ligand",
+  "selector": {"comp_id": "PYZ"},
+  "allowAmbiguous": true,
+  "showNeighborhood": true,
+  "radiusA": 5
+}' --wait-ms 12000
+
+# Add a visible 3D label to the last focused/selected ligand.
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "label_selection",
+  "selection": "last",
+  "text": "PYZ A:378"
+}' --wait-ms 12000
+
+# Reset camera after manual movement.
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{"type":"reset_camera","args":{"durationMs":250}}' --wait-ms 12000
+```
+
+When a user says "move the scene", decide which meaning applies:
+
+- camera movement/orientation: use `focus_selection`, `focus_ligand`,
+  `reset_camera`, or a future explicit camera action. Do not simulate this with
+  Browser drag events.
+- structure movement/rotation/instances: build and load a complete MVS scene
+  with `transform` or `instance` nodes via `load_mvs`.
+
+Use `load_mvs` only for complete MolViewSpec (`mvsj` or `mvsx`) payloads that
+should be handed to Mol* `loadMvsData` as scene state:
+
+```bash
+bun scripts/burrete-agent.mjs act --session-dir <dir> '{
+  "type": "load_mvs",
+  "json": {
+    "metadata": {"title": "Protein and ligand view", "version": "1"},
+    "root": {"kind": "root", "children": []}
+  },
+  "options": {"replaceExisting": true}
+}' --wait-ms 12000
+```
+
+## Upstream References
+
+Ground new scene language in:
+
+- MolViewSpec docs: https://molstar.org/mol-view-spec-docs/
+- Tree schema: https://molstar.org/mol-view-spec-docs/tree-schema/
+- Selectors: https://molstar.org/mol-view-spec-docs/selectors/
+- Camera settings: https://molstar.org/mol-view-spec-docs/camera-settings/
+- MolViewSpec repository: https://github.com/molstar/mol-view-spec
+- Mol* examples: https://github.com/molstar/molstar/tree/master/src/examples
+
+Relevant local Mol* examples when `node_modules` is installed:
+
+- `node_modules/molstar/lib/examples/basic-wrapper/index.js`
+- `node_modules/molstar/lib/examples/proteopedia-wrapper/index.js`
+- `node_modules/molstar/lib/examples/interactions/index.js`
+- `node_modules/molstar/lib/examples/mvs-stories/stories/`
+- `node_modules/molstar/lib/extensions/mvs/camera.js`
 
 ## Verification
 
@@ -36,7 +194,22 @@ Computer only for visual confirmation. If the active fixture has no waters,
 `hide_waters` should return a successful typed no-op such as `componentCount: 0`
 instead of a false failure.
 
+For browser-dev-shell and desktop sessions, check `observe.scene.selection`
+first. It reports the last known selection/focused ligand with `selectionId`,
+ligand identity, and counts when the active viewer returned them.
+
+Ligand focus can be a partial success. If `showNeighborhood` cannot resolve a
+protein/contact target, the action should still succeed when the ligand was
+selected/focused and return `neighborhood.ok: false` with a typed error. Do not
+retry the whole focus just because contacts failed.
+
 ## Unsupported Cases
 
 If a selector cannot resolve, return or report typed failures such as
 `SELECTION_EMPTY` or `NO_STRUCTURE`. Do not guess from screenshots.
+
+Persistent overpaint and arbitrary representation graph rewriting are not yet a
+general `apply_scene` guarantee. If durable representation, opacity, labels,
+tooltips, primitives, volumes, animations, or coordinate transforms are required,
+prefer a full `load_mvs` payload or implement a new allowlisted
+`BurreteSceneActions` handler first.

--- a/plugins/burette-agent/skills/open-workspace/SKILL.md
+++ b/plugins/burette-agent/skills/open-workspace/SKILL.md
@@ -12,19 +12,81 @@ or workflow result bundles in Burrete.
 
 1. Run Burrete preflight through [user-context](../user-context/SKILL.md).
 2. Choose mode:
-   - `browser-preview` when the user asks for the Codex Browser, quick visual
-     QA, screenshots, or localhost preview.
+   - `browser-dev-shell` when the user asks for the normal Browser UI, right
+     or bottom docks, sidebars, tabs, files/projects, or app-like browser
+     behavior. This is the full browser-dev application shell and should use a
+     URL shaped like `http://127.0.0.1:<port>/?devFiles=<encoded absolute path>`.
+   - `browser-preview` when the task needs the tokenized agent transport,
+     typed MCP/CLI `observe` and `act`, quick visual QA, screenshots, or a
+     localhost preview without the full app shell.
    - `desktop-app` when the user asks for the real Burrete application or wants
      results left open in the app.
-3. Open through the CLI:
+3. For `browser-dev-shell`, navigate the Codex in-app Browser to the
+   agent-owned full Browser shell URL returned by the CLI. The CLI must start
+   a fresh local port for this agent session; do not reuse another Browser tab,
+   a user-provided browser-dev port, or an already-running app unless the user
+   explicitly asks to attach to that exact surface.
 
 ```bash
-bun scripts/burrete-agent.mjs open --mode browser-preview <file>
+bun scripts/burrete-agent.mjs open --mode browser-dev-shell <file>
+```
+
+Use the returned URL shaped like:
+
+```text
+http://127.0.0.1:<fresh-port>/?devFiles=<url-encoded absolute file path>
+```
+
+Open that URL only through the Codex in-app Browser plugin. Do not start a
+separate tokenized agent preview only to get sidebars, the right dock, or the
+bottom dock.
+
+Keep the returned `sessionDir`. In agent shell mode, `observe` and `act` use
+the same CLI session contract as desktop app mode:
+
+```bash
+bun scripts/burrete-agent.mjs observe --session-dir <sessionDir>
+bun scripts/burrete-agent.mjs act --session-dir <sessionDir> '{"type":"focus_ligand","selector":{"comp_id":"PYZ"},"allowAmbiguous":true}' --wait-ms 12000
+```
+
+If the visible in-app Browser tab is already on the agent-owned
+browser-dev-shell URL but `sessionDir` is missing from the conversation, pass
+the URL directly:
+
+```bash
+bun scripts/burrete-agent.mjs observe --url 'http://127.0.0.1:<port>/?devFiles=...'
+bun scripts/burrete-agent.mjs act --url 'http://127.0.0.1:<port>/?devFiles=...' '{"type":"focus_ligand","selector":{"comp_id":"PYZ"},"allowAmbiguous":true}' --wait-ms 12000
+```
+
+The CLI resolves the live shell session through
+`/__burette/agent-session/session.json` and fails quickly when the shell port is
+dead.
+
+4. For `browser-preview`, create the preview URL without launching any external
+   browser, then open that URL only through the Codex in-app Browser plugin:
+
+```bash
+bun scripts/burrete-agent.mjs open --mode browser-preview <file> --no-launch
+```
+
+Use the returned tokenized URL with Browser. Do not use macOS `open`, Arc,
+Chrome, Safari, or another external browser for Browser preview unless the user
+explicitly asks for an external browser. If the in-app Browser is unavailable,
+report a typed blocker instead of falling back to an external browser.
+
+Use the returned tokenized URL when typed agent control is required. Do not use
+`browser-preview` as a substitute for the full browser-dev shell when the user
+is asking about ordinary Burrete UI chrome.
+
+5. For `desktop-app`, open through the CLI:
+
+```bash
 bun scripts/burrete-agent.mjs open --mode desktop-app <file> --session-dir <dir>
 ```
 
-4. Run `observe` after the app reports readiness.
-5. If visual confirmation matters, use [visual-qa](../visual-qa/SKILL.md).
+6. Run `observe` after the app reports readiness when the selected mode exposes
+   typed state.
+7. If visual confirmation matters, use [visual-qa](../visual-qa/SKILL.md).
 
 ## Handoff
 

--- a/plugins/burette-agent/skills/user-context/SKILL.md
+++ b/plugins/burette-agent/skills/user-context/SKILL.md
@@ -33,7 +33,7 @@ live state, run `burrete-agent observe`.
 Persisted context should stay narrow:
 
 - preferred installed Burrete app path;
-- preferred mode (`browser-preview` or `desktop-app`);
+- preferred mode (`browser-dev-shell`, `browser-preview`, or `desktop-app`);
 - known server workflow routes;
 - capability registry overrides only when explicitly configured.
 

--- a/plugins/burette-agent/skills/visual-qa/SKILL.md
+++ b/plugins/burette-agent/skills/visual-qa/SKILL.md
@@ -11,13 +11,31 @@ Use Browser and Computer as verification surfaces.
 
 Use Browser for:
 
+- full Browser shell URLs started by
+  `scripts/burrete-agent.mjs open --mode browser-dev-shell ...`, such as
+  `http://127.0.0.1:<fresh-port>/?devFiles=<encoded absolute path>`, when the user
+  wants ordinary Burrete UI chrome, sidebars, right dock, bottom dock, tabs, or
+  app-like behavior;
 - tokenized localhost browser-preview URLs;
 - screenshot and canvas nonblank checks;
 - DOM or Playwright checks for preview panels;
 - visual QA when the user asks to watch inside Codex.
 
-Do not reload an already useful browser tab unless a code or asset change
-requires it.
+Browser means the Codex in-app Browser plugin. Do not use macOS `open`, Arc,
+Chrome, Safari, or another external browser for Browser visual QA unless the
+user explicitly asks for an external browser. If the in-app Browser cannot open
+the local URL, report that blocker and keep the URL available for the user
+instead of silently switching browsers.
+
+Prefer browser-dev shell over tokenized browser-preview when the user is
+checking menus, docks, sidebars, tabs, or other shell-level UI. Prefer
+tokenized browser-preview when the QA depends on MCP agent transport,
+`observe`, `act`, or action logs.
+
+Do not reuse another browser-dev port for a new agent-owned shell. Reuse an
+already useful Browser tab only when the user explicitly asks to keep working
+on that exact surface or when a reload is required after a code or asset
+change.
 
 ## Computer
 

--- a/scripts/agent-preview.mjs
+++ b/scripts/agent-preview.mjs
@@ -10,6 +10,7 @@ const repoRoot = resolve(__dirname, '..');
 const webRoot = resolve(repoRoot, 'PreviewExtension', 'Web');
 const agentControlApiVersion = 'burette-agent-control/v1';
 const renderPanelReadLimit = 512 * 1024;
+const mvsReadLimit = 25 * 1024 * 1024;
 
 function usage() {
   console.error(`Usage: node scripts/agent-preview.mjs <structure-file> [--port 5177] [--host 127.0.0.1]
@@ -385,6 +386,7 @@ function js(name, value) {
 function controlConfig() {
   return {
     apiVersion: agentControlApiVersion,
+    observeUrl: '/__agent/observe',
     reportUrl: '/__agent/report',
     nextActionUrl: '/__agent/next-action',
     actionResultUrl: '/__agent/action-result',
@@ -512,6 +514,8 @@ function validateAction(action) {
     'show_surface',
     'color_by_chain',
     'render_panel',
+    'apply_scene',
+    'load_mvs',
     'screenshot',
     'export_image',
     'raw_burrete_agent'
@@ -522,10 +526,28 @@ function validateAction(action) {
     if (!['markdown', 'table', 'chart'].includes(kind)) return 'render_panel kind must be markdown, table, or chart.';
     if (typeof action.content !== 'string' && typeof action.file !== 'string') return 'render_panel requires file or content.';
   }
+  if (type === 'load_mvs') {
+    if (
+      typeof action.file !== 'string' &&
+      typeof action.data !== 'string' &&
+      typeof action.dataBase64 !== 'string' &&
+      action.json === undefined
+    ) {
+      return 'load_mvs requires file, data, dataBase64, or json.';
+    }
+  }
+  if (type === 'apply_scene') {
+    const components = Array.isArray(action.components) ? action.components : null;
+    const operations = Array.isArray(action.operations) ? action.operations : null;
+    if (!components && !operations) return 'apply_scene requires components or operations.';
+    if (components && components.length === 0) return 'apply_scene components must not be empty.';
+    if (operations && operations.length === 0) return 'apply_scene operations must not be empty.';
+  }
   return null;
 }
 
 async function prepareAction(action) {
+  if (action?.type === 'load_mvs') return prepareMvsAction(action);
   if (action?.type !== 'render_panel') return action;
   if (typeof action.content === 'string') {
     return {
@@ -555,6 +577,26 @@ async function prepareAction(action) {
       content,
       byteCount: info.size
     }
+  };
+}
+
+async function prepareMvsAction(action) {
+  if (typeof action.file !== 'string') return action;
+  const file = resolve(String(action.file));
+  const info = await stat(file);
+  if (!info.isFile()) throw new Error(`${file} is not a file.`);
+  if (info.size > mvsReadLimit) {
+    throw new Error(`load_mvs file exceeds ${mvsReadLimit} bytes.`);
+  }
+  const extension = extname(file).toLowerCase().replace(/^\./, '');
+  const format = String(action.format || extension || 'mvsj').toLowerCase();
+  const bytes = await readFile(file);
+  return {
+    ...action,
+    file,
+    format,
+    dataBase64: bytes.toString('base64'),
+    byteCount: info.size
   };
 }
 
@@ -601,6 +643,8 @@ async function main() {
     binary: preview.binary,
     byteCount: st.size,
     showPanelControls: true,
+    enablePreviewDocks: true,
+    defaultPreviewDocks: [],
     defaultLayoutState: { left: 'hidden', right: 'hidden', top: 'hidden', bottom: 'hidden' },
     theme: 'auto',
     canvasBackground: 'auto'
@@ -739,6 +783,15 @@ async function main() {
       const headers = { 'Content-Type': contentType(file) };
       if (url.pathname === '/' || url.pathname.endsWith('.html')) {
         headers['Set-Cookie'] = `${tokenCookieName}=${encodeURIComponent(token)}; Path=/; SameSite=Strict`;
+        const html = await readFile(file, 'utf8');
+        const assetVersion = String(Date.now());
+        res.writeHead(200, headers);
+        res.end(html
+          .replaceAll('./viewer-runtime.css"', `./viewer-runtime.css?v=${assetVersion}"`)
+          .replaceAll('./viewer-shell.js"', `./viewer-shell.js?v=${assetVersion}"`)
+          .replaceAll('./burette-agent.js"', `./burette-agent.js?v=${assetVersion}"`)
+          .replaceAll('./viewer.js"', `./viewer.js?v=${assetVersion}"`));
+        return;
       }
       res.writeHead(200, headers);
       createReadStream(file).pipe(res);

--- a/scripts/burrete-agent.mjs
+++ b/scripts/burrete-agent.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, open as openFile, readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -10,11 +11,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const agentPreviewScript = resolve(__dirname, 'agent-preview.mjs');
 const apiVersion = 'burette-agent-cli/v1';
-const supportedModes = new Set(['browser-preview', 'desktop-app']);
+const supportedModes = new Set(['browser-preview', 'browser-dev-shell', 'desktop-app']);
 
 function usage() {
   console.error(`Usage:
   node scripts/burrete-agent.mjs open --mode browser-preview <file> [--port 5177] [--host 127.0.0.1]
+  node scripts/burrete-agent.mjs open --mode browser-dev-shell <file> [--host 127.0.0.1]
   node scripts/burrete-agent.mjs open --mode desktop-app <file> [--app Burrete] [--session-dir /tmp/session] [--no-launch]
   node scripts/burrete-agent.mjs observe --url <tokenized-preview-url>
   node scripts/burrete-agent.mjs observe --session-dir <desktop-agent-session>
@@ -144,6 +146,10 @@ async function open(options) {
     await openDesktopApp(file, options);
     return;
   }
+  if (mode === 'browser-dev-shell') {
+    await openBrowserDevShell(file, options);
+    return;
+  }
 
   const childArgs = [agentPreviewScript, file];
   if (options.port) childArgs.push('--port', options.port);
@@ -158,12 +164,119 @@ async function open(options) {
   });
 }
 
+async function openBrowserDevShell(file, options) {
+  const initialFile = resolve(file);
+  const sessionDir = options.sessionDir ? resolve(options.sessionDir) : await mkdtemp(resolve(tmpdir(), 'burrete-agent-shell-'));
+  const token = randomUUID();
+  await mkdir(sessionDir, { recursive: true });
+  await writeJsonFile(resolve(sessionDir, 'session.json'), {
+    apiVersion,
+    mode: 'browser-dev-shell',
+    token,
+    createdAt: new Date().toISOString(),
+    initialPaths: [initialFile],
+  });
+  await writeJsonFile(resolve(sessionDir, 'actions.json'), {
+    apiVersion: 'burette-agent-control/v1',
+    actions: [],
+  });
+  const host = options.host || '127.0.0.1';
+  const port = options.port ? Number(options.port) : await allocatePort(host);
+  if (!Number.isInteger(port) || port <= 0) fail('INVALID_ARGS', '--port must be a positive integer.', 2);
+  const url = new URL(`http://${host}:${port}/`);
+  url.searchParams.set('devFiles', initialFile);
+  await writeJsonFile(resolve(sessionDir, 'session.json'), {
+    apiVersion,
+    mode: 'browser-dev-shell',
+    token,
+    createdAt: new Date().toISOString(),
+    initialPaths: [initialFile],
+    sessionDir,
+    host,
+    port,
+    url: url.toString(),
+  });
+  const env = {
+    ...process.env,
+    BURRETE_DEV_DEFAULT_FILES: initialFile,
+    BURRETE_DEV_FS_ALLOW: dirname(initialFile),
+    BURRETE_AGENT_SHELL_SESSION_DIR: sessionDir,
+    VITE_BURRETE_AGENT_SHELL: '1',
+    VITE_BURRETE_BUILD_IDENTIFIER: 'browser-agent-shell',
+    VITE_BURETTE_DEV_INSTANCE: 'agent',
+  };
+  const logPath = resolve(sessionDir, 'server.log');
+  const logHandle = await openFile(logPath, 'a');
+  const child = spawn('vp', ['dev', 'apps/desktop', '--host', host, '--port', String(port), '--strictPort', '--config', 'apps/desktop/vite.config.ts'], {
+    cwd: repoRoot,
+    env,
+    detached: true,
+    stdio: ['ignore', logHandle.fd, logHandle.fd],
+  });
+  child.unref();
+  await logHandle.close();
+  child.on('error', (error) => {
+    fail('BROWSER_DEV_SHELL_FAILED', `Failed to start browser-dev shell: ${error?.message || String(error)}.`, 1);
+  });
+  await waitForHttpReady(url, 30000);
+  console.log(JSON.stringify({
+    ok: true,
+    apiVersion,
+    result: {
+      mode: 'browser-dev-shell',
+      url: url.toString(),
+      host,
+      port,
+      launched: false,
+      sessionDir,
+      logPath,
+      initialPaths: [initialFile],
+      processId: child.pid,
+      browser: 'Codex in-app Browser',
+      observe: `node scripts/burrete-agent.mjs observe --session-dir ${JSON.stringify(sessionDir)}`,
+      act: `node scripts/burrete-agent.mjs act --session-dir ${JSON.stringify(sessionDir)} '<json-action>'`,
+    },
+  }, null, 2));
+}
+
+async function allocatePort(host) {
+  const server = createServer();
+  await new Promise((resolveReady, rejectReady) => {
+    server.once('error', rejectReady);
+    server.listen(0, host, resolveReady);
+  });
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : null;
+  await new Promise(resolveClose => server.close(resolveClose));
+  if (!port) fail('PORT_UNAVAILABLE', 'Could not allocate a browser-dev shell port.', 1);
+  return port;
+}
+
+async function waitForHttpReady(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch (_) {
+      // Vite is still booting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  fail('BROWSER_DEV_SHELL_TIMEOUT', `Timed out waiting for browser-dev shell at ${url}.`, 1);
+}
+
 async function observe(options) {
   if (options.sessionDir) {
     await observeDesktopSession(options);
     return;
   }
   if (!options.url) fail('INVALID_ARGS', 'observe requires --url with the tokenized browser-preview URL.', 2);
+  const shellSessionDir = await browserShellSessionDir(options.url);
+  if (shellSessionDir) {
+    await observeDesktopSession({ ...options, sessionDir: shellSessionDir });
+    return;
+  }
   const response = await fetch(buildAgentUrl(options.url, '/__agent/observe'));
   const body = await response.text();
   if (!response.ok) {
@@ -187,6 +300,11 @@ async function act(options) {
     return;
   }
   if (!options.url) fail('INVALID_ARGS', 'act requires --url with the tokenized browser-preview URL.', 2);
+  const shellSessionDir = await browserShellSessionDir(options.url);
+  if (shellSessionDir) {
+    await actDesktopSession({ ...options, sessionDir: shellSessionDir });
+    return;
+  }
   const actionText = options.rest[0];
   if (!actionText) fail('INVALID_ARGS', 'act requires a JSON action argument.', 2);
   let action;
@@ -291,6 +409,7 @@ async function observeDesktopSession(options) {
 }
 
 async function actDesktopSession(options) {
+  await assertSessionResponsive(options.sessionDir);
   const actionText = options.rest[0];
   if (!actionText) fail('INVALID_ARGS', 'act requires a JSON action argument.', 2);
   let action;
@@ -317,6 +436,46 @@ async function actDesktopSession(options) {
   }
   const result = await waitForDesktopAction(actionsPath, item.id, waitMs);
   console.log(JSON.stringify({ ok: true, apiVersion, result }, null, 2));
+}
+
+async function assertSessionResponsive(sessionDir) {
+  const session = await readJsonFile(resolve(sessionDir, 'session.json'), null);
+  if (!session || session.mode !== 'browser-dev-shell' || typeof session.url !== 'string') return;
+  try {
+    await fetchWithTimeout(session.url, 1500);
+  } catch (error) {
+    fail('BROWSER_DEV_SHELL_UNAVAILABLE', `Browser-dev shell is not reachable at ${session.url}. Reopen the workspace instead of waiting for an action timeout.`, 1, { sessionDir, cause: error?.message || String(error) });
+  }
+}
+
+async function browserShellSessionDir(urlText) {
+  if (!urlText) return null;
+  let url;
+  try {
+    url = new URL(urlText);
+  } catch (_) {
+    return null;
+  }
+  if (url.searchParams.has('token')) return null;
+  try {
+    const sessionUrl = new URL('/__burette/agent-session/session.json', url);
+    const response = await fetchWithTimeout(sessionUrl.toString(), 1500);
+    if (!response.ok) return null;
+    const session = await response.json();
+    return typeof session?.sessionDir === 'string' && session.sessionDir.trim() ? session.sessionDir : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function waitForDesktopAction(actionsPath, actionId, waitMs) {

--- a/tests/test-agent-preview-server.mjs
+++ b/tests/test-agent-preview-server.mjs
@@ -112,8 +112,10 @@ try {
 
   const htmlWithToken = await get(ready.url);
   assert.equal(htmlWithToken.statusCode, 200);
-  assert.match(htmlWithToken.body, /viewer-runtime\.css/);
-  assert.match(htmlWithToken.body, /viewer-shell\.js/);
+  assert.match(htmlWithToken.body, /viewer-runtime\.css\?v=\d+/);
+  assert.match(htmlWithToken.body, /viewer-shell\.js\?v=\d+/);
+  assert.match(htmlWithToken.body, /burette-agent\.js\?v=\d+/);
+  assert.match(htmlWithToken.body, /viewer\.js\?v=\d+/);
   const cookie = htmlWithToken.headers['set-cookie']?.find(value => value.startsWith('BurreteAgentPreviewToken='));
   assert.ok(cookie, 'authorized HTML response should set the preview token cookie');
 
@@ -125,7 +127,10 @@ try {
   const configWithCookie = await get(`${base}/preview-config.js`, { Cookie: cookieHeader });
   assert.equal(configWithCookie.statusCode, 200);
   assert.match(configWithCookie.body, /^window\.BurreteConfig = /);
+  assert.match(configWithCookie.body, /"enablePreviewDocks":true/);
+  assert.match(configWithCookie.body, /"defaultPreviewDocks":\[\]/);
   assert.match(configWithCookie.body, /window\.BurreteAgentControl = /);
+  assert.match(configWithCookie.body, /"observeUrl":"\/__agent\/observe"/);
 
   const tempDir = await mkdtemp(join(tmpdir(), 'burrete-agent-preview-'));
   const maePath = join(tempDir, 'ligand.mae');
@@ -236,6 +241,19 @@ f_m_ct {
   assert.equal(queuedScene.action.status, 'queued');
   assert.equal(queuedScene.action.type, 'hide_waters');
 
+  const sceneSpecAction = await postJson(`${base}/__agent/act`, {
+    type: 'apply_scene',
+    components: [
+      { selector: 'protein', label: 'Protein', highlight: true, color: '#4f8cff' },
+      { selector: { chain: 'A', range: [1, 3] }, label: 'Active loop', select: true, focus: true }
+    ]
+  }, { Cookie: cookieHeader });
+  assert.equal(sceneSpecAction.statusCode, 200);
+  const queuedSceneSpec = JSON.parse(sceneSpecAction.body);
+  assert.equal(queuedSceneSpec.ok, true);
+  assert.equal(queuedSceneSpec.action.status, 'queued');
+  assert.equal(queuedSceneSpec.action.type, 'apply_scene');
+
   const queuedAction = await postJson(`${base}/__agent/act`, {
     type: 'focus_ligand',
     selector: { label_comp_id: 'HEM' }
@@ -271,6 +289,14 @@ f_m_ct {
   assert.equal(completed.action.status, 'completed');
   assert.equal(completed.action.result.command, 'hide_waters');
 
+  const nextSceneSpecAction = await get(`${base}/__agent/next-action`, { Cookie: cookieHeader });
+  assert.equal(nextSceneSpecAction.statusCode, 200);
+  const nextSceneSpec = JSON.parse(nextSceneSpecAction.body);
+  assert.equal(nextSceneSpec.id, queuedSceneSpec.action.id);
+  assert.equal(nextSceneSpec.action.type, 'apply_scene');
+  assert.equal(nextSceneSpec.action.components[0].selector, 'protein');
+  assert.equal(nextSceneSpec.action.components[1].label, 'Active loop');
+
   const nextLigandAction = await get(`${base}/__agent/next-action`, { Cookie: cookieHeader });
   assert.equal(nextLigandAction.statusCode, 200);
   const nextLigand = JSON.parse(nextLigandAction.body);
@@ -288,11 +314,11 @@ f_m_ct {
   const actionObserve = await get(`${base}/__agent/observe`, { Cookie: cookieHeader });
   assert.equal(actionObserve.statusCode, 200);
   const observedAction = JSON.parse(actionObserve.body);
-  assert.equal(observedAction.actions.dispatched, 2);
+  assert.equal(observedAction.actions.dispatched, 3);
   assert.equal(observedAction.actions.completed, 1);
   assert.equal(observedAction.actions.last.id, queuedPanel.action.id);
   assert.equal(observedAction.actions.last.status, 'dispatched');
-  assert.equal(observedAction.actions.recent.length, 3);
+  assert.equal(observedAction.actions.recent.length, 4);
   assert.equal(observedAction.actions.recent[0].id, queuedScene.action.id);
   assert.equal(observedAction.actions.recent[0].status, 'completed');
   assert.equal(observedAction.panels.includes('agent-panel:right:markdown:README.md'), true);

--- a/tests/test-burette-agent-plugin.mjs
+++ b/tests/test-burette-agent-plugin.mjs
@@ -59,6 +59,7 @@ assert.match(workspaceRegistration, /registerAppTool/);
 assert.match(workspaceRegistration, /open_burrete_workspace/);
 assert.match(workspaceRegistration, /observe_burrete_workspace/);
 assert.match(workspaceRegistration, /act_molstar_scene/);
+assert.match(workspaceRegistration, /declarative Mol\* scene action/);
 assert.match(workspaceRegistration, /runBurreteAgent/);
 assert.match(workspaceRegistration, /visibility: \["model"\]/);
 assert.match(workspaceRegistration, /openai\/outputTemplate/);
@@ -181,9 +182,33 @@ const preflightPayload = JSON.parse(preflight.stdout);
 assert.equal(preflightPayload.schema, "burette_agent_preflight.v1");
 assert.equal(preflightPayload.files.cli.status, "available");
 assert.equal(preflightPayload.files.browserPreviewServer.status, "available");
-assert.equal(preflightPayload.context.transports[0].id, "browser-preview");
-assert.equal(preflightPayload.context.transports[1].id, "desktop-app");
+assert.equal(preflightPayload.context.transports[0].id, "browser-dev-shell");
+assert.equal(preflightPayload.context.transports[1].id, "browser-preview");
+assert.equal(preflightPayload.context.transports[2].id, "desktop-app");
 assert.equal(preflightPayload.context.workflowRoutes.molstarScene.includes("observe scene"), true);
+assert.equal(preflightPayload.context.workflowRoutes.molstarScene.includes("apply MolViewSpec-informed declarative scene schema"), true);
+assert.equal(preflightPayload.context.workflowRoutes.molstarScene.includes("load complete MolViewSpec scenes"), true);
+assert.equal(preflightPayload.capabilities.molstarActions.apply_scene, "supported");
+assert.equal(preflightPayload.capabilities.molstarActions.scene_language, "mvs_informed_active_viewer_dsl");
+assert.equal(preflightPayload.capabilities.molstarActions.load_mvs, "supported_for_complete_mvs_payloads");
+assert.equal(preflightPayload.capabilities.molstarActions.full_mvs_scene, "supported_via_load_mvs");
+
+const molstarSceneSkill = await read("skills/molstar-scene/SKILL.md");
+assert.match(molstarSceneSkill, /apply_scene/);
+assert.match(molstarSceneSkill, /MolViewSpec-informed scene language/);
+assert.match(molstarSceneSkill, /https:\/\/molstar\.org\/mol-view-spec-docs\/tree-schema\//);
+assert.match(molstarSceneSkill, /https:\/\/molstar\.org\/mol-view-spec-docs\/selectors\//);
+assert.match(molstarSceneSkill, /camera movement\/orientation/);
+assert.match(molstarSceneSkill, /structure movement\/rotation\/instances/);
+assert.match(molstarSceneSkill, /"selector": "protein"/);
+assert.match(molstarSceneSkill, /"label": "Active loop"/);
+assert.match(molstarSceneSkill, /"type": "label_selection"/);
+
+const readme = await read("README.md");
+assert.match(readme, /MolViewSpec Scene Language/);
+assert.match(readme, /"type":"apply_scene"/);
+assert.match(readme, /"selector":"protein"/);
+assert.match(readme, /load_mvs/);
 
 const syntaxTargets = [
   "plugins/burette-agent/mcp/server.mjs",

--- a/tests/test-burette-agent.mjs
+++ b/tests/test-burette-agent.mjs
@@ -51,12 +51,17 @@ function fakeStructure() {
 
 const agentSource = await readFile(resolve('PreviewExtension/Web/burette-agent.js'), 'utf8');
 const interactions = [];
+const selectionEntries = new Map();
+const measurementLabels = [];
 const context = {
   console,
   setTimeout,
   clearTimeout,
   Date,
   performance: { now: () => Date.now() },
+  TextDecoder,
+  Uint8Array,
+  atob: value => Buffer.from(value, 'base64').toString('binary'),
   window: {
     molstar: { version: '5.7.0-test' },
     dispatchEvent() {},
@@ -76,13 +81,29 @@ vm.runInContext(agentSource, context, { filename: 'burette-agent.js' });
 const viewer = {
   plugin: {
     managers: {
-      structure: { hierarchy: { current: { structures: [{ cell: { transform: { ref: 's0' }, obj: { data: fakeStructure(), label: 'fake.pdb' } } }] } } },
+      structure: {
+        hierarchy: { current: { structures: [{ cell: { transform: { ref: 's0' }, obj: { data: fakeStructure(), label: 'fake.pdb' } } }] } },
+        selection: { entries: selectionEntries },
+        measurement: {
+          addLabel: async (loci, options) => {
+            measurementLabels.push({ loci, options });
+            return { selection: { ref: 'label-selection-ref' }, representation: { ref: 'label-representation-ref' } };
+          }
+        }
+      },
       camera: { reset: () => { interactions.push({ action: 'reset' }); } }
     },
     helpers: { viewportScreenshot: { getImageDataUri: async () => 'data:image/png;base64,from-helper' } }
   },
-  structureInteractivity(payload) { interactions.push(payload); },
-  loadMvsData: async () => {}
+  structureInteractivity(payload) {
+    interactions.push(payload);
+    if (payload.action === 'select' && payload.elements) {
+      selectionEntries.set('s0', { selection: { elements: [{ indices: { size: 2 } }] } });
+    }
+  },
+  loadMvsData: async (data, format, options) => {
+    interactions.push({ action: 'loadMvsData', data, format, options });
+  }
 };
 
 context.window.BurreteAgent.attach({ viewer, plugin: viewer.plugin, config: { label: 'fake.pdb', format: 'pdb' } });
@@ -98,6 +119,8 @@ assert.equal(summary.ok, true);
 assert.equal(summary.result.counts.atoms, 6);
 assert.equal(summary.result.counts.ligands, 1);
 assert.equal(summary.result.structures[0].chains.length, 2);
+assert.equal(summary.result.structures[0].ligands[0].label_comp_id, 'HEM');
+assert.equal(summary.result.structures[0].ligands[0].category, 'small_molecule');
 
 const selected = await context.window.BurreteAgent.run({ command: 'selectResidues', args: { selector: { auth_asym_id: 'A', beg_auth_seq_id: 1, end_auth_seq_id: 2 } } });
 assert.equal(selected.ok, true);
@@ -114,9 +137,54 @@ assert.equal(lig.ok, true);
 assert.equal(lig.result.ligand.label_comp_id, 'HEM');
 assert.ok(lig.result.neighborhood.residues.some(r => r.auth_asym_id === 'A'));
 
+const ligByCompAlias = await context.window.BurreteAgent.run({ command: 'focusLigand', args: { selector: { comp_id: 'HEM' } } });
+assert.equal(ligByCompAlias.ok, true);
+assert.equal(ligByCompAlias.result.ligand.auth_seq_id, 100);
+
+const ligWithMissingNeighborhood = await context.window.BurreteAgent.run({
+  command: 'focusLigand',
+  args: { selector: { comp_id: 'HEM' }, showNeighborhood: true, target: { auth_asym_id: 'Z' } }
+});
+assert.equal(ligWithMissingNeighborhood.ok, true);
+assert.equal(ligWithMissingNeighborhood.result.ligand.label_comp_id, 'HEM');
+assert.equal(ligWithMissingNeighborhood.result.neighborhood.ok, false);
+assert.equal(ligWithMissingNeighborhood.result.neighborhood.error.code, 'SELECTION_EMPTY');
+
+const label = await context.window.BurreteAgent.run({
+  command: 'labelSelection',
+  args: { selection: 'last', text: 'HEM A:100', textSize: 0.42 }
+});
+assert.equal(label.ok, true);
+assert.equal(label.result.label, 'HEM A:100');
+assert.equal(label.result.labels[0].selectionRef, 'label-selection-ref');
+assert.equal(measurementLabels.length, 1);
+assert.equal(measurementLabels[0].options.labelParams.customText, 'HEM A:100');
+assert.equal(measurementLabels[0].options.labelParams.textSize, 0.42);
+assert.equal(measurementLabels[0].options.reprTags[0], 'burrete-agent-label');
+
 const shot = await context.window.BurreteAgent.run({ command: 'screenshot' });
 assert.equal(shot.ok, true);
 assert.equal(shot.result.dataUri, 'data:image/png;base64,from-helper');
+
+const mvs = await context.window.BurreteAgent.run({
+  command: 'loadMVS',
+  args: {
+    json: {
+      root: {
+        kind: 'root',
+        children: []
+      }
+    },
+    options: { replaceExisting: true }
+  }
+});
+assert.equal(mvs.ok, true);
+assert.equal(mvs.result.format, 'mvsj');
+const loadedMvs = interactions.find(x => x.action === 'loadMvsData');
+assert.ok(loadedMvs);
+assert.equal(loadedMvs.format, 'mvsj');
+assert.equal(JSON.parse(loadedMvs.data).root.kind, 'root');
+assert.equal(loadedMvs.options.replaceExisting, true);
 
 const bad = await context.window.BurreteAgent.run({ command: 'selectResidues', args: { selector: { auth_asym_id: 'Z' } } });
 assert.equal(bad.ok, false);

--- a/tests/test-burrete-agent-cli.mjs
+++ b/tests/test-burrete-agent-cli.mjs
@@ -46,6 +46,23 @@ const child = spawn(process.execPath, ['scripts/agent-preview.mjs', 'samples/min
 
 try {
   const cliSource = await readFile(resolve('scripts/burrete-agent.mjs'), 'utf8');
+  assert.match(cliSource, /'browser-dev-shell'/);
+  assert.match(cliSource, /function openBrowserDevShell\(file, options\)/);
+  assert.match(cliSource, /spawn\('vp', \['dev', 'apps\/desktop'/);
+  assert.match(cliSource, /await allocatePort\(host\)/);
+  assert.match(cliSource, /mkdtemp\(resolve\(tmpdir\(\), 'burrete-agent-shell-'\)\)/);
+  assert.match(cliSource, /BURRETE_AGENT_SHELL_SESSION_DIR: sessionDir/);
+  assert.match(cliSource, /const logPath = resolve\(sessionDir, 'server\.log'\)/);
+  assert.match(cliSource, /VITE_BURRETE_AGENT_SHELL: '1'/);
+  assert.match(cliSource, /VITE_BURETTE_DEV_INSTANCE: 'agent'/);
+  assert.match(cliSource, /url\.searchParams\.set\('devFiles', initialFile\)/);
+  assert.match(cliSource, /sessionDir,/);
+  assert.match(cliSource, /async function browserShellSessionDir\(urlText\)/);
+  assert.match(cliSource, /async function assertSessionResponsive\(sessionDir\)/);
+  assert.match(cliSource, /BROWSER_DEV_SHELL_UNAVAILABLE/);
+  assert.match(cliSource, /logPath,/);
+  assert.match(cliSource, /observe: `node scripts\/burrete-agent\.mjs observe --session-dir/);
+  assert.match(cliSource, /act: `node scripts\/burrete-agent\.mjs act --session-dir/);
   assert.match(cliSource, /function desktopOpenArgs\(app, sessionDir, file\)/);
   assert.match(cliSource, /spawn\('open', desktopOpenArgs\(app, sessionDir, resolve\(file\)\)/);
   assert.match(cliSource, /return \['-n', app, \.\.\.agentArgs\];/);
@@ -77,6 +94,13 @@ try {
   assert.equal(sceneActionPayload.ok, true);
   assert.equal(sceneActionPayload.result.action.status, 'queued');
   assert.equal(sceneActionPayload.result.action.type, 'hide_waters');
+
+  const sceneSpec = runCli(['act', '--url', ready.url, '{"type":"apply_scene","components":[{"selector":"protein","label":"Protein","highlight":true},{"selector":{"chain":"A","range":[1,3]},"label":"Active loop","select":true,"focus":true}]}']);
+  assert.equal(sceneSpec.status, 0, sceneSpec.stderr);
+  const sceneSpecPayload = JSON.parse(sceneSpec.stdout);
+  assert.equal(sceneSpecPayload.ok, true);
+  assert.equal(sceneSpecPayload.result.action.status, 'queued');
+  assert.equal(sceneSpecPayload.result.action.type, 'apply_scene');
 
   const browserPanel = runCli(['render-panel', '--url', ready.url, '--kind', 'markdown', '--file', 'README.md']);
   assert.equal(browserPanel.status, 0, browserPanel.stderr);

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -44,6 +44,7 @@ const [
   previewRuntimeViewer,
   previewRuntimeUtils,
   previewFormats,
+  previewFormatRegistrySource,
   previewXyzrender,
   quickLookPreviewController,
   moleculeGridPreview,
@@ -116,6 +117,7 @@ const [
   source('apps/desktop/src-tauri/src/preview/runtime_viewer.rs'),
   source('apps/desktop/src-tauri/src/preview/runtime_utils.rs'),
   source('apps/desktop/src-tauri/src/preview/formats.rs'),
+  source('config/preview-formats.json'),
   source('apps/desktop/src-tauri/src/preview/xyzrender.rs'),
   source('PreviewExtension/Platform/PreviewViewController.swift'),
   source('PreviewExtension/MoleculeGridPreview.swift'),
@@ -294,10 +296,17 @@ assert.match(lib, /startup::emit_agent_session\(app, session_dir\)/);
 assert.match(agentSessionHook, /invoke<string \| null>\("startup_agent_session"\)/);
 assert.match(agentSessionHook, /listen<string>\("agent-session"/);
 assert.match(agentSessionHook, /trackTauriListener\(listen<string>\("agent-session"/);
+assert.match(agentSessionHook, /VITE_BURRETE_AGENT_SHELL/);
+assert.match(agentSessionHook, /BROWSER_AGENT_SESSION_DIR/);
+assert.match(agentSessionHook, /activateSession\(BROWSER_AGENT_SESSION_DIR\)/);
 assert.doesNotMatch(agentSessionHook, /let unlisten/);
 assert.doesNotMatch(agentSessionHook, /unlisten\?\.\(\)/);
 assert.match(agentSessionHook, /joinSessionPath\(sessionDir, "observe\.json"\)/);
 assert.match(agentSessionHook, /joinSessionPath\(sessionDir, "actions\.json"\)/);
+assert.match(agentSessionHook, /__burette\/agent-session\/\$\{browserFile\}/);
+assert.match(agentSessionHook, /browser-agent-http-session/);
+assert.match(agentSessionHook, /new EventSource\("\/__burette\/agent-session\/events"\)/);
+assert.match(agentSessionHook, /browserActionEvents\?\.addEventListener\("actions", pollNow\)/);
 assert.match(agentSessionHook, /workspacePanelsRef/);
 assert.match(agentSessionHook, /workspacePanels/);
 assert.match(agentSessionHook, /viewerAgentStatesRef/);
@@ -503,6 +512,12 @@ assert.match(coreCargoSource, /name = "burrete-core"/);
 assert.match(previewFormatsSource, /pub\(crate\) use burrete_core::\{/);
 assert.match(previewFormatsSource, /format_for_extension/);
 assert.match(previewFormatsSource, /resolve_renderer/);
+assert.match(previewFormatRegistrySource, /"id": "mol-view-spec-json"/);
+assert.match(previewFormatRegistrySource, /"extensions": \["mvsj"\]/);
+assert.match(previewFormatRegistrySource, /"id": "mol-view-spec-archive"/);
+assert.match(previewFormatRegistrySource, /"extensions": \["mvsx"\]/);
+assert.ok(tauriConfig.bundle.fileAssociations?.[0]?.ext?.includes('mvsj'));
+assert.ok(tauriConfig.bundle.fileAssociations?.[0]?.ext?.includes('mvsx'));
 assert.match(rendererPolicySource, /enum BurreteCoreBridge/);
 assert.match(rendererPolicySource, /supported-extension/);
 assert.match(rendererPolicySource, /resolve-renderer/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -79,6 +79,7 @@ const [
   tauriSource,
   settingsSections,
   browserDevDocuments,
+  agentSessionHook,
   temporaryDocuments,
   windowScope,
   viteConfig,
@@ -176,6 +177,7 @@ const [
   source('apps/desktop/src/lib/tauri.ts'),
   source('apps/desktop/src/lib/settings-sections.ts'),
   source('apps/desktop/src/lib/browser-dev-documents.ts'),
+  source('apps/desktop/src/hooks/use-agent-session.ts'),
   source('apps/desktop/src/lib/temporary-documents.ts'),
   source('apps/desktop/src/lib/window-scope.ts'),
   source('apps/desktop/vite.config.ts'),
@@ -1319,7 +1321,11 @@ assert.match(sidebarWorkspaceSwitcher, /sidebar-build-badge/);
 assert.match(sidebarWorkspaceSwitcher, /const showBuildBadge = buildInfo\.isDevBuild \|\| buildInfo\.isBrowserDev;/);
 assert.match(sidebarWorkspaceSwitcher, /\{showBuildBadge \? \(/);
 assert.doesNotMatch(sidebarWorkspaceSwitcher, /return `v\$\{info\.version\}`;/);
+assert.match(sidebarWorkspaceSwitcher, /AGENT SHELL · v\$\{info\.version\}/);
 assert.match(sidebarWorkspaceSwitcher, /DEV \$\{info\.flavor \?\? "local"\} · v\$\{info\.version\}/);
+assert.match(sidebarFileBrowser, /const hideProjectPreviews = state\.buildInfo\.isAgentShell/);
+assert.match(sidebarFileBrowser, /const visibleProjects = hideProjectPreviews \? \[\] : filterSidebarProjects/);
+assert.match(sidebarFileBrowser, /\{!hideProjectPreviews && \(/);
 assert.match(ketcherKind, /export const ketcherKind = definePageKind/);
 assert.match(ketcherKind, /lazy\(\(\) => import\("\.\.\/\.\.\/ketcher-page"\)/);
 assert.match(ketcherKind, /<Suspense fallback=\{null\}>/);
@@ -2413,6 +2419,8 @@ assert.match(menuEventsHook, /export function useMenuEvents/);
 assert.match(windowTitle, /useWindowTitle/);
 assert.match(windowTitle, /appInstanceLabel/);
 assert.match(instance, /VITE_BURETTE_DEV_INSTANCE/);
+assert.match(instance, /VITE_BURRETE_AGENT_SHELL/);
+assert.match(instance, /"Burette Agent"/);
 assert.match(instance, /Burette Dev \$\{devInstanceSuffix\}/);
 assert.match(instance, /"8a18"/);
 assert.match(browserDevDocuments, /function browserRendererPlan/);
@@ -2420,6 +2428,18 @@ assert.match(browserDevDocuments, /export function browserDevRuntimeNeedsRefresh
 assert.match(browserDevDocuments, /const GRID_ASSET_VERSION = "grid-ui-v99"/);
 assert.match(browserDevDocuments, /const VIEWER_ASSET_VERSION = "viewer-ui-v34"/);
 assert.match(browserDevDocuments, /const XYZRENDER_LARGE_STRUCTURE_ATOM_LIMIT = 1500/);
+assert.match(viteConfig, /__burette\/agent-session\//);
+assert.match(viteConfig, /BURRETE_AGENT_SHELL_SESSION_DIR/);
+assert.match(viteConfig, /"actions\.json", "observe\.json", "session\.json", "events"/);
+assert.match(viteConfig, /text\/event-stream/);
+assert.match(viteConfig, /watch\(sessionDir/);
+assert.match(viteConfig, /changedFileName === "actions\.json"/);
+assert.match(agentSessionHook, /type AgentSceneAction = \{/);
+assert.match(agentSessionHook, /type AgentSceneSelection = \{/);
+assert.match(agentSessionHook, /viewerAgentStateWithActionResult/);
+assert.match(agentSessionHook, /sceneSelectionFromActionResult/);
+assert.match(agentSessionHook, /selection: activeAgentState\?\.selection \?\? null/);
+assert.match(agentSessionHook, /lastAction: activeAgentState\?\.lastAction \?\? null/);
 assert.match(browserDevDocuments, /if \(document\.renderer === "grid2d"\) return !document\.runtimePath\.includes\(GRID_ASSET_VERSION\);/);
 assert.match(browserDevDocuments, /if \(!document\.runtimePath\.includes\(VIEWER_ASSET_VERSION\)\) return true;/);
 assert.match(browserDevDocuments, /function resolvePreviewVisuals/);
@@ -2718,6 +2738,12 @@ assert.match(gridCss, /#status \[data-buret-status-dismiss\] \{/);
 assert.match(gridViewer, /function setStatusText\(text\)/);
 assert.match(gridViewer, /data-buret-status-dismiss/);
 assert.match(previewShell, /data-buret-toolbar-content/);
+assert.match(previewShell, /data-buret-dock-toggle="bottom"/);
+assert.match(previewShell, /aria-label="Show bottom dock"/);
+assert.match(previewShell, /data-buret-dock-toggle="right"/);
+assert.match(previewShell, /aria-label="Show right dock"/);
+assert.match(previewShell, /data-buret-preview-dock="right"/);
+assert.match(previewShell, /data-buret-preview-dock="bottom"/);
 assert.match(previewShell, /data-buret-action="ketcher"/);
 assert.match(previewShell, /data-buret-action="save-modified-structure"/);
 assert.match(previewShell, /class="buret-button buret-save-modified hidden"/);
@@ -2732,6 +2758,12 @@ assert.match(previewRuntimeCss, /\.buret-xyzrender-preset-slot \{ display: none;
 assert.match(previewRuntimeCss, /\.buret-xyzrender-preset-slot\.visible \{ display: flex; \}/);
 assert.match(previewRuntimeCss, /\.buret-molstar-style-slot \{ display: none; align-items: center; \}/);
 assert.match(previewRuntimeCss, /\.buret-molstar-style-slot\.visible \{ display: flex; \}/);
+assert.match(previewRuntimeCss, /body:not\(\.buret-preview-docks-enabled\) \.buret-preview-dock-toggle/);
+assert.match(previewRuntimeCss, /\.buret-preview-dock-right \{/);
+assert.match(previewRuntimeCss, /\.buret-preview-dock-bottom \{/);
+assert.match(previewRuntimeCss, /\.buret-preview-dock-section-title/);
+assert.match(previewRuntimeCss, /\.buret-preview-dock-status-pill/);
+assert.match(previewRuntimeCss, /body\.buret-preview-dock-right-open \.buret-preview-dock-bottom/);
 assert.match(previewRuntimeCss, /\.buret-corner-button \{/);
 assert.match(previewRuntimeCss, /body\.burette-quicklook-host \{\s*--buret-toolbar-safe-top: 56px;/s);
 assert.match(previewRuntimeCss, /body\.burette-quicklook-host \.buret-corner-button \{/);
@@ -2861,15 +2893,40 @@ assert.match(previewViewer, /await window\.BurreteAgent\.run\(\{ command: 'summa
 assert.match(previewViewer, /await fetch\(reportUrl, \{/);
 assert.match(previewViewer, /function startBurreteAgentActionPolling\(\)/);
 assert.match(previewViewer, /async function executeBurreteAgentAction\(action\)/);
+assert.match(previewViewer, /const previewDockState = \{ right: false, bottom: false \}/);
+assert.match(previewViewer, /function bindPreviewDockControls\(toolbar\)/);
+assert.match(previewViewer, /data-buret-dock-toggle/);
+assert.match(previewViewer, /function setPreviewDockOpen\(area, open\)/);
+assert.match(previewViewer, /function previewDocksEnabled\(\)/);
+assert.match(previewViewer, /config\.enablePreviewDocks === true/);
+assert.match(previewViewer, /buret-preview-docks-enabled/);
+assert.match(previewViewer, /function previewDockSceneDescription\(observe\)/);
+assert.match(previewViewer, /function previewDockActionList\(observe\)/);
+assert.match(previewViewer, /function refreshPreviewDockObserve\(\)/);
+assert.match(previewViewer, /fetch\(previewDockObserveUrl\(\), \{ cache: 'no-store', credentials: 'same-origin' \}\)/);
+assert.match(previewViewer, /function applyDefaultPreviewDocks\(toolbar\)/);
+assert.match(previewViewer, /config\.defaultPreviewDocks/);
+assert.match(previewViewer, /buret-preview-dock-\$\{area\}-open/);
 assert.match(previewViewer, /let burreteAgentActionPollBusy = false/);
 assert.match(previewViewer, /if \(burreteAgentActionPollBusy\) return;/);
 assert.match(previewViewer, /agentActionFailure\(actionType, 'ACTION_ERROR'/);
 assert.match(previewViewer, /type === 'focus_ligand'[\s\S]*?command: 'focusLigand'/);
+assert.match(previewViewer, /type === 'focus_ligand'[\s\S]*?allowAmbiguous: action\.allowAmbiguous === true/);
+assert.match(previewViewer, /type === 'focus_ligand'[\s\S]*?index: Number\.isInteger\(action\.index\) \? action\.index : undefined/);
+assert.match(previewViewer, /type === 'focus_ligand'[\s\S]*?durationMs: action\.durationMs/);
+assert.match(previewViewer, /type === 'focus_ligand'[\s\S]*?extraRadius: action\.extraRadius/);
+assert.match(previewViewer, /type === 'label_selection'[\s\S]*?command: 'labelSelection'/);
+assert.match(previewViewer, /type === 'label_selection'[\s\S]*?text: action\.text \|\| action\.label/);
 assert.match(previewViewer, /type === 'reset_camera'[\s\S]*?command: 'resetCamera'/);
 assert.match(previewViewer, /type === 'hide_waters'[\s\S]*?BurreteSceneActions\?\.hideWaters/);
 assert.match(previewViewer, /type === 'show_surface'[\s\S]*?BurreteSceneActions\?\.showSurface/);
 assert.match(previewViewer, /type === 'color_by_chain'[\s\S]*?BurreteSceneActions\?\.colorByChain/);
 assert.match(previewViewer, /type === 'render_panel'[\s\S]*?renderBurreteAgentPanel\(action\)/);
+assert.match(previewViewer, /type === 'apply_scene'[\s\S]*?executeBurreteSceneSpec\(action\)/);
+assert.match(previewViewer, /async function executeBurreteSceneSpec\(action\)/);
+assert.match(previewViewer, /command: 'colorSelection'[\s\S]*?selector: target/);
+assert.match(previewViewer, /command: 'selectResidues'[\s\S]*?selector: target/);
+assert.match(previewViewer, /command: 'focusSelection'[\s\S]*?selector: target/);
 assert.match(previewViewer, /function renderBurreteAgentPanel\(action\)/);
 assert.match(previewViewer, /data-burrete-agent-panel/);
 assert.match(previewViewer, /function renderAgentTable\(content\)/);
@@ -2882,6 +2939,10 @@ assert.match(previewViewer, /hideWaters: hideMolstarWaters/);
 assert.match(previewViewer, /showSurface: showMolstarSurface/);
 assert.match(previewViewer, /colorByChain: colorMolstarByChain/);
 assert.match(previewViewer, /agentActionFailure\(type, 'NOT_IMPLEMENTED'/);
+assert.match(previewViewer, /function isMolViewSpecFormat\(format\)/);
+assert.match(previewViewer, /if \(isMolViewSpecFormat\(normalized\)\) \{/);
+assert.match(previewViewer, /kind: 'mvs'/);
+assert.match(previewViewer, /viewer\.loadMvsData\(prepared\.data, prepared\.format, \{ replaceExisting: true \}\)/);
 assert.match(previewViewer, /loadPreparedStructure\(viewer, prepared\)[\s\S]*?applyLayoutState\(viewer\);[\s\S]*?notifyStructureLoaded/);
 assert.match(previewViewer, /notifyStructureLoaded[\s\S]*?postHostMessage\(\{ type: 'agentReady', message: 'Burrete agent ready' \}\)/);
 assert.match(previewViewer, /notifyStructureLoaded[\s\S]*?void reportBurreteAgentState\(\);[\s\S]*?trackMolstarOrientation/);
@@ -3024,8 +3085,10 @@ assert.match(previewViewer, /if \(!viewer \|\| \(!picked && !isMolstarContextMen
 assert.match(previewViewer, /const MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX = 4;/);
 assert.match(previewViewer, /let contextPointer = null;/);
 assert.match(previewViewer, /if \(event\.button === 2\) \{[\s\S]*?contextPointer = \{/);
-assert.match(previewViewer, /const contextPick = molstarContextPickFromEvent\(event\);[\s\S]*?contextPointer = \{[\s\S]*?pick: contextPick/);
-assert.doesNotMatch(previewViewer, /if \(event\.button === 2\) \{[\s\S]*?event\.preventDefault\(\);[\s\S]*?event\.stopPropagation\(\);[\s\S]*?contextPointer = \{/);
+assert.match(previewViewer, /const contextPick = molstarContextPickFromEvent\(event\);[\s\S]*?event\.preventDefault\(\);\s*event\.stopPropagation\(\);[\s\S]*?contextPointer = \{[\s\S]*?pick: contextPick/);
+assert.doesNotMatch(previewViewer, /if \(event\.button === 2\) \{\s*event\.preventDefault\(\);\s*event\.stopPropagation\(\);[\s\S]*?contextPointer = \{/);
+assert.doesNotMatch(previewViewer, /actionContainer\.querySelector\('button'\)\?\.focus\(\)/);
+assert.doesNotMatch(previewViewer, /menu\.querySelector\('button'\)\?\.focus\(\)/);
 assert.match(previewViewer, /const onPointerUp = \(event\) => \{[\s\S]*?if \(contextPointer\.moved\) \{[\s\S]*?hideMolstarContextMenu\(\);[\s\S]*?contextPointer = null;[\s\S]*?return;[\s\S]*?\}[\s\S]*?openFromEvent\(event, contextPointer\.pick\);[\s\S]*?contextPointer = null;/);
 assert.match(previewViewer, /document\.addEventListener\('pointerup', onPointerUp, true\)/);
 assert.match(previewViewer, /if \(contextPointer\) \{\s*event\.preventDefault\(\);\s*event\.stopPropagation\(\);\s*if \(!contextPointer\.moved\) return;\s*hideMolstarContextMenu\(\);\s*contextPointer = null;\s*return;/);


### PR DESCRIPTION
## Summary
- add full browser shell support for agent-opened molecular previews, with hidden project preview chrome and agent-visible docks
- extend Burrete agent Mol* actions for MVS loading, ligand focus/selection, scene descriptions, and label_selection annotations
- update plugin skills/CLI/preflight docs so agents use the browser shell and structured Mol* scene language

## Verification
- node --check PreviewExtension/Web/burette-agent.js
- node --check PreviewExtension/Web/viewer.js
- node --check scripts/burrete-agent.mjs
- node tests/test-burette-agent.mjs
- node tests/test-ui-shell-contract.mjs
- node tests/test-burette-agent-plugin.mjs
- node tests/test-agent-preview-server.mjs
- node tests/test-burrete-agent-cli.mjs
- node tests/test-tauri-structure.mjs
- cargo test -p burrete-core
- git diff --check
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: scripts/ci-fast.sh