### PR TITLE
Replace app UI icons with system symbols

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -7,6 +7,7 @@ import { OpenInEditorMenu } from "./open-in-editor-menu";
 import { QuickLookPreview } from "./quick-look-preview";
 import { Sidebar } from "./sidebar";
 import { ShortcutTooltip } from "./shortcut-tooltip";
+import { SystemIcon } from "./system-icon";
 import type { ShellActions, ShellViewState } from "./types";
 import { isTauriRuntime } from "../lib/tauri";
 import { buildThemeStyle, resolveThemeMode, useSystemThemeMode } from "../lib/theme";
@@ -120,7 +121,7 @@ export function AppLayout({
               onClick={onToggleSidebar}
               aria-label={state.sidebarOpen ? "Hide sidebar" : "Show sidebar"}
             >
-              <DockToggleIcon />
+              <SystemIcon name="sidebar.left" size={18} />
             </button>
           </div>
           <div className="chrome-trailing-controls" data-tauri-drag-region>
@@ -133,7 +134,7 @@ export function AppLayout({
               onClick={() => actions.toggleDock("bottom")}
               aria-label={state.bottomDockOpen ? "Hide bottom dock" : "Show bottom dock"}
             >
-              <DockToggleIcon className="dock-toggle-icon-bottom" />
+              <SystemIcon name="rectangle.bottomthird.inset.filled" size={18} />
               <ShortcutTooltip label={state.bottomDockOpen ? "Hide bottom dock" : "Show bottom dock"} shortcut="⌘J" />
             </button>
             <button
@@ -144,7 +145,7 @@ export function AppLayout({
               onClick={() => actions.toggleDock("right")}
               aria-label={state.rightDockOpen ? "Hide right dock" : "Show right dock"}
             >
-              <DockToggleIcon className="dock-toggle-icon-right" />
+              <SystemIcon name="sidebar.right" size={18} />
               <ShortcutTooltip label={state.rightDockOpen ? "Hide right dock" : "Show right dock"} shortcut="⌥⌘B" />
             </button>
           </div>
@@ -211,21 +212,5 @@ export function AppLayout({
         <QuickLookPreview document={state.quickLookDocument} onClose={actions.closeQuickLookPreview} />
       ) : null}
     </main>
-  );
-}
-
-function DockToggleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width="18"
-      height="18"
-      viewBox="0 0 18 18"
-      fill="none"
-      aria-hidden="true"
-    >
-      <rect x="2.25" y="2.25" width="13.5" height="13.5" rx="3.25" stroke="currentColor" strokeWidth="1.8" />
-      <path d="M6.75 4.75V13.25" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-    </svg>
   );
 }

--- a/apps/desktop/src/components/close-icon.tsx
+++ b/apps/desktop/src/components/close-icon.tsx
@@ -1,20 +1,5 @@
+import { SystemIcon } from "./system-icon";
+
 export function CloseIcon({ size = 14 }: { size?: number }) {
-  return (
-    <svg
-      className="close-glyph"
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M4.6 4.6L11.4 11.4M11.4 4.6L4.6 11.4"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.9"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
+  return <SystemIcon name="xmark" className="close-glyph" size={size} strokeWidth={2.4} />;
 }

--- a/apps/desktop/src/components/dock-panel.tsx
+++ b/apps/desktop/src/components/dock-panel.tsx
@@ -1,11 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import {
-  Atom01Icon,
-  File02Icon,
-  Folder01Icon,
-  Search01Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { DOCK_TAB_LABELS, dockFileEntries, dockTabCatalog, type DockArea, type DockFileEntry, type DockTabKind } from "../lib/dock";
 import { hasStructureDrag, readStructureDragPayload, writeStructureDragPayload } from "../lib/structure-drag";
 import type { StructureDragPayload } from "../lib/structure-drag";
@@ -21,6 +14,7 @@ import { SpectrumInfoPanel, SpectrumPeakTablePanel, SpectrumViewer } from "./spe
 import { readBrowserDevVirtualTextDocument } from "../lib/browser-dev-documents";
 import { readStructureTextDocument } from "../lib/structure-text";
 import type { ConformerJob, TextFileDocument, ViewerDocument, XtbJob, XyzrenderControls } from "../types";
+import { SystemIcon, type SystemIconName } from "./system-icon";
 
 type DockPanelProps = {
   area: DockArea;
@@ -29,19 +23,19 @@ type DockPanelProps = {
   onResizeStart: (event: React.PointerEvent<HTMLDivElement>) => void;
 };
 
-const dockTabIcons: Record<DockTabKind, typeof File02Icon> = {
-  xyzrender: Atom01Icon,
-  files: Folder01Icon,
-  spectrum: Atom01Icon,
-  text: File02Icon,
-  inspector: Search01Icon,
-  descriptors: Atom01Icon,
-  "structure-basket": Atom01Icon,
-  compare: Atom01Icon,
-  jobs: File02Icon,
-  logs: File02Icon,
-  diagnostics: Search01Icon,
-  review: Search01Icon,
+const dockTabIcons: Record<DockTabKind, SystemIconName> = {
+  xyzrender: "atom",
+  files: "folder",
+  spectrum: "chart.xyaxis.line",
+  text: "doc.text",
+  inspector: "info.circle",
+  descriptors: "list.bullet.rectangle",
+  "structure-basket": "tray.full",
+  compare: "square.split.2x1",
+  jobs: "terminal",
+  logs: "doc.plaintext",
+  diagnostics: "wrench.and.screwdriver",
+  review: "checklist",
 };
 
 export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProps) {
@@ -160,7 +154,7 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
         <div className="dock-header">
           <div className="dock-tab-strip" role="tablist" aria-label={`${area} dock tabs`}>
             {visibleTabs.map((tab) => {
-              const Icon = dockTabIcons[tab.kind];
+              const icon = dockTabIcons[tab.kind];
               const active = tab.kind === activeTab.kind;
               const closeTab = () => {
                 if (visibleTabs.length > 1) {
@@ -187,7 +181,7 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
                     aria-selected={active}
                     title={DOCK_TAB_LABELS[tab.kind]}
                   >
-                    <HugeiconsIcon icon={Icon} size={16} color="currentColor" strokeWidth={2} />
+                    <SystemIcon name={icon} size={16} />
                     <span>{DOCK_TAB_LABELS[tab.kind]}</span>
                   </button>
                   {active && (
@@ -205,7 +199,7 @@ export function DockPanel({ area, state, actions, onResizeStart }: DockPanelProp
             })}
           </div>
           <button type="button" className="dock-icon-button" onClick={showAddMenu} aria-label={`Add ${area} dock tab`}>
-            +
+            <SystemIcon name="plus" size={15} />
           </button>
           <button type="button" className="dock-icon-button" onClick={() => actions.setDockOpen(area, false)} aria-label={`Close ${area} dock`}>
             <CloseIcon size={15} />

--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -7,6 +7,7 @@ import { showNativeContextMenu } from "../native-context-menu";
 import { pageKind } from "./page-kinds";
 import { isMoleculeCollectionPath } from "../../lib/collection-documents";
 import { CloseIcon } from "../close-icon";
+import { SystemIcon } from "../system-icon";
 import type { DropTargetContext } from "../../lib/drop-actions";
 import type { DockArea, DockTabKind } from "../../lib/dock";
 
@@ -776,7 +777,7 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
         })}
       </ScrollFade>
       <button type="button" className="new-tab" onClick={actions.openNewTab} title="New tab" aria-label="New tab">
-        +
+        <SystemIcon name="plus" size={15} />
       </button>
       <div
         className="tab-strip-spacer"

--- a/apps/desktop/src/components/menu-types.ts
+++ b/apps/desktop/src/components/menu-types.ts
@@ -1,3 +1,5 @@
+import type { SystemIconName } from "./system-icon";
+
 export type MenuItemSpec =
-  | { kind: "item"; id: string; text: string; detail?: string; iconText?: string; iconUrl?: string; action?: () => void; accelerator?: string; disabled?: boolean }
+  | { kind: "item"; id: string; text: string; detail?: string; iconSymbol?: SystemIconName; iconText?: string; iconUrl?: string; action?: () => void; accelerator?: string; disabled?: boolean }
   | { kind: "separator" };

--- a/apps/desktop/src/components/open-in-editor-menu.tsx
+++ b/apps/desktop/src/components/open-in-editor-menu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { RadixDropdownMenu } from "./radix-menu";
 import { ShortcutTooltip } from "./shortcut-tooltip";
+import { SystemIcon, type SystemIconName } from "./system-icon";
 import type { ChemicalEditorTarget, ShellActions, ShellViewState } from "./types";
 import type { MenuItemSpec } from "./menu-types";
 import { isTauriRuntime } from "../lib/tauri";
@@ -48,8 +49,7 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
       kind: "item",
       id: `chemical-editor-${target.id}`,
       text: target.name,
-      iconText: editorIconText(target.name),
-      iconUrl: editorIconUrl(target) ?? undefined,
+      ...editorMenuIcon(target),
       action: () => {
         void actions.openPathInChemicalEditor(activeFile.path, target.id, target.name);
       },
@@ -72,7 +72,7 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
         kind: "item" as const,
         id: "chemical-editor-default",
         text: "Open with Default App",
-        iconText: "DA",
+        iconSymbol: "app",
         action: () => {
           void actions.openPathWithDefaultApp(activeFile.path);
         },
@@ -81,7 +81,7 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
         kind: "item" as const,
         id: "chemical-editor-finder",
         text: "Reveal in Finder",
-        iconText: "FI",
+        iconSymbol: "folder",
         iconUrl: finderIconUrl() ?? undefined,
         action: () => {
           void actions.revealPath(activeFile.path, activeFile.label);
@@ -95,6 +95,7 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
   const visibleTargets = targets.length > 0 ? targets : browserDevPreviewTargets(activeFile.path);
   const preferredTarget = preferredTargetForDestination(state.preferences.openInDefaultDestination, visibleTargets);
   const preferredIconUrl = openDestinationIconUrl(state.preferences.openInDefaultDestination, preferredTarget);
+  const preferredIconSymbol = openDestinationIconSymbol(state.preferences.openInDefaultDestination, preferredTarget);
   const label = openDestinationLabel(state.preferences.openInDefaultDestination, preferredTarget);
 
   return (
@@ -115,11 +116,11 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
           <span className={preferredIconUrl ? "open-editor-trigger-icon open-editor-trigger-icon-image" : "open-editor-trigger-icon"} aria-hidden="true">
             {preferredIconUrl ? (
               <img src={preferredIconUrl} alt="" aria-hidden="true" />
-            ) : openDestinationIconText(state.preferences.openInDefaultDestination, preferredTarget)}
+            ) : (
+              <SystemIcon name={preferredIconSymbol} size={13} strokeWidth={2.1} />
+            )}
           </span>
-          <svg className="open-editor-chevron" width="13" height="13" viewBox="0 0 13 13" aria-hidden="true">
-            <path d="M3.5 5 6.5 8 9.5 5" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          <SystemIcon name="chevron.down" className="open-editor-chevron" size={13} />
           <ShortcutTooltip label={label} />
         </button>
       )}
@@ -148,10 +149,10 @@ function openDestinationIconUrl(destination: string, target: ChemicalEditorTarge
   return null;
 }
 
-function openDestinationIconText(destination: string, target: ChemicalEditorTarget | null) {
-  if (destination === "default-app") return "DA";
-  if (destination === "finder" || destination === "auto") return "FI";
-  return target ? editorIconText(target.name) : "OP";
+function openDestinationIconSymbol(destination: string, target: ChemicalEditorTarget | null): SystemIconName {
+  if (destination === "default-app") return "app";
+  if (destination === "finder" || destination === "auto") return "folder";
+  return target ? "app" : "square.and.pencil";
 }
 
 function activeFileFromState(state: ShellViewState): ActiveFile | null {
@@ -166,18 +167,16 @@ function activeFileFromState(state: ShellViewState): ActiveFile | null {
   return document?.path ? { path: document.path, label: "file" } : null;
 }
 
-function editorIconText(name: string) {
-  const compact = name.replace(/[^a-z0-9]+/giu, " ").trim();
-  const parts = compact.split(/\s+/u).filter(Boolean);
-  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
-  return compact.slice(0, 2).toUpperCase() || "ED";
-}
-
 function editorIconUrl(target: ChemicalEditorTarget) {
   if (target.iconUrl) return target.iconUrl;
   if (target.iconPath && isTauriRuntime()) return convertFileSrc(target.iconPath);
   if (!isTauriRuntime() && import.meta.env.DEV) return browserDevIconUrl(target);
   return null;
+}
+
+function editorMenuIcon(target: ChemicalEditorTarget): Pick<Extract<MenuItemSpec, { kind: "item" }>, "iconSymbol" | "iconUrl"> {
+  const iconUrl = editorIconUrl(target);
+  return iconUrl ? { iconUrl } : { iconSymbol: "app" };
 }
 
 function finderIconUrl() {

--- a/apps/desktop/src/components/radix-menu.tsx
+++ b/apps/desktop/src/components/radix-menu.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root as ReactRoot } from "react-dom/client";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import type { MenuItemSpec } from "./menu-types";
+import { SystemIcon } from "./system-icon";
 
 type RadixDropdownProps = {
   items: MenuItemSpec[];
@@ -150,6 +151,10 @@ function renderItemBody(item: Extract<MenuItemSpec, { kind: "item" }>) {
     <span className="radix-menu-item-body">
       {item.iconUrl ? (
         <img className="radix-menu-item-icon" src={item.iconUrl} alt="" aria-hidden="true" />
+      ) : item.iconSymbol ? (
+        <span className="radix-menu-item-icon" aria-hidden="true">
+          <SystemIcon name={item.iconSymbol} size={14} strokeWidth={2.1} />
+        </span>
       ) : item.iconText ? (
         <span className="radix-menu-item-icon" aria-hidden="true">{item.iconText}</span>
       ) : null}

--- a/apps/desktop/src/components/settings-panel/index.tsx
+++ b/apps/desktop/src/components/settings-panel/index.tsx
@@ -9,6 +9,7 @@ import { isTauriRuntime } from "../../lib/tauri";
 import { AgentIntegrationPanel } from "../agent-integration-panel";
 import { EditorScrollContainer } from "../editor-area/editor-scroll-container";
 import { RadixDropdownMenu } from "../radix-menu";
+import { SystemIcon, type SystemIconName } from "../system-icon";
 import type { AppSettingsSectionId, ChemicalEditorTarget, ShellActions, ShellViewState } from "../types";
 import type { MenuItemSpec } from "../menu-types";
 import {
@@ -30,7 +31,7 @@ type OpenInDefaultDestination = ViewerPreferences["openInDefaultDestination"];
 type OpenDestinationOption = {
   value: OpenInDefaultDestination;
   label: string;
-  iconText: string;
+  iconSymbol: SystemIconName;
   iconUrl?: string;
 };
 
@@ -416,7 +417,7 @@ function OpenDestinationControl({
     kind: "item",
     id: `open-destination-${option.value}`,
     text: option.label,
-    iconText: option.iconText,
+    iconSymbol: option.iconSymbol,
     iconUrl: option.iconUrl,
     action: () => onChange(option.value),
   }));
@@ -433,12 +434,12 @@ function OpenDestinationControl({
           {selected.iconUrl ? (
             <img className="settings-open-destination-icon" src={selected.iconUrl} alt="" aria-hidden="true" />
           ) : (
-            <span className="settings-open-destination-icon" aria-hidden="true">{selected.iconText}</span>
+            <span className="settings-open-destination-icon" aria-hidden="true">
+              <SystemIcon name={selected.iconSymbol} size={14} strokeWidth={2.1} />
+            </span>
           )}
           <span>{selected.label}</span>
-          <svg width="13" height="13" viewBox="0 0 13 13" aria-hidden="true">
-            <path d="M3.5 5 6.5 8 9.5 5" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          <SystemIcon name="chevron.down" size={13} />
         </button>
       )}
     />
@@ -447,17 +448,17 @@ function OpenDestinationControl({
 
 function openDestinationOptions(value: OpenInDefaultDestination, targets: ChemicalEditorTarget[]): OpenDestinationOption[] {
   const options: OpenDestinationOption[] = [
-    { value: "finder", label: "Finder", iconText: "FI", iconUrl: finderIconUrl() ?? undefined },
-    { value: "default-app", label: "Default app", iconText: "DA" },
+    { value: "finder", label: "Finder", iconSymbol: "folder", iconUrl: finderIconUrl() ?? undefined },
+    { value: "default-app", label: "Default app", iconSymbol: "app" },
     ...targets.map((target) => ({
       value: `editor:${target.id}` as OpenInDefaultDestination,
       label: target.name,
-      iconText: editorIconText(target.name),
+      iconSymbol: "app" as const,
       iconUrl: editorIconUrl(target) ?? undefined,
     })),
   ];
   if (value.startsWith("editor:") && !options.some((option) => option.value === value)) {
-    options.push({ value, label: "Saved editor", iconText: "ED" });
+    options.push({ value, label: "Saved editor", iconSymbol: "square.and.pencil" });
   }
   return options;
 }
@@ -485,11 +486,4 @@ function browserDevIconUrl(target: ChemicalEditorTarget) {
   if (appPath.includes("datawarrior") || name === "datawarrior") return "/__burette/app-icon/datawarrior.png";
   if (appPath.includes("vesta") || name === "vesta") return "/__burette/app-icon/vesta.png";
   return null;
-}
-
-function editorIconText(name: string) {
-  const compact = name.replace(/[^a-z0-9]+/giu, " ").trim();
-  const parts = compact.split(/\s+/u).filter(Boolean);
-  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
-  return compact.slice(0, 2).toUpperCase() || "ED";
 }

--- a/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
+++ b/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { SystemIcon } from "../system-icon";
 
 type ShortcutRow = {
   command: string;
@@ -133,10 +134,5 @@ export function KeyboardShortcutsSection() {
 }
 
 function SearchIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M7.25 12.5C10.1495 12.5 12.5 10.1495 12.5 7.25C12.5 4.35051 10.1495 2 7.25 2C4.35051 2 2 4.35051 2 7.25C2 10.1495 4.35051 12.5 7.25 12.5Z" stroke="currentColor" strokeWidth="1.35" />
-      <path d="M11 11L14 14" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-    </svg>
-  );
+  return <SystemIcon name="magnifyingglass" size={16} />;
 }

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -1,11 +1,10 @@
 import { useState, type DragEvent as ReactDragEvent } from "react";
-import { Atom01Icon, Search01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { filterSidebarProjects } from "../../lib/sidebar-projects";
 import { hasStructureDrag, readStructureDragPayload, writeStructureDragItems } from "../../lib/structure-drag";
 import { runShellDropActionChoices, shellDropActionChoices } from "../drop-action-executor";
 import { RadixDropdownMenu } from "../radix-menu";
 import { ScrollFade } from "../scroll-fade";
+import { SystemIcon } from "../system-icon";
 import type { ShellActions, ShellViewState } from "../types";
 import { ProjectGroup, ProjectItem } from "./file-tree-node";
 
@@ -79,7 +78,7 @@ export function FileBrowser({
         aria-label="Search projects and structures"
       >
         <span className="sidebar-search-icon" aria-hidden="true">
-          <HugeiconsIcon icon={Search01Icon} size={16} color="currentColor" strokeWidth={2} />
+          <SystemIcon name="magnifyingglass" size={16} />
         </span>
         <span className="sidebar-search-label">Search</span>
         <kbd>⌘<span>P</span></kbd>
@@ -98,7 +97,7 @@ export function FileBrowser({
         aria-label="Open Ketcher"
       >
         <span className="sidebar-tool-icon" aria-hidden="true">
-          <HugeiconsIcon icon={Atom01Icon} size={16} color="currentColor" strokeWidth={2} />
+          <SystemIcon name="atom" size={16} />
         </span>
         <span className="sidebar-tool-label">Ketcher</span>
       </button>
@@ -205,37 +204,13 @@ export function FileBrowser({
 }
 
 function ExpandCollapseIcon({ collapsed }: { collapsed: boolean }) {
-  return collapsed ? (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M3.5 3.5L6.9 6.9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M6.9 4.7V6.9H4.7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M12.5 12.5L9.1 9.1" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M9.1 11.3V9.1H11.3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  ) : (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M6.9 6.9L3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M3.5 5.7V3.5H5.7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M9.1 9.1L12.5 12.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M12.5 10.3V12.5H10.3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
+  return <SystemIcon name={collapsed ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right"} size={16} />;
 }
 
 function ChevronIcon() {
-  return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-      <path d="M3.5 2L6.5 5L3.5 8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
+  return <SystemIcon name="chevron.forward" size={10} />;
 }
 
 function MoreIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <circle cx="4" cy="8" r="1.2" fill="currentColor" />
-      <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-      <circle cx="12" cy="8" r="1.2" fill="currentColor" />
-    </svg>
-  );
+  return <SystemIcon name="ellipsis" size={16} />;
 }

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -1,10 +1,4 @@
 import { useState, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
-import {
-  File02Icon,
-  Folder01Icon,
-  Folder02Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { isMoleculeCollectionPath } from "../../lib/collection-documents";
 import type { SidebarProject, SidebarProjectItem } from "../../lib/sidebar-projects";
 import { hasStructureDrag, readStructureDragPayload, writeStructureDragPayload } from "../../lib/structure-drag";
@@ -13,6 +7,7 @@ import { runShellDropActionChoices, shellDropActionChoices } from "../drop-actio
 import { rendererLabel } from "../format";
 import { showNativeContextMenu } from "../native-context-menu";
 import { RadixDropdownMenu } from "../radix-menu";
+import { SystemIcon } from "../system-icon";
 import type { ShellActions, ShellViewState } from "../types";
 
 const COLLAPSED_PROJECT_ITEM_LIMIT = 5;
@@ -135,7 +130,7 @@ export function ProjectGroup({
         aria-label={`${project.title}, ${project.items.length} structure${project.items.length === 1 ? "" : "s"}`}
       >
         <span className="project-folder-icon" aria-hidden="true">
-          <HugeiconsIcon icon={expanded ? Folder02Icon : Folder01Icon} size={16} color="currentColor" strokeWidth={2} />
+          <SystemIcon name={expanded ? "folder.fill" : "folder"} size={16} />
         </span>
         <span className="project-group-copy">
           <span className="project-group-title">{project.title}</span>
@@ -381,7 +376,7 @@ function ProjectTreeNodeView({
         title={node.path}
       >
         <span className="project-folder-icon" aria-hidden="true">
-          <HugeiconsIcon icon={Folder02Icon} size={16} color="currentColor" strokeWidth={2} />
+          <SystemIcon name="folder.fill" size={16} />
         </span>
         <span className="project-folder-name">{node.name}</span>
         <button
@@ -571,7 +566,7 @@ export function ProjectItem({
       title={item.relativePath}
     >
       <span className="project-icon" aria-hidden="true">
-        <HugeiconsIcon icon={File02Icon} size={16} color="currentColor" strokeWidth={2} />
+        <SystemIcon name="doc" size={16} />
       </span>
       <span className="project-copy">
         <span className="project-name">{item.title}</span>
@@ -654,45 +649,15 @@ function projectDepthStyle(depth: number): CSSProperties {
 }
 
 function PinIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-      <path
-        d="M8.25 1.75L12.25 5.75L10.4 7.6L9.25 6.45L6.8 8.9L7.15 11.2L6.35 12L4 9.65L1.9 11.75L1.25 11.1L3.35 9L1 6.65L1.8 5.85L4.1 6.2L6.55 3.75L5.4 2.6L8.25 1.75Z"
-        stroke="currentColor"
-        strokeWidth="1.15"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
+  return <SystemIcon name="pin" size={14} />;
 }
 
 function MoreIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <circle cx="4" cy="8" r="1.2" fill="currentColor" />
-      <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-      <circle cx="12" cy="8" r="1.2" fill="currentColor" />
-    </svg>
-  );
+  return <SystemIcon name="ellipsis" size={16} />;
 }
 
 function FolderExpandCollapseIcon({ collapse }: { collapse: boolean }) {
-  return collapse ? (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M3.5 3.5L6.9 6.9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M6.9 4.7V6.9H4.7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M12.5 12.5L9.1 9.1" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M9.1 11.3V9.1H11.3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  ) : (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M6.9 6.9L3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M3.5 5.7V3.5H5.7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M9.1 9.1L12.5 12.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-      <path d="M12.5 10.3V12.5H10.3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
+  return <SystemIcon name={collapse ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right"} size={16} />;
 }
 
 function sidebarDropTarget(item: SidebarProjectItem, state: ShellViewState) {

--- a/apps/desktop/src/components/sidebar/settings-sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/settings-sidebar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { settingsNavGroups, type SettingsSectionId } from "../../lib/settings-sections";
+import { SystemIcon, type SystemIconName } from "../system-icon";
 import type { ShellActions, ShellViewState } from "../types";
 
 export function SettingsSidebar({ state, actions }: { state: ShellViewState; actions: ShellActions }) {
@@ -94,79 +95,24 @@ function SettingsNavButton({
 }
 
 function BackIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M9.5 3.5L5 8L9.5 12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
+  return <SystemIcon name="chevron.left" size={16} />;
 }
 
 function SearchIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M7.25 12.5C10.1495 12.5 12.5 10.1495 12.5 7.25C12.5 4.35051 10.1495 2 7.25 2C4.35051 2 2 4.35051 2 7.25C2 10.1495 4.35051 12.5 7.25 12.5Z" stroke="currentColor" strokeWidth="1.35" />
-      <path d="M11 11L14 14" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-    </svg>
-  );
+  return <SystemIcon name="magnifyingglass" size={16} />;
 }
 
+const settingsItemSymbols: Record<SettingsSectionId, SystemIconName> = {
+  agent: "cpu",
+  appearance: "sun.max",
+  general: "gearshape",
+  keyboard: "keyboard",
+  maintenance: "wrench.and.screwdriver",
+  structure: "atom",
+  updates: "arrow.triangle.2.circlepath",
+  workspace: "folder",
+};
+
 function SettingsItemIcon({ id }: { id: SettingsSectionId }) {
-  if (id === "agent") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <path d="M3.2 5.7H13.8V12.4C13.8 13.2 13.2 13.8 12.4 13.8H4.6C3.8 13.8 3.2 13.2 3.2 12.4V5.7Z" stroke="currentColor" strokeWidth="1.35" />
-        <path d="M5.4 5.7V4.5C5.4 3.4 6.3 2.5 7.4 2.5H9.6C10.7 2.5 11.6 3.4 11.6 4.5V5.7" stroke="currentColor" strokeWidth="1.35" />
-        <path d="M6 9.2H6.01M11 9.2H11.01" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  if (id === "appearance") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <path d="M8.5 2.2V4M8.5 13V14.8M3.7 3.7L5 5M12 12L13.3 13.3M2.2 8.5H4M13 8.5H14.8M3.7 13.3L5 12M12 5L13.3 3.7" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-        <circle cx="8.5" cy="8.5" r="2.7" stroke="currentColor" strokeWidth="1.35" />
-      </svg>
-    );
-  }
-  if (id === "structure") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <circle cx="4.5" cy="5" r="1.6" stroke="currentColor" strokeWidth="1.35" />
-        <circle cx="11.8" cy="4.8" r="1.6" stroke="currentColor" strokeWidth="1.35" />
-        <circle cx="8.8" cy="12" r="1.8" stroke="currentColor" strokeWidth="1.35" />
-        <path d="M5.9 5.6L7.7 10.4M10.6 6.1L9.4 10.3" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  if (id === "keyboard") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <rect x="2.4" y="4.2" width="12.2" height="9.2" rx="1.6" stroke="currentColor" strokeWidth="1.35" />
-        <path d="M4.6 6.8H4.61M6.9 6.8H6.91M9.2 6.8H9.21M11.5 6.8H11.51M4.6 9.1H4.61M6.9 9.1H6.91M9.2 9.1H9.21M11.5 9.1H11.51M5.4 11.3H11.6" stroke="currentColor" strokeWidth="1.45" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  if (id === "updates") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <path d="M13.4 8.5C13.4 11.1 11.3 13.2 8.7 13.2C6.5 13.2 4.7 11.8 4.1 9.9" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-        <path d="M3.6 8.5C3.6 5.9 5.7 3.8 8.3 3.8C10.3 3.8 12 5 12.7 6.8" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-        <path d="M12.8 4.5V6.9H10.4M4.2 12.1V9.7H6.6" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    );
-  }
-  if (id === "maintenance") {
-    return (
-      <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-        <path d="M4.1 12.9L9.5 7.5M10.7 3.1L13.9 6.3L12.1 8.1L8.9 4.9L10.7 3.1Z" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M3.3 13.7L4.1 12.9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-      </svg>
-    );
-  }
-  return (
-    <svg width="17" height="17" viewBox="0 0 17 17" fill="none" aria-hidden="true">
-      <path d="M7.2 2.4H9.8L10.2 4.1C10.5 4.2 10.8 4.4 11.1 4.5L12.6 3.6L14.4 5.4L13.5 6.9C13.6 7.2 13.8 7.5 13.9 7.8L15.6 8.2V10.8L13.9 11.2C13.8 11.5 13.6 11.8 13.5 12.1L14.4 13.6L12.6 15.4L11.1 14.5C10.8 14.6 10.5 14.8 10.2 14.9L9.8 16.6H7.2L6.8 14.9C6.5 14.8 6.2 14.6 5.9 14.5L4.4 15.4L2.6 13.6L3.5 12.1C3.4 11.8 3.2 11.5 3.1 11.2L1.4 10.8V8.2L3.1 7.8C3.2 7.5 3.4 7.2 3.5 6.9L2.6 5.4L4.4 3.6L5.9 4.5C6.2 4.4 6.5 4.2 6.8 4.1L7.2 2.4Z" stroke="currentColor" strokeWidth="1.25" strokeLinejoin="round" />
-      <circle cx="8.5" cy="9.5" r="2.2" stroke="currentColor" strokeWidth="1.25" />
-    </svg>
-  );
+  return <SystemIcon name={settingsItemSymbols[id] ?? "gearshape"} size={17} />;
 }

--- a/apps/desktop/src/components/sidebar/workspace-switcher.tsx
+++ b/apps/desktop/src/components/sidebar/workspace-switcher.tsx
@@ -1,5 +1,6 @@
 import { appInstanceLabel } from "../../lib/instance";
 import { RadixDropdownMenu } from "../radix-menu";
+import { SystemIcon } from "../system-icon";
 import type { BuildInfo, ShellActions, ShellViewState } from "../types";
 
 function buildLabel(info: BuildInfo) {
@@ -96,10 +97,5 @@ export function WorkspaceSwitcher({ state, actions }: { state: ShellViewState; a
 }
 
 function GearIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-      <path d="M7.6 2.25H10.4L10.82 4.06C11.15 4.18 11.47 4.32 11.77 4.5L13.36 3.52L15.34 5.5L14.36 7.09C14.54 7.39 14.68 7.71 14.8 8.04L16.61 8.46V11.26L14.8 11.68C14.68 12.01 14.54 12.33 14.36 12.63L15.34 14.22L13.36 16.2L11.77 15.22C11.47 15.4 11.15 15.54 10.82 15.66L10.4 17.47H7.6L7.18 15.66C6.85 15.54 6.53 15.4 6.23 15.22L4.64 16.2L2.66 14.22L3.64 12.63C3.46 12.33 3.32 12.01 3.2 11.68L1.39 11.26V8.46L3.2 8.04C3.32 7.71 3.46 7.39 3.64 7.09L2.66 5.5L4.64 3.52L6.23 4.5C6.53 4.32 6.85 4.18 7.18 4.06L7.6 2.25Z" stroke="currentColor" strokeWidth="1.35" strokeLinejoin="round" />
-      <circle cx="9" cy="9.86" r="2.65" stroke="currentColor" strokeWidth="1.35" />
-    </svg>
-  );
+  return <SystemIcon name="gearshape" size={18} />;
 }

--- a/apps/desktop/src/components/system-icon.tsx
+++ b/apps/desktop/src/components/system-icon.tsx
@@ -1,0 +1,149 @@
+import {
+  Activity,
+  AppWindow,
+  Atom,
+  Bot,
+  ChartLine,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Columns2,
+  Cpu,
+  Ellipsis,
+  File,
+  FileText,
+  Folder,
+  FolderOpen,
+  Inbox,
+  Info,
+  Keyboard,
+  List,
+  ListChecks,
+  Maximize2,
+  Minimize2,
+  MonitorCog,
+  Palette,
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  Pin,
+  Plus,
+  RefreshCw,
+  Search,
+  Settings,
+  Sparkles,
+  SquarePen,
+  SquareSplitHorizontal,
+  Sun,
+  Terminal,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+export type SystemIconName =
+  | "app"
+  | "arrow.down.right.and.arrow.up.left"
+  | "arrow.triangle.2.circlepath"
+  | "arrow.up.left.and.arrow.down.right"
+  | "atom"
+  | "chart.xyaxis.line"
+  | "checklist"
+  | "chevron.down"
+  | "chevron.forward"
+  | "chevron.left"
+  | "cpu"
+  | "doc"
+  | "doc.plaintext"
+  | "doc.text"
+  | "ellipsis"
+  | "folder"
+  | "folder.fill"
+  | "gearshape"
+  | "gearshape.2"
+  | "info.circle"
+  | "keyboard"
+  | "list.bullet.rectangle"
+  | "magnifyingglass"
+  | "paintpalette"
+  | "pin"
+  | "pin.fill"
+  | "plus"
+  | "rectangle.bottomthird.inset.filled"
+  | "sidebar.left"
+  | "sidebar.right"
+  | "sparkles"
+  | "stethoscope"
+  | "square.and.pencil"
+  | "square.split.2x1"
+  | "sun.max"
+  | "terminal"
+  | "tray.full"
+  | "wrench.and.screwdriver"
+  | "xmark";
+
+const iconBySymbolName: Record<SystemIconName, LucideIcon> = {
+  app: AppWindow,
+  "arrow.down.right.and.arrow.up.left": Minimize2,
+  "arrow.triangle.2.circlepath": RefreshCw,
+  "arrow.up.left.and.arrow.down.right": Maximize2,
+  atom: Atom,
+  "chart.xyaxis.line": ChartLine,
+  checklist: ListChecks,
+  "chevron.down": ChevronDown,
+  "chevron.forward": ChevronRight,
+  "chevron.left": ChevronLeft,
+  cpu: Cpu,
+  doc: File,
+  "doc.plaintext": FileText,
+  "doc.text": FileText,
+  ellipsis: Ellipsis,
+  folder: Folder,
+  "folder.fill": FolderOpen,
+  gearshape: Settings,
+  "gearshape.2": MonitorCog,
+  "info.circle": Info,
+  keyboard: Keyboard,
+  "list.bullet.rectangle": List,
+  magnifyingglass: Search,
+  paintpalette: Palette,
+  pin: Pin,
+  "pin.fill": Pin,
+  plus: Plus,
+  "rectangle.bottomthird.inset.filled": PanelBottom,
+  "sidebar.left": PanelLeft,
+  "sidebar.right": PanelRight,
+  sparkles: Sparkles,
+  stethoscope: Activity,
+  "square.and.pencil": SquarePen,
+  "square.split.2x1": SquareSplitHorizontal,
+  "sun.max": Sun,
+  terminal: Terminal,
+  "tray.full": Inbox,
+  "wrench.and.screwdriver": Wrench,
+  xmark: X,
+};
+
+export function SystemIcon({
+  name,
+  size = 16,
+  className,
+  strokeWidth = 2,
+}: {
+  name: SystemIconName;
+  size?: number;
+  className?: string;
+  strokeWidth?: number;
+}) {
+  const Icon = iconBySymbolName[name];
+  return (
+    <Icon
+      className={className}
+      width={size}
+      height={size}
+      aria-hidden="true"
+      focusable="false"
+      strokeWidth={strokeWidth}
+    />
+  );
+}

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -806,10 +806,11 @@ assert.match(appLayout, /from "\.\/editor-area\/editor-tabs"/);
 assert.match(appLayout, /from "\.\/sidebar"/);
 assert.match(appLayout, /from "\.\/notification-popup"/);
 assert.doesNotMatch(appLayout, /SidebarLeftIcon/);
-assert.match(appLayout, /function DockToggleIcon\(\{ className \}: \{ className\?: string \}\)/);
+assert.match(appLayout, /from "\.\/system-icon"/);
+assert.match(appLayout, /<SystemIcon name="sidebar\.left" size=\{18\} \/>/);
 assert.match(appLayout, /function clampRightDockWidth\(width: number, viewportWidth: number, sidebarLayoutWidth: number\)/);
-assert.match(appLayout, /<rect x="2\.25" y="2\.25" width="13\.5" height="13\.5" rx="3\.25" stroke="currentColor" strokeWidth="1\.8" \/>/);
-assert.match(appLayout, /<path d="M6\.75 4\.75V13\.25" stroke="currentColor" strokeWidth="1\.8" strokeLinecap="round" \/>/);
+assert.match(appLayout, /<SystemIcon name="rectangle\.bottomthird\.inset\.filled" size=\{18\} \/>/);
+assert.match(appLayout, /<SystemIcon name="sidebar\.right" size=\{18\} \/>/);
 assert.match(appLayout, /onDismissStatus: \(\) => void;/);
 assert.match(appLayout, /<NotificationPopup notice=\{state\.status\} onDismiss=\{onDismissStatus\} \/>/);
 assert.doesNotMatch(appLayout, /StatusSurface/);
@@ -1363,7 +1364,8 @@ assert.match(styles, /\.tab-shell:focus-within \.tab-close \{[^}]*transform: tra
 assert.match(styles, /\.tab-close:hover \{ color: var\(--text-secondary\); \}/);
 assert.match(closeIcon, /export function CloseIcon/);
 assert.match(closeIcon, /className="close-glyph"/);
-assert.match(closeIcon, /strokeLinecap="round"/);
+assert.match(closeIcon, /from "\.\/system-icon"/);
+assert.match(closeIcon, /name="xmark"/);
 for (const sourceText of [dockPanel, editorTabs, notificationPopup, settingControl]) {
   assert.doesNotMatch(sourceText, /className="(?:tab-close|dock-tab-close|radix-dialog-close)"[\s\S]*?>\s*[x×]\s*<\/button>/);
 }
@@ -2339,8 +2341,9 @@ assert.match(sidebarSurface, /state\.projectsOpen/);
 assert.match(sidebarSurface, /actions\.toggleProjectsOpen/);
 assert.match(sidebarSurface, /actions\.setExpandedProjectIds/);
 assert.match(sidebarSurface, /actions\.openRecentStructure/);
-assert.match(sidebarSurface, /from "@hugeicons\/core-free-icons"/);
-assert.match(sidebarSurface, /from "@hugeicons\/react"/);
+assert.doesNotMatch(sidebarSurface, /from "@hugeicons\/core-free-icons"/);
+assert.doesNotMatch(sidebarSurface, /from "@hugeicons\/react"/);
+assert.match(sidebarSurface, /from "\.\.\/system-icon"/);
 assert.match(sidebarSurface, /actions\.openCommandPalette/);
 assert.doesNotMatch(sidebarFileBrowser, /from "\.\.\/shortcut-tooltip"/);
 assert.doesNotMatch(sidebarFileBrowser, /<ShortcutTooltip label="Search projects and structures" shortcut="⌘P" \/>/);
@@ -3990,11 +3993,6 @@ assert.match(previewViewer, /prepared\?\.kind !== 'sdf-collection' && !prepared\
 assert.match(previewViewer, /await applyDockingSceneVisibility\(activeViewer, prepared, activePose\)/);
 assert.match(previewViewer, /else if \(activeSdfPoseMode === 'all'\) \{/);
 assert.match(previewViewer, /async function applySdfCollectionMolstarStyle\(viewer, style, structures = null, alpha = 1\)/);
-assert.match(previewViewer, /const raw = await plugin\.builders\.data\.rawData\(\{ data, label \}\)/);
-assert.match(previewViewer, /const trajectory = await plugin\.builders\.structure\.parseTrajectory\(raw, 'pdb'\)/);
-assert.match(previewViewer, /const preset = await plugin\.builders\.structure\.hierarchy\.applyPreset\(trajectory, 'default', \{ representationPreset: 'empty' \}\)/);
-assert.match(previewViewer, /const structure = preset\?\.structureProperties \|\| preset\?\.structure \|\| null/);
-assert.match(previewViewer, /return structure \? \[structure\] : \[\]/);
 assert.match(previewViewer, /const backgroundData = sdfCollectionBackgroundPdb\(prepared, activeIndex\)/);
 assert.match(previewViewer, /if \(backgroundData\) \{/);
 assert.match(previewViewer, /const contextStructures = await loadSdfCollectionPdbLayer\(viewer, backgroundData,/);


### PR DESCRIPTION
## Summary
- Add a SystemIcon layer with SF Symbols-style names for the React shell
- Replace remaining generic UI icon fallbacks in dock, sidebar, settings, and open-in-editor menus
- Keep app/product identity icons as real assets while using system symbols for standard controls
- Update UI shell contract tests for the new icon layer

## Verification
- bun run build:web
- bun tests/test-ui-shell-contract.mjs
- git push pre-push ci-fast