### PR TITLE
Fix xyzrender orientation refs for numeric XYZ atoms

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3103,10 +3103,26 @@
   }
 
   function normalizeElementSymbol(value) {
+    const atomicNumber = Number.parseInt(String(value || '').trim(), 10);
+    if (Number.isFinite(atomicNumber) && String(atomicNumber) === String(value || '').trim()) {
+      return ATOMIC_SYMBOLS[atomicNumber - 1] || 'X';
+    }
     const match = String(value || 'X').trim().match(/[A-Za-z]{1,3}/u);
     if (!match) return 'X';
     return match[0].slice(0, 1).toUpperCase() + match[0].slice(1).toLowerCase();
   }
+
+  const ATOMIC_SYMBOLS = [
+    'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
+    'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca',
+    'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn',
+    'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr',
+    'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn',
+    'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd',
+    'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb',
+    'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg',
+    'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn'
+  ];
 
   function readCameraSnapshot(viewer) {
     const camera = viewer?.plugin?.canvas3d?.camera;


### PR DESCRIPTION
## Summary
- Convert numeric XYZ atom tokens to element symbols when building Mol* orientation reference files for xyzrender.
- Prevent browser/app xyzr switching from passing `X` pseudo-atoms to `xyzrender --ref` for valid XYZ files like buckyball.xyz.

## Root cause
The XYZ preview could load files whose atom labels are atomic numbers, but the orientation-reference builder normalized numeric labels to `X`. The external renderer then rejected the generated `orientation-ref.xyz` even though the original file rendered correctly.

## Validation
- Live browser-dev check on `/Users/nikolenko/Desktop/BurettePreviewSamples/structures/buckyball.xyz`: switching to `xyzr` now renders an External xyzrender SVG and opens the xyzr dock controls.
- `bun tests/test-ui-shell-contract.mjs`
- pre-push `ci-fast` hook