### PR TITLE
Unify Molstar toolbar controls

### DIFF
--- a/.github/blob-size-allowlist.txt
+++ b/.github/blob-size-allowlist.txt
@@ -1,7 +1,9 @@
 # Paths are matched exactly, relative to the repository root.
 # Keep this list short and limited to intentional large checked-in assets.
 PreviewExtension/Web/molstar.js
+PreviewExtension/Web/viewer.js
 PreviewExtension/Web/rdkit/RDKit_minimal.wasm
+plugins/burette-agent/preview-web/viewer.js
 docs/public/burrete-quick-look-preview.png
 samples/large/moses_10k.csv
 samples/large/moses_10k_descriptors_preview.csv

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -529,8 +529,8 @@ body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
-  width: 33px;
-  margin-left: -3px;
+  width: 36px;
+  margin-left: -5px;
   padding: 0;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
@@ -572,8 +572,8 @@ body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;
   box-sizing: border-box;
-  width: 33px !important;
-  min-width: 33px !important;
+  width: 36px !important;
+  min-width: 36px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -524,6 +524,7 @@ body .msp-plugin .msp-viewport-controls {
   z-index: 40;
 }
 body .msp-plugin .msp-viewport-controls-buttons {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
@@ -565,17 +566,23 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   border-radius: 0;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
+  display: grid !important;
+  place-items: center;
+  box-sizing: border-box;
   width: 30px !important;
   min-width: 30px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;
   border-radius: 8px;
+  padding: 0 !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
   box-shadow: none;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
+  font: 400 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  line-height: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -11,7 +11,7 @@
   --buret-toolbar-border: rgba(255, 255, 255, 0.10);
   --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
   --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-  --buret-viewport-controls-top: 64px;
+  --buret-viewport-controls-top: calc(var(--buret-toolbar-safe-top) + 42px);
   --buret-viewport-panel-max-height: calc(100vh - 96px);
   --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
   --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
@@ -465,27 +465,49 @@ body .msp-plugin .msp-viewport-controls {
   top: var(--buret-viewport-controls-top) !important;
   z-index: 40;
 }
-body .msp-plugin .msp-viewport-controls-buttons > div {
-  overflow: hidden;
+body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 4px;
-  border: 1px solid var(--buret-toolbar-border);
+  gap: 8px;
+  transform-origin: top center;
+  transition: opacity 150ms ease, transform 170ms cubic-bezier(0.22, 1, 0.36, 1), visibility 0s linear 0s;
+}
+body.buret-toolbar-collapsed .msp-plugin .msp-viewport-controls-buttons {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transition-delay: 0s, 0s, 150ms;
+}
+body .msp-plugin .msp-viewport-controls-buttons > div {
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+body .msp-plugin .msp-viewport-controls-buttons > div > div {
+  overflow: visible;
+  border-radius: 0;
+}
+body .msp-plugin .msp-viewport-controls-buttons button {
+  width: 40px !important;
+  min-width: 40px !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
   background: var(--buret-toolbar-background) !important;
   box-shadow: 0 8px 20px var(--buret-molstar-shadow);
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
-}
-body .msp-plugin .msp-viewport-controls-buttons > div > div {
-  overflow: hidden;
-  border-radius: 8px;
-}
-body .msp-plugin .msp-viewport-controls-buttons button {
-  border-radius: 8px;
-  color: var(--buret-toolbar-color) !important;
-  background: transparent !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {
@@ -1551,17 +1573,17 @@ body.burette-mobile-host .msp-plugin .msp-viewport-controls {
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons > div,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls > div:first-child {
-  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
-  border-radius: 18px !important;
-  background: rgba(28, 28, 30, 0.70) !important;
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
-  -webkit-backdrop-filter: blur(32px) saturate(1.6);
-  backdrop-filter: blur(32px) saturate(1.6);
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons > div,
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-animation-viewport-controls > div:first-child {
-  border-color: rgba(0, 0, 0, 0.10) !important;
-  background: rgba(246, 246, 242, 0.76) !important;
+  border-color: transparent !important;
+  background: transparent !important;
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls button,
@@ -1571,6 +1593,17 @@ body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
   min-height: 44px !important;
   border-radius: 14px !important;
   font-size: 16px !important;
+}
+body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
+  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
+  background: rgba(28, 28, 30, 0.70) !important;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
+  -webkit-backdrop-filter: blur(32px) saturate(1.6);
+  backdrop-filter: blur(32px) saturate(1.6);
+}
+body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
+  border-color: rgba(0, 0, 0, 0.10) !important;
+  background: rgba(246, 246, 242, 0.76) !important;
 }
 body.burette-mobile-host .msp-plugin .msp-control-group-header,
 body.burette-mobile-host .msp-plugin .msp-control-group-header > button,

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -910,10 +910,17 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   transform: translate(-50%, -4px) scale(0.98);
   transform-origin: top center;
   transition: opacity 110ms ease-out, transform 130ms ease-out, visibility 0s linear 110ms;
+}
+#buret-toolbar .buret-tooltip {
+  right: 0;
+  left: auto;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top right;
 }
 .buret-button:hover > .buret-tooltip,
 .buret-button:focus-visible > .buret-tooltip,
@@ -927,6 +934,14 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   visibility: visible;
   transform: translate(-50%, 0) scale(1);
   transition-delay: 180ms, 180ms, 0s;
+}
+#buret-toolbar .buret-button:hover > .buret-tooltip,
+#buret-toolbar .buret-button:focus-visible > .buret-tooltip,
+#buret-toolbar .buret-molstar-style-slot:hover > .buret-tooltip,
+#buret-toolbar .buret-molstar-style-slot:focus-within > .buret-tooltip,
+#buret-toolbar .buret-xyzrender-preset-slot:hover > .buret-tooltip,
+#buret-toolbar .buret-xyzrender-preset-slot:focus-within > .buret-tooltip {
+  transform: translateY(0) scale(1);
 }
 .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
 .buret-molstar-tooltip {

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -355,30 +355,33 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   overflow: hidden;
-  border: 1px solid var(--buret-molstar-border) !important;
-  border-radius: 10px;
-  color: var(--buret-molstar-text) !important;
-  background: var(--buret-molstar-panel-background) !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
   box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
-  border-left: 1px solid var(--buret-molstar-border) !important;
-  color: var(--buret-molstar-text) !important;
-  background: var(--buret-molstar-row-background) !important;
+  border-left: 1px solid var(--buret-toolbar-border) !important;
+  color: var(--buret-toolbar-color) !important;
+  background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
   border-left: 0 !important;
 }
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
-  color: var(--buret-molstar-text) !important;
+  border-radius: 8px;
+  color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls button:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn-link-toggle-on {
-  color: var(--buret-molstar-accent) !important;
-  background: var(--buret-molstar-hover-background) !important;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-hover) !important;
   outline: 0 !important;
 }
 body .msp-plugin .msp-semi-transparent-background {
@@ -442,14 +445,30 @@ body .msp-plugin .msp-viewport-controls {
 }
 body .msp-plugin .msp-viewport-controls-buttons > div {
   overflow: hidden;
-  border: 1px solid var(--buret-molstar-border);
-  border-radius: 8px;
-  background: var(--buret-molstar-row-background) !important;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--buret-toolbar-border);
+  border-radius: 12px;
+  background: var(--buret-toolbar-background) !important;
   box-shadow: 0 8px 20px var(--buret-molstar-shadow);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+body .msp-plugin .msp-viewport-controls-buttons > div > div {
+  overflow: hidden;
+  border-radius: 8px;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
-  color: var(--buret-molstar-text) !important;
+  border-radius: 8px;
+  color: var(--buret-toolbar-color) !important;
   background: transparent !important;
+}
+body .msp-plugin .msp-viewport-controls-buttons button:hover,
+body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-hover) !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button[disabled] {
   color: var(--buret-molstar-muted-text) !important;
@@ -924,6 +943,34 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 .buret-button svg { width: 17px; height: 17px; display: block; }
 .buret-pose-toggle { width: auto; min-width: 34px; }
 .buret-grip { width: 30px; padding: 0; cursor: grab; color: currentColor; opacity: 0.66; }
+.buret-molstar-lasso.active {
+  background: var(--buret-toolbar-hover);
+  box-shadow: inset 0 0 0 1px var(--buret-toolbar-border);
+}
+body.buret-molstar-lasso-active .msp-plugin canvas {
+  cursor: crosshair;
+}
+.buret-molstar-lasso-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483645;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+}
+.buret-molstar-lasso-overlay polygon {
+  fill: color-mix(in srgb, var(--buret-molstar-accent, #af52de) 18%, transparent);
+  stroke: none;
+}
+.buret-molstar-lasso-overlay polyline {
+  fill: none;
+  stroke: color-mix(in srgb, var(--buret-molstar-accent, #af52de) 88%, white);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.36));
+}
 .buret-generate-3d-control {
   position: absolute;
   top: var(--buret-viewport-controls-top);

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -893,7 +893,11 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 }
 #buret-toolbar.collapsed .buret-grip,
 #buret-toolbar.buret-suppressed-by-molstar-panel .buret-grip {
-  min-width: 30px;
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  border-radius: 12px;
   cursor: pointer;
   background: var(--buret-toolbar-background);
   border: 1px solid var(--buret-toolbar-border);
@@ -1585,7 +1589,6 @@ body.buret-theme-light.burette-mobile-host .msp-plugin .msp-animation-viewport-c
   border-color: transparent !important;
   background: transparent !important;
 }
-body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls button,
 body.burette-mobile-host .msp-plugin .msp-btn-icon,
 body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
@@ -1595,15 +1598,23 @@ body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
   font-size: 16px !important;
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
-  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
-  background: rgba(28, 28, 30, 0.70) !important;
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
-  -webkit-backdrop-filter: blur(32px) saturate(1.6);
-  backdrop-filter: blur(32px) saturate(1.6);
+  width: 40px !important;
+  min-width: 40px !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px !important;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
 }
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
-  border-color: rgba(0, 0, 0, 0.10) !important;
-  background: rgba(246, 246, 242, 0.76) !important;
+  border-color: var(--buret-toolbar-border) !important;
+  background: var(--buret-toolbar-background) !important;
 }
 body.burette-mobile-host .msp-plugin .msp-control-group-header,
 body.burette-mobile-host .msp-plugin .msp-control-group-header > button,

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -378,12 +378,12 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
-  position: absolute !important;
+  position: fixed !important;
   top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
-  right: var(--buret-control-island-right) !important;
-  left: auto !important;
-  width: auto !important;
-  max-width: calc(100vw - (var(--buret-control-island-right) * 2)) !important;
+  right: auto !important;
+  left: var(--buret-selection-controls-left, var(--buret-control-island-right)) !important;
+  width: min(var(--buret-selection-controls-width, 430px), var(--buret-selection-controls-max-width, calc(100vw - 24px))) !important;
+  max-width: var(--buret-selection-controls-max-width, calc(100vw - (var(--buret-control-island-right) * 2))) !important;
   margin: 0 !important;
   z-index: 2147483645 !important;
 }
@@ -396,6 +396,8 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   display: inline-flex !important;
   align-items: center;
   gap: var(--buret-control-island-gap);
+  width: 100%;
+  box-sizing: border-box;
   min-height: 0;
   max-width: 100%;
   overflow-x: auto;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -400,6 +400,7 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   box-sizing: border-box;
   min-height: 0;
   max-width: 100%;
+  margin-top: 0 !important;
   overflow-x: auto;
   overflow-y: hidden;
   padding: 6px;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -528,7 +528,9 @@ body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
-  padding: 6px;
+  width: 33px;
+  margin-left: -3px;
+  padding: 0;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
@@ -569,8 +571,8 @@ body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;
   box-sizing: border-box;
-  width: 30px !important;
-  min-width: 30px !important;
+  width: 33px !important;
+  min-width: 33px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -283,6 +283,9 @@ body .msp-plugin .msp-control-row-label .msp-help {
   background-color: var(--buret-molstar-field-background) !important;
   border-color: var(--buret-molstar-border) !important;
 }
+body .msp-plugin .msp-control-row-label .msp-help.msp-btn-link {
+  background-color: transparent !important;
+}
 body .msp-plugin .msp-control-row > span.msp-control-row-label,
 body .msp-plugin .msp-control-row > button.msp-control-button-label,
 body .msp-plugin .msp-control-group-header > button,
@@ -332,11 +335,30 @@ body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row {
   border-top: 1px solid var(--buret-molstar-border) !important;
   background: var(--buret-molstar-row-background) !important;
+  opacity: 1 !important;
+}
+body .msp-plugin .msp-control-row > span.msp-control-row-label,
+body .msp-plugin .msp-control-row > span.msp-control-row-label *,
+body .msp-plugin .msp-viewport-controls-panel .msp-control-row > span.msp-control-row-label,
+body .msp-plugin .msp-viewport-controls-panel .msp-control-row > span.msp-control-row-label * {
+  color: var(--buret-molstar-text) !important;
+  opacity: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div,
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div.msp-control-row-text,
 body .msp-plugin .msp-viewport-controls-panel .msp-control-current {
   background: var(--buret-molstar-field-background) !important;
+}
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row {
+  opacity: 1 !important;
+}
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label,
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label .msp-help,
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label .msp-btn-link {
+  color: var(--buret-molstar-text) !important;
+  -webkit-text-fill-color: var(--buret-molstar-text) !important;
+  font-weight: 500 !important;
+  opacity: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text,
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text div,

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -575,6 +575,9 @@ body .msp-plugin .msp-viewport-controls-buttons .msp-viewport-controls-panel {
 body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-spacer {
   right: 36px !important;
 }
+body .msp-plugin .msp-viewport-controls-buttons > div:nth-of-type(3) > button:first-of-type {
+  display: none !important;
+}
 body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -375,15 +375,25 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text i,
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
+body .msp-plugin .msp-selection-viewport-controls {
+  top: var(--buret-toolbar-safe-top) !important;
+  right: calc(18px + var(--buret-toolbar-current-width, 0px)) !important;
+  left: auto !important;
+  max-width: calc(100vw - var(--buret-toolbar-current-width, 0px) - 36px) !important;
+}
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+  min-height: 40px;
+  max-width: 100%;
   overflow: hidden;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
   background: var(--buret-toolbar-background) !important;
-  box-shadow: 0 12px 28px var(--buret-molstar-shadow);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
   border-left: 1px solid var(--buret-toolbar-border) !important;
@@ -395,9 +405,19 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-chil
 }
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
+  min-width: 40px !important;
+  min-height: 38px !important;
   border-radius: 8px;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
+}
+body .msp-plugin .msp-selection-viewport-controls select {
+  max-width: min(220px, 28vw) !important;
+  min-height: 38px !important;
+  border: 0 !important;
+  color: var(--buret-toolbar-color) !important;
+  background: transparent !important;
+  text-overflow: ellipsis;
 }
 body .msp-plugin .msp-selection-viewport-controls button:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -376,15 +376,23 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
-  top: var(--buret-toolbar-safe-top) !important;
-  right: calc(18px + var(--buret-toolbar-current-width, 0px)) !important;
+  top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
+  right: 12px !important;
   left: auto !important;
-  max-width: calc(100vw - var(--buret-toolbar-current-width, 0px) - 36px) !important;
+  max-width: calc(100vw - 24px) !important;
+  z-index: 2147483645 !important;
+}
+body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   min-height: 40px;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
@@ -394,6 +402,9 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
+}
+body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrollbar {
+  display: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
   border-left: 1px solid var(--buret-toolbar-border) !important;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -11,6 +11,8 @@
   --buret-toolbar-border: rgba(255, 255, 255, 0.10);
   --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
   --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+  --buret-control-island-right: 12px;
+  --buret-control-island-gap: 6px;
   --buret-viewport-controls-top: calc(var(--buret-toolbar-safe-top) + 42px);
   --buret-viewport-panel-max-height: calc(100vh - 96px);
   --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
@@ -376,10 +378,13 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
+  position: absolute !important;
   top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
-  right: 12px !important;
+  right: var(--buret-control-island-right) !important;
   left: auto !important;
-  max-width: calc(100vw - 24px) !important;
+  width: auto !important;
+  max-width: calc(100vw - (var(--buret-control-island-right) * 2)) !important;
+  margin: 0 !important;
   z-index: 2147483645 !important;
 }
 body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
@@ -388,10 +393,14 @@ body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
   pointer-events: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
-  min-height: 40px;
+  display: inline-flex !important;
+  align-items: center;
+  gap: var(--buret-control-island-gap);
+  min-height: 0;
   max-width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
+  padding: 6px;
   scrollbar-width: none;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
@@ -407,25 +416,32 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrol
   display: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
-  border-left: 1px solid var(--buret-toolbar-border) !important;
+  flex: 0 0 auto;
+  border-left: 0 !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
-body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
-  border-left: 0 !important;
-}
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
-  min-width: 40px !important;
-  min-height: 38px !important;
+  width: auto !important;
+  min-width: 30px !important;
+  height: 30px !important;
+  min-height: 30px !important;
   border-radius: 8px;
+  padding: 0 7px !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls select {
-  max-width: min(220px, 28vw) !important;
-  min-height: 38px !important;
+  flex: 0 1 auto !important;
+  width: auto !important;
+  min-width: 96px !important;
+  max-width: min(180px, 28vw) !important;
+  height: 30px !important;
+  min-height: 30px !important;
   border: 0 !important;
+  border-radius: 8px;
+  padding: 0 9px !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
   text-overflow: ellipsis;
@@ -862,8 +878,8 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   background: rgba(255, 255, 255, 0.20);
 }
 #buret-toolbar {
-  position: absolute; top: var(--buret-toolbar-safe-top); right: 12px; left: auto; z-index: 2147483646;
-  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - 24px); gap: 6px; padding: 6px;
+  position: absolute; top: var(--buret-toolbar-safe-top); right: var(--buret-control-island-right); left: auto; z-index: 2147483646;
+  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 6px;
   border: 1px solid var(--buret-toolbar-border);
   border-radius: 12px; color: var(--buret-toolbar-color);
   background: var(--buret-toolbar-background);

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -568,6 +568,13 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   overflow: visible;
   border-radius: 0;
 }
+body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-body,
+body .msp-plugin .msp-viewport-controls-buttons .msp-viewport-controls-panel {
+  right: 40px !important;
+}
+body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-spacer {
+  right: 36px !important;
+}
 body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -414,6 +414,15 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
+body.buret-selection-toolbar-open #buret-toolbar {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+body.buret-selection-toolbar-open .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.22);
+}
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrollbar {
   display: none;
 }

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -517,7 +517,17 @@ body .msp-plugin .msp-viewport-controls {
 body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--buret-control-island-gap);
+  padding: 6px;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   transform-origin: top center;
   transition: opacity 150ms ease, transform 170ms cubic-bezier(0.22, 1, 0.36, 1), visibility 0s linear 0s;
 }
@@ -532,7 +542,7 @@ body .msp-plugin .msp-viewport-controls-buttons > div {
   overflow: visible;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--buret-control-island-gap);
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -546,17 +556,17 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   border-radius: 0;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
-  width: 40px !important;
-  min-width: 40px !important;
-  height: 40px !important;
-  min-height: 40px !important;
-  border: 1px solid var(--buret-toolbar-border) !important;
-  border-radius: 12px;
+  width: 30px !important;
+  min-width: 30px !important;
+  height: 30px !important;
+  min-height: 30px !important;
+  border: 0 !important;
+  border-radius: 8px;
   color: var(--buret-toolbar-color) !important;
-  background: var(--buret-toolbar-background) !important;
-  box-shadow: 0 8px 20px var(--buret-molstar-shadow);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -24,6 +24,10 @@
             <select class="buret-select" data-buret-molstar-style aria-label="Mol* preview style" title="Mol* preview style"></select>
             <span class="buret-tooltip" role="tooltip">Choose Mol* representation style</span>
           </div>
+          <button class="buret-button buret-molstar-lasso" type="button" data-buret-action="molstar-lasso" aria-label="Lasso select" aria-pressed="false" title="Lasso select">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.2 5.6c2.3-2 6.6-2.4 10.2-.8 3.5 1.6 5.4 4.6 4.5 7.3-.8 2.5-3.7 4.2-7.3 4.2-1.5 0-3-.3-4.3-.9l-2.6 3.2c-.4.5-1.2.2-1.2-.4l.2-4.1C2.5 12 2.6 7.8 5.2 5.6Zm1.3 1.5c-1.8 1.5-1.7 4.4.2 5.8.2.1.3.4.3.7l-.1 1.8 1.6-1.9c.3-.3.7-.4 1-.2 1 .6 2 .9 3.1.9 2.8 0 4.9-1.2 5.4-2.7.5-1.6-.8-3.6-3.5-4.8-2.9-1.3-6.4-1.1-8 .4Z" fill="currentColor"/></svg>
+            <span class="buret-tooltip" role="tooltip">Lasso select visible residues</span>
+          </button>
           <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light<span class="buret-tooltip" role="tooltip">Switch to light theme</span></button>
           <button class="buret-button buret-save-modified hidden" type="button" data-buret-action="save-modified-structure" aria-label="Save modified structure" title="Save modified structure">Save<span class="buret-tooltip" role="tooltip">Save modified Mol* structure</span></button>
           <button class="buret-button hidden" type="button" data-buret-action="ketcher" aria-label="Open in Ketcher" title="Open in Ketcher">Ketcher<span class="buret-tooltip" role="tooltip">Open this structure in Ketcher</span></button>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3526,6 +3526,23 @@
     scheduleViewerResize(viewer, 40);
   }
 
+  function activateToolbarGrip(toolbar, viewer) {
+    if (toolbar.classList.contains('buret-suppressed-by-molstar-panel')) {
+      toolbar.dataset.molstarPanelSuppressOverride = '1';
+      toolbar.classList.remove('buret-suppressed-by-molstar-panel');
+      if (toolbar.classList.contains('collapsed')) {
+        setToolbarCollapsed(toolbar, false, viewer);
+      } else {
+        toolbar.dataset.defaultPosition = '1';
+        repositionToolbar(toolbar);
+        updateFloatingLayoutOffsets();
+        scheduleViewerResize(viewer, 40);
+      }
+      return;
+    }
+    setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), viewer);
+  }
+
   function initToolbarDrag(toolbar) {
     if (toolbar.dataset.dragBound === '1') return;
     toolbar.dataset.dragBound = '1';
@@ -3559,7 +3576,7 @@
         ignoreNextGripClick = false;
         return;
       }
-      setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
+      activateToolbarGrip(toolbar, resizeState.viewer);
     });
     toolbar.addEventListener('pointerdown', event => {
       if (event.target.closest('[data-buret-toggle]')) return;
@@ -3603,7 +3620,7 @@
       drag = null;
       if (shouldToggle) {
         ignoreNextGripClick = true;
-        setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
+        activateToolbarGrip(toolbar, resizeState.viewer);
       } else if (shouldSavePosition) {
         ignoreNextGripClick = startedOnHandle;
         toolbar.dataset.defaultPosition = '0';
@@ -3790,7 +3807,10 @@
       document.body?.classList.toggle('buret-molstar-selection-controls-open', selectionOpen);
       const toolbar = document.getElementById('buret-toolbar');
       if (toolbar) {
-        toolbar.classList.toggle('buret-suppressed-by-molstar-panel', suppressToolbar);
+        if (!suppressToolbar) {
+          delete toolbar.dataset.molstarPanelSuppressOverride;
+        }
+        toolbar.classList.toggle('buret-suppressed-by-molstar-panel', suppressToolbar && toolbar.dataset.molstarPanelSuppressOverride !== '1');
         if (toolbar.dataset.defaultPosition === '1') {
           requestAnimationFrame(() => applyDefaultToolbarPosition(toolbar));
         }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3727,6 +3727,9 @@
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
     root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
     root.style.setProperty('--buret-toolbar-current-height', toolbarRect ? Math.ceil(toolbarRect.height) + 'px' : '0px');
+    root.style.setProperty('--buret-selection-controls-left', toolbarRect ? Math.ceil(toolbarRect.left) + 'px' : `${TOOLBAR_MARGIN}px`);
+    root.style.setProperty('--buret-selection-controls-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : 'min(430px, calc(100vw - 24px))');
+    root.style.setProperty('--buret-selection-controls-max-width', toolbarRect ? Math.max(180, Math.floor(window.innerWidth - toolbarRect.left - TOOLBAR_MARGIN)) + 'px' : 'calc(100vw - 24px)');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3507,6 +3507,7 @@
   function setToolbarCollapsed(toolbar, collapsed, viewer, persist = true) {
     if (collapsed) setXyzrenderPopoverVisibility(toolbar, false);
     toolbar.classList.toggle('collapsed', collapsed);
+    document.body?.classList.toggle('buret-toolbar-collapsed', collapsed);
     const grip = toolbar.querySelector('[data-drag-handle]');
     if (grip) {
       grip.setAttribute('aria-expanded', collapsed ? 'false' : 'true');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3725,6 +3725,7 @@
     const panelState = refreshMolstarViewportPanelState();
     const toolbar = document.getElementById('buret-toolbar');
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
+    root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
@@ -3803,7 +3804,7 @@
     if (panelOpen !== molstarViewportPanelOpen || selectionOpen !== molstarSelectionControlsOpen) {
       molstarViewportPanelOpen = panelOpen;
       molstarSelectionControlsOpen = selectionOpen;
-      const suppressToolbar = panelOpen || selectionOpen;
+      const suppressToolbar = panelOpen;
       document.body?.classList.toggle('buret-molstar-viewport-panel-open', panelOpen);
       document.body?.classList.toggle('buret-molstar-selection-controls-open', selectionOpen);
       const toolbar = document.getElementById('buret-toolbar');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -17,6 +17,10 @@
   const MOLSTAR_TOUCH_CONTEXT_MENU_MOVE_THRESHOLD_PX = 12;
   const MOLSTAR_TOUCH_PICK_RADIUS_PX = 18;
   const MOLSTAR_TOUCH_PICK_STEP_PX = 6;
+  const MOLSTAR_LASSO_MIN_POINTS = 4;
+  const MOLSTAR_LASSO_MIN_DISTANCE_PX = 3;
+  const MOLSTAR_LASSO_SAMPLE_STEP_PX = 8;
+  const MOLSTAR_LASSO_SAMPLE_LIMIT = 4500;
   const MOLSTAR_PREVIEW_RDKIT_SVG_SIZE = 260;
   const MOLSTAR_STANDALONE_PREVIEW_MAX_ATOMS = 300;
   const MOLSTAR_EDIT_HISTORY_LIMIT = 20;
@@ -99,6 +103,11 @@
   let molstarSelectionPreviewCleanup = null;
   let molstarContextMenuPick = null;
   let molstarContextMenuMode = 'molecule';
+  let molstarLassoEnabled = false;
+  let molstarLassoStroke = null;
+  let molstarLassoOverlay = null;
+  let molstarSelectionPreserveClick = null;
+  let molstarLassoSuppressClickUntil = 0;
   let molstarMoleculePreview = null;
   let molstarMoleculePreviewFrame = 0;
   let molstarMoleculePreviewDrag = null;
@@ -1373,6 +1382,7 @@
     const generate3dButton = document.querySelector('[data-buret-action="generate-3d-conformer"]');
     const generate3dMenu = document.querySelector('[data-buret-generate-3d-menu]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+    const lassoButton = toolbar.querySelector('[data-buret-action="molstar-lasso"]');
     control.classList.toggle('visible', canSwitchRenderer);
     const molstarStyleSlot = toolbar.querySelector('[data-buret-molstar-style-slot]');
     const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
@@ -1381,6 +1391,11 @@
       populateMolstarStyleSelect(molstarStyleSelect);
       molstarStyleSelect.value = configuredMolstarStyle(config);
       molstarStyleSelect.disabled = renderer !== 'molstar';
+    }
+    lassoButton?.classList.toggle('hidden', renderer !== 'molstar');
+    if (lassoButton) {
+      lassoButton.disabled = renderer !== 'molstar';
+      lassoButton.setAttribute('aria-hidden', renderer === 'molstar' ? 'false' : 'true');
     }
     const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
     presetSlot?.classList.remove('visible');
@@ -2258,9 +2273,12 @@
     const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
     const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+    const lassoButton = toolbar.querySelector('[data-buret-action="molstar-lasso"]');
     const external = normalized === 'xyzrender-external';
     molstarStyleSlot?.classList.toggle('visible', !external);
     if (molstarStyleSelect) molstarStyleSelect.disabled = external;
+    lassoButton?.classList.toggle('hidden', external);
+    if (lassoButton) lassoButton.disabled = external;
     presetSlot?.classList.toggle('visible', external);
     if (preset) preset.disabled = !external;
     tuneButton?.classList.toggle('hidden', !external);
@@ -3218,6 +3236,10 @@
     bindSaveModifiedStructureButton(toolbar);
     installMolstarEditUndoShortcuts();
     bindMolstarStyleControls(toolbar);
+    bindMolstarLassoButton(toolbar);
+    bindMolstarLassoKeyboardButton(toolbar);
+    installMolstarLassoSelection();
+    installMolstarToolbarActionDelegates();
     bindXyzrenderControls(toolbar);
     const sdfPoseButton = toolbar.querySelector('[data-buret-action="sdf-poses"]');
     if (sdfPoseButton && sdfPoseButton.dataset.bound !== '1') {
@@ -3342,6 +3364,70 @@
       select.addEventListener('change', () => requestMolstarStyle(select.value));
     }
     toolbar.dataset.molstarStyleBound = '1';
+  }
+
+  function bindMolstarLassoButton(toolbar) {
+    const button = toolbar?.querySelector('[data-buret-action="molstar-lasso"]');
+    if (!button || button.dataset.bound === '1') return;
+    button.dataset.bound = '1';
+    updateMolstarLassoButton();
+  }
+
+  function installMolstarToolbarActionDelegates() {
+    if (window.__buretteMolstarToolbarActionDelegatesInstalled) return;
+    window.__buretteMolstarToolbarActionDelegatesInstalled = true;
+    document.addEventListener('pointerdown', event => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target || event.button !== 0) return;
+      const lassoButton = target.closest('[data-buret-action="molstar-lasso"]');
+      if (lassoButton) {
+        molstarLassoSuppressClickUntil = Date.now() + 500;
+        event.preventDefault();
+        event.stopPropagation();
+        setMolstarLassoEnabled(!molstarLassoEnabled);
+        return;
+      }
+    }, true);
+    document.addEventListener('click', event => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target) return;
+      if (target.closest('[data-buret-action="molstar-lasso"]') && Date.now() < molstarLassoSuppressClickUntil) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }, true);
+  }
+
+  function bindMolstarLassoKeyboardButton(toolbar) {
+    const button = toolbar?.querySelector('[data-buret-action="molstar-lasso"]');
+    if (!button || button.dataset.keyboardBound === '1') return;
+    button.dataset.keyboardBound = '1';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (Date.now() < molstarLassoSuppressClickUntil) return;
+      setMolstarLassoEnabled(!molstarLassoEnabled);
+    });
+  }
+
+  function updateMolstarLassoButton() {
+    const button = document.querySelector('#buret-toolbar [data-buret-action="molstar-lasso"]');
+    if (!button) return;
+    button.classList.toggle('active', molstarLassoEnabled);
+    button.setAttribute('aria-pressed', molstarLassoEnabled ? 'true' : 'false');
+    const label = molstarLassoEnabled ? 'Exit lasso select' : 'Lasso select';
+    button.setAttribute('aria-label', label);
+    button.setAttribute('title', label);
+    setTooltipLabel(button, molstarLassoEnabled ? 'Drag over visible residues to select' : 'Lasso select visible residues');
+  }
+
+  function setMolstarLassoEnabled(enabled) {
+    const next = enabled === true;
+    molstarLassoEnabled = next;
+    if (!next) cancelMolstarLassoStroke();
+    document.body?.classList.toggle('buret-molstar-lasso-active', molstarLassoEnabled);
+    updateMolstarLassoButton();
+    setStatus(molstarLassoEnabled ? '[web] Lasso selection enabled.' : '[web] Lasso selection disabled.');
   }
 
   function bindXyzrenderControls(toolbar) {
@@ -8503,6 +8589,22 @@
     return target.closest('canvas') || target.closest('.msp-plugin')?.querySelector('canvas') || null;
   }
 
+  function molstarPickFromCanvasPoint(canvas, clientX, clientY) {
+    const canvas3d = activeViewer?.plugin?.canvas3d;
+    if (!canvas || !canvas3d || typeof canvas3d.identify !== 'function' || typeof canvas3d.getLoci !== 'function') return null;
+    const rect = canvas.getBoundingClientRect();
+    if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) return null;
+    try {
+      const picking = canvas3d.identify([clientX - rect.left, clientY - rect.top]);
+      const pick = picking?.id ? canvas3d.getLoci(picking.id) : null;
+      if (!pick?.loci || molstarLociIsEmpty(pick.loci)) return null;
+      return { ...pick, position: picking.position };
+    } catch (error) {
+      debug('Mol* canvas pick failed: ' + (error?.message || String(error)));
+      return null;
+    }
+  }
+
   function molstarContextPickFromEvent(event, options = {}) {
     const canvas3d = activeViewer?.plugin?.canvas3d;
     if (!canvas3d || typeof canvas3d.identify !== 'function' || typeof canvas3d.getLoci !== 'function') return null;
@@ -8532,10 +8634,9 @@
         const x = event.clientX + dx;
         const y = event.clientY + dy;
         if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) continue;
-        const picking = canvas3d.identify([x - rect.left, y - rect.top]);
-        const pick = picking?.id ? canvas3d.getLoci(picking.id) : null;
+        const pick = molstarPickFromCanvasPoint(canvas, x, y);
         if (!pick?.loci || molstarLociIsEmpty(pick.loci)) continue;
-        return { ...pick, position: picking.position, touchAdjusted: dx !== 0 || dy !== 0 };
+        return { ...pick, touchAdjusted: dx !== 0 || dy !== 0 };
       }
       return null;
     } catch (error) {
@@ -8552,6 +8653,281 @@
     return molstarContextEventIsTouch(event)
       ? { radiusPx: MOLSTAR_TOUCH_PICK_RADIUS_PX, stepPx: MOLSTAR_TOUCH_PICK_STEP_PX }
       : {};
+  }
+
+  function installMolstarLassoSelection() {
+    if (window.__buretteMolstarLassoSelectionInstalled) return;
+    window.__buretteMolstarLassoSelectionInstalled = true;
+    document.addEventListener('pointerdown', onMolstarLassoPointerDown, true);
+    document.addEventListener('pointermove', onMolstarLassoPointerMove, true);
+    document.addEventListener('pointerup', onMolstarLassoPointerUp, true);
+    document.addEventListener('pointercancel', onMolstarLassoPointerCancel, true);
+    document.addEventListener('keydown', onMolstarLassoKeyDown, true);
+    window.addEventListener('resize', cancelMolstarLassoStroke);
+  }
+
+  function onMolstarLassoKeyDown(event) {
+    if (event.key !== 'Escape') return;
+    if (molstarLassoStroke) {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelMolstarLassoStroke();
+      setStatus('[web] Lasso selection canceled.');
+      return;
+    }
+    if (molstarLassoEnabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      setMolstarLassoEnabled(false);
+    }
+  }
+
+  function onMolstarLassoPointerDown(event) {
+    if (!molstarLassoEnabled || event.button !== 0 || !isMolstarContextMenuTarget(event.target)) return;
+    const canvas = molstarContextCanvasFromEvent(event);
+    if (!canvas) return;
+    hideMolstarContextMenu();
+    hideMolstarMoleculePreview();
+    molstarLassoStroke = {
+      pointerId: event.pointerId,
+      canvas,
+      additive: event.shiftKey || event.metaKey || event.ctrlKey,
+      dragging: false,
+      points: [{ x: event.clientX, y: event.clientY }]
+    };
+    try { canvas.setPointerCapture?.(event.pointerId); } catch (_) {}
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerMove(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    const last = stroke.points[stroke.points.length - 1];
+    if (Math.hypot(event.clientX - last.x, event.clientY - last.y) >= MOLSTAR_LASSO_MIN_DISTANCE_PX) {
+      if (!stroke.dragging) {
+        stroke.dragging = true;
+        hideMolstarContextMenu();
+        hideMolstarMoleculePreview();
+        ensureMolstarLassoOverlay();
+        try { stroke.canvas.setPointerCapture?.(event.pointerId); } catch (_) {}
+      }
+      stroke.points.push({ x: event.clientX, y: event.clientY });
+      updateMolstarLassoOverlay(stroke.points);
+    }
+    if (!stroke.dragging) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerUp(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    if (!stroke.dragging) {
+      molstarLassoStroke = null;
+      return;
+    }
+    if (Math.hypot(event.clientX - stroke.points[0].x, event.clientY - stroke.points[0].y) >= MOLSTAR_LASSO_MIN_DISTANCE_PX) {
+      stroke.points.push({ x: event.clientX, y: event.clientY });
+    }
+    finishMolstarLassoStroke(stroke);
+    try { stroke.canvas.releasePointerCapture?.(event.pointerId); } catch (_) {}
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerCancel(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    cancelMolstarLassoStroke();
+    if (!stroke.dragging) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function ensureMolstarLassoOverlay() {
+    if (molstarLassoOverlay) return molstarLassoOverlay;
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('buret-molstar-lasso-overlay');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.innerHTML = '<polygon data-buret-lasso-fill></polygon><polyline data-buret-lasso-line></polyline>';
+    document.body.appendChild(svg);
+    molstarLassoOverlay = svg;
+    return svg;
+  }
+
+  function updateMolstarLassoOverlay(points) {
+    const overlay = ensureMolstarLassoOverlay();
+    const value = points.map(point => `${Math.round(point.x)},${Math.round(point.y)}`).join(' ');
+    overlay.querySelector('[data-buret-lasso-fill]')?.setAttribute('points', value);
+    overlay.querySelector('[data-buret-lasso-line]')?.setAttribute('points', value);
+  }
+
+  function removeMolstarLassoOverlay() {
+    molstarLassoOverlay?.remove();
+    molstarLassoOverlay = null;
+  }
+
+  function cancelMolstarLassoStroke() {
+    molstarLassoStroke = null;
+    removeMolstarLassoOverlay();
+  }
+
+  function finishMolstarLassoStroke(stroke) {
+    molstarLassoStroke = null;
+    removeMolstarLassoOverlay();
+    const bounds = molstarLassoBounds(stroke.points);
+    if (stroke.points.length < MOLSTAR_LASSO_MIN_POINTS || bounds.width < MOLSTAR_LASSO_SAMPLE_STEP_PX || bounds.height < MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+      setStatus('[web] Lasso selection was too small.');
+      return;
+    }
+    const picks = molstarLassoPicks(stroke);
+    if (!picks.length) {
+      setStatus('[web] No visible atoms inside lasso.');
+      return;
+    }
+    const selected = applyMolstarLassoPicks(picks, stroke.additive);
+    setStatus(selected > 0
+      ? `[web] Selected ${selected} visible target${selected === 1 ? '' : 's'} with lasso.`
+      : '[web] Lasso selection did not match selectable atoms.');
+  }
+
+  function molstarLassoBounds(points) {
+    const xs = points.map(point => point.x);
+    const ys = points.map(point => point.y);
+    const left = Math.min(...xs);
+    const right = Math.max(...xs);
+    const top = Math.min(...ys);
+    const bottom = Math.max(...ys);
+    return { left, right, top, bottom, width: right - left, height: bottom - top };
+  }
+
+  function molstarPointInPolygon(point, polygon) {
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+      const pi = polygon[i];
+      const pj = polygon[j];
+      const intersects = ((pi.y > point.y) !== (pj.y > point.y)) &&
+        point.x < ((pj.x - pi.x) * (point.y - pi.y)) / ((pj.y - pi.y) || 1e-6) + pi.x;
+      if (intersects) inside = !inside;
+    }
+    return inside;
+  }
+
+  function molstarLassoPickKey(pick, fallback) {
+    const atom = molstarContextAtomFromLoci(pick?.loci);
+    if (atom) {
+      return [
+        atom.model?.id || atom.model?.entryId || 'model',
+        atom.label_entity_id || '',
+        atom.label_asym_id || atom.auth_asym_id || '',
+        atom.label_seq_id ?? atom.auth_seq_id ?? '',
+        atom.label_comp_id || atom.auth_comp_id || '',
+        atom.atomIndex ?? ''
+      ].join(':');
+    }
+    return `${pick?.loci?.kind || 'loci'}:${fallback}`;
+  }
+
+  function molstarLassoPicks(stroke) {
+    const bounds = molstarLassoBounds(stroke.points);
+    const picks = [];
+    const seen = new Set();
+    let sampled = 0;
+    const addPick = (x, y) => {
+      if (sampled >= MOLSTAR_LASSO_SAMPLE_LIMIT) return;
+      sampled += 1;
+      const pick = molstarPickFromCanvasPoint(stroke.canvas, x, y);
+      if (!pick?.loci) return;
+      const key = molstarLassoPickKey(pick, `${Math.round(x)}:${Math.round(y)}`);
+      if (seen.has(key)) return;
+      seen.add(key);
+      picks.push(pick);
+    };
+    for (const point of stroke.points) {
+      addPick(point.x, point.y);
+    }
+    for (let y = bounds.top; y <= bounds.bottom; y += MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+      for (let x = bounds.left; x <= bounds.right; x += MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+        if (molstarPointInPolygon({ x, y }, stroke.points)) addPick(x, y);
+      }
+    }
+    return picks;
+  }
+
+  function applyMolstarLassoPicks(picks, additive) {
+    const selects = activeViewer?.plugin?.managers?.interactivity?.lociSelects;
+    const selection = activeViewer?.plugin?.managers?.structure?.selection;
+    const canSelect = typeof selects?.select === 'function';
+    const canSelectStructure = typeof selection?.fromLoci === 'function';
+    if (!canSelect && !canSelectStructure) return 0;
+    if (!additive) {
+      selects?.deselectAll?.();
+      selection?.clear?.();
+    }
+    let selected = 0;
+    for (const pick of picks) {
+      const loci = molstarContextNormalizeLoci(pick?.loci, 'residue');
+      if (!loci || molstarLociIsEmpty(loci)) continue;
+      if (canSelect) selects.select({ loci }, true);
+      if (canSelectStructure) selection.fromLoci('add', loci, true);
+      selected += 1;
+    }
+    if (selected > 0) scheduleMolstarSelectedMoleculePreview();
+    return selected;
+  }
+
+  function molstarCurrentSelectionLociList() {
+    return molstarContextStructures()
+      .map(structure => molstarContextSelectionLociForStructure(structure))
+      .filter(loci => loci && !molstarLociIsEmpty(loci));
+  }
+
+  function restoreMolstarSelectionLociList(lociList) {
+    if (!Array.isArray(lociList) || !lociList.length) return false;
+    const selects = activeViewer?.plugin?.managers?.interactivity?.lociSelects;
+    const selection = activeViewer?.plugin?.managers?.structure?.selection;
+    const canSelect = typeof selects?.select === 'function';
+    const canSelectStructure = typeof selection?.fromLoci === 'function';
+    if (!canSelect && !canSelectStructure) return false;
+    selects?.deselectAll?.();
+    selection?.clear?.();
+    for (const loci of lociList) {
+      if (!loci || molstarLociIsEmpty(loci)) continue;
+      if (canSelect) selects.select({ loci }, false);
+      if (canSelectStructure) selection.fromLoci('add', loci, false);
+    }
+    scheduleMolstarSelectedMoleculePreview();
+    return true;
+  }
+
+  function beginMolstarEmptyClickSelectionPreserve(event) {
+    if (molstarLassoEnabled || molstarLassoStroke || event.button !== 0 || !isMolstarContextMenuTarget(event.target)) return;
+    const lociList = molstarCurrentSelectionLociList();
+    if (!lociList.length) return;
+    if (molstarContextPickFromEvent(event, molstarContextTouchPickOptions(event))) return;
+    molstarSelectionPreserveClick = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      lociList
+    };
+  }
+
+  function finishMolstarEmptyClickSelectionPreserve(event) {
+    const preserve = molstarSelectionPreserveClick;
+    if (!preserve || event.pointerId !== preserve.pointerId) return;
+    molstarSelectionPreserveClick = null;
+    const moved = Math.hypot(event.clientX - preserve.startX, event.clientY - preserve.startY) > MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX;
+    if (moved) return;
+    setTimeout(() => {
+      if (molstarCurrentSelectionLociList().length) return;
+      restoreMolstarSelectionLociList(preserve.lociList);
+    }, 0);
   }
 
   function molstarContextStructures() {
@@ -10792,6 +11168,7 @@
       contextPointer = null;
     };
     const onPointerDown = (event) => {
+      beginMolstarEmptyClickSelectionPreserve(event);
       clearTouchContextPointer();
       if (event.button === 2) {
         if (!viewer || !isMolstarContextMenuTarget(event.target)) {
@@ -10873,6 +11250,7 @@
         Math.abs(event.clientY - contextPointer.startY) > MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX;
     };
     const onPointerUp = (event) => {
+      finishMolstarEmptyClickSelectionPreserve(event);
       if (touchContextPointer && event.pointerId === touchContextPointer.pointerId) {
         const opened = touchContextPointer.opened;
         clearTouchContextPointer();

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3726,6 +3726,8 @@
     const toolbar = document.getElementById('buret-toolbar');
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
     root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
+    root.style.setProperty('--buret-toolbar-current-height', toolbarRect ? Math.ceil(toolbarRect.height) + 'px' : '0px');
+    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
@@ -3736,8 +3738,13 @@
     const panelOpenTop = selectionToolbarRect
       ? Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP)
       : defaultViewportTop;
+    const controlsOpenTop = selectionToolbarRect
+      ? Math.max(defaultViewportTop, panelOpenTop)
+      : defaultViewportTop;
     const viewportControlsViewportTop = panelState.open
       ? Math.max(defaultViewportTop, panelOpenTop)
+      : selectionToolbarRect
+      ? controlsOpenTop
       : toolbarRect && (!viewportControlsRect || rectsOverlapX(toolbarRect, viewportControlsRect, 18))
       ? Math.max(defaultViewportTop, Math.ceil(toolbarBottom))
       : defaultViewportTop;

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3730,11 +3730,12 @@
     root.style.setProperty('--buret-selection-controls-left', toolbarRect ? Math.ceil(toolbarRect.left) + 'px' : `${TOOLBAR_MARGIN}px`);
     root.style.setProperty('--buret-selection-controls-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : 'min(430px, calc(100vw - 24px))');
     root.style.setProperty('--buret-selection-controls-max-width', toolbarRect ? Math.max(180, Math.floor(window.innerWidth - toolbarRect.left - TOOLBAR_MARGIN)) + 'px' : 'calc(100vw - 24px)');
-    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
+    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const selectionToolbarRect = visibleRect('.msp-plugin .msp-selection-viewport-controls > .msp-flex-row');
+    document.body?.classList.toggle('buret-selection-toolbar-open', !!selectionToolbarRect && !!toolbarRect);
     const mainRect = visibleRect('.msp-plugin .msp-layout-main');
     const mainTop = mainRect ? mainRect.top : 0;
     const defaultViewportTop = mainTop + 64;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -529,8 +529,8 @@ body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
-  width: 33px;
-  margin-left: -3px;
+  width: 36px;
+  margin-left: -5px;
   padding: 0;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
@@ -572,8 +572,8 @@ body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;
   box-sizing: border-box;
-  width: 33px !important;
-  min-width: 33px !important;
+  width: 36px !important;
+  min-width: 36px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -524,6 +524,7 @@ body .msp-plugin .msp-viewport-controls {
   z-index: 40;
 }
 body .msp-plugin .msp-viewport-controls-buttons {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
@@ -565,17 +566,23 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   border-radius: 0;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
+  display: grid !important;
+  place-items: center;
+  box-sizing: border-box;
   width: 30px !important;
   min-width: 30px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;
   border-radius: 8px;
+  padding: 0 !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
   box-shadow: none;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
+  font: 400 12px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  line-height: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -11,7 +11,7 @@
   --buret-toolbar-border: rgba(255, 255, 255, 0.10);
   --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
   --buret-toolbar-color: rgba(255, 255, 255, 0.94);
-  --buret-viewport-controls-top: 64px;
+  --buret-viewport-controls-top: calc(var(--buret-toolbar-safe-top) + 42px);
   --buret-viewport-panel-max-height: calc(100vh - 96px);
   --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
   --buret-molstar-row-background: rgba(24, 26, 29, var(--buret-overlay-strong-opacity));
@@ -465,27 +465,49 @@ body .msp-plugin .msp-viewport-controls {
   top: var(--buret-viewport-controls-top) !important;
   z-index: 40;
 }
-body .msp-plugin .msp-viewport-controls-buttons > div {
-  overflow: hidden;
+body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 4px;
-  border: 1px solid var(--buret-toolbar-border);
+  gap: 8px;
+  transform-origin: top center;
+  transition: opacity 150ms ease, transform 170ms cubic-bezier(0.22, 1, 0.36, 1), visibility 0s linear 0s;
+}
+body.buret-toolbar-collapsed .msp-plugin .msp-viewport-controls-buttons {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transition-delay: 0s, 0s, 150ms;
+}
+body .msp-plugin .msp-viewport-controls-buttons > div {
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+body .msp-plugin .msp-viewport-controls-buttons > div > div {
+  overflow: visible;
+  border-radius: 0;
+}
+body .msp-plugin .msp-viewport-controls-buttons button {
+  width: 40px !important;
+  min-width: 40px !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
   background: var(--buret-toolbar-background) !important;
   box-shadow: 0 8px 20px var(--buret-molstar-shadow);
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
-}
-body .msp-plugin .msp-viewport-controls-buttons > div > div {
-  overflow: hidden;
-  border-radius: 8px;
-}
-body .msp-plugin .msp-viewport-controls-buttons button {
-  border-radius: 8px;
-  color: var(--buret-toolbar-color) !important;
-  background: transparent !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {
@@ -1551,17 +1573,17 @@ body.burette-mobile-host .msp-plugin .msp-viewport-controls {
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons > div,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls > div:first-child {
-  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
-  border-radius: 18px !important;
-  background: rgba(28, 28, 30, 0.70) !important;
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
-  -webkit-backdrop-filter: blur(32px) saturate(1.6);
-  backdrop-filter: blur(32px) saturate(1.6);
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons > div,
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-animation-viewport-controls > div:first-child {
-  border-color: rgba(0, 0, 0, 0.10) !important;
-  background: rgba(246, 246, 242, 0.76) !important;
+  border-color: transparent !important;
+  background: transparent !important;
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls button,
@@ -1571,6 +1593,17 @@ body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
   min-height: 44px !important;
   border-radius: 14px !important;
   font-size: 16px !important;
+}
+body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
+  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
+  background: rgba(28, 28, 30, 0.70) !important;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
+  -webkit-backdrop-filter: blur(32px) saturate(1.6);
+  backdrop-filter: blur(32px) saturate(1.6);
+}
+body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
+  border-color: rgba(0, 0, 0, 0.10) !important;
+  background: rgba(246, 246, 242, 0.76) !important;
 }
 body.burette-mobile-host .msp-plugin .msp-control-group-header,
 body.burette-mobile-host .msp-plugin .msp-control-group-header > button,

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -910,10 +910,17 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   transform: translate(-50%, -4px) scale(0.98);
   transform-origin: top center;
   transition: opacity 110ms ease-out, transform 130ms ease-out, visibility 0s linear 110ms;
+}
+#buret-toolbar .buret-tooltip {
+  right: 0;
+  left: auto;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top right;
 }
 .buret-button:hover > .buret-tooltip,
 .buret-button:focus-visible > .buret-tooltip,
@@ -927,6 +934,14 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   visibility: visible;
   transform: translate(-50%, 0) scale(1);
   transition-delay: 180ms, 180ms, 0s;
+}
+#buret-toolbar .buret-button:hover > .buret-tooltip,
+#buret-toolbar .buret-button:focus-visible > .buret-tooltip,
+#buret-toolbar .buret-molstar-style-slot:hover > .buret-tooltip,
+#buret-toolbar .buret-molstar-style-slot:focus-within > .buret-tooltip,
+#buret-toolbar .buret-xyzrender-preset-slot:hover > .buret-tooltip,
+#buret-toolbar .buret-xyzrender-preset-slot:focus-within > .buret-tooltip {
+  transform: translateY(0) scale(1);
 }
 .buret-button:hover, .buret-button.active { background: var(--buret-toolbar-hover); }
 .buret-molstar-tooltip {

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -355,30 +355,33 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   overflow: hidden;
-  border: 1px solid var(--buret-molstar-border) !important;
-  border-radius: 10px;
-  color: var(--buret-molstar-text) !important;
-  background: var(--buret-molstar-panel-background) !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
   box-shadow: 0 12px 28px var(--buret-molstar-shadow);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
-  border-left: 1px solid var(--buret-molstar-border) !important;
-  color: var(--buret-molstar-text) !important;
-  background: var(--buret-molstar-row-background) !important;
+  border-left: 1px solid var(--buret-toolbar-border) !important;
+  color: var(--buret-toolbar-color) !important;
+  background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
   border-left: 0 !important;
 }
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
-  color: var(--buret-molstar-text) !important;
+  border-radius: 8px;
+  color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls button:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn-link-toggle-on {
-  color: var(--buret-molstar-accent) !important;
-  background: var(--buret-molstar-hover-background) !important;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-hover) !important;
   outline: 0 !important;
 }
 body .msp-plugin .msp-semi-transparent-background {
@@ -442,14 +445,30 @@ body .msp-plugin .msp-viewport-controls {
 }
 body .msp-plugin .msp-viewport-controls-buttons > div {
   overflow: hidden;
-  border: 1px solid var(--buret-molstar-border);
-  border-radius: 8px;
-  background: var(--buret-molstar-row-background) !important;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--buret-toolbar-border);
+  border-radius: 12px;
+  background: var(--buret-toolbar-background) !important;
   box-shadow: 0 8px 20px var(--buret-molstar-shadow);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+body .msp-plugin .msp-viewport-controls-buttons > div > div {
+  overflow: hidden;
+  border-radius: 8px;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
-  color: var(--buret-molstar-text) !important;
+  border-radius: 8px;
+  color: var(--buret-toolbar-color) !important;
   background: transparent !important;
+}
+body .msp-plugin .msp-viewport-controls-buttons button:hover,
+body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-hover) !important;
 }
 body .msp-plugin .msp-viewport-controls-buttons button[disabled] {
   color: var(--buret-molstar-muted-text) !important;
@@ -581,19 +600,6 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
 }
 .buret-molstar-molecule-preview-image svg {
   padding: 9px;
-}
-.buret-molstar-molecule-preview-bonds line {
-  stroke: currentColor;
-  stroke-width: 0.085;
-  stroke-linecap: round;
-}
-.buret-molstar-molecule-preview-atoms text {
-  font: 0.42px -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  font-weight: 700;
-  letter-spacing: 0;
-  paint-order: stroke;
-  stroke: #ffffff;
-  stroke-width: 0.11px;
 }
 .buret-molstar-molecule-preview-title {
   margin-top: 5px;
@@ -937,6 +943,34 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 .buret-button svg { width: 17px; height: 17px; display: block; }
 .buret-pose-toggle { width: auto; min-width: 34px; }
 .buret-grip { width: 30px; padding: 0; cursor: grab; color: currentColor; opacity: 0.66; }
+.buret-molstar-lasso.active {
+  background: var(--buret-toolbar-hover);
+  box-shadow: inset 0 0 0 1px var(--buret-toolbar-border);
+}
+body.buret-molstar-lasso-active .msp-plugin canvas {
+  cursor: crosshair;
+}
+.buret-molstar-lasso-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483645;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+}
+.buret-molstar-lasso-overlay polygon {
+  fill: color-mix(in srgb, var(--buret-molstar-accent, #af52de) 18%, transparent);
+  stroke: none;
+}
+.buret-molstar-lasso-overlay polyline {
+  fill: none;
+  stroke: color-mix(in srgb, var(--buret-molstar-accent, #af52de) 88%, white);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.36));
+}
 .buret-generate-3d-control {
   position: absolute;
   top: var(--buret-viewport-controls-top);

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -893,7 +893,11 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 }
 #buret-toolbar.collapsed .buret-grip,
 #buret-toolbar.buret-suppressed-by-molstar-panel .buret-grip {
-  min-width: 30px;
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  border-radius: 12px;
   cursor: pointer;
   background: var(--buret-toolbar-background);
   border: 1px solid var(--buret-toolbar-border);
@@ -1585,7 +1589,6 @@ body.buret-theme-light.burette-mobile-host .msp-plugin .msp-animation-viewport-c
   border-color: transparent !important;
   background: transparent !important;
 }
-body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button,
 body.burette-mobile-host .msp-plugin .msp-animation-viewport-controls button,
 body.burette-mobile-host .msp-plugin .msp-btn-icon,
 body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
@@ -1595,15 +1598,23 @@ body.burette-mobile-host .msp-plugin .msp-btn-icon-small {
   font-size: 16px !important;
 }
 body.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
-  border: 0.5px solid rgba(255, 255, 255, 0.20) !important;
-  background: rgba(28, 28, 30, 0.70) !important;
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
-  -webkit-backdrop-filter: blur(32px) saturate(1.6);
-  backdrop-filter: blur(32px) saturate(1.6);
+  width: 40px !important;
+  min-width: 40px !important;
+  height: 40px !important;
+  min-height: 40px !important;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px !important;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
 }
 body.buret-theme-light.burette-mobile-host .msp-plugin .msp-viewport-controls-buttons button {
-  border-color: rgba(0, 0, 0, 0.10) !important;
-  background: rgba(246, 246, 242, 0.76) !important;
+  border-color: var(--buret-toolbar-border) !important;
+  background: var(--buret-toolbar-background) !important;
 }
 body.burette-mobile-host .msp-plugin .msp-control-group-header,
 body.burette-mobile-host .msp-plugin .msp-control-group-header > button,

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -378,12 +378,12 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
-  position: absolute !important;
+  position: fixed !important;
   top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
-  right: var(--buret-control-island-right) !important;
-  left: auto !important;
-  width: auto !important;
-  max-width: calc(100vw - (var(--buret-control-island-right) * 2)) !important;
+  right: auto !important;
+  left: var(--buret-selection-controls-left, var(--buret-control-island-right)) !important;
+  width: min(var(--buret-selection-controls-width, 430px), var(--buret-selection-controls-max-width, calc(100vw - 24px))) !important;
+  max-width: var(--buret-selection-controls-max-width, calc(100vw - (var(--buret-control-island-right) * 2))) !important;
   margin: 0 !important;
   z-index: 2147483645 !important;
 }
@@ -396,6 +396,8 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   display: inline-flex !important;
   align-items: center;
   gap: var(--buret-control-island-gap);
+  width: 100%;
+  box-sizing: border-box;
   min-height: 0;
   max-width: 100%;
   overflow-x: auto;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -400,6 +400,7 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   box-sizing: border-box;
   min-height: 0;
   max-width: 100%;
+  margin-top: 0 !important;
   overflow-x: auto;
   overflow-y: hidden;
   padding: 6px;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -528,7 +528,9 @@ body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
   gap: var(--buret-control-island-gap);
-  padding: 6px;
+  width: 33px;
+  margin-left: -3px;
+  padding: 0;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
@@ -569,8 +571,8 @@ body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;
   box-sizing: border-box;
-  width: 30px !important;
-  min-width: 30px !important;
+  width: 33px !important;
+  min-width: 33px !important;
   height: 30px !important;
   min-height: 30px !important;
   border: 0 !important;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -283,6 +283,9 @@ body .msp-plugin .msp-control-row-label .msp-help {
   background-color: var(--buret-molstar-field-background) !important;
   border-color: var(--buret-molstar-border) !important;
 }
+body .msp-plugin .msp-control-row-label .msp-help.msp-btn-link {
+  background-color: transparent !important;
+}
 body .msp-plugin .msp-control-row > span.msp-control-row-label,
 body .msp-plugin .msp-control-row > button.msp-control-button-label,
 body .msp-plugin .msp-control-group-header > button,
@@ -332,11 +335,30 @@ body .msp-plugin .msp-viewport-controls-panel .msp-control-group-header > button
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row {
   border-top: 1px solid var(--buret-molstar-border) !important;
   background: var(--buret-molstar-row-background) !important;
+  opacity: 1 !important;
+}
+body .msp-plugin .msp-control-row > span.msp-control-row-label,
+body .msp-plugin .msp-control-row > span.msp-control-row-label *,
+body .msp-plugin .msp-viewport-controls-panel .msp-control-row > span.msp-control-row-label,
+body .msp-plugin .msp-viewport-controls-panel .msp-control-row > span.msp-control-row-label * {
+  color: var(--buret-molstar-text) !important;
+  opacity: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div,
 body .msp-plugin .msp-viewport-controls-panel .msp-control-row > div.msp-control-row-text,
 body .msp-plugin .msp-viewport-controls-panel .msp-control-current {
   background: var(--buret-molstar-field-background) !important;
+}
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row {
+  opacity: 1 !important;
+}
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label,
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label .msp-help,
+body .msp-plugin .msp-viewport-controls-panel.buret-draggable-viewport-panel .msp-viewport-controls-panel-controls > .msp-control-row > .msp-control-row-label .msp-btn-link {
+  color: var(--buret-molstar-text) !important;
+  -webkit-text-fill-color: var(--buret-molstar-text) !important;
+  font-weight: 500 !important;
+  opacity: 1 !important;
 }
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text,
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text div,

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -575,6 +575,9 @@ body .msp-plugin .msp-viewport-controls-buttons .msp-viewport-controls-panel {
 body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-spacer {
   right: 36px !important;
 }
+body .msp-plugin .msp-viewport-controls-buttons > div:nth-of-type(3) > button:first-of-type {
+  display: none !important;
+}
 body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -375,15 +375,25 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text i,
 body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
+body .msp-plugin .msp-selection-viewport-controls {
+  top: var(--buret-toolbar-safe-top) !important;
+  right: calc(18px + var(--buret-toolbar-current-width, 0px)) !important;
+  left: auto !important;
+  max-width: calc(100vw - var(--buret-toolbar-current-width, 0px) - 36px) !important;
+}
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+  min-height: 40px;
+  max-width: 100%;
   overflow: hidden;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
   background: var(--buret-toolbar-background) !important;
-  box-shadow: 0 12px 28px var(--buret-molstar-shadow);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
   border-left: 1px solid var(--buret-toolbar-border) !important;
@@ -395,9 +405,19 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-chil
 }
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
+  min-width: 40px !important;
+  min-height: 38px !important;
   border-radius: 8px;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
+}
+body .msp-plugin .msp-selection-viewport-controls select {
+  max-width: min(220px, 28vw) !important;
+  min-height: 38px !important;
+  border: 0 !important;
+  color: var(--buret-toolbar-color) !important;
+  background: transparent !important;
+  text-overflow: ellipsis;
 }
 body .msp-plugin .msp-selection-viewport-controls button:hover,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn:hover,

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -376,15 +376,23 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
-  top: var(--buret-toolbar-safe-top) !important;
-  right: calc(18px + var(--buret-toolbar-current-width, 0px)) !important;
+  top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
+  right: 12px !important;
   left: auto !important;
-  max-width: calc(100vw - var(--buret-toolbar-current-width, 0px) - 36px) !important;
+  max-width: calc(100vw - 24px) !important;
+  z-index: 2147483645 !important;
+}
+body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   min-height: 40px;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
   color: var(--buret-toolbar-color) !important;
@@ -394,6 +402,9 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
+}
+body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrollbar {
+  display: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
   border-left: 1px solid var(--buret-toolbar-border) !important;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -11,6 +11,8 @@
   --buret-toolbar-border: rgba(255, 255, 255, 0.10);
   --buret-toolbar-hover: rgba(255, 255, 255, 0.14);
   --buret-toolbar-color: rgba(255, 255, 255, 0.94);
+  --buret-control-island-right: 12px;
+  --buret-control-island-gap: 6px;
   --buret-viewport-controls-top: calc(var(--buret-toolbar-safe-top) + 42px);
   --buret-viewport-panel-max-height: calc(100vh - 96px);
   --buret-molstar-panel-background: rgba(14, 15, 17, var(--buret-overlay-strong-opacity));
@@ -376,10 +378,13 @@ body .msp-plugin .msp-viewport-controls-panel .msp-help-text em {
   color: var(--buret-molstar-muted-text) !important;
 }
 body .msp-plugin .msp-selection-viewport-controls {
+  position: absolute !important;
   top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px)) !important;
-  right: 12px !important;
+  right: var(--buret-control-island-right) !important;
   left: auto !important;
-  max-width: calc(100vw - 24px) !important;
+  width: auto !important;
+  max-width: calc(100vw - (var(--buret-control-island-right) * 2)) !important;
+  margin: 0 !important;
   z-index: 2147483645 !important;
 }
 body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
@@ -388,10 +393,14 @@ body.buret-toolbar-collapsed .msp-plugin .msp-selection-viewport-controls {
   pointer-events: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
-  min-height: 40px;
+  display: inline-flex !important;
+  align-items: center;
+  gap: var(--buret-control-island-gap);
+  min-height: 0;
   max-width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
+  padding: 6px;
   scrollbar-width: none;
   border: 1px solid var(--buret-toolbar-border) !important;
   border-radius: 12px;
@@ -407,25 +416,32 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrol
   display: none;
 }
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > * {
-  border-left: 1px solid var(--buret-toolbar-border) !important;
+  flex: 0 0 auto;
+  border-left: 0 !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
-body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row > *:first-child {
-  border-left: 0 !important;
-}
 body .msp-plugin .msp-selection-viewport-controls button,
 body .msp-plugin .msp-selection-viewport-controls .msp-btn {
-  min-width: 40px !important;
-  min-height: 38px !important;
+  width: auto !important;
+  min-width: 30px !important;
+  height: 30px !important;
+  min-height: 30px !important;
   border-radius: 8px;
+  padding: 0 7px !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
 }
 body .msp-plugin .msp-selection-viewport-controls select {
-  max-width: min(220px, 28vw) !important;
-  min-height: 38px !important;
+  flex: 0 1 auto !important;
+  width: auto !important;
+  min-width: 96px !important;
+  max-width: min(180px, 28vw) !important;
+  height: 30px !important;
+  min-height: 30px !important;
   border: 0 !important;
+  border-radius: 8px;
+  padding: 0 9px !important;
   color: var(--buret-toolbar-color) !important;
   background: transparent !important;
   text-overflow: ellipsis;
@@ -862,8 +878,8 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
   background: rgba(255, 255, 255, 0.20);
 }
 #buret-toolbar {
-  position: absolute; top: var(--buret-toolbar-safe-top); right: 12px; left: auto; z-index: 2147483646;
-  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - 24px); gap: 6px; padding: 6px;
+  position: absolute; top: var(--buret-toolbar-safe-top); right: var(--buret-control-island-right); left: auto; z-index: 2147483646;
+  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 6px;
   border: 1px solid var(--buret-toolbar-border);
   border-radius: 12px; color: var(--buret-toolbar-color);
   background: var(--buret-toolbar-background);

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -568,6 +568,13 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   overflow: visible;
   border-radius: 0;
 }
+body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-body,
+body .msp-plugin .msp-viewport-controls-buttons .msp-viewport-controls-panel {
+  right: 40px !important;
+}
+body .msp-plugin .msp-viewport-controls-buttons .msp-hover-box-wrapper .msp-hover-box-spacer {
+  right: 36px !important;
+}
 body .msp-plugin .msp-viewport-controls-buttons button {
   display: grid !important;
   place-items: center;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -414,6 +414,15 @@ body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
+body.buret-selection-toolbar-open #buret-toolbar {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+body.buret-selection-toolbar-open .msp-plugin .msp-selection-viewport-controls > .msp-flex-row {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.22);
+}
 body .msp-plugin .msp-selection-viewport-controls > .msp-flex-row::-webkit-scrollbar {
   display: none;
 }

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -517,7 +517,17 @@ body .msp-plugin .msp-viewport-controls {
 body .msp-plugin .msp-viewport-controls-buttons {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--buret-control-island-gap);
+  padding: 6px;
+  border: 1px solid var(--buret-toolbar-border) !important;
+  border-radius: 12px;
+  color: var(--buret-toolbar-color) !important;
+  background: var(--buret-toolbar-background) !important;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   transform-origin: top center;
   transition: opacity 150ms ease, transform 170ms cubic-bezier(0.22, 1, 0.36, 1), visibility 0s linear 0s;
 }
@@ -532,7 +542,7 @@ body .msp-plugin .msp-viewport-controls-buttons > div {
   overflow: visible;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--buret-control-island-gap);
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -546,17 +556,17 @@ body .msp-plugin .msp-viewport-controls-buttons > div > div {
   border-radius: 0;
 }
 body .msp-plugin .msp-viewport-controls-buttons button {
-  width: 40px !important;
-  min-width: 40px !important;
-  height: 40px !important;
-  min-height: 40px !important;
-  border: 1px solid var(--buret-toolbar-border) !important;
-  border-radius: 12px;
+  width: 30px !important;
+  min-width: 30px !important;
+  height: 30px !important;
+  min-height: 30px !important;
+  border: 0 !important;
+  border-radius: 8px;
   color: var(--buret-toolbar-color) !important;
-  background: var(--buret-toolbar-background) !important;
-  box-shadow: 0 8px 20px var(--buret-molstar-shadow);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
+  background: transparent !important;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
 }
 body .msp-plugin .msp-viewport-controls-buttons button:hover,
 body .msp-plugin .msp-viewport-controls-buttons .msp-btn-link-toggle-on {

--- a/plugins/burette-agent/preview-web/viewer-shell.js
+++ b/plugins/burette-agent/preview-web/viewer-shell.js
@@ -24,6 +24,10 @@
             <select class="buret-select" data-buret-molstar-style aria-label="Mol* preview style" title="Mol* preview style"></select>
             <span class="buret-tooltip" role="tooltip">Choose Mol* representation style</span>
           </div>
+          <button class="buret-button buret-molstar-lasso" type="button" data-buret-action="molstar-lasso" aria-label="Lasso select" aria-pressed="false" title="Lasso select">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5.2 5.6c2.3-2 6.6-2.4 10.2-.8 3.5 1.6 5.4 4.6 4.5 7.3-.8 2.5-3.7 4.2-7.3 4.2-1.5 0-3-.3-4.3-.9l-2.6 3.2c-.4.5-1.2.2-1.2-.4l.2-4.1C2.5 12 2.6 7.8 5.2 5.6Zm1.3 1.5c-1.8 1.5-1.7 4.4.2 5.8.2.1.3.4.3.7l-.1 1.8 1.6-1.9c.3-.3.7-.4 1-.2 1 .6 2 .9 3.1.9 2.8 0 4.9-1.2 5.4-2.7.5-1.6-.8-3.6-3.5-4.8-2.9-1.3-6.4-1.1-8 .4Z" fill="currentColor"/></svg>
+            <span class="buret-tooltip" role="tooltip">Lasso select visible residues</span>
+          </button>
           <button class="buret-button" type="button" data-buret-action="theme" aria-label="Switch to light theme" title="Switch to light theme">Light<span class="buret-tooltip" role="tooltip">Switch to light theme</span></button>
           <button class="buret-button buret-save-modified hidden" type="button" data-buret-action="save-modified-structure" aria-label="Save modified structure" title="Save modified structure">Save<span class="buret-tooltip" role="tooltip">Save modified Mol* structure</span></button>
           <button class="buret-button hidden" type="button" data-buret-action="ketcher" aria-label="Open in Ketcher" title="Open in Ketcher">Ketcher<span class="buret-tooltip" role="tooltip">Open this structure in Ketcher</span></button>

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3708,11 +3708,12 @@
     root.style.setProperty('--buret-selection-controls-left', toolbarRect ? Math.ceil(toolbarRect.left) + 'px' : `${TOOLBAR_MARGIN}px`);
     root.style.setProperty('--buret-selection-controls-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : 'min(430px, calc(100vw - 24px))');
     root.style.setProperty('--buret-selection-controls-max-width', toolbarRect ? Math.max(180, Math.floor(window.innerWidth - toolbarRect.left - TOOLBAR_MARGIN)) + 'px' : 'calc(100vw - 24px)');
-    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
+    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const selectionToolbarRect = visibleRect('.msp-plugin .msp-selection-viewport-controls > .msp-flex-row');
+    document.body?.classList.toggle('buret-selection-toolbar-open', !!selectionToolbarRect && !!toolbarRect);
     const mainRect = visibleRect('.msp-plugin .msp-layout-main');
     const mainTop = mainRect ? mainRect.top : 0;
     const defaultViewportTop = mainTop + 64;

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3485,6 +3485,7 @@
   function setToolbarCollapsed(toolbar, collapsed, viewer, persist = true) {
     if (collapsed) setXyzrenderPopoverVisibility(toolbar, false);
     toolbar.classList.toggle('collapsed', collapsed);
+    document.body?.classList.toggle('buret-toolbar-collapsed', collapsed);
     const grip = toolbar.querySelector('[data-drag-handle]');
     if (grip) {
       grip.setAttribute('aria-expanded', collapsed ? 'false' : 'true');

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3504,6 +3504,23 @@
     scheduleViewerResize(viewer, 40);
   }
 
+  function activateToolbarGrip(toolbar, viewer) {
+    if (toolbar.classList.contains('buret-suppressed-by-molstar-panel')) {
+      toolbar.dataset.molstarPanelSuppressOverride = '1';
+      toolbar.classList.remove('buret-suppressed-by-molstar-panel');
+      if (toolbar.classList.contains('collapsed')) {
+        setToolbarCollapsed(toolbar, false, viewer);
+      } else {
+        toolbar.dataset.defaultPosition = '1';
+        repositionToolbar(toolbar);
+        updateFloatingLayoutOffsets();
+        scheduleViewerResize(viewer, 40);
+      }
+      return;
+    }
+    setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), viewer);
+  }
+
   function initToolbarDrag(toolbar) {
     if (toolbar.dataset.dragBound === '1') return;
     toolbar.dataset.dragBound = '1';
@@ -3537,7 +3554,7 @@
         ignoreNextGripClick = false;
         return;
       }
-      setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
+      activateToolbarGrip(toolbar, resizeState.viewer);
     });
     toolbar.addEventListener('pointerdown', event => {
       if (event.target.closest('[data-buret-toggle]')) return;
@@ -3581,7 +3598,7 @@
       drag = null;
       if (shouldToggle) {
         ignoreNextGripClick = true;
-        setToolbarCollapsed(toolbar, !toolbar.classList.contains('collapsed'), resizeState.viewer);
+        activateToolbarGrip(toolbar, resizeState.viewer);
       } else if (shouldSavePosition) {
         ignoreNextGripClick = startedOnHandle;
         toolbar.dataset.defaultPosition = '0';
@@ -3768,7 +3785,10 @@
       document.body?.classList.toggle('buret-molstar-selection-controls-open', selectionOpen);
       const toolbar = document.getElementById('buret-toolbar');
       if (toolbar) {
-        toolbar.classList.toggle('buret-suppressed-by-molstar-panel', suppressToolbar);
+        if (!suppressToolbar) {
+          delete toolbar.dataset.molstarPanelSuppressOverride;
+        }
+        toolbar.classList.toggle('buret-suppressed-by-molstar-panel', suppressToolbar && toolbar.dataset.molstarPanelSuppressOverride !== '1');
         if (toolbar.dataset.defaultPosition === '1') {
           requestAnimationFrame(() => applyDefaultToolbarPosition(toolbar));
         }

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3703,6 +3703,7 @@
     const panelState = refreshMolstarViewportPanelState();
     const toolbar = document.getElementById('buret-toolbar');
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
+    root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
@@ -3781,7 +3782,7 @@
     if (panelOpen !== molstarViewportPanelOpen || selectionOpen !== molstarSelectionControlsOpen) {
       molstarViewportPanelOpen = panelOpen;
       molstarSelectionControlsOpen = selectionOpen;
-      const suppressToolbar = panelOpen || selectionOpen;
+      const suppressToolbar = panelOpen;
       document.body?.classList.toggle('buret-molstar-viewport-panel-open', panelOpen);
       document.body?.classList.toggle('buret-molstar-selection-controls-open', selectionOpen);
       const toolbar = document.getElementById('buret-toolbar');

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -17,8 +17,13 @@
   const MOLSTAR_TOUCH_CONTEXT_MENU_MOVE_THRESHOLD_PX = 12;
   const MOLSTAR_TOUCH_PICK_RADIUS_PX = 18;
   const MOLSTAR_TOUCH_PICK_STEP_PX = 6;
+  const MOLSTAR_LASSO_MIN_POINTS = 4;
+  const MOLSTAR_LASSO_MIN_DISTANCE_PX = 3;
+  const MOLSTAR_LASSO_SAMPLE_STEP_PX = 8;
+  const MOLSTAR_LASSO_SAMPLE_LIMIT = 4500;
   const MOLSTAR_PREVIEW_RDKIT_SVG_SIZE = 260;
   const MOLSTAR_STANDALONE_PREVIEW_MAX_ATOMS = 300;
+  const MOLSTAR_EDIT_HISTORY_LIMIT = 20;
   const VIEWER_THEME_STORAGE_KEY = 'buret.viewer.theme';
   const SDF_POSE_MODE_STORAGE_KEY = 'buret.sdf.poseMode';
   const SDF_CONTEXT_STYLE_STORAGE_KEY = 'buret.sdf.contextStyle';
@@ -87,7 +92,6 @@
   const DOCKING_MODEL_TRAJECTORY_FORMATS = new Set(['pdb', 'pdbqt', 'mmcif', 'gro']);
   const DOCKING_TOPOLOGY_TRAJECTORY_FORMATS = new Set(['top', 'psf', 'prmtop']);
   const STRUCTURE_DRAG_MIME = 'application/x-burrete-structure-paths';
-  const XYZRENDER_POPOVER_OPEN_KEY_PREFIX = 'buret.xyzrender.popover.open.v2';
   const MOLSTAR_VIEWPORT_PANEL_OPEN_CLASS = 'buret-molstar-viewport-panel-open';
   let xyzrenderControlsApplyTimer = 0;
   let xyzrenderInlineRequestSerial = 0;
@@ -99,16 +103,20 @@
   let molstarSelectionPreviewCleanup = null;
   let molstarContextMenuPick = null;
   let molstarContextMenuMode = 'molecule';
+  let molstarLassoEnabled = false;
+  let molstarLassoStroke = null;
+  let molstarLassoOverlay = null;
+  let molstarSelectionPreserveClick = null;
+  let molstarLassoSuppressClickUntil = 0;
   let molstarMoleculePreview = null;
   let molstarMoleculePreviewFrame = 0;
   let molstarMoleculePreviewDrag = null;
   let molstarMoleculePreviewTarget = null;
   let molstarMoleculePreviewSuppressClickUntil = 0;
-  let molstarPersistentMoleculePreviewTarget = null;
-  let molstarStandalonePreviewTarget = null;
   let molstarPreviewRdkit = null;
   let molstarPreviewRdkitPromise = null;
   const molstarPreviewSvgCache = new Map();
+  const molstarEditUndoStack = [];
   let activeDockingPrepared = null;
   let burreteAgentActionPollTimer = 0;
   let burreteAgentActionPollBusy = false;
@@ -118,10 +126,10 @@
   let molstarStructureFocusSerial = 0;
   try { window.__mqlDebug && window.__mqlDebug('[viewer.js] top-level IIFE entered; readyState=' + document.readyState); } catch (_) {}
 
-  function post(type, message) {
+  function post(type, message, payload = {}) {
     try {
-      if (window.__mqlPost) window.__mqlPost(type, message || '');
-      else postHostMessage({ type, message: message || '' });
+      if (window.__mqlPost) window.__mqlPost(type, message || '', payload || {});
+      else postHostMessage({ type, message: message || '', ...(payload || {}) });
     } catch (_) {
       // Browser-only testing, not WKWebView.
     }
@@ -1335,6 +1343,26 @@
     });
   }
 
+  function xyzrenderPopoverDocumentKey(config = {}) {
+    const documentId = String(config?.documentId || '').trim();
+    if (documentId) return `document:${documentId}`;
+    const requestID = String(config?.previewRequestID || config?.requestID || '').trim();
+    if (requestID) return `request:${requestID}`;
+    const sourcePath = String(config?.path || config?.filePath || config?.sourcePath || config?.label || '').trim();
+    return sourcePath ? `source:${sourcePath}` : '';
+  }
+
+  function syncXyzrenderPopoverDocument(toolbar, config = {}) {
+    if (!toolbar) return false;
+    const key = xyzrenderPopoverDocumentKey(config);
+    if (!key) return false;
+    const previous = toolbar.dataset.xyzrenderPopoverDocumentKey || '';
+    toolbar.dataset.xyzrenderPopoverDocumentKey = key;
+    if (!previous || previous === key) return false;
+    setXyzrenderPopoverVisibility(toolbar, false, { persist: false });
+    return true;
+  }
+
   function configureRendererControls(config) {
     const control = document.querySelector('[data-buret-renderer-control]');
     const toolbar = document.getElementById('buret-toolbar');
@@ -1354,6 +1382,7 @@
     const generate3dButton = document.querySelector('[data-buret-action="generate-3d-conformer"]');
     const generate3dMenu = document.querySelector('[data-buret-generate-3d-menu]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+    const lassoButton = toolbar.querySelector('[data-buret-action="molstar-lasso"]');
     control.classList.toggle('visible', canSwitchRenderer);
     const molstarStyleSlot = toolbar.querySelector('[data-buret-molstar-style-slot]');
     const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
@@ -1362,6 +1391,11 @@
       populateMolstarStyleSelect(molstarStyleSelect);
       molstarStyleSelect.value = configuredMolstarStyle(config);
       molstarStyleSelect.disabled = renderer !== 'molstar';
+    }
+    lassoButton?.classList.toggle('hidden', renderer !== 'molstar');
+    if (lassoButton) {
+      lassoButton.disabled = renderer !== 'molstar';
+      lassoButton.setAttribute('aria-hidden', renderer === 'molstar' ? 'false' : 'true');
     }
     const presetSlot = toolbar.querySelector('[data-buret-xyzrender-preset-slot]');
     presetSlot?.classList.remove('visible');
@@ -1402,7 +1436,8 @@
       });
     }
     observeMolstarViewportPanel();
-    const popoverWasOpen = popover?.classList.contains('hidden') === false;
+    const popoverDocumentChanged = syncXyzrenderPopoverDocument(toolbar, config);
+    const popoverWasOpen = popover?.classList.contains('hidden') === false && !popoverDocumentChanged;
     const popoverScrollTop = popover?.scrollTop || 0;
     control.querySelectorAll('[data-buret-renderer]').forEach(button => {
       const value = button.getAttribute('data-buret-renderer');
@@ -1443,7 +1478,7 @@
       if (renderer === 'xyzrender-external') {
         populateXyzrenderControlsForm(toolbar, normalizeXyzrenderControls(config.xyzrenderControls || DEFAULT_XYZRENDER_CONTROLS, config));
         updateXyzrenderFormVisibility(toolbar);
-        if (popoverWasOpen || shouldRestoreXyzrenderPopoverOpen(config)) {
+        if (popoverWasOpen) {
           setXyzrenderPopoverVisibility(toolbar, true, { resetScroll: false });
           if (popover) popover.scrollTop = popoverScrollTop;
         }
@@ -1492,51 +1527,21 @@
     return DEFAULT_XYZRENDER_PRESETS.some(row => row.value === raw) ? raw : 'default';
   }
 
-  function xyzrenderPopoverStorageKey() {
-    const documentId = String(window.BurreteConfig?.documentId || '').trim();
-    return documentId ? `${XYZRENDER_POPOVER_OPEN_KEY_PREFIX}:${documentId}` : XYZRENDER_POPOVER_OPEN_KEY_PREFIX;
-  }
-
   function setXyzrenderPopoverVisibility(toolbar, open, options = {}) {
     const popover = toolbar?.querySelector('[data-buret-xyzrender-popover]');
     const tuneButton = toolbar?.querySelector('[data-buret-action="xyzrender-tune"]');
     if (!popover) return;
     const resetScroll = options.resetScroll === true;
-    const persist = options.persist !== false;
     popover.classList.toggle('hidden', !open);
     toolbar?.classList.toggle('buret-popover-open', open);
     if (tuneButton) {
       tuneButton.classList.toggle('active', open);
       tuneButton.toggleAttribute('data-open', open);
     }
-    if (persist) setXyzrenderPopoverOpenPersisted(open);
     if (open) {
       if (resetScroll) popover.scrollTop = 0;
       positionXyzrenderPopover(toolbar);
     }
-  }
-
-  function setXyzrenderPopoverOpenPersisted(open) {
-    try {
-      const key = xyzrenderPopoverStorageKey();
-      if (open) window.localStorage?.setItem(key, '1');
-      else window.localStorage?.setItem(key, '0');
-    } catch (_) {}
-  }
-
-  function shouldRestoreXyzrenderPopoverOpen(config = {}) {
-    try {
-      const stored = window.localStorage?.getItem(xyzrenderPopoverStorageKey());
-      if (stored === '1') return true;
-    } catch (_) {
-      // Fall through to the first-open default.
-    }
-    return shouldOpenXyzrenderPopoverByDefault(config);
-  }
-
-  function shouldOpenXyzrenderPopoverByDefault(config = {}) {
-    return normalizeRenderer(config.renderer) === 'xyzrender-external' &&
-      config.xyzrenderViewer === true;
   }
 
   function normalizeXyzrenderControls(value, config = {}) {
@@ -1864,6 +1869,7 @@
     const transitionFrame = captureMolstarTransitionFrame();
     let prepared = null;
     try {
+      clearMolstarEditUndoHistory();
       if (typeof plugin?.clear === 'function') await plugin.clear();
       prepared = structureDataForMolstar(nextConfig);
       await withTimeout(
@@ -1961,7 +1967,7 @@
   }
 
   function molstarAutoFocusEnabled(config) {
-    return config?.autoFocusStructure !== false;
+    return config?.autoFocusStructure === true;
   }
 
   function hasMolstarContextFocus(config) {
@@ -2081,6 +2087,7 @@
       const poseCount = Number(prepared?.poseCount || 0);
       return Number.isFinite(poseCount) && poseCount > 1;
     }
+    if (prepared?.pdbModelOverlayAvailable === true) return true;
     if (prepared?.sdfPoseOverlayAvailable === true || prepared?.xyzFrameOverlayAvailable === true) return true;
     const poseCount = Number(prepared?.poseCount || prepared?.sdfPoseRecordCount || prepared?.xyzFrameCount || activeConfig?.trajectoryFrameCount || 0);
     if (!Number.isFinite(poseCount) || poseCount <= 1) return false;
@@ -2092,6 +2099,7 @@
     const format = normalizeFormat(activeConfig?.molstarFormat || activeConfig?.format);
     if (prepared?.dockingSceneMode) return 'structures';
     if (prepared?.kind === 'sdf-collection') return 'molecules';
+    if (prepared?.pdbModelOverlayAvailable === true) return 'models';
     return prepared?.xyzFrameOverlayAvailable === true || format === 'xyz' ? 'XYZ frames' : 'SDF poses';
   }
 
@@ -2147,6 +2155,10 @@
       await applyXyzFrameOverlayVisibility(activeViewer, activeMolstarPrepared, activePose);
       return;
     }
+    if (activeMolstarPrepared?.pdbModelOverlayAvailable === true) {
+      await reloadActiveMolstarStructure();
+      return;
+    }
     await reloadActiveMolstarStructure();
   }
 
@@ -2180,12 +2192,17 @@
       debug('BurreteAgent notifyStructureLoaded failed: ' + (error && error.message || String(error)));
     }
     await applyMolstarContextFocus(config);
-    molstarStandalonePreviewTarget = molstarStandaloneMoleculePreviewTarget(config);
-    if (molstarStandalonePreviewTarget) showMolstarPersistentMoleculePreview(molstarStandalonePreviewTarget);
     void reportBurreteAgentState();
     startBurreteAgentActionPolling();
-    setStatus(`[web] Rendered ${config.label || 'structure'}`);
-    setTimeout(hideStatus, isQuickLookHost() ? 0 : 700);
+    {
+      const poseCount = Number(prepared?.poseCount || prepared?.sdfPoseRecordCount || prepared?.xyzFrameCount || config?.trajectoryFrameCount || 0);
+      setStatus(`[web] Rendered ${config.label || 'structure'}`);
+      setTimeout(() => hideStatus(molstarReadyPayload(config, prepared, {
+        molstarStructureCount: currentMolstarStructureCount(viewer),
+        poseCount,
+        trajectoryFrameCount: Math.max(Number(config?.trajectoryFrameCount || 0), poseCount)
+      })), isQuickLookHost() ? 0 : 700);
+    }
   }
 
   function toggleSdfPoseMode() {
@@ -2250,9 +2267,12 @@
     const molstarStyleSelect = toolbar.querySelector('[data-buret-molstar-style]');
     const tuneButton = toolbar.querySelector('[data-buret-action="xyzrender-tune"]');
     const popover = toolbar.querySelector('[data-buret-xyzrender-popover]');
+    const lassoButton = toolbar.querySelector('[data-buret-action="molstar-lasso"]');
     const external = normalized === 'xyzrender-external';
     molstarStyleSlot?.classList.toggle('visible', !external);
     if (molstarStyleSelect) molstarStyleSelect.disabled = external;
+    lassoButton?.classList.toggle('hidden', external);
+    if (lassoButton) lassoButton.disabled = external;
     presetSlot?.classList.toggle('visible', external);
     if (preset) preset.disabled = !external;
     tuneButton?.classList.toggle('hidden', !external);
@@ -2260,7 +2280,6 @@
       tuneButton?.classList.remove('active');
       tuneButton?.removeAttribute('data-open');
       popover?.classList.add('hidden');
-      setXyzrenderPopoverOpenPersisted(false);
     }
   }
 
@@ -2697,7 +2716,11 @@
     });
     configureRendererControls(activeConfig);
     setStatus(`[web] Rendered ${(activeConfig || {}).label || 'structure'} with external xyzrender`);
-    setTimeout(hideStatus, 450);
+    setTimeout(() => hideStatus(previewReadyPayload(activeConfig, {
+      renderer: 'xyzrender-external',
+      externalArtifact: true,
+      xyzrenderSvgBytes: String(payload.svg || '').length
+    })), 450);
   }
 
   function populateXyzrenderControlsForm(toolbar, controls) {
@@ -3189,7 +3212,12 @@
     }
     bindThemeButton(toolbar, viewer);
     bindSaveModifiedStructureButton(toolbar);
+    installMolstarEditUndoShortcuts();
     bindMolstarStyleControls(toolbar);
+    bindMolstarLassoButton(toolbar);
+    bindMolstarLassoKeyboardButton(toolbar);
+    installMolstarLassoSelection();
+    installMolstarToolbarActionDelegates();
     bindXyzrenderControls(toolbar);
     const sdfPoseButton = toolbar.querySelector('[data-buret-action="sdf-poses"]');
     if (sdfPoseButton && sdfPoseButton.dataset.bound !== '1') {
@@ -3213,6 +3241,28 @@
   function setMolstarStructureDirty(dirty) {
     molstarStructureDirty = dirty === true;
     updateSaveModifiedStructureButton();
+  }
+
+  function isMolstarEditUndoKeyboardTarget(target) {
+    if (!(target instanceof Element)) return false;
+    if (target.closest('#buret-toolbar, .buret-molecule-context-menu')) return true;
+    if (target.closest('input, textarea, select, [contenteditable="true"]')) return false;
+    return true;
+  }
+
+  function installMolstarEditUndoShortcuts() {
+    if (window.__buretteMolstarEditUndoShortcutsInstalled) return;
+    window.__buretteMolstarEditUndoShortcutsInstalled = true;
+    document.addEventListener('keydown', event => {
+      const key = String(event.key || '').toLowerCase();
+      if (key !== 'z' || event.shiftKey || event.altKey || !(event.metaKey || event.ctrlKey)) return;
+      if (!molstarEditUndoStack.length || !isMolstarEditUndoKeyboardTarget(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      void undoMolstarLastEdit().catch(error => {
+        setStatus(`[web] Undo failed.\n\n${error?.message || String(error)}`, 'error');
+      });
+    }, true);
   }
 
   function updateSaveModifiedStructureButton() {
@@ -3292,6 +3342,70 @@
       select.addEventListener('change', () => requestMolstarStyle(select.value));
     }
     toolbar.dataset.molstarStyleBound = '1';
+  }
+
+  function bindMolstarLassoButton(toolbar) {
+    const button = toolbar?.querySelector('[data-buret-action="molstar-lasso"]');
+    if (!button || button.dataset.bound === '1') return;
+    button.dataset.bound = '1';
+    updateMolstarLassoButton();
+  }
+
+  function installMolstarToolbarActionDelegates() {
+    if (window.__buretteMolstarToolbarActionDelegatesInstalled) return;
+    window.__buretteMolstarToolbarActionDelegatesInstalled = true;
+    document.addEventListener('pointerdown', event => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target || event.button !== 0) return;
+      const lassoButton = target.closest('[data-buret-action="molstar-lasso"]');
+      if (lassoButton) {
+        molstarLassoSuppressClickUntil = Date.now() + 500;
+        event.preventDefault();
+        event.stopPropagation();
+        setMolstarLassoEnabled(!molstarLassoEnabled);
+        return;
+      }
+    }, true);
+    document.addEventListener('click', event => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target) return;
+      if (target.closest('[data-buret-action="molstar-lasso"]') && Date.now() < molstarLassoSuppressClickUntil) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }, true);
+  }
+
+  function bindMolstarLassoKeyboardButton(toolbar) {
+    const button = toolbar?.querySelector('[data-buret-action="molstar-lasso"]');
+    if (!button || button.dataset.keyboardBound === '1') return;
+    button.dataset.keyboardBound = '1';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (Date.now() < molstarLassoSuppressClickUntil) return;
+      setMolstarLassoEnabled(!molstarLassoEnabled);
+    });
+  }
+
+  function updateMolstarLassoButton() {
+    const button = document.querySelector('#buret-toolbar [data-buret-action="molstar-lasso"]');
+    if (!button) return;
+    button.classList.toggle('active', molstarLassoEnabled);
+    button.setAttribute('aria-pressed', molstarLassoEnabled ? 'true' : 'false');
+    const label = molstarLassoEnabled ? 'Exit lasso select' : 'Lasso select';
+    button.setAttribute('aria-label', label);
+    button.setAttribute('title', label);
+    setTooltipLabel(button, molstarLassoEnabled ? 'Drag over visible residues to select' : 'Lasso select visible residues');
+  }
+
+  function setMolstarLassoEnabled(enabled) {
+    const next = enabled === true;
+    molstarLassoEnabled = next;
+    if (!next) cancelMolstarLassoStroke();
+    document.body?.classList.toggle('buret-molstar-lasso-active', molstarLassoEnabled);
+    updateMolstarLassoButton();
+    setStatus(molstarLassoEnabled ? '[web] Lasso selection enabled.' : '[web] Lasso selection disabled.');
   }
 
   function bindXyzrenderControls(toolbar) {
@@ -3991,8 +4105,40 @@
   }
 
 
-  function hideStatus() {
-    post('ready', 'ready');
+  function previewReadyPayload(config = activeConfig || window.BurreteConfig || {}, extra = {}) {
+    const cfg = config && typeof config === 'object' ? config : {};
+    return {
+      mode: cfg.mode || 'structure',
+      renderer: normalizeRenderer(extra.renderer || cfg.renderer),
+      format: cfg.molstarFormat || cfg.format || '',
+      sourceExtension: cfg.sourceExtension || '',
+      trajectoryFrameCount: Number(cfg.trajectoryFrameCount || 0),
+      externalArtifact: Boolean(cfg.externalArtifact || extra.externalArtifact),
+      ...extra
+    };
+  }
+
+  function molstarReadyPayload(config, prepared, extra = {}) {
+    const poseCount = Number(prepared?.poseCount || prepared?.sdfPoseRecordCount || prepared?.xyzFrameCount || config?.trajectoryFrameCount || 0);
+    return previewReadyPayload(config, {
+      renderer: 'molstar',
+      molstarStructureCount: Number(extra.molstarStructureCount || 0),
+      poseCount: Number.isFinite(poseCount) ? poseCount : 0,
+      trajectoryFrameCount: Math.max(Number(config?.trajectoryFrameCount || 0), Number.isFinite(poseCount) ? poseCount : 0),
+      ...extra
+    });
+  }
+
+  function currentMolstarStructureCount(viewer = activeViewer) {
+    try {
+      return Array.from(viewer?.plugin?.managers?.structure?.hierarchy?.current?.structures || []).length;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  function hideStatus(payload = null) {
+    post('ready', 'ready', payload || previewReadyPayload());
     if (window.BurreteDebug) return;
     if (status) status.classList.add('hidden');
   }
@@ -4223,6 +4369,23 @@
     return entry.binary ? bytes : new TextDecoder('utf-8', { fatal: false }).decode(bytes);
   }
 
+  function isStructureSceneEntry(entry) {
+    return entry?.representation === 'structure-scene-entry';
+  }
+
+  function structureSceneEntriesFromConfig(config) {
+    const entries = Array.isArray(config?.stagedEntries) ? config.stagedEntries : [];
+    return entries
+      .filter(entry => isStructureSceneEntry(entry) && entry?.binary !== true && typeof entry?.dataBase64 === 'string' && entry.dataBase64.trim())
+      .map((entry, index) => ({
+        data: base64ToText(entry.dataBase64),
+        format: normalizeFormat(entry.format || 'pdb'),
+        label: entry.label || `Structure ${index + 1}`,
+        sourcePath: config?.sourcePath || ''
+      }))
+      .filter(entry => entry.data.trim());
+  }
+
   function normalizeFormat(format) {
     const value = String(format || 'auto').toLowerCase();
     if (value === 'cifcore' || value === 'corecif' || value === 'core-cif') return 'cifCore';
@@ -4310,7 +4473,7 @@
   }
 
   function dockingSceneMode(config) {
-    const mode = String(config?.docking?.sceneMode || '').trim();
+    const mode = String(config?.docking?.sceneMode || config?.structureSceneMode || '').trim();
     return mode === 'structureAll' || mode === 'structurePoses' ? mode : '';
   }
 
@@ -4461,17 +4624,18 @@
         collectionSinglePdbs: prepared?.collectionSinglePdbs || []
       };
     }
-    if (prepared?.sdfPoseMode === 'all') {
-      const poseCount = Number(prepared?.xyzFrameCount || prepared?.sdfPoseRecordCount || activeConfig?.trajectoryFrameCount || 0);
+    if (prepared?.sdfPoseMode === 'all' || prepared?.pdbModelMode === 'all') {
+      const poseCount = Number(prepared?.xyzFrameCount || prepared?.sdfPoseRecordCount || prepared?.pdbModelCount || activeConfig?.trajectoryFrameCount || 0);
       return {
         kind: 'trajectory-overlay',
         activePose: 0,
         poseCount: Number.isFinite(poseCount) && poseCount > 0 ? poseCount : 1,
         nativeTrajectoryControls: false,
         ligandLabel: prepared?.label || activeConfig?.label || 'Mol* overlay',
-        controlLabel: prepared?.xyzFrameOverlayAvailable === true ? 'Frame' : 'Pose',
+        controlLabel: prepared?.xyzFrameOverlayAvailable === true ? 'Frame' : prepared?.pdbModelOverlayAvailable === true ? 'Model' : 'Pose',
         sdfPoseOverlayAvailable: prepared?.sdfPoseOverlayAvailable === true,
         xyzFrameOverlayAvailable: prepared?.xyzFrameOverlayAvailable === true,
+        pdbModelOverlayAvailable: prepared?.pdbModelOverlayAvailable === true,
         overlayOnly: true
       };
     }
@@ -4544,39 +4708,6 @@
       label: receptor.label || 'Receptor',
       sourcePath: receptor.path || ''
     };
-    const sceneMode = dockingSceneMode(config);
-    if (sceneMode) {
-      const sceneEntries = [receptorEntry];
-      ligandSources.forEach((source, ligandIndex) => {
-        const data = dockingPayloadData(source, ligandPayloads[ligandIndex]);
-        sceneEntries.push({
-          data,
-          format: normalizeFormat(source.format),
-          label: source.label || `Structure ${ligandIndex + 2}`,
-          sourcePath: source.path || ''
-        });
-      });
-      const poses = sceneEntries.map((entry, poseIndex) => ({
-        ...entry,
-        ligandIndex: poseIndex,
-        poseIndex,
-        poseCount: sceneEntries.length
-      }));
-      const activePose = readDockingPoseIndex(config, poses.length);
-      const allMode = activeSdfPoseMode === 'all';
-      return {
-        kind: 'docking',
-        dockingSceneMode: sceneMode,
-        label: config.label || 'Mol* scene',
-        activePose,
-        poseCount: poses.length,
-        ligandLabel: poses[activePose].label,
-        controlLabel: 'Structure',
-        receptorEntry,
-        poses,
-        entries: allMode ? sceneEntries : [poses[activePose]]
-      };
-    }
     const entries = [receptorEntry];
     let nativeTrajectoryPoseCount = 0;
     ligandSources.forEach((source, ligandIndex) => {
@@ -4621,7 +4752,6 @@
         poseCount: 1
       });
     });
-    if (poses.length === 0) throw new Error('Docking view has no ligand poses.');
     const trajectoryPair = dockingTrajectoryPair(entries);
     if (trajectoryPair) {
       return {
@@ -4638,6 +4768,40 @@
         trajectoryPair
       };
     }
+    const sceneMode = dockingSceneMode(config);
+    if (sceneMode) {
+      const sceneEntries = [receptorEntry];
+      ligandSources.forEach((source, ligandIndex) => {
+        const data = dockingPayloadData(source, ligandPayloads[ligandIndex]);
+        sceneEntries.push({
+          data,
+          format: normalizeFormat(source.format),
+          label: source.label || `Structure ${ligandIndex + 2}`,
+          sourcePath: source.path || ''
+        });
+      });
+      const poses = sceneEntries.map((entry, poseIndex) => ({
+        ...entry,
+        ligandIndex: poseIndex,
+        poseIndex,
+        poseCount: sceneEntries.length
+      }));
+      const activePose = readDockingPoseIndex(config, poses.length);
+      const allMode = activeSdfPoseMode === 'all';
+      return {
+        kind: 'docking',
+        dockingSceneMode: sceneMode,
+        label: config.label || 'Mol* scene',
+        activePose,
+        poseCount: poses.length,
+        ligandLabel: poses[activePose].label,
+        controlLabel: 'Structure',
+        receptorEntry,
+        poses,
+        entries: allMode ? sceneEntries : [poses[activePose]]
+      };
+    }
+    if (poses.length === 0) throw new Error('Docking view has no ligand poses.');
     const activePose = readDockingPoseIndex(config, poses.length);
     if (nativeTrajectoryPoseCount > 1) {
       return {
@@ -4679,6 +4843,10 @@
     }
     const normalized = normalizeFormat(config.format);
     const sourceFormat = normalizeFormat(config.sourceExtension || config.molstarFormat || config.format);
+    const sceneEntries = structureSceneEntriesFromConfig(config);
+    if (sceneEntries.length > 1) {
+      return prepareStagedStructureScene(config, sceneEntries);
+    }
     if (isMolViewSpecFormat(normalized)) {
       return {
         kind: 'mvs',
@@ -4701,26 +4869,58 @@
     if (normalized === 'xyz') {
       return prepareXyzStructure(rawStructureData(config), config);
     }
-    if ((normalized === 'pdb' || normalized === 'pdbqt') && sourceFormat === 'pdbqt') {
-      const data = rawStructureData(config);
-      const modelTexts = splitPdbModelTexts(data);
-      const poseCount = modelTexts.length;
-      return {
-        data,
-        format: 'pdb',
-        label: config.label || 'structure',
-        loadPreset: 'default',
-        nativeTrajectoryControls: poseCount > 1,
-        poseCount,
-        activePose: readTrajectoryControlIndex(config, { controlLabel: 'Pose' }, poseCount),
-        controlLabel: 'Pose'
-      };
+    if (normalized === 'pdb' || normalized === 'pdbqt') {
+      const preparedPdbModels = preparePdbModelStructure(rawStructureData(config), config, sourceFormat);
+      if (preparedPdbModels) return preparedPdbModels;
     }
 
     return {
       data: rawStructureData(config),
       format: normalized,
       label: config.label || 'structure'
+    };
+  }
+
+  function prepareStagedStructureScene(config, entries) {
+    const activePose = readTrajectoryControlIndex(config, { kind: 'docking' }, entries.length);
+    const allMode = activeSdfPoseMode === 'all';
+    const poses = entries.map((entry, poseIndex) => ({
+      ...entry,
+      ligandIndex: poseIndex,
+      poseIndex,
+      poseCount: entries.length
+    }));
+    return {
+      kind: 'docking',
+      dockingSceneMode: 'structurePoses',
+      label: config.label || 'Mol* scene',
+      activePose,
+      poseCount: poses.length,
+      ligandLabel: poses[activePose]?.label || config.label || 'Structure',
+      controlLabel: 'Structure',
+      poses,
+      entries: allMode ? poses : [poses[activePose]]
+    };
+  }
+
+  function preparePdbModelStructure(data, config, sourceFormat) {
+    const modelTexts = splitPdbModelTexts(data);
+    const poseCount = modelTexts.length;
+    if (poseCount <= 1) return null;
+    const controlLabel = sourceFormat === 'pdbqt' ? 'Pose' : 'Model';
+    const allMode = activeSdfPoseMode === 'all';
+    return {
+      data,
+      format: 'pdb',
+      label: config.label || 'structure',
+      loadPreset: allMode ? 'all-models' : 'default',
+      nativeTrajectoryControls: !allMode,
+      poseCount,
+      activePose: readTrajectoryControlIndex(config, { controlLabel }, poseCount),
+      controlLabel,
+      pdbModelOverlayAvailable: true,
+      pdbModelCount: poseCount,
+      pdbModelMode: allMode ? 'all' : 'single'
     };
   }
 
@@ -4748,7 +4948,11 @@
     if (root) installExternalArtifactInteractions(root);
     initStaticRendererToolbar();
     setStatus(`[web] Rendered ${config.label || 'structure'} with external xyzrender`);
-    setTimeout(hideStatus, 450);
+    setTimeout(() => hideStatus(previewReadyPayload(config, {
+      renderer: 'xyzrender-external',
+      externalArtifact: true,
+      xyzrenderSvgBytes: inlineSvg ? inlineSvg.length : 0
+    })), 450);
   }
 
   function initStaticRendererToolbar() {
@@ -6448,8 +6652,9 @@
   }
 
   function dockingSceneBackgroundStyle(contextStyle, foregroundStyle) {
-    if (contextStyle !== 'match') return normalizeMolstarStyle(contextStyle);
-    return normalizeMolstarStyle(foregroundStyle);
+    const resolved = contextStyle !== 'match' ? normalizeMolstarStyle(contextStyle) : normalizeMolstarStyle(foregroundStyle);
+    if (resolved === 'cartoon' || resolved === 'spacefill') return 'line';
+    return resolved;
   }
 
   async function loadSdfCollectionPdbLayer(viewer, data, label) {
@@ -7268,7 +7473,7 @@
   }
 
   async function loadStagedMolstarEntries(viewer, config, cb) {
-    const entries = Array.isArray(config?.stagedEntries) ? config.stagedEntries : [];
+    const entries = Array.isArray(config?.stagedEntries) ? config.stagedEntries.filter(entry => !isStructureSceneEntry(entry)) : [];
     if (!entries.length) return;
     setStatus(`[web] Loading ${entries[0]?.label || 'staged structure'}…`);
     await waitForAnimationFrame();
@@ -8011,9 +8216,6 @@
     const refreshNativeTrajectoryStandalonePreview = () => {
       if (!prepared.nativeTrajectoryControls || !activeConfig) return;
       try { sessionStorage.setItem(trajectoryControlStorageKey(activeConfig, prepared), String(activePose)); } catch (_) {}
-      molstarStandalonePreviewTarget = molstarStandaloneMoleculePreviewTarget(activeConfig);
-      molstarPersistentMoleculePreviewTarget = null;
-      if (molstarStandalonePreviewTarget) showMolstarPersistentMoleculePreview(molstarStandalonePreviewTarget);
     };
     const updateControls = () => {
       label.textContent = trajectoryPoseLabel(prepared, controlLabel, activePose);
@@ -8346,6 +8548,22 @@
     return target.closest('canvas') || target.closest('.msp-plugin')?.querySelector('canvas') || null;
   }
 
+  function molstarPickFromCanvasPoint(canvas, clientX, clientY) {
+    const canvas3d = activeViewer?.plugin?.canvas3d;
+    if (!canvas || !canvas3d || typeof canvas3d.identify !== 'function' || typeof canvas3d.getLoci !== 'function') return null;
+    const rect = canvas.getBoundingClientRect();
+    if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) return null;
+    try {
+      const picking = canvas3d.identify([clientX - rect.left, clientY - rect.top]);
+      const pick = picking?.id ? canvas3d.getLoci(picking.id) : null;
+      if (!pick?.loci || molstarLociIsEmpty(pick.loci)) return null;
+      return { ...pick, position: picking.position };
+    } catch (error) {
+      debug('Mol* canvas pick failed: ' + (error?.message || String(error)));
+      return null;
+    }
+  }
+
   function molstarContextPickFromEvent(event, options = {}) {
     const canvas3d = activeViewer?.plugin?.canvas3d;
     if (!canvas3d || typeof canvas3d.identify !== 'function' || typeof canvas3d.getLoci !== 'function') return null;
@@ -8375,10 +8593,9 @@
         const x = event.clientX + dx;
         const y = event.clientY + dy;
         if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) continue;
-        const picking = canvas3d.identify([x - rect.left, y - rect.top]);
-        const pick = picking?.id ? canvas3d.getLoci(picking.id) : null;
+        const pick = molstarPickFromCanvasPoint(canvas, x, y);
         if (!pick?.loci || molstarLociIsEmpty(pick.loci)) continue;
-        return { ...pick, position: picking.position, touchAdjusted: dx !== 0 || dy !== 0 };
+        return { ...pick, touchAdjusted: dx !== 0 || dy !== 0 };
       }
       return null;
     } catch (error) {
@@ -8395,6 +8612,281 @@
     return molstarContextEventIsTouch(event)
       ? { radiusPx: MOLSTAR_TOUCH_PICK_RADIUS_PX, stepPx: MOLSTAR_TOUCH_PICK_STEP_PX }
       : {};
+  }
+
+  function installMolstarLassoSelection() {
+    if (window.__buretteMolstarLassoSelectionInstalled) return;
+    window.__buretteMolstarLassoSelectionInstalled = true;
+    document.addEventListener('pointerdown', onMolstarLassoPointerDown, true);
+    document.addEventListener('pointermove', onMolstarLassoPointerMove, true);
+    document.addEventListener('pointerup', onMolstarLassoPointerUp, true);
+    document.addEventListener('pointercancel', onMolstarLassoPointerCancel, true);
+    document.addEventListener('keydown', onMolstarLassoKeyDown, true);
+    window.addEventListener('resize', cancelMolstarLassoStroke);
+  }
+
+  function onMolstarLassoKeyDown(event) {
+    if (event.key !== 'Escape') return;
+    if (molstarLassoStroke) {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelMolstarLassoStroke();
+      setStatus('[web] Lasso selection canceled.');
+      return;
+    }
+    if (molstarLassoEnabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      setMolstarLassoEnabled(false);
+    }
+  }
+
+  function onMolstarLassoPointerDown(event) {
+    if (!molstarLassoEnabled || event.button !== 0 || !isMolstarContextMenuTarget(event.target)) return;
+    const canvas = molstarContextCanvasFromEvent(event);
+    if (!canvas) return;
+    hideMolstarContextMenu();
+    hideMolstarMoleculePreview();
+    molstarLassoStroke = {
+      pointerId: event.pointerId,
+      canvas,
+      additive: event.shiftKey || event.metaKey || event.ctrlKey,
+      dragging: false,
+      points: [{ x: event.clientX, y: event.clientY }]
+    };
+    try { canvas.setPointerCapture?.(event.pointerId); } catch (_) {}
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerMove(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    const last = stroke.points[stroke.points.length - 1];
+    if (Math.hypot(event.clientX - last.x, event.clientY - last.y) >= MOLSTAR_LASSO_MIN_DISTANCE_PX) {
+      if (!stroke.dragging) {
+        stroke.dragging = true;
+        hideMolstarContextMenu();
+        hideMolstarMoleculePreview();
+        ensureMolstarLassoOverlay();
+        try { stroke.canvas.setPointerCapture?.(event.pointerId); } catch (_) {}
+      }
+      stroke.points.push({ x: event.clientX, y: event.clientY });
+      updateMolstarLassoOverlay(stroke.points);
+    }
+    if (!stroke.dragging) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerUp(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    if (!stroke.dragging) {
+      molstarLassoStroke = null;
+      return;
+    }
+    if (Math.hypot(event.clientX - stroke.points[0].x, event.clientY - stroke.points[0].y) >= MOLSTAR_LASSO_MIN_DISTANCE_PX) {
+      stroke.points.push({ x: event.clientX, y: event.clientY });
+    }
+    finishMolstarLassoStroke(stroke);
+    try { stroke.canvas.releasePointerCapture?.(event.pointerId); } catch (_) {}
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMolstarLassoPointerCancel(event) {
+    const stroke = molstarLassoStroke;
+    if (!stroke || event.pointerId !== stroke.pointerId) return;
+    cancelMolstarLassoStroke();
+    if (!stroke.dragging) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+  }
+
+  function ensureMolstarLassoOverlay() {
+    if (molstarLassoOverlay) return molstarLassoOverlay;
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('buret-molstar-lasso-overlay');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.innerHTML = '<polygon data-buret-lasso-fill></polygon><polyline data-buret-lasso-line></polyline>';
+    document.body.appendChild(svg);
+    molstarLassoOverlay = svg;
+    return svg;
+  }
+
+  function updateMolstarLassoOverlay(points) {
+    const overlay = ensureMolstarLassoOverlay();
+    const value = points.map(point => `${Math.round(point.x)},${Math.round(point.y)}`).join(' ');
+    overlay.querySelector('[data-buret-lasso-fill]')?.setAttribute('points', value);
+    overlay.querySelector('[data-buret-lasso-line]')?.setAttribute('points', value);
+  }
+
+  function removeMolstarLassoOverlay() {
+    molstarLassoOverlay?.remove();
+    molstarLassoOverlay = null;
+  }
+
+  function cancelMolstarLassoStroke() {
+    molstarLassoStroke = null;
+    removeMolstarLassoOverlay();
+  }
+
+  function finishMolstarLassoStroke(stroke) {
+    molstarLassoStroke = null;
+    removeMolstarLassoOverlay();
+    const bounds = molstarLassoBounds(stroke.points);
+    if (stroke.points.length < MOLSTAR_LASSO_MIN_POINTS || bounds.width < MOLSTAR_LASSO_SAMPLE_STEP_PX || bounds.height < MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+      setStatus('[web] Lasso selection was too small.');
+      return;
+    }
+    const picks = molstarLassoPicks(stroke);
+    if (!picks.length) {
+      setStatus('[web] No visible atoms inside lasso.');
+      return;
+    }
+    const selected = applyMolstarLassoPicks(picks, stroke.additive);
+    setStatus(selected > 0
+      ? `[web] Selected ${selected} visible target${selected === 1 ? '' : 's'} with lasso.`
+      : '[web] Lasso selection did not match selectable atoms.');
+  }
+
+  function molstarLassoBounds(points) {
+    const xs = points.map(point => point.x);
+    const ys = points.map(point => point.y);
+    const left = Math.min(...xs);
+    const right = Math.max(...xs);
+    const top = Math.min(...ys);
+    const bottom = Math.max(...ys);
+    return { left, right, top, bottom, width: right - left, height: bottom - top };
+  }
+
+  function molstarPointInPolygon(point, polygon) {
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+      const pi = polygon[i];
+      const pj = polygon[j];
+      const intersects = ((pi.y > point.y) !== (pj.y > point.y)) &&
+        point.x < ((pj.x - pi.x) * (point.y - pi.y)) / ((pj.y - pi.y) || 1e-6) + pi.x;
+      if (intersects) inside = !inside;
+    }
+    return inside;
+  }
+
+  function molstarLassoPickKey(pick, fallback) {
+    const atom = molstarContextAtomFromLoci(pick?.loci);
+    if (atom) {
+      return [
+        atom.model?.id || atom.model?.entryId || 'model',
+        atom.label_entity_id || '',
+        atom.label_asym_id || atom.auth_asym_id || '',
+        atom.label_seq_id ?? atom.auth_seq_id ?? '',
+        atom.label_comp_id || atom.auth_comp_id || '',
+        atom.atomIndex ?? ''
+      ].join(':');
+    }
+    return `${pick?.loci?.kind || 'loci'}:${fallback}`;
+  }
+
+  function molstarLassoPicks(stroke) {
+    const bounds = molstarLassoBounds(stroke.points);
+    const picks = [];
+    const seen = new Set();
+    let sampled = 0;
+    const addPick = (x, y) => {
+      if (sampled >= MOLSTAR_LASSO_SAMPLE_LIMIT) return;
+      sampled += 1;
+      const pick = molstarPickFromCanvasPoint(stroke.canvas, x, y);
+      if (!pick?.loci) return;
+      const key = molstarLassoPickKey(pick, `${Math.round(x)}:${Math.round(y)}`);
+      if (seen.has(key)) return;
+      seen.add(key);
+      picks.push(pick);
+    };
+    for (const point of stroke.points) {
+      addPick(point.x, point.y);
+    }
+    for (let y = bounds.top; y <= bounds.bottom; y += MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+      for (let x = bounds.left; x <= bounds.right; x += MOLSTAR_LASSO_SAMPLE_STEP_PX) {
+        if (molstarPointInPolygon({ x, y }, stroke.points)) addPick(x, y);
+      }
+    }
+    return picks;
+  }
+
+  function applyMolstarLassoPicks(picks, additive) {
+    const selects = activeViewer?.plugin?.managers?.interactivity?.lociSelects;
+    const selection = activeViewer?.plugin?.managers?.structure?.selection;
+    const canSelect = typeof selects?.select === 'function';
+    const canSelectStructure = typeof selection?.fromLoci === 'function';
+    if (!canSelect && !canSelectStructure) return 0;
+    if (!additive) {
+      selects?.deselectAll?.();
+      selection?.clear?.();
+    }
+    let selected = 0;
+    for (const pick of picks) {
+      const loci = molstarContextNormalizeLoci(pick?.loci, 'residue');
+      if (!loci || molstarLociIsEmpty(loci)) continue;
+      if (canSelect) selects.select({ loci }, true);
+      if (canSelectStructure) selection.fromLoci('add', loci, true);
+      selected += 1;
+    }
+    if (selected > 0) scheduleMolstarSelectedMoleculePreview();
+    return selected;
+  }
+
+  function molstarCurrentSelectionLociList() {
+    return molstarContextStructures()
+      .map(structure => molstarContextSelectionLociForStructure(structure))
+      .filter(loci => loci && !molstarLociIsEmpty(loci));
+  }
+
+  function restoreMolstarSelectionLociList(lociList) {
+    if (!Array.isArray(lociList) || !lociList.length) return false;
+    const selects = activeViewer?.plugin?.managers?.interactivity?.lociSelects;
+    const selection = activeViewer?.plugin?.managers?.structure?.selection;
+    const canSelect = typeof selects?.select === 'function';
+    const canSelectStructure = typeof selection?.fromLoci === 'function';
+    if (!canSelect && !canSelectStructure) return false;
+    selects?.deselectAll?.();
+    selection?.clear?.();
+    for (const loci of lociList) {
+      if (!loci || molstarLociIsEmpty(loci)) continue;
+      if (canSelect) selects.select({ loci }, false);
+      if (canSelectStructure) selection.fromLoci('add', loci, false);
+    }
+    scheduleMolstarSelectedMoleculePreview();
+    return true;
+  }
+
+  function beginMolstarEmptyClickSelectionPreserve(event) {
+    if (molstarLassoEnabled || molstarLassoStroke || event.button !== 0 || !isMolstarContextMenuTarget(event.target)) return;
+    const lociList = molstarCurrentSelectionLociList();
+    if (!lociList.length) return;
+    if (molstarContextPickFromEvent(event, molstarContextTouchPickOptions(event))) return;
+    molstarSelectionPreserveClick = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      lociList
+    };
+  }
+
+  function finishMolstarEmptyClickSelectionPreserve(event) {
+    const preserve = molstarSelectionPreserveClick;
+    if (!preserve || event.pointerId !== preserve.pointerId) return;
+    molstarSelectionPreserveClick = null;
+    const moved = Math.hypot(event.clientX - preserve.startX, event.clientY - preserve.startY) > MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX;
+    if (moved) return;
+    setTimeout(() => {
+      if (molstarCurrentSelectionLociList().length) return;
+      restoreMolstarSelectionLociList(preserve.lociList);
+    }, 0);
   }
 
   function molstarContextStructures() {
@@ -9555,6 +10047,104 @@
     return postMolstarModifiedStructureExport(molstarModifiedStructureExportPayloadForFormat(format, target));
   }
 
+  function molstarEditSnapshotFormat(payload) {
+    const explicit = String(payload?.format || '').trim();
+    if (explicit) return normalizeFormat(explicit);
+    const name = String(payload?.name || '').toLowerCase();
+    const mimeType = String(payload?.mimeType || '').toLowerCase();
+    if (mimeType.includes('pdb') || name.endsWith('.pdb')) return 'pdb';
+    if (mimeType.includes('cif') || name.endsWith('.cif') || name.endsWith('.mcif') || name.endsWith('.mmcif')) return 'mmcif';
+    return normalizeFormat(activeConfig?.molstarFormat || activeConfig?.format || 'mmcif');
+  }
+
+  function captureMolstarEditUndoSnapshot(label) {
+    const payload = molstarModifiedStructureExportPayload();
+    const text = String(payload?.text || '');
+    if (!text.trim()) throw new Error('Mol* returned an empty undo snapshot.');
+    return {
+      label: String(label || payload.name || 'Mol* edit'),
+      dirty: molstarStructureDirty,
+      payload: {
+        name: payload.name,
+        mimeType: payload.mimeType,
+        text,
+        format: molstarEditSnapshotFormat(payload)
+      }
+    };
+  }
+
+  function pushMolstarEditUndoSnapshot(snapshot) {
+    if (!snapshot?.payload?.text) return;
+    molstarEditUndoStack.push(snapshot);
+    while (molstarEditUndoStack.length > MOLSTAR_EDIT_HISTORY_LIMIT) molstarEditUndoStack.shift();
+  }
+
+  function clearMolstarEditUndoHistory() {
+    molstarEditUndoStack.length = 0;
+  }
+
+  async function restoreMolstarEditUndoSnapshot(snapshot) {
+    if (!activeViewer) throw new Error('Mol* viewer is not ready.');
+    const payload = snapshot?.payload || {};
+    const text = String(payload.text || '');
+    if (!text.trim()) throw new Error('Undo snapshot is empty.');
+    const format = molstarEditSnapshotFormat(payload);
+    const label = String(snapshot.label || payload.name || 'Mol* undo snapshot');
+    const prepared = {
+      data: text,
+      format,
+      label,
+      molstarStyleOverride: configuredMolstarStyle(activeConfig || window.BurreteConfig || {})
+    };
+    const plugin = activeViewer.plugin;
+    const transitionFrame = captureMolstarTransitionFrame();
+    try {
+      if (typeof plugin?.clear !== 'function') throw new Error('Mol* cannot replace the current structure in this runtime.');
+      await plugin.clear();
+      await withTimeout(
+        loadPreparedStructure(activeViewer, prepared),
+        45000,
+        `Mol* timed out while restoring ${label}.`
+      );
+      applyLayoutState(activeViewer);
+      scheduleLayoutStateReapply(activeViewer);
+      try { activeViewer.handleResize(); } catch (_) {}
+      fadeMolstarTransitionFrame(transitionFrame);
+    } catch (error) {
+      removeMolstarTransitionFrame(transitionFrame);
+      throw error;
+    }
+    setMolstarStructureDirty(snapshot.dirty === true);
+    clearMolstarSelection();
+    try {
+      window.BurreteAgent?.notifyStructureLoaded?.({
+        viewer: activeViewer,
+        plugin: activeViewer.plugin,
+        config: activeConfig || window.BurreteConfig || {},
+        prepared
+      });
+      postHostMessage({ type: 'agentReady', message: 'Burrete agent ready' });
+    } catch (error) {
+      debug('BurreteAgent notifyStructureLoaded failed after Mol* undo: ' + (error && error.message || String(error)));
+    }
+  }
+
+  async function undoMolstarLastEdit() {
+    const snapshot = molstarEditUndoStack.pop();
+    if (!snapshot) {
+      setStatus('[web] Nothing to undo.');
+      return;
+    }
+    try {
+      await restoreMolstarEditUndoSnapshot(snapshot);
+    } catch (error) {
+      molstarEditUndoStack.push(snapshot);
+      throw error;
+    }
+    setStatus(`[web] Undid ${snapshot.label}.`);
+    setTimeout(hideStatus, isQuickLookHost() ? 0 : 700);
+  }
+
   async function resetMolstarCameraForContext() {
     try {
       const result = await window.BurreteAgent?.run?.({
@@ -9787,26 +10377,36 @@
         if (target.scope === 'ligand' || target.scope === 'ion') previewAfterAction = target;
         setStatus(`[web] Selected ${targetLabel}.`);
       } else if (action === 'remove') {
+        const undoSnapshot = captureMolstarEditUndoSnapshot(`delete ${targetLabel}`);
         if (!await deleteMolstarContextPick(target)) throw new Error('No editable Mol* residue or ligand is available to delete.');
+        pushMolstarEditUndoSnapshot(undoSnapshot);
         setMolstarStructureDirty(true);
         setStatus(`[web] Deleted ${targetLabel}.`);
       } else if (action === 'remove-type') {
         const bulkLabel = molstarContextBulkDeleteLabel(target);
+        const undoSnapshot = captureMolstarEditUndoSnapshot(`delete ${bulkLabel}`);
         if (!await deleteMolstarContextBulkType(target)) throw new Error(`No editable Mol* ${bulkLabel} is available to delete.`);
+        pushMolstarEditUndoSnapshot(undoSnapshot);
         setMolstarStructureDirty(true);
         setStatus(`[web] Deleted ${bulkLabel}.`);
       } else if (action === 'remove-chain') {
+        const chainLabel = molstarContextChainLabel(target.atom);
+        const undoSnapshot = captureMolstarEditUndoSnapshot(`delete ${chainLabel}`);
         if (!await deleteMolstarContextChain(target)) throw new Error('No editable Mol* protein chain is available to delete.');
+        pushMolstarEditUndoSnapshot(undoSnapshot);
         setMolstarStructureDirty(true);
-        setStatus(`[web] Deleted ${molstarContextChainLabel(target.atom)}.`);
+        setStatus(`[web] Deleted ${chainLabel}.`);
       } else if (action === 'select-atom') {
         if (!target.atomLoci || !selectMolstarContextPick({ ...target, loci: target.atomLoci }, { additive: molstarContextMenuMode === 'atom', applyGranularity: false })) throw new Error('No Mol* atom is available to select.');
         if (target.scope === 'ligand' || target.scope === 'ion') previewAfterAction = target;
         setStatus(`[web] Selected ${molstarContextAtomLabel(target)}.`);
       } else if (action === 'remove-atom') {
+        const atomLabel = molstarContextAtomLabel(target);
+        const undoSnapshot = captureMolstarEditUndoSnapshot(`delete ${atomLabel}`);
         if (!target.atomLoci || !await deleteMolstarContextLoci(target, target.atomLoci, false)) throw new Error('No editable Mol* atom is available to delete.');
+        pushMolstarEditUndoSnapshot(undoSnapshot);
         setMolstarStructureDirty(true);
-        setStatus(`[web] Deleted ${molstarContextAtomLabel(target)}.`);
+        setStatus(`[web] Deleted ${atomLabel}.`);
       } else if (action === 'molstar') {
         const contextDocument = molstarContextDocumentPayload(target);
         if (!contextDocument) throw new Error('No molecule-level Mol* context is available for this target.');
@@ -9840,7 +10440,7 @@
       setStatus(`[web] ${label} failed.\n\n${error?.message || String(error)}`, 'error');
     } finally {
       if (!(action === 'select-atom' && molstarContextMenuMode === 'atom')) hideMolstarContextMenu();
-      if (previewAfterAction) showMolstarPersistentMoleculePreview(previewAfterAction);
+      if (previewAfterAction) scheduleMolstarSelectedMoleculePreview(previewAfterAction);
     }
   }
 
@@ -9891,52 +10491,6 @@
       sourceEntry,
       selectedEntry
     };
-  }
-
-  function molstarMoleculePreviewSVG(entry) {
-    if (normalizeFormat(entry?.format) !== 'sdf') return '';
-    const record = splitSdfRecords(String(entry.data || ''))[0] || String(entry.data || '');
-    const molecule = parseV2000SdfRecord(record);
-    if (!molecule || !molecule.atoms.length) return '';
-    const padding = 1.2;
-    const minX = Math.min(...molecule.atoms.map(atom => atom.x));
-    const maxX = Math.max(...molecule.atoms.map(atom => atom.x));
-    const minY = Math.min(...molecule.atoms.map(atom => atom.y));
-    const maxY = Math.max(...molecule.atoms.map(atom => atom.y));
-    const viewBox = [
-      minX - padding,
-      -(maxY + padding),
-      Math.max(1, maxX - minX + padding * 2),
-      Math.max(1, maxY - minY + padding * 2)
-    ].map(value => Number(value).toFixed(3)).join(' ');
-    const atomColor = atom => ({
-      C: '#111111',
-      N: '#2554ff',
-      O: '#e53935',
-      S: '#d6a100',
-      P: '#ff8a00',
-      F: '#22b8b8',
-      Cl: '#25a244',
-      Br: '#8a4f12',
-      I: '#7b2cbf',
-      H: '#8f8f8f'
-    }[atom.element] || '#111111');
-    const atomByIndex = index => molecule.atoms[Math.max(0, index - 1)];
-    const bonds = molecule.bonds.map(bond => {
-      const a = atomByIndex(bond.a);
-      const b = atomByIndex(bond.b);
-      if (!a || !b) return '';
-      return `<line x1="${a.x}" y1="${-a.y}" x2="${b.x}" y2="${-b.y}" />`;
-    }).join('');
-    const atoms = molecule.atoms.map(atom => {
-      const color = atomColor(atom);
-      const label = atom.element && atom.element !== 'C' ? `<text x="${atom.x + 0.08}" y="${-atom.y - 0.08}" fill="${color}">${escapeHTML(atom.element)}</text>` : '';
-      return `<circle cx="${atom.x}" cy="${-atom.y}" r="0.075" fill="${color}" />${label}`;
-    }).join('');
-    return `<svg viewBox="${viewBox}" aria-hidden="true" focusable="false">
-      <g class="buret-molstar-molecule-preview-bonds">${bonds}</g>
-      <g class="buret-molstar-molecule-preview-atoms">${atoms}</g>
-    </svg>`;
   }
 
   function molstarPreviewKey(entry) {
@@ -10102,17 +10656,75 @@
     });
   }
 
+  async function molstarPreviewLoadRDKitScript() {
+    const sources = [
+      runtimeURL('BurreteRDKitJSURL', '../assets/rdkit/RDKit_minimal.js'),
+      'rdkit/RDKit_minimal.js'
+    ];
+    let lastError = null;
+    for (const src of sources) {
+      if (!src) continue;
+      try {
+        await molstarPreviewLoadScript(src);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('RDKit_minimal.js is missing.');
+  }
+
+  function molstarPreviewRDKitWasmCandidates() {
+    const candidates = [];
+    const add = value => {
+      const text = String(value || '').trim();
+      if (text && !candidates.includes(text)) candidates.push(text);
+    };
+    add(window.BurreteConfig?.rdkitWasmPath);
+    add(runtimeURL('BurreteRDKitWasmURL', ''));
+    add('rdkit/RDKit_minimal.wasm');
+    add('../assets/rdkit/RDKit_minimal.wasm');
+    add('/__burette/rdkit-wasm');
+    return candidates;
+  }
+
+  async function molstarPreviewLoadRDKitWasmBinary() {
+    let lastError = null;
+    for (const path of molstarPreviewRDKitWasmCandidates()) {
+      try {
+        const response = await fetch(path, { cache: 'force-cache' });
+        if (!response.ok) throw new Error(`Failed to load RDKit wasm from ${path}: ${response.status} ${response.statusText}`);
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (!bytes.length) throw new Error(`Failed to load RDKit wasm from ${path}: empty response`);
+        return bytes;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('RDKit_minimal.wasm is missing.');
+  }
+
+  function molstarPreviewRDKitWasmPath(file) {
+    if (!String(file || '').endsWith('.wasm')) return file;
+    return molstarPreviewRDKitWasmCandidates()[0] || 'rdkit/RDKit_minimal.wasm';
+  }
+
   async function molstarPreviewInitRDKit() {
     if (molstarPreviewRdkit) return molstarPreviewRdkit;
     if (molstarPreviewRdkitPromise) return molstarPreviewRdkitPromise;
     molstarPreviewRdkitPromise = (async () => {
       if (typeof window.initRDKitModule !== 'function') {
-        await molstarPreviewLoadScript('rdkit/RDKit_minimal.js');
+        await molstarPreviewLoadRDKitScript();
       }
       if (typeof window.initRDKitModule !== 'function') throw new Error('RDKit_minimal.js is missing.');
-      molstarPreviewRdkit = await window.initRDKitModule({
-        locateFile: file => String(file || '').endsWith('.wasm') ? 'rdkit/RDKit_minimal.wasm' : file
-      });
+      const options = { locateFile: molstarPreviewRDKitWasmPath };
+      if (window.BurreteRDKitWasmBase64) {
+        options.wasmBinary = base64ToBytes(window.BurreteRDKitWasmBase64);
+        window.BurreteRDKitWasmBase64 = '';
+      } else {
+        options.wasmBinary = await molstarPreviewLoadRDKitWasmBinary();
+      }
+      molstarPreviewRdkit = await window.initRDKitModule(options);
       return molstarPreviewRdkit;
     })().finally(() => {
       molstarPreviewRdkitPromise = null;
@@ -10131,23 +10743,125 @@
       });
   }
 
+  function molstarPreviewParseMolblock2D(data) {
+    const lines = String(data || '').replace(/\r\n/gu, '\n').replace(/\r/gu, '\n').split('\n');
+    const countsIndex = lines.findIndex(line => /\bV2000\b/u.test(line));
+    if (countsIndex < 0) return null;
+    const countsLine = lines[countsIndex] || '';
+    const countsTokens = countsLine.trim().split(/\s+/u);
+    const atomCount = Number.parseInt(countsLine.slice(0, 3).trim() || countsTokens[0], 10);
+    const bondCount = Number.parseInt(countsLine.slice(3, 6).trim() || countsTokens[1], 10);
+    if (!Number.isFinite(atomCount) || atomCount <= 0 || atomCount > 512) return null;
+    const atoms = [];
+    for (let i = 0; i < atomCount; i++) {
+      const line = lines[countsIndex + 1 + i] || '';
+      const tokens = line.trim().split(/\s+/u);
+      const x = Number.parseFloat(line.slice(0, 10).trim() || tokens[0]);
+      const y = Number.parseFloat(line.slice(10, 20).trim() || tokens[1]);
+      const z = Number.parseFloat(line.slice(20, 30).trim() || tokens[2]);
+      const element = (line.slice(31, 34).trim() || tokens[3] || 'C').replace(/[^A-Za-z0-9+-]/gu, '') || 'C';
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+      atoms.push({ x, y, z: Number.isFinite(z) ? z : 0, element });
+    }
+    const bonds = [];
+    for (let i = 0; i < bondCount; i++) {
+      const line = lines[countsIndex + 1 + atomCount + i] || '';
+      const tokens = line.trim().split(/\s+/u);
+      const a = Number.parseInt(line.slice(0, 3).trim() || tokens[0], 10) - 1;
+      const b = Number.parseInt(line.slice(3, 6).trim() || tokens[1], 10) - 1;
+      const order = Number.parseInt(line.slice(6, 9).trim() || tokens[2], 10);
+      if (Number.isInteger(a) && Number.isInteger(b) && atoms[a] && atoms[b]) {
+        bonds.push({ a, b, order: Number.isFinite(order) ? Math.max(1, Math.min(3, order)) : 1 });
+      }
+    }
+    return { atoms, bonds };
+  }
+
+  function molstarPreviewAtomColor(element) {
+    const key = String(element || '').toUpperCase();
+    if (key === 'O') return '#ef3124';
+    if (key === 'N') return '#3157d8';
+    if (key === 'S') return '#d6c51d';
+    if (key === 'P') return '#f28c28';
+    if (key === 'F' || key === 'CL') return '#52b947';
+    if (key === 'BR') return '#8f4b2e';
+    if (key === 'I') return '#7442a8';
+    if (key === 'H') return '#f7f7f7';
+    return '#8f9499';
+  }
+
+  function molstarMoleculePreviewFallbackSVG(entry) {
+    const parsed = molstarPreviewParseMolblock2D(entry?.data);
+    if (!parsed?.atoms?.length) return '';
+    const size = MOLSTAR_PREVIEW_RDKIT_SVG_SIZE;
+    const pad = 18;
+    let atoms = parsed.atoms;
+    let minX = Math.min(...atoms.map(atom => atom.x));
+    let maxX = Math.max(...atoms.map(atom => atom.x));
+    let minY = Math.min(...atoms.map(atom => atom.y));
+    let maxY = Math.max(...atoms.map(atom => atom.y));
+    if (Math.abs(maxX - minX) < 0.001 && Math.abs(maxY - minY) < 0.001) {
+      atoms = atoms.map((atom, index) => {
+        const angle = (Math.PI * 2 * index) / Math.max(1, parsed.atoms.length);
+        return { ...atom, x: Math.cos(angle), y: Math.sin(angle) };
+      });
+      minX = Math.min(...atoms.map(atom => atom.x));
+      maxX = Math.max(...atoms.map(atom => atom.x));
+      minY = Math.min(...atoms.map(atom => atom.y));
+      maxY = Math.max(...atoms.map(atom => atom.y));
+    }
+    const width = Math.max(0.001, maxX - minX);
+    const height = Math.max(0.001, maxY - minY);
+    const scale = Math.min((size - pad * 2) / width, (size - pad * 2) / height);
+    const dx = (size - width * scale) / 2;
+    const dy = (size - height * scale) / 2;
+    const point = atom => ({
+      x: dx + (atom.x - minX) * scale,
+      y: size - (dy + (atom.y - minY) * scale)
+    });
+    const bondLines = parsed.bonds.map(bond => {
+      const a = point(atoms[bond.a]);
+      const b = point(atoms[bond.b]);
+      return `<line x1="${a.x.toFixed(1)}" y1="${a.y.toFixed(1)}" x2="${b.x.toFixed(1)}" y2="${b.y.toFixed(1)}" stroke="#4c5258" stroke-width="${Math.max(2, bond.order + 1)}" stroke-linecap="round" />`;
+    }).join('');
+    const atomNodes = atoms.map(atom => {
+      const p = point(atom);
+      const color = molstarPreviewAtomColor(atom.element);
+      const label = escapeHTML(atom.element);
+      return `<g><circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="8.5" fill="${color}" stroke="#202326" stroke-width="1.5" /><text x="${p.x.toFixed(1)}" y="${(p.y + 3.5).toFixed(1)}" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="8" font-weight="700" fill="#111">${label}</text></g>`;
+    }).join('');
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" data-buret-rdkit-svg="fallback" style="width:100%;height:100%;display:block"><rect width="${size}" height="${size}" rx="14" fill="#fff"/>${bondLines}${atomNodes}</svg>`;
+  }
+
+  function molstarPreviewCacheSVG(key, svg) {
+    molstarPreviewSvgCache.set(key, svg);
+    while (molstarPreviewSvgCache.size > 64) molstarPreviewSvgCache.delete(molstarPreviewSvgCache.keys().next().value);
+  }
+
   async function molstarMoleculePreviewRDKitSVG(entry) {
     if (normalizeFormat(entry?.format) !== 'sdf') return '';
     const key = molstarPreviewKey(entry);
     if (molstarPreviewSvgCache.has(key)) return molstarPreviewSvgCache.get(key);
-    const rdkit = await molstarPreviewInitRDKit();
-    let mol = null;
     try {
-      mol = rdkit.get_mol(String(entry.data || ''));
-      if (!mol || (typeof mol.is_valid === 'function' && !mol.is_valid())) throw new Error('invalid molecule');
-      try { mol.set_new_coords?.(); } catch (_) {}
-      const svg = molstarPreviewCleanRDKitSVG(mol.get_svg(MOLSTAR_PREVIEW_RDKIT_SVG_SIZE, MOLSTAR_PREVIEW_RDKIT_SVG_SIZE));
-      if (!svg.includes('<svg')) throw new Error('empty drawing');
-      molstarPreviewSvgCache.set(key, svg);
-      while (molstarPreviewSvgCache.size > 64) molstarPreviewSvgCache.delete(molstarPreviewSvgCache.keys().next().value);
-      return svg;
-    } finally {
-      try { mol?.delete?.(); } catch (_) {}
+      const rdkit = await molstarPreviewInitRDKit();
+      let mol = null;
+      try {
+        mol = rdkit.get_mol(String(entry.data || ''));
+        if (!mol || (typeof mol.is_valid === 'function' && !mol.is_valid())) throw new Error('invalid molecule');
+        try { mol.set_new_coords?.(); } catch (_) {}
+        const svg = molstarPreviewCleanRDKitSVG(mol.get_svg(MOLSTAR_PREVIEW_RDKIT_SVG_SIZE, MOLSTAR_PREVIEW_RDKIT_SVG_SIZE));
+        if (!svg.includes('<svg')) throw new Error('empty drawing');
+        molstarPreviewCacheSVG(key, svg);
+        return svg;
+      } finally {
+        try { mol?.delete?.(); } catch (_) {}
+      }
+    } catch (error) {
+      debug(`RDKit molecule preview failed; using SVG fallback: ${error?.message || error}`);
+      const fallback = molstarMoleculePreviewFallbackSVG(entry);
+      if (!fallback) throw error;
+      molstarPreviewCacheSVG(key, fallback);
+      return fallback;
     }
   }
 
@@ -10158,7 +10872,7 @@
       return;
     }
     const key = molstarPreviewKey(entry);
-    const image = molstarPreviewSvgCache.get(key) || molstarMoleculePreviewSVG(entry);
+    const image = molstarPreviewSvgCache.get(key) || '';
     const label = target?.label || entry?.label || (target?.scope === 'ion' ? 'Ion' : 'Ligand');
     const subtitle = target?.scope === 'ion' ? 'Ion' : 'Small molecule';
     let popover = molstarMoleculePreview;
@@ -10185,7 +10899,10 @@
         if (imageEl) imageEl.innerHTML = svg;
       })
       .catch(() => {
-        if (!image && molstarMoleculePreview?.dataset?.buretPreviewKey === key) hideMolstarMoleculePreview({ force: true });
+        if (!image && molstarMoleculePreview?.dataset?.buretPreviewKey === key) {
+          const imageEl = molstarMoleculePreview.querySelector('.buret-molstar-molecule-preview-image');
+          if (imageEl) imageEl.textContent = '2D preview unavailable';
+        }
       });
   }
 
@@ -10205,32 +10922,36 @@
     return null;
   }
 
-  function showMolstarPersistentMoleculePreview(target) {
+  function showMolstarSelectedMoleculePreviewNow(target) {
     const resolved = molstarSelectedMoleculePreviewTarget(target);
     if (!molstarMoleculePreviewEntry(resolved)) return false;
-    molstarPersistentMoleculePreviewTarget = resolved;
     showMolstarMoleculePreview(resolved);
-    if (!molstarMoleculePreview) molstarPersistentMoleculePreviewTarget = null;
     return !!molstarMoleculePreview;
   }
 
   function showMolstarSelectedMoleculePreview(fallbackTarget = null) {
     const target = molstarSelectedMoleculePreviewTarget();
-    if (target && showMolstarPersistentMoleculePreview(target)) return true;
-    if (fallbackTarget && showMolstarPersistentMoleculePreview(fallbackTarget)) return true;
-    if (molstarPersistentMoleculePreviewTarget && showMolstarPersistentMoleculePreview(molstarPersistentMoleculePreviewTarget)) return true;
-    if (molstarStandalonePreviewTarget && showMolstarPersistentMoleculePreview(molstarStandalonePreviewTarget)) return true;
+    if (target && showMolstarSelectedMoleculePreviewNow(target)) return true;
+    if (fallbackTarget && showMolstarSelectedMoleculePreviewNow(fallbackTarget)) return true;
     return false;
   }
 
   function scheduleMolstarSelectedMoleculePreview(fallbackTarget = null) {
+    const hasCandidate = Boolean(molstarSelectedMoleculePreviewTarget() || fallbackTarget);
+    if (!hasCandidate) {
+      hideMolstarMoleculePreview({ force: true });
+      return;
+    }
     if (showMolstarSelectedMoleculePreview(fallbackTarget)) return;
     if (molstarMoleculePreviewFrame) cancelAnimationFrame(molstarMoleculePreviewFrame);
+    const showOrHide = () => {
+      if (!showMolstarSelectedMoleculePreview(fallbackTarget)) hideMolstarMoleculePreview({ force: true });
+    };
     molstarMoleculePreviewFrame = requestAnimationFrame(() => {
       molstarMoleculePreviewFrame = 0;
       if (showMolstarSelectedMoleculePreview(fallbackTarget)) return;
-      setTimeout(() => showMolstarSelectedMoleculePreview(fallbackTarget), 250);
-      setTimeout(() => showMolstarSelectedMoleculePreview(fallbackTarget), 900);
+      setTimeout(showOrHide, 250);
+      setTimeout(showOrHide, 900);
     });
   }
 
@@ -10241,12 +10962,10 @@
   }
 
   function clearMolstarPersistentMoleculePreview() {
-    molstarPersistentMoleculePreviewTarget = null;
     hideMolstarMoleculePreview({ force: true });
   }
 
   function hideMolstarMoleculePreview(options = {}) {
-    if (!options.force && molstarPersistentMoleculePreviewTarget) return;
     if (molstarMoleculePreviewFrame) {
       cancelAnimationFrame(molstarMoleculePreviewFrame);
       molstarMoleculePreviewFrame = 0;
@@ -10408,6 +11127,7 @@
       contextPointer = null;
     };
     const onPointerDown = (event) => {
+      beginMolstarEmptyClickSelectionPreserve(event);
       clearTouchContextPointer();
       if (event.button === 2) {
         if (!viewer || !isMolstarContextMenuTarget(event.target)) {
@@ -10489,6 +11209,7 @@
         Math.abs(event.clientY - contextPointer.startY) > MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX;
     };
     const onPointerUp = (event) => {
+      finishMolstarEmptyClickSelectionPreserve(event);
       if (touchContextPointer && event.pointerId === touchContextPointer.pointerId) {
         const opened = touchContextPointer.opened;
         clearTouchContextPointer();
@@ -10674,7 +11395,7 @@
       viewportShowToggleFullscreen: false,
       viewportShowSelectionMode: option('viewportShowSelectionMode', true),
       // Keep the native Mol* top-left animation button on every Mol* screen. Do not remove.
-      viewportShowAnimation: option('viewportShowAnimation', true),
+      viewportShowAnimation: true,
       viewportShowTrajectoryControls: showTrajectoryControls,
       viewportShowSettings: option('viewportShowSettings', true),
       collapseLeftPanel: true,
@@ -10736,6 +11457,7 @@
 
   function disposeActiveMolstarViewer() {
     setMolstarStructureDirty(false);
+    clearMolstarEditUndoHistory();
     const viewer = activeViewer || window.BurreteViewer || window.BuretteViewer;
     try { viewer?.plugin?.dispose?.(); } catch (_) {}
     if (molstarContainerResizeCleanup) {
@@ -10834,8 +11556,6 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
       debug('BurreteAgent notifyStructureLoaded failed: ' + (error && error.message || String(error)));
     }
     await applyMolstarContextFocus(config);
-    const standaloneMoleculePreview = molstarStandaloneMoleculePreviewTarget(config);
-    if (standaloneMoleculePreview) showMolstarPersistentMoleculePreview(standaloneMoleculePreview);
     void reportBurreteAgentState();
     startBurreteAgentActionPolling();
     trackMolstarOrientation(viewer, config);
@@ -10863,8 +11583,15 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
         }
       }
     }
-    setStatus(`[web] Rendered ${config.label || 'structure'}`);
-    setTimeout(hideStatus, isQuickLookHost() ? 0 : 700);
+    {
+      const poseCount = Number(prepared?.poseCount || prepared?.sdfPoseRecordCount || prepared?.xyzFrameCount || config?.trajectoryFrameCount || 0);
+      setStatus(`[web] Rendered ${config.label || 'structure'}`);
+      setTimeout(() => hideStatus(molstarReadyPayload(config, prepared, {
+        molstarStructureCount: currentMolstarStructureCount(viewer),
+        poseCount,
+        trajectoryFrameCount: Math.max(Number(config?.trajectoryFrameCount || 0), poseCount)
+      })), isQuickLookHost() ? 0 : 700);
+    }
   }
 
   async function start() {

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3704,6 +3704,8 @@
     const toolbar = document.getElementById('buret-toolbar');
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
     root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
+    root.style.setProperty('--buret-toolbar-current-height', toolbarRect ? Math.ceil(toolbarRect.height) + 'px' : '0px');
+    root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
@@ -3714,8 +3716,13 @@
     const panelOpenTop = selectionToolbarRect
       ? Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP)
       : defaultViewportTop;
+    const controlsOpenTop = selectionToolbarRect
+      ? Math.max(defaultViewportTop, panelOpenTop)
+      : defaultViewportTop;
     const viewportControlsViewportTop = panelState.open
       ? Math.max(defaultViewportTop, panelOpenTop)
+      : selectionToolbarRect
+      ? controlsOpenTop
       : toolbarRect && (!viewportControlsRect || rectsOverlapX(toolbarRect, viewportControlsRect, 18))
       ? Math.max(defaultViewportTop, Math.ceil(toolbarBottom))
       : defaultViewportTop;

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -3705,6 +3705,9 @@
     const toolbarRect = toolbar && !panelState.open ? toolbar.getBoundingClientRect() : null;
     root.style.setProperty('--buret-toolbar-current-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : '0px');
     root.style.setProperty('--buret-toolbar-current-height', toolbarRect ? Math.ceil(toolbarRect.height) + 'px' : '0px');
+    root.style.setProperty('--buret-selection-controls-left', toolbarRect ? Math.ceil(toolbarRect.left) + 'px' : `${TOOLBAR_MARGIN}px`);
+    root.style.setProperty('--buret-selection-controls-width', toolbarRect ? Math.ceil(toolbarRect.width) + 'px' : 'min(430px, calc(100vw - 24px))');
+    root.style.setProperty('--buret-selection-controls-max-width', toolbarRect ? Math.max(180, Math.floor(window.innerWidth - toolbarRect.left - TOOLBAR_MARGIN)) + 'px' : 'calc(100vw - 24px)');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom + FLOATING_LAYOUT_GAP) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -1124,7 +1124,7 @@ assert.match(previewRuntimeGrid, /runtime\.join\("preview-rdkit-wasm\.js"\)/);
 assert.match(previewRuntimeGrid, /<script src="\{rdkit_wasm_js\}"><\/script>/);
 assert.match(previewRuntimeViewer, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
 assert.match(viewerRuntimeCSS, /--buret-toolbar-safe-top: 12px/);
-assert.match(viewerRuntimeCSS, /--buret-viewport-controls-top: 64px/);
+assert.match(viewerRuntimeCSS, /--buret-viewport-controls-top: calc\(var\(--buret-toolbar-safe-top\) \+ 42px\)/);
 assert.match(viewerRuntimeCSS, /#buret-toolbar\.collapsed/);
 assert.match(viewerRuntimeCSS, /#buret-toolbar\.buret-suppressed-by-molstar-panel/);
 assert.doesNotMatch(viewerRuntimeCSS, /#buret-toolbar\.collapsed:hover/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4430,7 +4430,9 @@ assert.doesNotMatch(previewViewer, /canvas3d\.setProps\(\{ pickPadding: 0 \}\)/)
 assert.doesNotMatch(previewViewer, /canvas3d\.setProps\(\{ pickPadding: previousPickPadding \}\)/);
 assert.match(previewViewer, /const radius = Math\.max\(0, Number\(options\.radiusPx\) \|\| 0\);/);
 assert.match(previewViewer, /const offsets = \[\[0, 0\]\];/);
-assert.match(previewViewer, /canvas3d\.identify\(\[x - rect\.left, y - rect\.top\]\)/);
+assert.match(previewViewer, /function molstarPickFromCanvasPoint\(canvas, clientX, clientY\)/);
+assert.match(previewViewer, /canvas3d\.identify\(\[clientX - rect\.left, clientY - rect\.top\]\)/);
+assert.match(previewViewer, /molstarPickFromCanvasPoint\(canvas, x, y\)/);
 assert.match(previewViewer, /canvas3d\.getLoci\(picking\.id\)/);
 assert.match(previewViewer, /\.msp-plugin \.msp-viewport-host/);
 assert.match(previewViewer, /className = 'buret-molecule-context-menu'/);


### PR DESCRIPTION
## Summary
- Unify Molstar viewport and selection controls with the Burette toolbar styling
- Attach the selection controls as a live dropdown under the draggable toolbar
- Hide the redundant viewport settings entry and update UI contracts for the new layout

## Validation
- bun run test:ui
- bun run test:tauri-structure
- pre-push ci-fast