### PR TITLE
Fix dock targets for tab drag drops

### DIFF
--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -8,6 +8,7 @@ import { pageKind } from "./page-kinds";
 import { isMoleculeCollectionPath } from "../../lib/collection-documents";
 import { CloseIcon } from "../close-icon";
 import type { DropTargetContext } from "../../lib/drop-actions";
+import type { DockArea, DockTabKind } from "../../lib/dock";
 
 const TAB_DRAG_MIME = "application/x-burrete-tab-id";
 const TAB_REORDER_ANIMATION_MS = 170;
@@ -227,10 +228,25 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
     };
   }, [state.activeDocument, state.activeTabId]);
 
+  const dockDropTargetAtPoint = useCallback((clientX: number, clientY: number): { area: DockArea; tabKind: DockTabKind } | null => {
+    const element = typeof document === "undefined" ? null : document.elementFromPoint(clientX, clientY);
+    const dockTarget = element?.closest<HTMLElement>(".dock-panel[data-area][data-active-tab]");
+    const area = dockTarget?.dataset.area;
+    const tabKind = dockTarget?.dataset.activeTab;
+    if ((area !== "right" && area !== "bottom") || !tabKind) return null;
+    return { area, tabKind: tabKind as DockTabKind };
+  }, []);
+
   const runTabDropAtPoint = useCallback((sourceTabId: string, clientX: number, clientY: number) => {
     if (clientX <= 0 && clientY <= 0) return false;
     const payload = tabStructurePayload(sourceTabId);
     if (!payload || (payload.paths.length === 0 && payload.records.length === 0)) return false;
+    const dockTarget = dockDropTargetAtPoint(clientX, clientY);
+    if (dockTarget) {
+      actions.setStructureDragActive(false);
+      void actions.openDockPayload({ area: dockTarget.area, tabKind: dockTarget.tabKind, payload });
+      return true;
+    }
     const targetTabId = tabIdFromPoint(clientX, clientY, sourceTabId);
     const target = targetTabId
       ? dropTargetForTabId(targetTabId)
@@ -240,7 +256,7 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
     if (choices.length === 0) return false;
     actions.setStructureDragActive(false);
     return runShellDropActionChoices(actions, payload, choices, { x: clientX, y: clientY });
-  }, [actions, activeViewerDropTargetAtPoint, dropTargetForTabId, tabIdFromPoint, tabStructurePayload]);
+  }, [actions, activeViewerDropTargetAtPoint, dockDropTargetAtPoint, dropTargetForTabId, tabIdFromPoint, tabStructurePayload]);
 
   const moveDraggedTab = useCallback((tabId: string, pointerX: number) => {
     const orderedTabs = latestTabsRef.current;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1432,7 +1432,8 @@ img.radix-menu-item-icon {
   width: 100%;
   min-height: 180px;
 }
-.dock-panel[data-drop-active] {
+.dock-panel[data-drop-active],
+.app-shell[data-structure-drag-active="true"] .dock-panel[data-open="true"]:hover {
   background: color-mix(in srgb, var(--accent) 8%, var(--bg-base));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 48%, transparent);
 }

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1574,6 +1574,7 @@ assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer::after \{
 assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer::after \{[\s\S]*width: 1px;/);
 assert.match(styles, /\.dock-panel\[data-area="bottom"\] \.dock-resizer::after \{[\s\S]*height: 1px;/);
 assert.match(styles, /\.dock-panel\[data-area="right"\] \.dock-resizer:hover::after,[\s\S]*?\.dock-panel\[data-area="bottom"\] \.dock-resizer:active::after \{\s*background: var\(--dock-divider-active-color\);\s*\}/);
+assert.match(styles, /\.dock-panel\[data-drop-active\],[\s\S]*?\.app-shell\[data-structure-drag-active="true"\] \.dock-panel\[data-open="true"\]:hover \{/);
 assert.match(styles, /\.dock-viewer \.ketcher-page \{[\s\S]*position: relative;[\s\S]*inset: auto;[\s\S]*overflow: hidden;/);
 assert.match(styles, /\.dock-viewer \.ketcher-page-header \{[\s\S]*grid-template-columns: minmax\(0, 1fr\);/);
 assert.match(styles, /\.dock-viewer \.ketcher-page-actions \{[\s\S]*overflow-x: auto;/);
@@ -2725,6 +2726,11 @@ assert.match(openDropHook, /document\.elementFromPoint\(position\.x, position\.y
 assert.match(openDropHook, /candidates\.find\(\(element\) => element\.closest\("\.dock-panel"\)\) \?\? candidates\[0\]/);
 assert.match(openDropHook, /const dockTarget = element\?\.closest<HTMLElement>\("\.dock-panel\[data-area\]\[data-active-tab\]"\)/);
 assert.match(openDropHook, /void openDockPayload\?\.\(\{ area: target\.area, tabKind: target\.tabKind, payload \}\)/);
+assert.match(editorTabs, /import type \{ DockArea, DockTabKind \} from "\.\.\/\.\.\/lib\/dock";/);
+assert.match(editorTabs, /const dockDropTargetAtPoint = useCallback\(\(clientX: number, clientY: number\): \{ area: DockArea; tabKind: DockTabKind \} \| null => \{/);
+assert.match(editorTabs, /document\.elementFromPoint\(clientX, clientY\)/);
+assert.match(editorTabs, /element\?\.closest<HTMLElement>\("\.dock-panel\[data-area\]\[data-active-tab\]"\)/);
+assert.match(editorTabs, /void actions\.openDockPayload\(\{ area: dockTarget\.area, tabKind: dockTarget\.tabKind, payload \}\)/);
 assert.match(dock, /export type DockFileEntry/);
 assert.match(dock, /export function dockFileEntries/);
 assert.match(dockPanel, /dockFileEntries\(\{/);


### PR DESCRIPTION
## Summary
- route tab drag fallback drops to right and bottom dock panels when released over a dock
- show dock hover affordance while a structure drag is active
- add shell contract coverage for the dock target path

## Root cause
Tab drag fallback only resolved other tabs or the active viewer at the release point. Open dock panels were not checked, so dropping over the right or bottom dock returned without calling openDockPayload.

## Validation
- git diff --check -- apps/desktop/src/components/editor-area/editor-tabs.tsx apps/desktop/src/styles.css tests/test-ui-shell-contract.mjs
- bun tests/test-ui-shell-contract.mjs
- bun tests/test-open-drop-contract.mjs
- bun run test:ui
- vp build
- pre-push ci-fast