### PR TITLE
Add browser Quick Look debug loop

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -330,6 +330,7 @@ function delimitedColumnChoiceLabel(choice: GridDelimitedColumnChoice) {
 
 async function browserDevFilesFromLocation() {
   const params = new URLSearchParams(window.location.search);
+  if (params.has("quickLookFile")) return [];
   if (params.has("devDocking")) return [];
   if (params.has("devFiles")) {
     return splitDevFiles(params.get("devFiles") ?? "");
@@ -346,6 +347,13 @@ async function browserDevFilesFromLocation() {
 
 function splitDevFiles(rawFiles: string) {
   return rawFiles.split("\n").map((path) => path.trim()).filter(Boolean);
+}
+
+function browserDevQuickLookFileFromLocation() {
+  if (typeof window === "undefined" || isTauriRuntime()) return null;
+  const params = new URLSearchParams(window.location.search);
+  const path = params.get("quickLookFile")?.trim();
+  return path || null;
 }
 
 function browserDevHasExplicitFiles() {
@@ -558,6 +566,7 @@ export default function App() {
   const [ketcherDraftMolfile, setKetcherDraftMolfile] = useState("");
   const [descriptorSource, setDescriptorSource] = useState<DescriptorSourcePayload | null>(null);
   const [quickLookDocument, setQuickLookDocument] = useState<ViewerDocument | null>(null);
+  const [quickLookError, setQuickLookError] = useState<string | null>(null);
   const [dirtyGridDocuments, setDirtyGridDocuments] = useState<Set<string>>(() => new Set());
   const [status, setStatus] = useState<StatusNotice | null>(null);
   const [buildInfo, setBuildInfo] = useState(defaultBuildInfo);
@@ -580,6 +589,7 @@ export default function App() {
     availableRelease: null,
   }));
   const openedBrowserDevFilesRef = useRef<string | null>(null);
+  const openedBrowserDevQuickLookRef = useRef<string | null>(null);
   const openedBrowserDevDockingRef = useRef<string | null>(null);
   const prunedPersistedPathsRef = useRef(false);
   const refreshedPersistedSessionRef = useRef(false);
@@ -1528,6 +1538,32 @@ export default function App() {
   }, [closeDocument, openDocuments, openSpectrumDocuments, openTextDocuments, setActiveDocument]);
 
   useEffect(() => {
+    const quickLookPath = browserDevQuickLookFileFromLocation();
+    if (!quickLookPath || openedBrowserDevQuickLookRef.current === quickLookPath) return;
+    let cancelled = false;
+    openedBrowserDevQuickLookRef.current = quickLookPath;
+    setQuickLookDocument(null);
+    setQuickLookError(null);
+    void openBrowserDevDocuments([quickLookPath], preferences).then((result) => {
+      if (cancelled) return;
+      const document = result.documents[0] ?? null;
+      if (document) {
+        setQuickLookDocument(document);
+        return;
+      }
+      setQuickLookError("Quick Look debug file did not produce a preview document.");
+    }).catch((error) => {
+      if (cancelled) return;
+      const message = error instanceof Error ? error.message : String(error);
+      setQuickLookError(`Open Quick Look debug file failed: ${message}`);
+      pushErrorStatus(error, "Open Quick Look debug file failed");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [preferences, pushErrorStatus]);
+
+  useEffect(() => {
     if (isTauriRuntime() || syncingBrowserDevFilesRef.current) return;
     let cancelled = false;
     void (async () => {
@@ -2015,10 +2051,6 @@ export default function App() {
       `Size: ${formatBytes(document.byteCount)}`,
     ]);
   }, [pushStatus]);
-
-  const showQuickLookPreview = useCallback((document: ViewerDocument) => {
-    setQuickLookDocument(document);
-  }, []);
 
   const closeQuickLookPreview = useCallback(() => {
     setQuickLookDocument(null);
@@ -4826,7 +4858,6 @@ export default function App() {
     showActiveDocumentMetadata,
     showDocumentMetadata,
     showTextFileMetadata,
-    showQuickLookPreview,
     closeQuickLookPreview,
     generate3DConformer,
     runStructureViewerAction,
@@ -4885,7 +4916,7 @@ export default function App() {
     },
     setPreference,
     setUpdatePreferences,
-  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyGridDescriptorControls, applyGridDescriptorResults, applyKetcherToGridRow, backToApp, calculateGridDescriptors, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearDescriptorSource, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeQuickLookPreview, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, generate3DConformer, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDescriptorSource, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openNewWindow, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openTextDocuments, openWorkspaceFolder, pushErrorStatus, pushStatus, reloadXyzrenderDocument, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, runStructureViewerAction, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, selectTextStructure, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showQuickLookPreview, showTextFileMetadata, tabs, toggleDock, toggleDockTab, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
+  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyGridDescriptorControls, applyGridDescriptorResults, applyKetcherToGridRow, backToApp, calculateGridDescriptors, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearDescriptorSource, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeQuickLookPreview, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, generate3DConformer, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDescriptorSource, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openNewWindow, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openTextDocuments, openWorkspaceFolder, pushErrorStatus, pushStatus, reloadXyzrenderDocument, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, runStructureViewerAction, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, selectTextStructure, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showTextFileMetadata, tabs, toggleDock, toggleDockTab, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
 
   const page = activeTab?.location.kind === "settings" ? "settings" : "viewer";
 
@@ -4898,6 +4929,8 @@ export default function App() {
     activeDocument,
     activeDocumentId: activeDocument?.id ?? null,
     quickLookDocument,
+    quickLookError,
+    quickLookStandalone: Boolean(browserDevQuickLookFileFromLocation()),
     visibleDocuments: documents,
     recentStructures,
     sidebarProjects: allSidebarProjects,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -557,6 +557,7 @@ export default function App() {
   const [ketcherImportRequest, setKetcherImportRequest] = useState<KetcherImportRequest | null>(null);
   const [ketcherDraftMolfile, setKetcherDraftMolfile] = useState("");
   const [descriptorSource, setDescriptorSource] = useState<DescriptorSourcePayload | null>(null);
+  const [quickLookDocument, setQuickLookDocument] = useState<ViewerDocument | null>(null);
   const [dirtyGridDocuments, setDirtyGridDocuments] = useState<Set<string>>(() => new Set());
   const [status, setStatus] = useState<StatusNotice | null>(null);
   const [buildInfo, setBuildInfo] = useState(defaultBuildInfo);
@@ -2014,6 +2015,14 @@ export default function App() {
       `Size: ${formatBytes(document.byteCount)}`,
     ]);
   }, [pushStatus]);
+
+  const showQuickLookPreview = useCallback((document: ViewerDocument) => {
+    setQuickLookDocument(document);
+  }, []);
+
+  const closeQuickLookPreview = useCallback(() => {
+    setQuickLookDocument(null);
+  }, []);
 
   const showTextFileMetadata = useCallback((document: TextFileDocument) => {
     const details = [
@@ -4817,6 +4826,8 @@ export default function App() {
     showActiveDocumentMetadata,
     showDocumentMetadata,
     showTextFileMetadata,
+    showQuickLookPreview,
+    closeQuickLookPreview,
     generate3DConformer,
     runStructureViewerAction,
     reloadXyzrenderDocument,
@@ -4874,7 +4885,7 @@ export default function App() {
     },
     setPreference,
     setUpdatePreferences,
-  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyGridDescriptorControls, applyGridDescriptorResults, applyKetcherToGridRow, backToApp, calculateGridDescriptors, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearDescriptorSource, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, generate3DConformer, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDescriptorSource, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openNewWindow, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openTextDocuments, openWorkspaceFolder, pushErrorStatus, pushStatus, reloadXyzrenderDocument, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, runStructureViewerAction, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, selectTextStructure, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showTextFileMetadata, tabs, toggleDock, toggleDockTab, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
+  }), [activeDocument, addDockDrop, addXyzrenderSheetItemsToDocument, appendGridRecords, applyGridDescriptorControls, applyGridDescriptorResults, applyKetcherToGridRow, backToApp, calculateGridDescriptors, canNavigateBack, canNavigateForward, checkForUpdates, chooseFiles, chooseWorkspace, clearCache, clearDescriptorSource, clearKetcherImportRequest, clearRecentStructures, closeActiveDocument, closeAllDocuments, closeDocument, closeDockTab, closeGridRuntime, closeQuickLookPreview, closeTab, confirmDiscardDirtyGridDocument, confirmDiscardDirtyGridDocuments, copyActiveDocumentPath, copyDocumentPath, copyPath, documents, exportActivePreviewAsPng, exportActivePreviewAsSvg, focusSidebarSearch, generate3DConformer, installUpdate, listChemicalEditorTargets, mergeMoleculeCollections, moveTab, navigateBack, navigateForward, openClipboard, openCommandPalette, openDescriptorSource, openDockingDocument, openDockingStructureRecords, openDockPayload, openDockTab, openDocuments, openFepNetworkPreview, openFepSetupWorkspace, openKetcher, openKetcherExportRaw, openKetcherSketch, openKetcherWithStructures, openLogs, openMostRecentStructure, openNewTab, openNewWindow, openPathInChemicalEditor, openPathWithDefaultApp, openPaths, openProjectFolder, openRecentStructure, openSettings, openSettingsSection, openStructureRecords, openTextDocuments, openWorkspaceFolder, pushErrorStatus, pushStatus, reloadXyzrenderDocument, removeProjectRoot, renameProjectRoot, resetQuickLook, revealActiveDocument, revealDocument, revealPath, runStructureViewerAction, saveKetcherExportFile, saveMoleculeCollectionAs, selectDocument, selectTextStructure, setActiveTab, setDockActiveTab, setDockDocument, setDockOpen, setDockSize, setDockTool, setExpandedProjectIds, setPreference, setSidebarQuery, setUpdatePreferences, showActiveDocumentMetadata, showDocumentMetadata, showQuickLookPreview, showTextFileMetadata, tabs, toggleDock, toggleDockTab, togglePinnedProjectRoot, togglePinnedStructure, toggleProjectExpanded, toggleProjectsOpen, toggleSidebar, update.availableRelease]);
 
   const page = activeTab?.location.kind === "settings" ? "settings" : "viewer";
 
@@ -4886,6 +4897,7 @@ export default function App() {
     activeTabId,
     activeDocument,
     activeDocumentId: activeDocument?.id ?? null,
+    quickLookDocument,
     visibleDocuments: documents,
     recentStructures,
     sidebarProjects: allSidebarProjects,

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -70,6 +70,27 @@ export function AppLayout({
   } as CSSProperties;
   const effectiveTheme = resolveThemeMode(state.preferences.theme, systemThemeMode);
   const activePageKind = state.activeTab?.location.kind ?? null;
+  if (state.quickLookStandalone) {
+    return (
+      <main
+        className="app-shell"
+        data-theme={state.preferences.theme}
+        data-effective-theme={effectiveTheme}
+        data-runtime={isTauriRuntime() ? "tauri" : "browser"}
+        data-quicklook-debug="true"
+        style={shellStyle}
+      >
+        {state.quickLookDocument ? (
+          <QuickLookPreview document={state.quickLookDocument} onClose={actions.closeQuickLookPreview} standalone />
+        ) : state.quickLookError ? (
+          <div className="web-quicklook-debug-loading" role="alert">{state.quickLookError}</div>
+        ) : (
+          <div className="web-quicklook-debug-loading" role="status">Loading Quick Look preview...</div>
+        )}
+      </main>
+    );
+  }
+
   return (
     <main
       className="app-shell"

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -4,6 +4,7 @@ import { ViewerArea } from "./editor-area";
 import { EditorTabs } from "./editor-area/editor-tabs";
 import { NotificationPopup } from "./notification-popup";
 import { OpenInEditorMenu } from "./open-in-editor-menu";
+import { QuickLookPreview } from "./quick-look-preview";
 import { Sidebar } from "./sidebar";
 import { ShortcutTooltip } from "./shortcut-tooltip";
 import type { ShellActions, ShellViewState } from "./types";
@@ -185,6 +186,9 @@ export function AppLayout({
       {state.status && (
         <NotificationPopup notice={state.status} onDismiss={onDismissStatus} />
       )}
+      {state.quickLookDocument ? (
+        <QuickLookPreview document={state.quickLookDocument} onClose={actions.closeQuickLookPreview} />
+      ) : null}
     </main>
   );
 }

--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -546,6 +546,15 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
                     },
                     {
                       kind: "item" as const,
+                      id: "quick-look-tab-document",
+                      text: "Quick Look",
+                      accelerator: "Space",
+                      action: () => {
+                        actions.showQuickLookPreview(tabDocument);
+                      },
+                    },
+                    {
+                      kind: "item" as const,
                       id: "show-tab-document-metadata",
                       text: "Show Metadata",
                       action: () => {

--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -546,15 +546,6 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
                     },
                     {
                       kind: "item" as const,
-                      id: "quick-look-tab-document",
-                      text: "Quick Look",
-                      accelerator: "Space",
-                      action: () => {
-                        actions.showQuickLookPreview(tabDocument);
-                      },
-                    },
-                    {
-                      kind: "item" as const,
                       id: "show-tab-document-metadata",
                       text: "Show Metadata",
                       action: () => {

--- a/apps/desktop/src/components/quick-look-preview.tsx
+++ b/apps/desktop/src/components/quick-look-preview.tsx
@@ -6,9 +6,11 @@ import type { ViewerDocument } from "../types";
 export function QuickLookPreview({
   document,
   onClose,
+  standalone = false,
 }: {
   document: ViewerDocument;
   onClose: () => void;
+  standalone?: boolean;
 }) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
 
@@ -27,7 +29,7 @@ export function QuickLookPreview({
   return (
     <div
       ref={dialogRef}
-      className="web-quicklook-backdrop"
+      className={standalone ? "web-quicklook-backdrop web-quicklook-backdrop-standalone" : "web-quicklook-backdrop"}
       role="dialog"
       aria-modal="true"
       aria-label={`Quick Look ${document.title}`}

--- a/apps/desktop/src/components/quick-look-preview.tsx
+++ b/apps/desktop/src/components/quick-look-preview.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+import { SpectrumViewer } from "./spectrum-viewer";
+import { ViewerFrame } from "./editor-area/viewer-frame";
+import type { ViewerDocument } from "../types";
+
+export function QuickLookPreview({
+  document,
+  onClose,
+}: {
+  document: ViewerDocument;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={dialogRef}
+      className="web-quicklook-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Quick Look ${document.title}`}
+      tabIndex={-1}
+    >
+      <section className="web-quicklook-window">
+        <header className="web-quicklook-titlebar">
+          <div className="web-quicklook-traffic-lights">
+            <button type="button" className="web-quicklook-light web-quicklook-close-dot" onClick={onClose} aria-label="Close Quick Look" />
+            <span className="web-quicklook-light web-quicklook-minimize-dot" aria-hidden="true" />
+            <span className="web-quicklook-light web-quicklook-zoom-dot" aria-hidden="true" />
+          </div>
+          <div className="web-quicklook-title">
+            <span>{document.title}</span>
+            <small>{document.extension.toUpperCase()} / {document.renderer}</small>
+          </div>
+          <button type="button" className="web-quicklook-done" onClick={onClose}>
+            Done
+          </button>
+        </header>
+        <div className="web-quicklook-content">
+          {document.renderer === "spectrum" ? (
+            <SpectrumViewer document={document} />
+          ) : (
+            <ViewerFrame document={document} className="web-quicklook-iframe" />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/types.ts
+++ b/apps/desktop/src/components/types.ts
@@ -216,7 +216,6 @@ export type ShellActions = {
   showActiveDocumentMetadata: () => void | Promise<void>;
   showDocumentMetadata: (document: ViewerDocument) => void | Promise<void>;
   showTextFileMetadata: (document: TextFileDocument) => void | Promise<void>;
-  showQuickLookPreview: (document: ViewerDocument) => void;
   closeQuickLookPreview: () => void;
   generate3DConformer: (document: ViewerDocument) => void | Promise<void>;
   runStructureViewerAction: (document: ViewerDocument, action: StructureViewerAction) => void;
@@ -246,6 +245,8 @@ export type ShellViewState = {
   activeDocument: ViewerDocument | null;
   activeDocumentId: string | null;
   quickLookDocument: ViewerDocument | null;
+  quickLookError: string | null;
+  quickLookStandalone: boolean;
   visibleDocuments: ViewerDocument[];
   recentStructures: RecentStructure[];
   sidebarProjects: SidebarProject[];

--- a/apps/desktop/src/components/types.ts
+++ b/apps/desktop/src/components/types.ts
@@ -216,6 +216,8 @@ export type ShellActions = {
   showActiveDocumentMetadata: () => void | Promise<void>;
   showDocumentMetadata: (document: ViewerDocument) => void | Promise<void>;
   showTextFileMetadata: (document: TextFileDocument) => void | Promise<void>;
+  showQuickLookPreview: (document: ViewerDocument) => void;
+  closeQuickLookPreview: () => void;
   generate3DConformer: (document: ViewerDocument) => void | Promise<void>;
   runStructureViewerAction: (document: ViewerDocument, action: StructureViewerAction) => void;
   reloadXyzrenderDocument: (document: ViewerDocument, options: ViewerReloadOptions) => void | Promise<void>;
@@ -243,6 +245,7 @@ export type ShellViewState = {
   activeTabId: string | null;
   activeDocument: ViewerDocument | null;
   activeDocumentId: string | null;
+  quickLookDocument: ViewerDocument | null;
   visibleDocuments: ViewerDocument[];
   recentStructures: RecentStructure[];
   sidebarProjects: SidebarProject[];

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -4337,6 +4337,114 @@ img.radix-menu-item-icon {
   background: var(--bg-base);
 }
 .viewer-iframe { width: 100%; height: 100%; border: 0; display: block; background: transparent; }
+.web-quicklook-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 950;
+  display: grid;
+  place-items: center;
+  padding: 52px;
+  background: rgb(0 0 0 / 0.16);
+  pointer-events: auto;
+}
+.web-quicklook-window {
+  width: min(980px, calc(100vw - 96px));
+  height: min(720px, calc(100vh - 104px));
+  min-width: min(680px, calc(100vw - 32px));
+  min-height: min(460px, calc(100vh - 32px));
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 48px minmax(0, 1fr);
+  border: 1px solid color-mix(in srgb, var(--fg-base) calc(var(--contrast) * 34%), transparent);
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+  color: var(--text-primary);
+  box-shadow: 0 28px 80px rgb(0 0 0 / 0.38), 0 1px 0 rgb(255 255 255 / 0.16) inset;
+  backdrop-filter: blur(34px) saturate(1.35);
+  -webkit-backdrop-filter: blur(34px) saturate(1.35);
+}
+.web-quicklook-titlebar {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr) 86px;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--line-subtler);
+  background: color-mix(in srgb, var(--fg-base) calc(var(--contrast) * 10%), transparent);
+}
+.web-quicklook-traffic-lights {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.web-quicklook-light {
+  width: 12px;
+  height: 12px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0;
+  display: block;
+  box-shadow: 0 0 0 0.5px rgb(0 0 0 / 0.18) inset;
+}
+.web-quicklook-close-dot { background: #ff5f57; }
+.web-quicklook-minimize-dot { background: #ffbd2e; }
+.web-quicklook-zoom-dot { background: #28c840; }
+.web-quicklook-title {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+  text-align: center;
+  line-height: 1.1;
+}
+.web-quicklook-title span,
+.web-quicklook-title small {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.web-quicklook-title span {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+}
+.web-quicklook-title small {
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 400;
+}
+.web-quicklook-done {
+  justify-self: end;
+  min-width: 54px;
+  min-height: 26px;
+  border: 0;
+  border-radius: 7px;
+  padding: 0 10px;
+  background: var(--surface-subtle);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.web-quicklook-done:hover,
+.web-quicklook-done:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  outline: none;
+}
+.web-quicklook-content {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: rgb(0 0 0 / 0.12);
+}
+.web-quicklook-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: transparent;
+}
 .spectrum-stage {
   position: absolute;
   inset: var(--chrome-height) 0 0;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -4347,6 +4347,26 @@ img.radix-menu-item-icon {
   background: rgb(0 0 0 / 0.16);
   pointer-events: auto;
 }
+.web-quicklook-backdrop-standalone {
+  padding: 32px;
+  background:
+    radial-gradient(circle at 24% 18%, color-mix(in srgb, var(--accent) 24%, transparent), transparent 30%),
+    color-mix(in srgb, var(--bg-base) 92%, transparent);
+}
+.app-shell[data-quicklook-debug="true"] {
+  background: var(--bg);
+}
+.web-quicklook-debug-loading {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  background:
+    radial-gradient(circle at 24% 18%, color-mix(in srgb, var(--accent) 24%, transparent), transparent 30%),
+    color-mix(in srgb, var(--bg-base) 92%, transparent);
+}
 .web-quicklook-window {
   width: min(980px, calc(100vw - 96px));
   height: min(720px, calc(100vh - 104px));

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,8 @@ contains only documents that describe the active project.
   check paths that avoid full local rebuilds.
 - [Control affordances](control-affordances.md): tooltip and menu-detail rules
   for compact controls across React, Mol*, `xyzrender`, Grid, and Ketcher.
-- [Quick Look debugging](quicklook-debugging.md): Finder preview diagnosis and
-  cache reset workflow.
+- [Quick Look debugging](quicklook-debugging.md): browser-only preview debug,
+  Finder preview diagnosis, and cache reset workflow.
 - [Launch modes](launch-modes.md): normal, file-open, tray, and registration
   launch semantics.
 - [Releasing](releasing.md): version, build, signing, update, and artifact

--- a/docs/quicklook-debugging.md
+++ b/docs/quicklook-debugging.md
@@ -59,6 +59,52 @@ qlmanage -r cache
 killall quicklookd 2>/dev/null || true
 ```
 
+## Browser-Only Preview Debug Loop
+
+Use the browser-only Quick Look debug loop when changing React/CSS/viewer web
+surfaces and you need to inspect the Quick Look-shaped preview without building
+or registering the native Finder extension. This route is for development and
+debugging only. It must not be exposed as an end-user command or menu item.
+
+Start the desktop Vite server:
+
+```bash
+vp dev
+```
+
+Open the dedicated debug URL in the built-in Browser:
+
+```text
+http://127.0.0.1:1420/?quickLookFile=/absolute/path/to/file.pdb
+```
+
+For repository samples, use:
+
+```text
+http://127.0.0.1:1420/?quickLookFile=/absolute/path/to/Burette/samples/mini.pdb
+```
+
+Build the sample path from the current repository root and URL-encode it when
+constructing the URL from tooling. Do not use `devFiles` for this check.
+`devFiles` opens the normal browser-dev app shell; `quickLookFile` is the
+isolated Quick Look debug surface.
+
+Expected browser state:
+
+- The page renders a single `Quick Look <filename>` dialog.
+- The preview content is the same viewer runtime that the selected renderer
+  would use for that file.
+- The normal browser-dev app chrome is absent: no `Open structures` tablist, no
+  project sidebar search, and no main workbench behind the preview.
+- The dialog has an explicit `Done` close control and the red close dot.
+
+Use this loop for fast visual checks of toolbar spacing, preview sizing,
+transparent surfaces, renderer controls, and CSS regressions. It does not prove
+Launch Services registration, extension signing, cache invalidation, or Finder
+Quick Look process behavior. After changes to Swift, packaging, content types,
+extension assets, or native runtime generation, still run the forced preview
+smoke path below.
+
 ## Smoke Tests
 
 Use forced previews to bypass Launch Services ambiguity while debugging:


### PR DESCRIPTION
## Summary
- add a browser-only Quick Look debug URL via `quickLookFile`
- keep the debug preview out of end-user menus and normal browser-dev shell
- document the development testing path

## Checks
- pre-push ci-fast
- bun run typecheck
- uv run node tests/test-ui-shell-contract.mjs