### PR TITLE
Update Cargo lock for 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",


### PR DESCRIPTION
## Summary
- align root Cargo.lock with the 1.0.3 Rust crate version after the release bump

## Checks
- pre-push ci-fast