### PR TITLE
Release 1.0.1

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.48;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -362,7 +362,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.48;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -387,7 +387,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.48;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -412,7 +412,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 0.10.48;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "0.10.48"
+version = "1.0.1"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "0.10.48"
+version = "1.0.1"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "0.10.48",
+  "version": "1.0.1",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "0.10.48",
+      "version": "1.0.1",
       "bin": "bin/burrete.mjs",
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "0.10.48",
+  "version": "1.0.1",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -263,7 +263,7 @@ case "$ROOT" in *"/.Trash/"*|*"/Library/Mobile Documents/.Trash/"*)
 esac
 
 # Prevent accidentally running old v5/v6/v7/v8 folders.
-grep -Eq '"version": "0\.10\.[0-9]+(-[0-9A-Za-z.-]+)?"' package.json || { echo "error: this is not a v10 release package; package.json version is:" >&2; grep '"version"' package.json >&2 || true; exit 1; }
+grep -Eq '"version": "1\.0\.[0-9]+(-[0-9A-Za-z.-]+)?"' package.json || { echo "error: this is not a v1 release package; package.json version is:" >&2; grep '"version"' package.json >&2 || true; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj || { echo "error: this Xcode project is not v10." >&2; exit 1; }
 grep -q 'preview-content-type.mjs' scripts/force-preview.sh || { echo "error: force-preview.sh is not using the preview format registry helper." >&2; exit 1; }
 grep -q 'config.*preview-formats.json' scripts/preview-content-type.mjs || { echo "error: preview content type helper is not using the preview format registry." >&2; exit 1; }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -12,7 +12,7 @@ grep -n 'burrete' scripts/force-preview.sh || true
 grep -n 'burrete' scripts/preview-content-type.mjs || true
 echo "Trash check:"
 case "$ROOT" in *"/.Trash/"*|*"/Library/Mobile Documents/.Trash/"*) echo "ERROR: project is inside Trash"; exit 1;; *) echo "OK: not in Trash";; esac
-echo "Expected v10 markers:"
-grep -Eq '"version": "0\.10\.[0-9]+"' package.json && echo "OK package v10" || { echo "ERROR package is not v10"; exit 1; }
+echo "Expected v1 markers:"
+grep -Eq '"version": "1\.0\.[0-9]+"' package.json && echo "OK package v1" || { echo "ERROR package is not v1"; exit 1; }
 grep -q 'com.local.BurreteV10.Preview' Burrete.xcodeproj/project.pbxproj && echo "OK project v10" || { echo "ERROR project is not v10"; exit 1; }
 grep -q 'preview-content-type.mjs' scripts/force-preview.sh && grep -q 'com.local.burrete10.pdb' config/preview-formats.json && echo "OK force-preview v10" || { echo "ERROR force-preview is not v10"; exit 1; }


### PR DESCRIPTION
## Summary
- bump Burrete release metadata to 1.0.1
- update local release guard scripts for the v1 release line

## Checks
- bun run check:release
- BURRETE_RELEASE_ALLOW_ADHOC=1 ./scripts/release.sh --dry-run
- ./scripts/doctor.sh
- bun run ci:fast (pre-push)