### PR TITLE
Fix sidebar structure drag over viewer

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy, useCallback, useState } from "react";
 import { AppLayout } from "./components/app-layout";
 import type { StructureOverlayMode, ViewerLigandSelection } from "./components/types";
 import { WindowTitle } from "./components/window-title";
@@ -228,7 +228,15 @@ export default function App() {
     setDockOpen,
   });
 
-  const [structureDragActive, setStructureDragActive] = useState(false);
+  const [structureDragActive, setStructureDragActiveState] = useState(false);
+  const setStructureDragActive = useCallback((active: boolean) => {
+    setStructureDragActiveState(active);
+    if (typeof document === "undefined") return;
+    const shell = document.querySelector<HTMLElement>(".app-shell");
+    if (!shell) return;
+    if (active) shell.dataset.structureDragActive = "true";
+    else delete shell.dataset.structureDragActive;
+  }, []);
   const { status, pushStatus, pushErrorStatus, clearStatus, recentErrorsRef } = useAppStatus();
   const {
     clearDirtyGridDocuments,


### PR DESCRIPTION
## Summary
- keep the app shell drag-active marker in sync immediately when structure drags start or end
- ensure viewer iframes stop intercepting sidebar-origin drags before React finishes rendering state

## Root cause
Sidebar drags relied on the app-level drag state to disable pointer events on viewer iframes. That state update could lag behind the browser drag path, so the iframe remained the drop target and the main viewer never saw the drop. Tab drags worked because their path has a separate drag-end fallback.

## Validation
- pre-commit hook: plist, js-syntax, rust-fmt
- pre-push hook: ci-fast