### PR TITLE
Support Amber NetCDF trajectory previews

### DIFF
--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -92,6 +92,7 @@ const GRID_ASSET_VERSION = "grid-ui-v138";
 const VIEWER_ASSET_VERSION = "viewer-ui-v66";
 const REPO_ROOT = String(import.meta.env.BURRETE_REPO_ROOT || "");
 const WEB_ASSETS_BASE = fsUrl(`${REPO_ROOT}/PreviewExtension/Web/`);
+const AMBER_NETCDF_EXTENSIONS = new Set(["nc", "ncdf", "netcdf", "ncrst"]);
 const browserDevVirtualTextDocuments = new Map<string, string>();
 
 type ResolvedPreviewVisuals = {
@@ -579,6 +580,17 @@ async function openBrowserDevDocument(
   reloadOptions?: ViewerReloadOptions,
 ): Promise<ViewerDocument> {
   const extension = fileExtension(path);
+  const amberNcPreview = await requestBrowserDevAmberNcPreview(path, extension);
+  if (amberNcPreview) {
+    return openBrowserDevDocumentFromBytes(
+      `${path}.amber-preview.pdb`,
+      "pdb",
+      amberNcPreview.bytes,
+      amberNcPreview.sourceByteCount,
+      preferences,
+      reloadOptions,
+    );
+  }
   const desmondPreview = await requestBrowserDevDesmondPreview(path, extension);
   if (desmondPreview) {
     return openBrowserDevDocumentFromBytes(
@@ -605,6 +617,22 @@ async function openBrowserDevDocument(
 
   const sourceByteCount = browserDevSourceByteCount(response, bytes.length);
   return openBrowserDevDocumentFromBytes(path, extension, bytes, sourceByteCount, preferences, reloadOptions);
+}
+
+async function requestBrowserDevAmberNcPreview(path: string, extension: string) {
+  if (!AMBER_NETCDF_EXTENSIONS.has(extension)) return null;
+  const response = await fetch(`/__burette/trajectory-preview?path=${encodeURIComponent(path)}`);
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    const message = await browserDevJsonError(response).catch(() => response.statusText);
+    throw new Error(`${path}: Amber NetCDF preview failed: ${message || response.statusText}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (!bytes.length) return null;
+  return {
+    bytes,
+    sourceByteCount: browserDevSourceByteCount(response, bytes.length),
+  };
 }
 
 async function requestBrowserDevDesmondPreview(path: string, extension: string) {
@@ -1828,6 +1856,8 @@ async function decodeStructureText(bytes: Uint8Array, extension: string) {
 }
 
 function browserDevSourceByteCount(response: Response, fallback: number) {
+  const sourceByteCount = Number(response.headers.get("x-burrete-source-byte-count"));
+  if (Number.isFinite(sourceByteCount) && sourceByteCount > 0) return sourceByteCount;
   const contentRange = response.headers.get("content-range");
   const total = contentRange?.match(/\/(\d+)$/u)?.[1];
   if (total) {
@@ -1836,6 +1866,11 @@ function browserDevSourceByteCount(response: Response, fallback: number) {
   }
   const contentLength = Number(response.headers.get("content-length"));
   return Number.isFinite(contentLength) && contentLength > 0 ? contentLength : fallback;
+}
+
+async function browserDevJsonError(response: Response) {
+  const payload = await response.json().catch(() => null) as { error?: unknown } | null;
+  return typeof payload?.error === "string" ? payload.error : response.statusText;
 }
 
 function convertedDataFromText(text: string, extension: string, label: string): ConvertedStructureData | null {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "install:plugin": "bun plugins/burette-agent/scripts/install-local.mjs",
     "agent:preview": "bun scripts/agent-preview.mjs",
     "agent": "bun scripts/burrete-agent.mjs",
-    "test:agent": "bun tests/test-burette-agent.mjs && bun tests/test-agent-preview-server.mjs && bun tests/test-burrete-agent-cli.mjs && bun tests/test-burette-agent-plugin.mjs && bun tests/test-burette-agent-mcp.mjs",
+    "test:agent": "bun tests/test-burette-agent.mjs && bun tests/test-agent-preview-server.mjs && bun tests/test-amber-nc-preview.mjs && bun tests/test-burrete-agent-cli.mjs && bun tests/test-burette-agent-plugin.mjs && bun tests/test-burette-agent-mcp.mjs",
     "test:plugin": "bun tests/test-burette-agent-plugin.mjs && bun tests/test-burette-agent-mcp.mjs && npm --prefix plugins/burette-agent run check",
     "test:update": "bun tests/test-update-versioning.mjs && bun tests/test-bun-installer-behavior.mjs && bun tests/test-dev-namespace.mjs && bun tests/test-quicklook-preview-smoke-contract.mjs",
     "test:ui": "bun tests/test-sidebar-projects.mjs && bun tests/test-sidebar-tree-render.mjs && bun tests/test-shell-store-behavior.mjs && bun tests/test-docking-documents.mjs && bun tests/test-dock-file-entries.mjs && bun tests/test-structure-brief.mjs && bun tests/test-browser-dev-maestro-preview.mjs && bun tests/test-ui-shell-contract.mjs && bun tests/test-tauri-listener-tracking.mjs && bun tests/test-text-file-viewer-contract.mjs && bun tests/test-text-structure-selection.mjs && bun tests/test-collection-documents.mjs && bun tests/test-structure-drag.mjs && bun tests/test-drop-actions.mjs && bun tests/test-molecule-store-behavior.mjs && bun tests/test-fep-setup-store.mjs",

--- a/plugins/burette-agent/scripts/agent-preview.mjs
+++ b/plugins/burette-agent/scripts/agent-preview.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { createServer } from 'node:http';
-import { readFile, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
 import { createReadStream, existsSync } from 'node:fs';
-import { basename, extname, join, resolve, normalize } from 'node:path';
+import { basename, dirname, extname, join, resolve, normalize } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -13,8 +15,11 @@ const webRoot = process.env.BURRETE_AGENT_PREVIEW_WEB_ROOT
 const agentControlApiVersion = 'burette-agent-control/v1';
 const renderPanelReadLimit = 512 * 1024;
 const mvsReadLimit = 25 * 1024 * 1024;
+const amberNcPreviewFrameLimit = 100;
 const coordinateArtifactExtensions = new Set(['xml', 'inpcrd', 'rst7', 'restrt', 'crd', 'rst', 'state', 'lammpstrj', 'dump']);
 const textArtifactExtensions = new Set(['par', 'prm', 'rtf', 'str', 'key', 'chk', 'checkpoint']);
+const amberNetcdfExtensions = new Set(['nc', 'ncdf', 'netcdf', 'ncrst']);
+const topologyPreviewExtensions = new Set(['pdb', 'ent', 'pdbqt', 'pqr', 'xpdb']);
 
 function defaultPreviewWebRoot() {
   const pluginPreviewWeb = resolve(repoRoot, 'preview-web');
@@ -61,6 +66,10 @@ function isMaestroPreviewFile(file) {
   return ext === 'cms' || ext === 'mae';
 }
 
+function isAmberNetcdfFile(file) {
+  return amberNetcdfExtensions.has(extname(file).toLowerCase().replace(/^\./, ''));
+}
+
 function preparePreviewPayload(file, bytes) {
   const extension = extname(file).toLowerCase().replace(/^\./, '');
   if (coordinateArtifactExtensions.has(extension)) {
@@ -74,6 +83,92 @@ function preparePreviewPayload(file, bytes) {
   const converted = maestroPdbDataFromText(bytes.toString('utf8'));
   if (!converted) return { bytes, format: inferFormat(file), binary: isBinaryFormat(file) };
   return { bytes: Buffer.from(converted, 'utf8'), format: 'pdb', binary: false };
+}
+
+async function amberNcPreviewPayload(file) {
+  if (!isAmberNetcdfFile(file)) return null;
+  const topology = await findAmberNcTopology(file);
+  if (!topology) {
+    throw new Error(`${file}: Amber NetCDF trajectory requires a matching PDB topology/reference file in the same folder.`);
+  }
+  const tempDir = await mkdtemp(resolve(tmpdir(), 'burrete-amber-nc-preview-'));
+  const outputPath = resolve(tempDir, 'amber-nc-preview.pdb');
+  try {
+    const frameCount = runAmberNcExtractor(topology, file, outputPath);
+    const bytes = await readFile(outputPath);
+    return {
+      bytes,
+      format: 'pdb',
+      binary: false,
+      topologyPath: topology,
+      trajectoryPath: file,
+      trajectoryFrameCount: frameCount || countPdbModels(bytes.toString('utf8')),
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function findAmberNcTopology(trajectoryPath) {
+  const folder = dirname(trajectoryPath);
+  const stem = basename(trajectoryPath).replace(/\.[^.]+$/u, '');
+  const preferred = [
+    'reference.pdb',
+    `${stem}.pdb`,
+    'topology.pdb',
+    'structure.pdb',
+    'system.pdb',
+    'top.pdb',
+  ].map((name) => resolve(folder, name));
+  const entries = await readdir(folder, { withFileTypes: true }).catch(() => []);
+  const discovered = entries
+    .filter((entry) => entry.isFile() && topologyPreviewExtensions.has(extname(entry.name).toLowerCase().replace(/^\./, '')))
+    .map((entry) => resolve(folder, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+  const candidates = Array.from(new Set([...preferred, ...discovered]));
+  const errors = [];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const tempDir = await mkdtemp(resolve(tmpdir(), 'burrete-amber-nc-probe-'));
+    const outputPath = resolve(tempDir, 'probe.pdb');
+    try {
+      runAmberNcExtractor(candidate, trajectoryPath, outputPath);
+      return candidate;
+    } catch (error) {
+      errors.push(`${basename(candidate)}: ${error?.message || String(error)}`);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  if (errors.length) {
+    throw new Error(`${trajectoryPath}: no matching PDB topology found. ${errors.join('; ')}`);
+  }
+  return null;
+}
+
+function runAmberNcExtractor(topologyPath, trajectoryPath, outputPath) {
+  const extractor = resolve(__dirname, 'amber_nc_preview_extract.py');
+  if (!existsSync(extractor)) throw new Error(`Missing Amber NetCDF extractor: ${extractor}`);
+  const result = spawnSync('python3', [
+    extractor,
+    topologyPath,
+    trajectoryPath,
+    '--frames',
+    String(amberNcPreviewFrameLimit),
+    '--output',
+    outputPath,
+  ], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const details = (result.stderr || result.stdout || '').trim();
+    throw new Error(details || `extractor exited with status ${result.status}`);
+  }
+  const match = String(result.stdout || '').match(/frames=(\d+)/u);
+  return match ? Number(match[1]) : 0;
+}
+
+function countPdbModels(text) {
+  return text.match(/^MODEL\b/gmu)?.length ?? 0;
 }
 
 function genericPdbDataFromText(text, extension, label) {
@@ -918,14 +1013,20 @@ async function main() {
   const structurePath = resolve(args.structure);
   const sourceBytes = await readFile(structurePath);
   const st = await stat(structurePath);
-  const preview = preparePreviewPayload(structurePath, sourceBytes);
+  const preview = await amberNcPreviewPayload(structurePath) ?? preparePreviewPayload(structurePath, sourceBytes);
   const extension = extname(structurePath).toLowerCase().replace(/^\./, '');
+  const trajectoryFrameCount = Number(preview.trajectoryFrameCount || 0);
   const config = {
-    label: basename(structurePath),
+    label: preview.topologyPath ? `${basename(structurePath)} + ${basename(preview.topologyPath)}` : basename(structurePath),
     format: preview.format,
     binary: preview.binary,
     byteCount: st.size,
     sourceExtension: extension,
+    sourcePath: structurePath,
+    topologyPath: preview.topologyPath || null,
+    trajectoryPath: preview.trajectoryPath || null,
+    trajectoryControls: trajectoryFrameCount > 1,
+    trajectoryFrameCount,
     textPreview: Boolean(preview.textPreview),
     showPanelControls: true,
     enablePreviewDocks: true,

--- a/plugins/burette-agent/scripts/agent-shell-server.mjs
+++ b/plugins/burette-agent/scripts/agent-shell-server.mjs
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 import { createServer } from 'node:http';
-import { existsSync, watch } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, watch } from 'node:fs';
 import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
-import { basename, extname, join, relative, resolve } from 'node:path';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const TEXT_FILE_READ_LIMIT = 12 * 1024 * 1024;
 const DEV_FILE_SIZE_LIMIT = 75 * 1024 * 1024;
+const AMBER_NC_PREVIEW_FRAME_LIMIT = 100;
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 const STRUCTURE_EXTENSIONS = new Set([
   'pdb', 'ent', 'pdbqt', 'pqr', 'xpdb',
   'cif', 'mmcif', 'mcif', 'bcif', 'mmtf',
   'sdf', 'sd', 'smi', 'smiles', 'csv', 'tsv',
   'mol', 'mol2', 'xyz', 'gro', 'mae', 'maegz', 'cms', 'dtr',
+  'nc', 'ncdf', 'netcdf', 'ncrst',
 ]);
+const AMBER_NC_EXTENSIONS = new Set(['nc', 'ncdf', 'netcdf', 'ncrst']);
+const TOPOLOGY_PREVIEW_EXTENSIONS = new Set(['pdb', 'ent', 'pdbqt', 'pqr', 'xpdb']);
 const TEXT_EXTENSIONS = new Set([
   ...STRUCTURE_EXTENSIONS,
   'md', 'markdown', 'mdx', 'txt', 'log', 'err',
@@ -149,6 +156,10 @@ async function handleRequest(req, res) {
     await handleFileBundle(res, method, url);
     return;
   }
+  if (url.pathname === '/__burette/trajectory-preview') {
+    await handleTrajectoryPreview(res, method, url);
+    return;
+  }
   if (url.pathname === '/__burette/dev-files') {
     await handleDevFiles(res, method, url);
     return;
@@ -283,6 +294,115 @@ async function handleFileBundle(res, method, url) {
     inputPath: filePath,
     attachments: [],
   });
+}
+
+async function handleTrajectoryPreview(res, method, url) {
+  if (method !== 'GET') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+  const filePath = allowedPathFromQuery(url);
+  if (!filePath) {
+    sendJson(res, 400, { error: 'Missing, forbidden, or unsupported path' });
+    return;
+  }
+  if (!AMBER_NC_EXTENSIONS.has(fileExtension(filePath))) {
+    sendJson(res, 404, { error: 'No trajectory preview converter is available for this file type' });
+    return;
+  }
+  try {
+    const preview = await createAmberNcPreview(filePath);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'chemical/x-pdb; charset=us-ascii');
+    res.setHeader('Content-Length', String(preview.bytes.length));
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('X-Burrete-Source-Byte-Count', String(preview.sourceByteCount));
+    res.setHeader('X-Burrete-Trajectory-Topology', preview.topologyPath);
+    res.setHeader('X-Burrete-Trajectory-Frame-Count', String(preview.frameCount));
+    res.end(preview.bytes);
+  } catch (error) {
+    sendJson(res, 400, { error: error?.message || String(error) });
+  }
+}
+
+async function createAmberNcPreview(trajectoryPath) {
+  const trajectoryInfo = await stat(trajectoryPath);
+  const candidates = await amberNcTopologyCandidates(trajectoryPath);
+  const errors = [];
+  for (const topologyPath of candidates) {
+    const outputPath = resolve(sessionDir, `${safeFileStem(basename(trajectoryPath))}.amber-preview.pdb`);
+    try {
+      const frameCount = runAmberNcExtractor(topologyPath, trajectoryPath, outputPath);
+      return {
+        bytes: await readFile(outputPath),
+        topologyPath,
+        frameCount,
+        sourceByteCount: trajectoryInfo.size,
+      };
+    } catch (error) {
+      errors.push(`${basename(topologyPath)}: ${error?.message || String(error)}`);
+    }
+  }
+  const details = errors.length ? ` Tried: ${errors.join('; ')}` : '';
+  throw new Error(`Amber NetCDF trajectory requires a matching PDB topology/reference file in the same folder.${details}`);
+}
+
+async function amberNcTopologyCandidates(trajectoryPath) {
+  const folder = dirname(trajectoryPath);
+  const stem = basename(trajectoryPath).replace(/\.[^.]+$/u, '');
+  const preferredNames = [
+    'reference.pdb',
+    `${stem}.pdb`,
+    'topology.pdb',
+    'structure.pdb',
+    'system.pdb',
+    'top.pdb',
+  ];
+  const preferred = preferredNames.map((name) => resolve(folder, name));
+  const entries = await readdir(folder, { withFileTypes: true }).catch(() => []);
+  const discovered = entries
+    .filter((entry) => entry.isFile() && TOPOLOGY_PREVIEW_EXTENSIONS.has(fileExtension(entry.name)))
+    .map((entry) => resolve(folder, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+  const unique = Array.from(new Set([...preferred, ...discovered]));
+  const candidates = [];
+  for (const candidate of unique) {
+    if (!isAllowed(candidate)) continue;
+    const info = await stat(candidate).catch(() => null);
+    if (info?.isFile()) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function runAmberNcExtractor(topologyPath, trajectoryPath, outputPath) {
+  const extractor = resolve(scriptDir, 'amber_nc_preview_extract.py');
+  if (!existsSync(extractor)) throw new Error(`Missing Amber NetCDF extractor: ${extractor}`);
+  const result = spawnSync('python3', [
+    extractor,
+    topologyPath,
+    trajectoryPath,
+    '--frames',
+    String(AMBER_NC_PREVIEW_FRAME_LIMIT),
+    '--output',
+    outputPath,
+  ], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const details = (result.stderr || result.stdout || '').trim();
+    throw new Error(details || `extractor exited with status ${result.status}`);
+  }
+  const match = String(result.stdout || '').match(/frames=(\d+)/u);
+  return match ? Number(match[1]) : countPdbModelsFromFile(outputPath);
+}
+
+function countPdbModelsFromFile(path) {
+  const text = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const matches = text.match(/^MODEL\b/gmu);
+  return matches?.length ?? 0;
+}
+
+function safeFileStem(value) {
+  return String(value || 'trajectory').replace(/[^A-Za-z0-9._-]+/gu, '_').slice(0, 80) || 'trajectory';
 }
 
 async function handleDevFiles(res, method, url) {

--- a/plugins/burette-agent/scripts/amber_nc_preview_extract.py
+++ b/plugins/burette-agent/scripts/amber_nc_preview_extract.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Extract a bounded multi-model PDB preview from an Amber NetCDF trajectory."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import struct
+import sys
+from pathlib import Path
+
+
+NC_DIMENSION = 10
+NC_VARIABLE = 11
+NC_ATTRIBUTE = 12
+NC_BYTE = 1
+NC_CHAR = 2
+NC_SHORT = 3
+NC_INT = 4
+NC_FLOAT = 5
+NC_DOUBLE = 6
+
+TYPE_INFO = {
+    NC_BYTE: (1, ">b"),
+    NC_CHAR: (1, "c"),
+    NC_SHORT: (2, ">h"),
+    NC_INT: (4, ">i"),
+    NC_FLOAT: (4, ">f"),
+    NC_DOUBLE: (8, ">d"),
+}
+HEADER_READ_LIMIT = 16 * 1024 * 1024
+
+
+class Reader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.offset = 0
+
+    def read(self, size: int) -> bytes:
+        end = self.offset + size
+        if end > len(self.data):
+            raise ValueError("Unexpected end of NetCDF header")
+        value = self.data[self.offset:end]
+        self.offset = end
+        return value
+
+    def u32(self) -> int:
+        return struct.unpack(">I", self.read(4))[0]
+
+    def i64(self) -> int:
+        return struct.unpack(">q", self.read(8))[0]
+
+    def name(self) -> str:
+        size = self.u32()
+        raw = self.read(size)
+        self.align4(size)
+        return raw.decode("utf-8", "replace")
+
+    def align4(self, size: int) -> None:
+        padding = (-size) % 4
+        if padding:
+            self.read(padding)
+
+
+def read_attrs(reader: Reader) -> None:
+    tag = reader.u32()
+    if tag == 0:
+        reader.u32()
+        return
+    if tag != NC_ATTRIBUTE:
+        raise ValueError(f"Unexpected NetCDF attribute tag: {tag}")
+    count = reader.u32()
+    for _ in range(count):
+        reader.name()
+        type_id = reader.u32()
+        nelems = reader.u32()
+        size, _ = TYPE_INFO[type_id]
+        byte_count = size * nelems
+        reader.read(byte_count)
+        reader.align4(byte_count)
+
+
+def parse_header(data: bytes) -> tuple[dict[str, int | None], list[dict[str, object]], int]:
+    reader = Reader(data)
+    magic = reader.read(4)
+    if magic not in (b"CDF\x01", b"CDF\x02"):
+        raise ValueError("Only classic NetCDF/CDF-2 Amber trajectories are supported")
+    is_cdf2 = magic == b"CDF\x02"
+    record_count = reader.u32()
+
+    dim_tag = reader.u32()
+    dimensions: dict[str, int | None] = {}
+    dim_names: list[str] = []
+    if dim_tag == NC_DIMENSION:
+        dim_count = reader.u32()
+        for _ in range(dim_count):
+            name = reader.name()
+            length = reader.u32()
+            dimensions[name] = None if length == 0 else length
+            dim_names.append(name)
+    elif dim_tag != 0:
+        raise ValueError(f"Unexpected NetCDF dimension tag: {dim_tag}")
+    else:
+        reader.u32()
+
+    read_attrs(reader)
+
+    variables: list[dict[str, object]] = []
+    var_tag = reader.u32()
+    if var_tag == NC_VARIABLE:
+        var_count = reader.u32()
+        for _ in range(var_count):
+            name = reader.name()
+            dim_ids = [reader.u32() for _ in range(reader.u32())]
+            read_attrs(reader)
+            type_id = reader.u32()
+            size = reader.u32()
+            begin = reader.i64() if is_cdf2 else reader.u32()
+            variables.append(
+                {
+                    "name": name,
+                    "dim_names": [dim_names[index] for index in dim_ids],
+                    "type_id": type_id,
+                    "size": size,
+                    "begin": begin,
+                }
+            )
+    elif var_tag != 0:
+        raise ValueError(f"Unexpected NetCDF variable tag: {var_tag}")
+
+    return dimensions, variables, record_count
+
+
+def read_header(path: Path) -> tuple[dict[str, int | None], list[dict[str, object]], int]:
+    file_size = path.stat().st_size
+    read_size = min(64 * 1024, file_size)
+    while read_size <= min(file_size, HEADER_READ_LIMIT):
+        with path.open("rb") as handle:
+            data = handle.read(read_size)
+        try:
+            return parse_header(data)
+        except ValueError as error:
+            if "Unexpected end of NetCDF header" not in str(error) or read_size == file_size:
+                raise
+        read_size = min(read_size * 2, file_size)
+    raise ValueError(f"NetCDF header exceeds {HEADER_READ_LIMIT} bytes")
+
+
+def record_size(variables: list[dict[str, object]], dimensions: dict[str, int | None]) -> int:
+    size = 0
+    for variable in variables:
+        dim_names = list(variable["dim_names"])
+        if dim_names and dimensions[dim_names[0]] is None:
+            item_size, _ = TYPE_INFO[int(variable["type_id"])]
+            values = math.prod(int(dimensions[name]) for name in dim_names[1:])
+            byte_count = item_size * values
+            size += byte_count + (-byte_count) % 4
+    return size
+
+
+def coordinate_frame(
+    path: Path,
+    variable: dict[str, object],
+    dimensions: dict[str, int | None],
+    variables: list[dict[str, object]],
+    frame_index: int,
+) -> list[tuple[float, float, float]]:
+    type_id = int(variable["type_id"])
+    item_size, fmt = TYPE_INFO[type_id]
+    dim_names = list(variable["dim_names"])
+    if not dim_names or dimensions[dim_names[0]] is not None:
+        raise ValueError("coordinates must be a NetCDF record variable")
+    tail_shape = [int(dimensions[name]) for name in dim_names[1:]]
+    if len(tail_shape) != 2 or tail_shape[1] != 3:
+        raise ValueError(f"Unsupported coordinates shape: record,{','.join(map(str, tail_shape))}")
+    atom_count = tail_shape[0]
+    values_per_record = atom_count * 3
+    byte_count = values_per_record * item_size
+    stride = record_size(variables, dimensions)
+    if stride <= 0:
+        raise ValueError("NetCDF record size is zero")
+    with path.open("rb") as handle:
+        handle.seek(int(variable["begin"]) + frame_index * stride)
+        raw = handle.read(byte_count)
+    if len(raw) != byte_count:
+        raise ValueError(f"Could not read coordinates for frame {frame_index}")
+    values = [item[0] for item in struct.iter_unpack(fmt, raw)]
+    return [
+        (values[index], values[index + 1], values[index + 2])
+        for index in range(0, len(values), 3)
+    ]
+
+
+def pdb_atom_lines(path: Path) -> list[str]:
+    lines = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith(("ATOM  ", "HETATM")):
+            lines.append(line)
+    if not lines:
+        raise ValueError(f"{path} does not contain ATOM/HETATM records")
+    return lines
+
+
+def replace_coords(line: str, xyz: tuple[float, float, float]) -> str:
+    padded = line.ljust(80)
+    return f"{padded[:30]}{xyz[0]:8.3f}{xyz[1]:8.3f}{xyz[2]:8.3f}{padded[54:]}"
+
+
+def frame_indices(frame_count: int, frame_limit: int) -> list[int]:
+    if frame_count <= frame_limit:
+        return list(range(frame_count))
+    if frame_limit <= 1:
+        return [0]
+    return sorted(
+        set(round(index * (frame_count - 1) / (frame_limit - 1)) for index in range(frame_limit))
+    )
+
+
+def convert(topology: Path, trajectory: Path, output: Path, frame_limit: int) -> int:
+    dimensions, variables, record_count = read_header(trajectory)
+    coord_var = next((var for var in variables if var["name"] == "coordinates"), None)
+    if coord_var is None:
+        raise ValueError("NetCDF trajectory does not contain a coordinates variable")
+    atoms = pdb_atom_lines(topology)
+    atom_dim = int(dimensions[list(coord_var["dim_names"])[1]])
+    if atom_dim != len(atoms):
+        raise ValueError(f"Atom count mismatch: topology has {len(atoms)} atoms, trajectory has {atom_dim}")
+    indices = frame_indices(record_count, frame_limit)
+    with output.open("w", encoding="ascii") as handle:
+        for model_index, frame_index in enumerate(indices, start=1):
+            handle.write(f"MODEL{model_index:9d}\n")
+            frame = coordinate_frame(trajectory, coord_var, dimensions, variables, frame_index)
+            for atom_line, xyz in zip(atoms, frame, strict=True):
+                handle.write(replace_coords(atom_line, xyz))
+                handle.write("\n")
+            handle.write("ENDMDL\n")
+        handle.write("END\n")
+    return len(indices)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("topology", type=Path)
+    parser.add_argument("trajectory", type=Path)
+    parser.add_argument("--frames", type=int, default=100)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    frame_count = convert(args.topology, args.trajectory, args.output, max(1, args.frames))
+    print(f"frames={frame_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/agent-preview.mjs
+++ b/scripts/agent-preview.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { createServer } from 'node:http';
-import { readFile, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
 import { createReadStream, existsSync } from 'node:fs';
-import { basename, extname, join, resolve, normalize } from 'node:path';
+import { basename, dirname, extname, join, resolve, normalize } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -13,8 +15,11 @@ const webRoot = process.env.BURRETE_AGENT_PREVIEW_WEB_ROOT
 const agentControlApiVersion = 'burette-agent-control/v1';
 const renderPanelReadLimit = 512 * 1024;
 const mvsReadLimit = 25 * 1024 * 1024;
+const amberNcPreviewFrameLimit = 100;
 const coordinateArtifactExtensions = new Set(['xml', 'inpcrd', 'rst7', 'restrt', 'crd', 'rst', 'state', 'lammpstrj', 'dump']);
 const textArtifactExtensions = new Set(['par', 'prm', 'rtf', 'str', 'key', 'chk', 'checkpoint']);
+const amberNetcdfExtensions = new Set(['nc', 'ncdf', 'netcdf', 'ncrst']);
+const topologyPreviewExtensions = new Set(['pdb', 'ent', 'pdbqt', 'pqr', 'xpdb']);
 
 function defaultPreviewWebRoot() {
   const pluginPreviewWeb = resolve(repoRoot, 'preview-web');
@@ -61,6 +66,10 @@ function isMaestroPreviewFile(file) {
   return ext === 'cms' || ext === 'mae';
 }
 
+function isAmberNetcdfFile(file) {
+  return amberNetcdfExtensions.has(extname(file).toLowerCase().replace(/^\./, ''));
+}
+
 function preparePreviewPayload(file, bytes) {
   const extension = extname(file).toLowerCase().replace(/^\./, '');
   if (coordinateArtifactExtensions.has(extension)) {
@@ -74,6 +83,92 @@ function preparePreviewPayload(file, bytes) {
   const converted = maestroPdbDataFromText(bytes.toString('utf8'));
   if (!converted) return { bytes, format: inferFormat(file), binary: isBinaryFormat(file) };
   return { bytes: Buffer.from(converted, 'utf8'), format: 'pdb', binary: false };
+}
+
+async function amberNcPreviewPayload(file) {
+  if (!isAmberNetcdfFile(file)) return null;
+  const topology = await findAmberNcTopology(file);
+  if (!topology) {
+    throw new Error(`${file}: Amber NetCDF trajectory requires a matching PDB topology/reference file in the same folder.`);
+  }
+  const tempDir = await mkdtemp(resolve(tmpdir(), 'burrete-amber-nc-preview-'));
+  const outputPath = resolve(tempDir, 'amber-nc-preview.pdb');
+  try {
+    const frameCount = runAmberNcExtractor(topology, file, outputPath);
+    const bytes = await readFile(outputPath);
+    return {
+      bytes,
+      format: 'pdb',
+      binary: false,
+      topologyPath: topology,
+      trajectoryPath: file,
+      trajectoryFrameCount: frameCount || countPdbModels(bytes.toString('utf8')),
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function findAmberNcTopology(trajectoryPath) {
+  const folder = dirname(trajectoryPath);
+  const stem = basename(trajectoryPath).replace(/\.[^.]+$/u, '');
+  const preferred = [
+    'reference.pdb',
+    `${stem}.pdb`,
+    'topology.pdb',
+    'structure.pdb',
+    'system.pdb',
+    'top.pdb',
+  ].map((name) => resolve(folder, name));
+  const entries = await readdir(folder, { withFileTypes: true }).catch(() => []);
+  const discovered = entries
+    .filter((entry) => entry.isFile() && topologyPreviewExtensions.has(extname(entry.name).toLowerCase().replace(/^\./, '')))
+    .map((entry) => resolve(folder, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+  const candidates = Array.from(new Set([...preferred, ...discovered]));
+  const errors = [];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const tempDir = await mkdtemp(resolve(tmpdir(), 'burrete-amber-nc-probe-'));
+    const outputPath = resolve(tempDir, 'probe.pdb');
+    try {
+      runAmberNcExtractor(candidate, trajectoryPath, outputPath);
+      return candidate;
+    } catch (error) {
+      errors.push(`${basename(candidate)}: ${error?.message || String(error)}`);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  if (errors.length) {
+    throw new Error(`${trajectoryPath}: no matching PDB topology found. ${errors.join('; ')}`);
+  }
+  return null;
+}
+
+function runAmberNcExtractor(topologyPath, trajectoryPath, outputPath) {
+  const extractor = resolve(__dirname, 'amber_nc_preview_extract.py');
+  if (!existsSync(extractor)) throw new Error(`Missing Amber NetCDF extractor: ${extractor}`);
+  const result = spawnSync('python3', [
+    extractor,
+    topologyPath,
+    trajectoryPath,
+    '--frames',
+    String(amberNcPreviewFrameLimit),
+    '--output',
+    outputPath,
+  ], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const details = (result.stderr || result.stdout || '').trim();
+    throw new Error(details || `extractor exited with status ${result.status}`);
+  }
+  const match = String(result.stdout || '').match(/frames=(\d+)/u);
+  return match ? Number(match[1]) : 0;
+}
+
+function countPdbModels(text) {
+  return text.match(/^MODEL\b/gmu)?.length ?? 0;
 }
 
 function genericPdbDataFromText(text, extension, label) {
@@ -918,14 +1013,20 @@ async function main() {
   const structurePath = resolve(args.structure);
   const sourceBytes = await readFile(structurePath);
   const st = await stat(structurePath);
-  const preview = preparePreviewPayload(structurePath, sourceBytes);
+  const preview = await amberNcPreviewPayload(structurePath) ?? preparePreviewPayload(structurePath, sourceBytes);
   const extension = extname(structurePath).toLowerCase().replace(/^\./, '');
+  const trajectoryFrameCount = Number(preview.trajectoryFrameCount || 0);
   const config = {
-    label: basename(structurePath),
+    label: preview.topologyPath ? `${basename(structurePath)} + ${basename(preview.topologyPath)}` : basename(structurePath),
     format: preview.format,
     binary: preview.binary,
     byteCount: st.size,
     sourceExtension: extension,
+    sourcePath: structurePath,
+    topologyPath: preview.topologyPath || null,
+    trajectoryPath: preview.trajectoryPath || null,
+    trajectoryControls: trajectoryFrameCount > 1,
+    trajectoryFrameCount,
     textPreview: Boolean(preview.textPreview),
     showPanelControls: true,
     enablePreviewDocks: true,

--- a/scripts/agent-shell-server.mjs
+++ b/scripts/agent-shell-server.mjs
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 import { createServer } from 'node:http';
-import { existsSync, watch } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, watch } from 'node:fs';
 import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
-import { basename, extname, join, relative, resolve } from 'node:path';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const TEXT_FILE_READ_LIMIT = 12 * 1024 * 1024;
 const DEV_FILE_SIZE_LIMIT = 75 * 1024 * 1024;
+const AMBER_NC_PREVIEW_FRAME_LIMIT = 100;
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 const STRUCTURE_EXTENSIONS = new Set([
   'pdb', 'ent', 'pdbqt', 'pqr', 'xpdb',
   'cif', 'mmcif', 'mcif', 'bcif', 'mmtf',
   'sdf', 'sd', 'smi', 'smiles', 'csv', 'tsv',
   'mol', 'mol2', 'xyz', 'gro', 'mae', 'maegz', 'cms', 'dtr',
+  'nc', 'ncdf', 'netcdf', 'ncrst',
 ]);
+const AMBER_NC_EXTENSIONS = new Set(['nc', 'ncdf', 'netcdf', 'ncrst']);
+const TOPOLOGY_PREVIEW_EXTENSIONS = new Set(['pdb', 'ent', 'pdbqt', 'pqr', 'xpdb']);
 const TEXT_EXTENSIONS = new Set([
   ...STRUCTURE_EXTENSIONS,
   'md', 'markdown', 'mdx', 'txt', 'log', 'err',
@@ -149,6 +156,10 @@ async function handleRequest(req, res) {
     await handleFileBundle(res, method, url);
     return;
   }
+  if (url.pathname === '/__burette/trajectory-preview') {
+    await handleTrajectoryPreview(res, method, url);
+    return;
+  }
   if (url.pathname === '/__burette/dev-files') {
     await handleDevFiles(res, method, url);
     return;
@@ -283,6 +294,115 @@ async function handleFileBundle(res, method, url) {
     inputPath: filePath,
     attachments: [],
   });
+}
+
+async function handleTrajectoryPreview(res, method, url) {
+  if (method !== 'GET') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+  const filePath = allowedPathFromQuery(url);
+  if (!filePath) {
+    sendJson(res, 400, { error: 'Missing, forbidden, or unsupported path' });
+    return;
+  }
+  if (!AMBER_NC_EXTENSIONS.has(fileExtension(filePath))) {
+    sendJson(res, 404, { error: 'No trajectory preview converter is available for this file type' });
+    return;
+  }
+  try {
+    const preview = await createAmberNcPreview(filePath);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'chemical/x-pdb; charset=us-ascii');
+    res.setHeader('Content-Length', String(preview.bytes.length));
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('X-Burrete-Source-Byte-Count', String(preview.sourceByteCount));
+    res.setHeader('X-Burrete-Trajectory-Topology', preview.topologyPath);
+    res.setHeader('X-Burrete-Trajectory-Frame-Count', String(preview.frameCount));
+    res.end(preview.bytes);
+  } catch (error) {
+    sendJson(res, 400, { error: error?.message || String(error) });
+  }
+}
+
+async function createAmberNcPreview(trajectoryPath) {
+  const trajectoryInfo = await stat(trajectoryPath);
+  const candidates = await amberNcTopologyCandidates(trajectoryPath);
+  const errors = [];
+  for (const topologyPath of candidates) {
+    const outputPath = resolve(sessionDir, `${safeFileStem(basename(trajectoryPath))}.amber-preview.pdb`);
+    try {
+      const frameCount = runAmberNcExtractor(topologyPath, trajectoryPath, outputPath);
+      return {
+        bytes: await readFile(outputPath),
+        topologyPath,
+        frameCount,
+        sourceByteCount: trajectoryInfo.size,
+      };
+    } catch (error) {
+      errors.push(`${basename(topologyPath)}: ${error?.message || String(error)}`);
+    }
+  }
+  const details = errors.length ? ` Tried: ${errors.join('; ')}` : '';
+  throw new Error(`Amber NetCDF trajectory requires a matching PDB topology/reference file in the same folder.${details}`);
+}
+
+async function amberNcTopologyCandidates(trajectoryPath) {
+  const folder = dirname(trajectoryPath);
+  const stem = basename(trajectoryPath).replace(/\.[^.]+$/u, '');
+  const preferredNames = [
+    'reference.pdb',
+    `${stem}.pdb`,
+    'topology.pdb',
+    'structure.pdb',
+    'system.pdb',
+    'top.pdb',
+  ];
+  const preferred = preferredNames.map((name) => resolve(folder, name));
+  const entries = await readdir(folder, { withFileTypes: true }).catch(() => []);
+  const discovered = entries
+    .filter((entry) => entry.isFile() && TOPOLOGY_PREVIEW_EXTENSIONS.has(fileExtension(entry.name)))
+    .map((entry) => resolve(folder, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+  const unique = Array.from(new Set([...preferred, ...discovered]));
+  const candidates = [];
+  for (const candidate of unique) {
+    if (!isAllowed(candidate)) continue;
+    const info = await stat(candidate).catch(() => null);
+    if (info?.isFile()) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function runAmberNcExtractor(topologyPath, trajectoryPath, outputPath) {
+  const extractor = resolve(scriptDir, 'amber_nc_preview_extract.py');
+  if (!existsSync(extractor)) throw new Error(`Missing Amber NetCDF extractor: ${extractor}`);
+  const result = spawnSync('python3', [
+    extractor,
+    topologyPath,
+    trajectoryPath,
+    '--frames',
+    String(AMBER_NC_PREVIEW_FRAME_LIMIT),
+    '--output',
+    outputPath,
+  ], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const details = (result.stderr || result.stdout || '').trim();
+    throw new Error(details || `extractor exited with status ${result.status}`);
+  }
+  const match = String(result.stdout || '').match(/frames=(\d+)/u);
+  return match ? Number(match[1]) : countPdbModelsFromFile(outputPath);
+}
+
+function countPdbModelsFromFile(path) {
+  const text = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const matches = text.match(/^MODEL\b/gmu);
+  return matches?.length ?? 0;
+}
+
+function safeFileStem(value) {
+  return String(value || 'trajectory').replace(/[^A-Za-z0-9._-]+/gu, '_').slice(0, 80) || 'trajectory';
 }
 
 async function handleDevFiles(res, method, url) {

--- a/scripts/amber_nc_preview_extract.py
+++ b/scripts/amber_nc_preview_extract.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Extract a bounded multi-model PDB preview from an Amber NetCDF trajectory."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import struct
+import sys
+from pathlib import Path
+
+
+NC_DIMENSION = 10
+NC_VARIABLE = 11
+NC_ATTRIBUTE = 12
+NC_BYTE = 1
+NC_CHAR = 2
+NC_SHORT = 3
+NC_INT = 4
+NC_FLOAT = 5
+NC_DOUBLE = 6
+
+TYPE_INFO = {
+    NC_BYTE: (1, ">b"),
+    NC_CHAR: (1, "c"),
+    NC_SHORT: (2, ">h"),
+    NC_INT: (4, ">i"),
+    NC_FLOAT: (4, ">f"),
+    NC_DOUBLE: (8, ">d"),
+}
+HEADER_READ_LIMIT = 16 * 1024 * 1024
+
+
+class Reader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.offset = 0
+
+    def read(self, size: int) -> bytes:
+        end = self.offset + size
+        if end > len(self.data):
+            raise ValueError("Unexpected end of NetCDF header")
+        value = self.data[self.offset:end]
+        self.offset = end
+        return value
+
+    def u32(self) -> int:
+        return struct.unpack(">I", self.read(4))[0]
+
+    def i64(self) -> int:
+        return struct.unpack(">q", self.read(8))[0]
+
+    def name(self) -> str:
+        size = self.u32()
+        raw = self.read(size)
+        self.align4(size)
+        return raw.decode("utf-8", "replace")
+
+    def align4(self, size: int) -> None:
+        padding = (-size) % 4
+        if padding:
+            self.read(padding)
+
+
+def read_attrs(reader: Reader) -> None:
+    tag = reader.u32()
+    if tag == 0:
+        reader.u32()
+        return
+    if tag != NC_ATTRIBUTE:
+        raise ValueError(f"Unexpected NetCDF attribute tag: {tag}")
+    count = reader.u32()
+    for _ in range(count):
+        reader.name()
+        type_id = reader.u32()
+        nelems = reader.u32()
+        size, _ = TYPE_INFO[type_id]
+        byte_count = size * nelems
+        reader.read(byte_count)
+        reader.align4(byte_count)
+
+
+def parse_header(data: bytes) -> tuple[dict[str, int | None], list[dict[str, object]], int]:
+    reader = Reader(data)
+    magic = reader.read(4)
+    if magic not in (b"CDF\x01", b"CDF\x02"):
+        raise ValueError("Only classic NetCDF/CDF-2 Amber trajectories are supported")
+    is_cdf2 = magic == b"CDF\x02"
+    record_count = reader.u32()
+
+    dim_tag = reader.u32()
+    dimensions: dict[str, int | None] = {}
+    dim_names: list[str] = []
+    if dim_tag == NC_DIMENSION:
+        dim_count = reader.u32()
+        for _ in range(dim_count):
+            name = reader.name()
+            length = reader.u32()
+            dimensions[name] = None if length == 0 else length
+            dim_names.append(name)
+    elif dim_tag != 0:
+        raise ValueError(f"Unexpected NetCDF dimension tag: {dim_tag}")
+    else:
+        reader.u32()
+
+    read_attrs(reader)
+
+    variables: list[dict[str, object]] = []
+    var_tag = reader.u32()
+    if var_tag == NC_VARIABLE:
+        var_count = reader.u32()
+        for _ in range(var_count):
+            name = reader.name()
+            dim_ids = [reader.u32() for _ in range(reader.u32())]
+            read_attrs(reader)
+            type_id = reader.u32()
+            size = reader.u32()
+            begin = reader.i64() if is_cdf2 else reader.u32()
+            variables.append(
+                {
+                    "name": name,
+                    "dim_names": [dim_names[index] for index in dim_ids],
+                    "type_id": type_id,
+                    "size": size,
+                    "begin": begin,
+                }
+            )
+    elif var_tag != 0:
+        raise ValueError(f"Unexpected NetCDF variable tag: {var_tag}")
+
+    return dimensions, variables, record_count
+
+
+def read_header(path: Path) -> tuple[dict[str, int | None], list[dict[str, object]], int]:
+    file_size = path.stat().st_size
+    read_size = min(64 * 1024, file_size)
+    while read_size <= min(file_size, HEADER_READ_LIMIT):
+        with path.open("rb") as handle:
+            data = handle.read(read_size)
+        try:
+            return parse_header(data)
+        except ValueError as error:
+            if "Unexpected end of NetCDF header" not in str(error) or read_size == file_size:
+                raise
+        read_size = min(read_size * 2, file_size)
+    raise ValueError(f"NetCDF header exceeds {HEADER_READ_LIMIT} bytes")
+
+
+def record_size(variables: list[dict[str, object]], dimensions: dict[str, int | None]) -> int:
+    size = 0
+    for variable in variables:
+        dim_names = list(variable["dim_names"])
+        if dim_names and dimensions[dim_names[0]] is None:
+            item_size, _ = TYPE_INFO[int(variable["type_id"])]
+            values = math.prod(int(dimensions[name]) for name in dim_names[1:])
+            byte_count = item_size * values
+            size += byte_count + (-byte_count) % 4
+    return size
+
+
+def coordinate_frame(
+    path: Path,
+    variable: dict[str, object],
+    dimensions: dict[str, int | None],
+    variables: list[dict[str, object]],
+    frame_index: int,
+) -> list[tuple[float, float, float]]:
+    type_id = int(variable["type_id"])
+    item_size, fmt = TYPE_INFO[type_id]
+    dim_names = list(variable["dim_names"])
+    if not dim_names or dimensions[dim_names[0]] is not None:
+        raise ValueError("coordinates must be a NetCDF record variable")
+    tail_shape = [int(dimensions[name]) for name in dim_names[1:]]
+    if len(tail_shape) != 2 or tail_shape[1] != 3:
+        raise ValueError(f"Unsupported coordinates shape: record,{','.join(map(str, tail_shape))}")
+    atom_count = tail_shape[0]
+    values_per_record = atom_count * 3
+    byte_count = values_per_record * item_size
+    stride = record_size(variables, dimensions)
+    if stride <= 0:
+        raise ValueError("NetCDF record size is zero")
+    with path.open("rb") as handle:
+        handle.seek(int(variable["begin"]) + frame_index * stride)
+        raw = handle.read(byte_count)
+    if len(raw) != byte_count:
+        raise ValueError(f"Could not read coordinates for frame {frame_index}")
+    values = [item[0] for item in struct.iter_unpack(fmt, raw)]
+    return [
+        (values[index], values[index + 1], values[index + 2])
+        for index in range(0, len(values), 3)
+    ]
+
+
+def pdb_atom_lines(path: Path) -> list[str]:
+    lines = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith(("ATOM  ", "HETATM")):
+            lines.append(line)
+    if not lines:
+        raise ValueError(f"{path} does not contain ATOM/HETATM records")
+    return lines
+
+
+def replace_coords(line: str, xyz: tuple[float, float, float]) -> str:
+    padded = line.ljust(80)
+    return f"{padded[:30]}{xyz[0]:8.3f}{xyz[1]:8.3f}{xyz[2]:8.3f}{padded[54:]}"
+
+
+def frame_indices(frame_count: int, frame_limit: int) -> list[int]:
+    if frame_count <= frame_limit:
+        return list(range(frame_count))
+    if frame_limit <= 1:
+        return [0]
+    return sorted(
+        set(round(index * (frame_count - 1) / (frame_limit - 1)) for index in range(frame_limit))
+    )
+
+
+def convert(topology: Path, trajectory: Path, output: Path, frame_limit: int) -> int:
+    dimensions, variables, record_count = read_header(trajectory)
+    coord_var = next((var for var in variables if var["name"] == "coordinates"), None)
+    if coord_var is None:
+        raise ValueError("NetCDF trajectory does not contain a coordinates variable")
+    atoms = pdb_atom_lines(topology)
+    atom_dim = int(dimensions[list(coord_var["dim_names"])[1]])
+    if atom_dim != len(atoms):
+        raise ValueError(f"Atom count mismatch: topology has {len(atoms)} atoms, trajectory has {atom_dim}")
+    indices = frame_indices(record_count, frame_limit)
+    with output.open("w", encoding="ascii") as handle:
+        for model_index, frame_index in enumerate(indices, start=1):
+            handle.write(f"MODEL{model_index:9d}\n")
+            frame = coordinate_frame(trajectory, coord_var, dimensions, variables, frame_index)
+            for atom_line, xyz in zip(atoms, frame, strict=True):
+                handle.write(replace_coords(atom_line, xyz))
+                handle.write("\n")
+            handle.write("ENDMDL\n")
+        handle.write("END\n")
+    return len(indices)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("topology", type=Path)
+    parser.add_argument("trajectory", type=Path)
+    parser.add_argument("--frames", type=int, default=100)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    frame_count = convert(args.topology, args.trajectory, args.output, max(1, args.frames))
+    print(f"frames={frame_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/build-agent-shell-plugin.mjs
+++ b/scripts/build-agent-shell-plugin.mjs
@@ -10,6 +10,7 @@ const pluginRoot = resolve(repoRoot, 'plugins/burette-agent');
 const shellDist = resolve(pluginRoot, 'browser-shell-dist');
 const previewWeb = resolve(pluginRoot, 'preview-web');
 const runtimeScripts = [
+  'amber_nc_preview_extract.py',
   'agent-preview.mjs',
   'agent-shell-server.mjs',
   'burrete-agent.mjs',

--- a/tests/test-amber-nc-preview.mjs
+++ b/tests/test-amber-nc-preview.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { createServer, request } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const NC_DIMENSION = 10;
+const NC_VARIABLE = 11;
+const NC_FLOAT = 5;
+
+async function freePort() {
+  const server = createServer();
+  await new Promise(resolveReady => server.listen(0, '127.0.0.1', resolveReady));
+  const port = server.address().port;
+  await new Promise(resolveClose => server.close(resolveClose));
+  return port;
+}
+
+function requestBuffer(url) {
+  return new Promise((resolveRequest, rejectRequest) => {
+    const req = request(url, res => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolveRequest({
+        statusCode: res.statusCode,
+        headers: res.headers,
+        body: Buffer.concat(chunks),
+      }));
+    });
+    req.on('error', rejectRequest);
+    req.end();
+  });
+}
+
+function u32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value);
+  return buffer;
+}
+
+function paddedName(value) {
+  const bytes = Buffer.from(value, 'utf8');
+  return Buffer.concat([u32(bytes.length), bytes, Buffer.alloc((4 - (bytes.length % 4)) % 4)]);
+}
+
+function emptyList() {
+  return Buffer.concat([u32(0), u32(0)]);
+}
+
+function amberNetcdfBytes() {
+  const variableSize = 2 * 3 * 4;
+  const buildHeader = begin => Buffer.concat([
+    Buffer.from('CDF\x01', 'binary'),
+    u32(2),
+    u32(NC_DIMENSION),
+    u32(3),
+    paddedName('frame'),
+    u32(0),
+    paddedName('atom'),
+    u32(2),
+    paddedName('spatial'),
+    u32(3),
+    emptyList(),
+    u32(NC_VARIABLE),
+    u32(1),
+    paddedName('coordinates'),
+    u32(3),
+    u32(0),
+    u32(1),
+    u32(2),
+    emptyList(),
+    u32(NC_FLOAT),
+    u32(variableSize),
+    u32(begin),
+  ]);
+  const placeholder = buildHeader(0);
+  const header = buildHeader(placeholder.length);
+  assert.equal(header.length, placeholder.length);
+
+  const data = Buffer.alloc(variableSize * 2);
+  [
+    1, 2, 3,
+    4, 5, 6,
+    7, 8, 9,
+    10, 11, 12,
+  ].forEach((value, index) => data.writeFloatBE(value, index * 4));
+  return Buffer.concat([header, data]);
+}
+
+async function waitForHealth(port, child, log) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (child.exitCode != null) break;
+    try {
+      const response = await requestBuffer(`http://127.0.0.1:${port}/healthz`);
+      if (response.statusCode === 200) return;
+    } catch {}
+    await new Promise(resolveWait => setTimeout(resolveWait, 25));
+  }
+  throw new Error(`agent shell server did not become ready. stdout=${log.stdout} stderr=${log.stderr}`);
+}
+
+const tempDir = await mkdtemp(join(tmpdir(), 'burrete-amber-nc-test-'));
+const topologyPath = join(tempDir, 'reference.pdb');
+const trajectoryPath = join(tempDir, 'trajectory.nc');
+const outputPath = join(tempDir, 'preview.pdb');
+const distDir = join(tempDir, 'dist');
+const sessionDir = join(tempDir, 'session');
+
+try {
+  await writeFile(topologyPath, [
+    'ATOM      1  N   GLY A   1       0.000   0.000   0.000  1.00  0.00           N  ',
+    'ATOM      2  CA  GLY A   1       0.000   0.000   0.000  1.00  0.00           C  ',
+    'END',
+    '',
+  ].join('\n'));
+  await writeFile(trajectoryPath, amberNetcdfBytes());
+
+  const extracted = spawnSync('python3', [
+    'scripts/amber_nc_preview_extract.py',
+    topologyPath,
+    trajectoryPath,
+    '--frames',
+    '2',
+    '--output',
+    outputPath,
+  ], { encoding: 'utf8' });
+  assert.equal(extracted.status, 0, extracted.stderr || extracted.stdout);
+  assert.match(extracted.stdout, /frames=2/);
+  const pdb = await readFile(outputPath, 'utf8');
+  assert.match(pdb, /^MODEL\s+1$/m);
+  assert.match(pdb, /^MODEL\s+2$/m);
+  assert.match(pdb, /  1\.000   2\.000   3\.000/);
+  assert.match(pdb, / 10\.000  11\.000  12\.000/);
+
+  await mkdir(distDir);
+  await writeFile(join(distDir, 'index.html'), '<!doctype html><title>Burrete</title>');
+  const port = await freePort();
+  const log = { stdout: '', stderr: '' };
+  const child = spawn(process.execPath, [
+    'scripts/agent-shell-server.mjs',
+    '--dist',
+    distDir,
+    '--session-dir',
+    sessionDir,
+    '--allow',
+    tempDir,
+    '--host',
+    '127.0.0.1',
+    '--port',
+    String(port),
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  child.stdout.on('data', chunk => { log.stdout += chunk.toString('utf8'); });
+  child.stderr.on('data', chunk => { log.stderr += chunk.toString('utf8'); });
+  try {
+    await waitForHealth(port, child, log);
+    const url = new URL(`http://127.0.0.1:${port}/__burette/trajectory-preview`);
+    url.searchParams.set('path', trajectoryPath);
+    const response = await requestBuffer(url);
+    assert.equal(response.statusCode, 200, response.body.toString('utf8'));
+    assert.equal(response.headers['x-burrete-trajectory-topology'], topologyPath);
+    assert.equal(response.headers['x-burrete-trajectory-frame-count'], '2');
+    assert.equal(response.headers['x-burrete-source-byte-count'], String((await stat(trajectoryPath)).size));
+    const routedPdb = response.body.toString('utf8');
+    assert.match(routedPdb, /^MODEL\s+1$/m);
+    assert.match(routedPdb, /^MODEL\s+2$/m);
+  } finally {
+    child.kill('SIGTERM');
+  }
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}
+
+console.log('Amber NetCDF preview tests passed');


### PR DESCRIPTION
## Summary
- Add a bounded Amber NetCDF-to-PDB preview extractor with automatic same-folder PDB topology/reference discovery.
- Route `.nc`, `.ncdf`, `.netcdf`, and `.ncrst` through the converter in both browser-preview and browser-agent-shell flows.
- Include the extractor in the packaged Burrete agent plugin and add a generated Amber NetCDF contract test.

## Verification
- `bun run test:agent`
- `bun run test:ui`
- `bun run check:js`
- `git diff --check`
- `node --check scripts/agent-shell-server.mjs scripts/agent-preview.mjs` plus plugin script checks
- Real sample smoke: `/Users/nikolenko/Desktop/QuickPCA-main/data/trajectory.nc` opens via `reference.pdb`, produces 100 PDB models through `/__burette/trajectory-preview`, and browser-preview config reports `trajectoryControls=true` / `trajectoryFrameCount=100`.
- Pre-push hook: `scripts/ci-fast.sh` passed.

## Notes
- `vp check` was not used as the final validator because it reports broad existing formatting issues across generated/plugin-dist assets; the repo-owned `ci-fast` path passed.
