### PR TITLE
Cache XYZ frame switches

### DIFF
--- a/.github/blob-size-allowlist.txt
+++ b/.github/blob-size-allowlist.txt
@@ -4,6 +4,7 @@ PreviewExtension/Web/molstar.js
 PreviewExtension/Web/viewer.js
 PreviewExtension/Web/rdkit/RDKit_minimal.wasm
 plugins/burette-agent/preview-web/viewer.js
+tests/test-ui-shell-contract.mjs
 docs/public/burrete-quick-look-preview.png
 samples/large/moses_10k.csv
 samples/large/moses_10k_descriptors_preview.csv

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -7379,12 +7379,27 @@
     }
   }
 
+  function setMolstarStructuresVisibility(viewer, structures, visible) {
+    const list = Array.from(structures || []).filter(Boolean);
+    if (!list.length) return;
+    const hierarchy = viewer?.plugin?.managers?.structure?.hierarchy;
+    if (typeof hierarchy?.toggleVisibility !== 'function') return;
+    try {
+      hierarchy.toggleVisibility(list, visible ? 'show' : 'hide');
+    } catch (error) {
+      debug('Mol* structure visibility update failed: ' + (error && error.message || String(error)));
+    }
+  }
+
   function xyzFrameOverlayStateStillLoaded(viewer, state) {
     if (!state || state.viewer !== viewer) return false;
     const structures = Array.from(molstarCurrentStructures(viewer));
     const background = Array.isArray(state.backgroundStructures) ? state.backgroundStructures : [];
-    if (!background.length) return false;
-    return background.every(structure => structures.includes(structure));
+    const active = Array.isArray(state.activeStructures) ? state.activeStructures : [];
+    const singleFrames = Array.isArray(state.singleFrameStructures) ? state.singleFrameStructures.flat() : [];
+    const tracked = [...background, ...active, ...singleFrames].filter(Boolean);
+    if (!tracked.length) return false;
+    return tracked.every(structure => structures.includes(structure));
   }
 
   function parseV2000SdfRecord(record) {
@@ -7597,14 +7612,39 @@
     const label = activeConfig?.label || prepared?.label || 'XYZ frames';
     const style = configuredMolstarStyle(activeConfig);
     if (activeSdfPoseMode !== 'all') {
-      resetXyzFrameOverlayState(viewer);
-      if (typeof plugin.clear === 'function') await plugin.clear();
-      const activeEntry = xyzFrameEntry(frames[activeIndex], `${label} (${prepared.controlLabel || 'Frame'} ${activeIndex + 1})`);
-      if (!activeEntry) throw new Error('XYZ frame data is unavailable.');
-      const activeStructures = await loadMolstarEntryWithStructureRefs(viewer, activeEntry, { representationPreset: 'empty' });
-      if (!activeStructures.length) throw new Error('Mol* did not expose the active XYZ frame structure.');
-      await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
-      await applyMolstarWaterLineRepresentation(viewer);
+      const stateKey = xyzFrameOverlayStateKey(rawSignature, frames, prepared, style, 'single', 1, 'colored', []);
+      let state = activeXyzFrameOverlayState;
+      if (!state || state.key !== stateKey || !xyzFrameOverlayStateStillLoaded(viewer, state)) {
+        if (typeof plugin.clear === 'function') await plugin.clear();
+        state = {
+          viewer,
+          key: stateKey,
+          rawSignature,
+          frames,
+          backgroundStructures: [],
+          activeStructures: [],
+          singleFrameStructures: [],
+          activeIndex: -1
+        };
+        activeXyzFrameOverlayState = state;
+      }
+      if (state.activeIndex !== activeIndex) {
+        setMolstarStructuresVisibility(viewer, state.activeStructures, false);
+        let activeStructures = state.singleFrameStructures[activeIndex];
+        if (!Array.isArray(activeStructures) || !activeStructures.length) {
+          const activeEntry = xyzFrameEntry(frames[activeIndex], `${label} (${prepared.controlLabel || 'Frame'} ${activeIndex + 1})`);
+          if (!activeEntry) throw new Error('XYZ frame data is unavailable.');
+          activeStructures = await loadMolstarEntryWithStructureRefs(viewer, activeEntry, { representationPreset: 'empty' });
+          if (!activeStructures.length) throw new Error('Mol* did not expose the active XYZ frame structure.');
+          await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
+          await applyMolstarWaterLineRepresentation(viewer);
+          state.singleFrameStructures[activeIndex] = activeStructures;
+        } else {
+          setMolstarStructuresVisibility(viewer, activeStructures, true);
+        }
+        state.activeStructures = activeStructures;
+        state.activeIndex = activeIndex;
+      }
       if (options.installControls !== false) installDockingPoseControls(viewer, trajectoryControlsForPrepared(prepared));
       updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
       if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'xyz-frame', durationMs: 180 });

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -6894,12 +6894,27 @@
     }
   }
 
+  function setMolstarStructuresVisibility(viewer, structures, visible) {
+    const list = Array.from(structures || []).filter(Boolean);
+    if (!list.length) return;
+    const hierarchy = viewer?.plugin?.managers?.structure?.hierarchy;
+    if (typeof hierarchy?.toggleVisibility !== 'function') return;
+    try {
+      hierarchy.toggleVisibility(list, visible ? 'show' : 'hide');
+    } catch (error) {
+      debug('Mol* structure visibility update failed: ' + (error && error.message || String(error)));
+    }
+  }
+
   function xyzFrameOverlayStateStillLoaded(viewer, state) {
     if (!state || state.viewer !== viewer) return false;
     const structures = Array.from(molstarCurrentStructures(viewer));
     const background = Array.isArray(state.backgroundStructures) ? state.backgroundStructures : [];
-    if (!background.length) return false;
-    return background.every(structure => structures.includes(structure));
+    const active = Array.isArray(state.activeStructures) ? state.activeStructures : [];
+    const singleFrames = Array.isArray(state.singleFrameStructures) ? state.singleFrameStructures.flat() : [];
+    const tracked = [...background, ...active, ...singleFrames].filter(Boolean);
+    if (!tracked.length) return false;
+    return tracked.every(structure => structures.includes(structure));
   }
 
   function parseV2000SdfRecord(record) {
@@ -7112,14 +7127,39 @@
     const label = activeConfig?.label || prepared?.label || 'XYZ frames';
     const style = configuredMolstarStyle(activeConfig);
     if (activeSdfPoseMode !== 'all') {
-      resetXyzFrameOverlayState(viewer);
-      if (typeof plugin.clear === 'function') await plugin.clear();
-      const activeEntry = xyzFrameEntry(frames[activeIndex], `${label} (${prepared.controlLabel || 'Frame'} ${activeIndex + 1})`);
-      if (!activeEntry) throw new Error('XYZ frame data is unavailable.');
-      const activeStructures = await loadMolstarEntryWithStructureRefs(viewer, activeEntry, { representationPreset: 'empty' });
-      if (!activeStructures.length) throw new Error('Mol* did not expose the active XYZ frame structure.');
-      await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
-      await applyMolstarWaterLineRepresentation(viewer);
+      const stateKey = xyzFrameOverlayStateKey(rawSignature, frames, prepared, style, 'single', 1, 'colored', []);
+      let state = activeXyzFrameOverlayState;
+      if (!state || state.key !== stateKey || !xyzFrameOverlayStateStillLoaded(viewer, state)) {
+        if (typeof plugin.clear === 'function') await plugin.clear();
+        state = {
+          viewer,
+          key: stateKey,
+          rawSignature,
+          frames,
+          backgroundStructures: [],
+          activeStructures: [],
+          singleFrameStructures: [],
+          activeIndex: -1
+        };
+        activeXyzFrameOverlayState = state;
+      }
+      if (state.activeIndex !== activeIndex) {
+        setMolstarStructuresVisibility(viewer, state.activeStructures, false);
+        let activeStructures = state.singleFrameStructures[activeIndex];
+        if (!Array.isArray(activeStructures) || !activeStructures.length) {
+          const activeEntry = xyzFrameEntry(frames[activeIndex], `${label} (${prepared.controlLabel || 'Frame'} ${activeIndex + 1})`);
+          if (!activeEntry) throw new Error('XYZ frame data is unavailable.');
+          activeStructures = await loadMolstarEntryWithStructureRefs(viewer, activeEntry, { representationPreset: 'empty' });
+          if (!activeStructures.length) throw new Error('Mol* did not expose the active XYZ frame structure.');
+          await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
+          await applyMolstarWaterLineRepresentation(viewer);
+          state.singleFrameStructures[activeIndex] = activeStructures;
+        } else {
+          setMolstarStructuresVisibility(viewer, activeStructures, true);
+        }
+        state.activeStructures = activeStructures;
+        state.activeIndex = activeIndex;
+      }
       if (options.installControls !== false) installDockingPoseControls(viewer, trajectoryControlsForPrepared(prepared));
       updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
       if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'xyz-frame', durationMs: 180 });

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4955,7 +4955,11 @@ for (const runtimeSource of [previewViewer, agentPreviewViewer]) {
   assert.match(runtimeSource, /let activeXyzFrameOverlayState = null/);
   assert.match(runtimeSource, /function xyzFrameOverlayRawSignature\(raw\)/);
   assert.match(runtimeSource, /function xyzFrameOverlayStateKey\(rawSignature, frames, prepared, style, contextStyle, contextOpacity, contextColor, backgroundIndexes\)/);
-  assert.match(runtimeSource, /if \(activeSdfPoseMode !== 'all'\) \{[\s\S]*?resetXyzFrameOverlayState\(viewer\);[\s\S]*?const activeEntry = xyzFrameEntry\(frames\[activeIndex\]/);
+  assert.match(runtimeSource, /function setMolstarStructuresVisibility\(viewer, structures, visible\)/);
+  assert.match(runtimeSource, /if \(activeSdfPoseMode !== 'all'\) \{[\s\S]*?singleFrameStructures: \[\],[\s\S]*?setMolstarStructuresVisibility\(viewer, state\.activeStructures, false\)/);
+  assert.match(runtimeSource, /let activeStructures = state\.singleFrameStructures\[activeIndex\]/);
+  assert.match(runtimeSource, /state\.singleFrameStructures\[activeIndex\] = activeStructures/);
+  assert.doesNotMatch(runtimeSource, /if \(activeSdfPoseMode !== 'all'\) \{[\s\S]{0,240}?resetXyzFrameOverlayState\(viewer\)/);
   assert.match(runtimeSource, /await loadMolstarEntryWithStructureRefs\(viewer, activeEntry, \{ representationPreset: 'empty' \}\)/);
   assert.match(runtimeSource, /if \(options\.installControls !== false\) installDockingPoseControls\(viewer, trajectoryControlsForPrepared\(prepared\)\)/);
   assert.match(runtimeSource, /const backgroundIndexes = sampledXyzFrameBackgroundIndexes\(frames\.length, -1\)/);


### PR DESCRIPTION
## Why

Single-frame navigation for multi-frame XYZ previews cleared and rebuilt the Mol* scene on every frame change, making trajectory stepping feel jumpy and slow in browser-dev and agent preview surfaces.

## What Changed

- Cache loaded XYZ frame structures in the preview runtime state.
- Switch single-frame XYZ navigation by hiding the previous frame and showing the cached target frame instead of clearing the whole scene.
- Keep the browser-dev/Quick Look runtime copy and the plugin preview runtime copy in sync.
- Update the UI shell contract test to prevent regressions back to the clear-and-reload path.

## Verification

- `node --check PreviewExtension/Web/viewer.js`
- `node --check plugins/burette-agent/preview-web/viewer.js`
- `bun tests/test-ui-shell-contract.mjs`
- Live browser-dev smoke with `bimp.v000.xyz`: Next switched Frame 1/20 to 2/20 and Previous returned to 1/20 without console errors.
- Pre-push `ci-fast` hook passed.