### PR TITLE
Fix docking pose controls

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -4962,6 +4962,8 @@
     };
     const entries = [receptorEntry];
     let nativeTrajectoryPoseCount = 0;
+    const nativeTrajectorySdfRecords = [];
+    const nativeTrajectorySdfMolecules = [];
     ligandSources.forEach((source, ligandIndex) => {
       const data = dockingPayloadData(source, ligandPayloads[ligandIndex]);
       const format = normalizeFormat(source.format);
@@ -4969,12 +4971,8 @@
         const records = splitSdfRecords(data);
         if (records.length > 1) {
           nativeTrajectoryPoseCount += records.length;
-          entries.push({
-            data,
-            format: 'sdf',
-            label: source.label || `Ligand ${ligandIndex + 1}`,
-            loadPreset: 'default'
-          });
+          nativeTrajectorySdfRecords.push(...records);
+          nativeTrajectorySdfMolecules.push(...records.map(parseV2000SdfRecord));
           records.forEach((record, poseIndex) => {
             poses.push({
               data: `${record}\n$$$$\n`,
@@ -5004,6 +5002,18 @@
         poseCount: 1
       });
     });
+    if (nativeTrajectoryPoseCount > 1) {
+      entries.push({
+        data: `${nativeTrajectorySdfRecords.join('\n$$$$\n')}\n$$$$\n`,
+        format: 'sdf',
+        label: 'Ligand poses',
+        loadPreset: 'default'
+      });
+    }
+    const nativeTrajectoryCollection = nativeTrajectoryPoseCount > 1 && nativeTrajectorySdfMolecules.length === nativeTrajectoryPoseCount &&
+      nativeTrajectorySdfMolecules.every(Boolean)
+      ? sdfMoleculesToPdbCollection(nativeTrajectorySdfMolecules, 'Ligand poses')
+      : null;
     const trajectoryPair = dockingTrajectoryPair(entries);
     if (trajectoryPair) {
       return {
@@ -5056,16 +5066,42 @@
     if (poses.length === 0) throw new Error('Docking view has no ligand poses.');
     const activePose = readDockingPoseIndex(config, poses.length);
     if (nativeTrajectoryPoseCount > 1) {
+      if (activeSdfPoseMode === 'all') {
+        return {
+          kind: 'docking',
+          label: config.label || 'Docking view',
+          activePose,
+          poseCount: nativeTrajectoryPoseCount,
+          nativeTrajectoryControls: false,
+          ligandLabel: 'Ligand poses',
+          controlLabel: 'Pose',
+          receptorEntry,
+          poses,
+          entries: [receptorEntry, ...poses],
+          sdfPoseMode: 'all',
+          sdfPoseOverlayAvailable: true,
+          sdfPoseRecordCount: nativeTrajectoryPoseCount,
+          collectionResidues: nativeTrajectoryCollection?.residues || [],
+          collectionSinglePdbs: nativeTrajectoryCollection?.singlePdbs || [],
+          collectionMolecules: nativeTrajectoryCollection?.molecules || []
+        };
+      }
       return {
         kind: 'docking',
         label: config.label || 'Docking view',
         activePose,
         poseCount: nativeTrajectoryPoseCount,
-        nativeTrajectoryControls: true,
-        ligandLabel: 'Mol* trajectory',
+        nativeTrajectoryControls: !nativeTrajectoryCollection,
+        ligandLabel: 'Ligand poses',
+        controlLabel: 'Pose',
         receptorEntry,
         poses,
-        entries
+        entries,
+        sdfPoseOverlayAvailable: true,
+        sdfPoseRecordCount: nativeTrajectoryPoseCount,
+        collectionResidues: nativeTrajectoryCollection?.residues || [],
+        collectionSinglePdbs: nativeTrajectoryCollection?.singlePdbs || [],
+        collectionMolecules: nativeTrajectoryCollection?.molecules || []
       };
     }
     return {
@@ -7763,6 +7799,93 @@
     scheduleMolstarStructureFocus(viewer, { reason: 'docking-scene', durationMs: 180 });
   }
 
+  let activeDockingSdfPoseState = null;
+
+  function resetDockingSdfPoseState(viewer = null) {
+    if (!viewer || activeDockingSdfPoseState?.viewer === viewer) {
+      activeDockingSdfPoseState = null;
+    }
+  }
+
+  function dockingSdfPoseStateStillLoaded(viewer, state) {
+    if (!state || state.viewer !== viewer) return false;
+    const structures = Array.from(molstarCurrentStructures(viewer));
+    const receptor = Array.isArray(state.receptorStructures) ? state.receptorStructures : [];
+    return receptor.length > 0 && receptor.every(structure => structures.includes(structure));
+  }
+
+  async function applyDockingSdfPoseVisibility(viewer, prepared, activePose = 0, options = {}) {
+    if (!viewer || prepared?.kind !== 'docking' || prepared.sdfPoseOverlayAvailable !== true) return;
+    const singlePdbs = Array.isArray(prepared.collectionSinglePdbs) ? prepared.collectionSinglePdbs : [];
+    const activeIndex = Math.max(0, Math.min(singlePdbs.length - 1, Math.trunc(Number(activePose) || 0)));
+    const activeData = singlePdbs[activeIndex];
+    if (!activeData) throw new Error('Mol* docking pose data is unavailable.');
+    const plugin = viewer.plugin;
+    const style = configuredMolstarStyle(activeConfig);
+    const allMode = activeSdfPoseMode === 'all';
+    const contextStyle = allMode ? readSdfCollectionContextStyle(activeConfig) : 'match';
+    const contextOpacity = allMode ? readSdfCollectionContextOpacity(activeConfig) : 1;
+    const contextColor = allMode ? readSdfCollectionContextColor(activeConfig) : 'gray';
+    const stateKey = [
+      prepared.receptorEntry?.sourcePath || prepared.receptorEntry?.label || 'receptor',
+      allMode ? 'all' : 'single',
+      style,
+      contextStyle,
+      contextOpacity,
+      contextColor,
+      singlePdbs.length
+    ].join('|');
+    let state = activeDockingSdfPoseState;
+    if (!state || state.key !== stateKey || !dockingSdfPoseStateStillLoaded(viewer, state)) {
+      if (typeof plugin.clear === 'function') await plugin.clear();
+      const receptorStructures = prepared.receptorEntry
+        ? await loadMolstarEntryWithStructureRefs(viewer, prepared.receptorEntry)
+        : [];
+      state = {
+        viewer,
+        key: stateKey,
+        receptorStructures,
+        backgroundStructures: [],
+        activeStructures: [],
+        activeIndex: -1
+      };
+      activeDockingSdfPoseState = state;
+    }
+
+    if (allMode) {
+      await removeMolstarStructures(viewer, [...state.backgroundStructures, ...state.activeStructures]);
+      state.backgroundStructures = [];
+      state.activeStructures = [];
+      const backgroundData = sdfCollectionBackgroundPdb(prepared, activeIndex);
+      const resolvedContextStyle = dockingSceneBackgroundStyle(contextStyle, style);
+      if (backgroundData) {
+        const contextStructures = await loadSdfCollectionPdbLayer(viewer, backgroundData, `${prepared.label || 'Docking poses'} background`);
+        if (contextStructures.length) {
+          await applySdfCollectionMolstarStyle(viewer, resolvedContextStyle, contextStructures, contextOpacity, contextColor);
+          state.backgroundStructures = contextStructures;
+        }
+      }
+    } else if (state.activeIndex === activeIndex && dockingSdfPoseStateStillLoaded(viewer, state)) {
+      if (options.installControls !== false) installDockingPoseControls(viewer, prepared);
+      updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
+      return;
+    } else {
+      await removeMolstarStructures(viewer, [...state.backgroundStructures, ...state.activeStructures]);
+      state.backgroundStructures = [];
+      state.activeStructures = [];
+    }
+
+    const activeStructures = await loadSdfCollectionPdbLayer(viewer, activeData, `${prepared.label || 'Docking poses'} Pose ${activeIndex + 1}`);
+    if (!activeStructures.length) throw new Error('Mol* did not expose the active docking pose structure.');
+    await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
+    state.activeStructures = activeStructures;
+    state.activeIndex = activeIndex;
+    await applyMolstarWaterLineRepresentation(viewer);
+    if (options.installControls !== false) installDockingPoseControls(viewer, prepared);
+    updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
+    if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'docking-sdf-pose', durationMs: 180 });
+  }
+
   function dockingSceneBackgroundStyle(contextStyle, foregroundStyle) {
     return contextStyle !== 'match' ? normalizeMolstarStyle(contextStyle) : normalizeMolstarStyle(foregroundStyle);
   }
@@ -8638,7 +8761,12 @@
       installDockingPoseControls(viewer, prepared);
       return;
     }
+    if (prepared.sdfPoseOverlayAvailable === true && Array.isArray(prepared.collectionSinglePdbs) && prepared.collectionSinglePdbs.length > 1) {
+      await applyDockingSdfPoseVisibility(viewer, prepared, prepared.activePose);
+      return;
+    }
     if (typeof plugin.clear === 'function') {
+      resetDockingSdfPoseState(viewer);
       await plugin.clear();
     }
     if (prepared.trajectoryPair) {
@@ -8854,9 +8982,9 @@
   function nativeTrajectoryControlsRoot() {
     const roots = Array.from(document.querySelectorAll('.msp-viewport-top-left-controls, .msp-animation-viewport-controls'));
     return roots.find(root => {
-      if (/\b(?:Model|Frame)\s+\d+\s*\/\s*\d+/i.test(root.textContent || '')) return true;
+      if (/\b(?:Model|Frame|Pose)\s+\d+\s*\/\s*\d+/i.test(root.textContent || '')) return true;
       return Array.from(root.querySelectorAll('button')).some(button => (
-        /\b(Model|Frame)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
+        /\b(Model|Frame|Pose)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
       ));
     }) || null;
   }
@@ -8875,7 +9003,7 @@
   function readNativeTrajectoryPositionFromDom(expectedCount) {
     const root = nativeTrajectoryControlsRoot();
     const text = root?.textContent || '';
-    const match = text.match(/\b(?:Model|Frame)\s+(\d+)\s*\/\s*(\d+)/i) || text.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+    const match = text.match(/\b(?:Model|Frame|Pose)\s+(\d+)\s*\/\s*(\d+)/i) || text.match(/\b(\d+)\s*\/\s*(\d+)\b/);
     if (!match) return null;
     const index = Number(match[1]) - 1;
     const total = Number(match[2]);
@@ -8948,7 +9076,7 @@
     const root = nativeTrajectoryControlsRoot();
     if (!root) return null;
     const buttons = Array.from(root.querySelectorAll('button')).filter(button => (
-      /\b(Model|Frame)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
+      /\b(Model|Frame|Pose)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
     ));
     const named = buttons.find(button => {
       const name = `${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`.toLowerCase();
@@ -9443,6 +9571,10 @@
           updateControls();
         } else if (prepared.kind === 'docking' && prepared.dockingSceneMode) {
           await applyDockingSceneVisibility(viewer, activeMolstarPrepared || prepared, nextIndex);
+          activePose = nextIndex;
+          updateControls();
+        } else if (prepared.kind === 'docking' && prepared.sdfPoseOverlayAvailable === true) {
+          await applyDockingSdfPoseVisibility(viewer, activeMolstarPrepared || prepared, nextIndex, { installControls: false });
           activePose = nextIndex;
           updateControls();
         } else {

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -264,7 +264,7 @@ export async function openBrowserDevDockingDocument(
   if (ligands.length === 0) throw new Error("Choose at least one ligand or pose file for docking view");
   const hasCoordinateTrajectory = ligands.some(isCoordinateTrajectoryPayload);
   const effectiveSceneMode = hasCoordinateTrajectory ? null : (options.sceneMode ?? null);
-  const dockingLigands = effectiveSceneMode ? ligands : expandBrowserDevDockingLigandPoses(ligands);
+  const dockingLigands = ligands;
 
   const id = stableId(`docking:${receptor.path}:${ligands.map((ligand) => ligand.path).join("|")}`);
   const label = effectiveSceneMode
@@ -845,73 +845,6 @@ async function readBrowserDevDockingPayload(path: string): Promise<BrowserDevDoc
     throw new Error(`${path} cannot be added to Mol* docking view because it needs xyzrender conversion`);
   }
   return { path, title, extension, format, bytes: originalBytes, byteCount: originalBytes.length };
-}
-
-function expandBrowserDevDockingLigandPoses(ligands: BrowserDevDockingPayload[]) {
-  return ligands.flatMap((ligand) => {
-    if (ligand.format.binary) return [ligand];
-    const text = decodeUtf8(ligand.bytes);
-    const poseTexts = dockingPoseTextsForLigand(ligand, text);
-    if (poseTexts.length <= 1) return [ligand];
-    return poseTexts.map((poseText, index) => {
-      const bytes = new TextEncoder().encode(poseText);
-      return {
-        ...ligand,
-        title: `${ligand.title} pose ${index + 1}`,
-        bytes,
-        byteCount: bytes.length,
-      };
-    });
-  });
-}
-
-function dockingPoseTextsForLigand(ligand: BrowserDevDockingPayload, text: string) {
-  const format = ligand.format.molstarFormat;
-  if (format === "sdf") return parseSdf(text).map((record) => record.molblock).filter((record): record is string => Boolean(record));
-  if (format === "pdb") return splitPdbModelTexts(text);
-  if (format === "xyz") return splitXyzFrameTexts(text);
-  return [];
-}
-
-function splitPdbModelTexts(text: string) {
-  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
-  const firstModelIndex = lines.findIndex((line) => /^MODEL\b/u.test(line));
-  if (firstModelIndex < 0) return [];
-  const header = lines.slice(0, firstModelIndex).filter((line) => !/^END\b/u.test(line));
-  const models: string[][] = [];
-  let current: string[] | null = null;
-  for (const line of lines.slice(firstModelIndex)) {
-    if (/^MODEL\b/u.test(line)) {
-      current = [];
-      continue;
-    }
-    if (/^ENDMDL\b/u.test(line)) {
-      if (current?.some((modelLine) => /^(?:ATOM|HETATM)\b/u.test(modelLine))) models.push(current);
-      current = null;
-      continue;
-    }
-    if (current) current.push(line);
-  }
-  if (models.length <= 1) return [];
-  return models.map((model) => [...header, ...model.filter((line) => !/^END\b/u.test(line)), "END", ""].join("\n"));
-}
-
-function splitXyzFrameTexts(text: string) {
-  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
-  const frames: string[] = [];
-  let index = 0;
-  while (index < lines.length && frames.length < 100000) {
-    while (index < lines.length && !lines[index].trim()) index += 1;
-    const atomCount = Number.parseInt(lines[index]?.trim().split(/\s+/u)[0] ?? "", 10);
-    if (!Number.isFinite(atomCount) || atomCount <= 0) break;
-    if (index + atomCount + 1 >= lines.length) break;
-    const frameLines = lines.slice(index, index + atomCount + 2);
-    const atomLines = frameLines.slice(2);
-    if (atomLines.length !== atomCount || atomLines.some((line) => !line.trim())) break;
-    frames.push(`${frameLines.join("\n")}\n`);
-    index += atomCount + 2;
-  }
-  return frames.length > 1 ? frames : [];
 }
 
 function dockingConfigSource(source: BrowserDevDockingPayload) {

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -4872,6 +4872,8 @@
     };
     const entries = [receptorEntry];
     let nativeTrajectoryPoseCount = 0;
+    const nativeTrajectorySdfRecords = [];
+    const nativeTrajectorySdfMolecules = [];
     ligandSources.forEach((source, ligandIndex) => {
       const data = dockingPayloadData(source, ligandPayloads[ligandIndex]);
       const format = normalizeFormat(source.format);
@@ -4879,12 +4881,8 @@
         const records = splitSdfRecords(data);
         if (records.length > 1) {
           nativeTrajectoryPoseCount += records.length;
-          entries.push({
-            data,
-            format: 'sdf',
-            label: source.label || `Ligand ${ligandIndex + 1}`,
-            loadPreset: 'default'
-          });
+          nativeTrajectorySdfRecords.push(...records);
+          nativeTrajectorySdfMolecules.push(...records.map(parseV2000SdfRecord));
           records.forEach((record, poseIndex) => {
             poses.push({
               data: `${record}\n$$$$\n`,
@@ -4914,6 +4912,18 @@
         poseCount: 1
       });
     });
+    if (nativeTrajectoryPoseCount > 1) {
+      entries.push({
+        data: `${nativeTrajectorySdfRecords.join('\n$$$$\n')}\n$$$$\n`,
+        format: 'sdf',
+        label: 'Ligand poses',
+        loadPreset: 'default'
+      });
+    }
+    const nativeTrajectoryCollection = nativeTrajectoryPoseCount > 1 && nativeTrajectorySdfMolecules.length === nativeTrajectoryPoseCount &&
+      nativeTrajectorySdfMolecules.every(Boolean)
+      ? sdfMoleculesToPdbCollection(nativeTrajectorySdfMolecules, 'Ligand poses')
+      : null;
     const trajectoryPair = dockingTrajectoryPair(entries);
     if (trajectoryPair) {
       return {
@@ -4966,16 +4976,42 @@
     if (poses.length === 0) throw new Error('Docking view has no ligand poses.');
     const activePose = readDockingPoseIndex(config, poses.length);
     if (nativeTrajectoryPoseCount > 1) {
+      if (activeSdfPoseMode === 'all') {
+        return {
+          kind: 'docking',
+          label: config.label || 'Docking view',
+          activePose,
+          poseCount: nativeTrajectoryPoseCount,
+          nativeTrajectoryControls: false,
+          ligandLabel: 'Ligand poses',
+          controlLabel: 'Pose',
+          receptorEntry,
+          poses,
+          entries: [receptorEntry, ...poses],
+          sdfPoseMode: 'all',
+          sdfPoseOverlayAvailable: true,
+          sdfPoseRecordCount: nativeTrajectoryPoseCount,
+          collectionResidues: nativeTrajectoryCollection?.residues || [],
+          collectionSinglePdbs: nativeTrajectoryCollection?.singlePdbs || [],
+          collectionMolecules: nativeTrajectoryCollection?.molecules || []
+        };
+      }
       return {
         kind: 'docking',
         label: config.label || 'Docking view',
         activePose,
         poseCount: nativeTrajectoryPoseCount,
-        nativeTrajectoryControls: true,
-        ligandLabel: 'Mol* trajectory',
+        nativeTrajectoryControls: !nativeTrajectoryCollection,
+        ligandLabel: 'Ligand poses',
+        controlLabel: 'Pose',
         receptorEntry,
         poses,
-        entries
+        entries,
+        sdfPoseOverlayAvailable: true,
+        sdfPoseRecordCount: nativeTrajectoryPoseCount,
+        collectionResidues: nativeTrajectoryCollection?.residues || [],
+        collectionSinglePdbs: nativeTrajectoryCollection?.singlePdbs || [],
+        collectionMolecules: nativeTrajectoryCollection?.molecules || []
       };
     }
     return {
@@ -7278,6 +7314,93 @@
     scheduleMolstarStructureFocus(viewer, { reason: 'docking-scene', durationMs: 180 });
   }
 
+  let activeDockingSdfPoseState = null;
+
+  function resetDockingSdfPoseState(viewer = null) {
+    if (!viewer || activeDockingSdfPoseState?.viewer === viewer) {
+      activeDockingSdfPoseState = null;
+    }
+  }
+
+  function dockingSdfPoseStateStillLoaded(viewer, state) {
+    if (!state || state.viewer !== viewer) return false;
+    const structures = Array.from(molstarCurrentStructures(viewer));
+    const receptor = Array.isArray(state.receptorStructures) ? state.receptorStructures : [];
+    return receptor.length > 0 && receptor.every(structure => structures.includes(structure));
+  }
+
+  async function applyDockingSdfPoseVisibility(viewer, prepared, activePose = 0, options = {}) {
+    if (!viewer || prepared?.kind !== 'docking' || prepared.sdfPoseOverlayAvailable !== true) return;
+    const singlePdbs = Array.isArray(prepared.collectionSinglePdbs) ? prepared.collectionSinglePdbs : [];
+    const activeIndex = Math.max(0, Math.min(singlePdbs.length - 1, Math.trunc(Number(activePose) || 0)));
+    const activeData = singlePdbs[activeIndex];
+    if (!activeData) throw new Error('Mol* docking pose data is unavailable.');
+    const plugin = viewer.plugin;
+    const style = configuredMolstarStyle(activeConfig);
+    const allMode = activeSdfPoseMode === 'all';
+    const contextStyle = allMode ? readSdfCollectionContextStyle(activeConfig) : 'match';
+    const contextOpacity = allMode ? readSdfCollectionContextOpacity(activeConfig) : 1;
+    const contextColor = allMode ? readSdfCollectionContextColor(activeConfig) : 'gray';
+    const stateKey = [
+      prepared.receptorEntry?.sourcePath || prepared.receptorEntry?.label || 'receptor',
+      allMode ? 'all' : 'single',
+      style,
+      contextStyle,
+      contextOpacity,
+      contextColor,
+      singlePdbs.length
+    ].join('|');
+    let state = activeDockingSdfPoseState;
+    if (!state || state.key !== stateKey || !dockingSdfPoseStateStillLoaded(viewer, state)) {
+      if (typeof plugin.clear === 'function') await plugin.clear();
+      const receptorStructures = prepared.receptorEntry
+        ? await loadMolstarEntryWithStructureRefs(viewer, prepared.receptorEntry)
+        : [];
+      state = {
+        viewer,
+        key: stateKey,
+        receptorStructures,
+        backgroundStructures: [],
+        activeStructures: [],
+        activeIndex: -1
+      };
+      activeDockingSdfPoseState = state;
+    }
+
+    if (allMode) {
+      await removeMolstarStructures(viewer, [...state.backgroundStructures, ...state.activeStructures]);
+      state.backgroundStructures = [];
+      state.activeStructures = [];
+      const backgroundData = sdfCollectionBackgroundPdb(prepared, activeIndex);
+      const resolvedContextStyle = dockingSceneBackgroundStyle(contextStyle, style);
+      if (backgroundData) {
+        const contextStructures = await loadSdfCollectionPdbLayer(viewer, backgroundData, `${prepared.label || 'Docking poses'} background`);
+        if (contextStructures.length) {
+          await applySdfCollectionMolstarStyle(viewer, resolvedContextStyle, contextStructures, contextOpacity, contextColor);
+          state.backgroundStructures = contextStructures;
+        }
+      }
+    } else if (state.activeIndex === activeIndex && dockingSdfPoseStateStillLoaded(viewer, state)) {
+      if (options.installControls !== false) installDockingPoseControls(viewer, prepared);
+      updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
+      return;
+    } else {
+      await removeMolstarStructures(viewer, [...state.backgroundStructures, ...state.activeStructures]);
+      state.backgroundStructures = [];
+      state.activeStructures = [];
+    }
+
+    const activeStructures = await loadSdfCollectionPdbLayer(viewer, activeData, `${prepared.label || 'Docking poses'} Pose ${activeIndex + 1}`);
+    if (!activeStructures.length) throw new Error('Mol* did not expose the active docking pose structure.');
+    await applySdfCollectionMolstarStyle(viewer, style, activeStructures, 1, 'colored');
+    state.activeStructures = activeStructures;
+    state.activeIndex = activeIndex;
+    await applyMolstarWaterLineRepresentation(viewer);
+    if (options.installControls !== false) installDockingPoseControls(viewer, prepared);
+    updateStructureOverlayToggleButton(document.querySelector('[data-buret-action="structure-overlay-toggle"]'), prepared);
+    if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'docking-sdf-pose', durationMs: 180 });
+  }
+
   function dockingSceneBackgroundStyle(contextStyle, foregroundStyle) {
     return contextStyle !== 'match' ? normalizeMolstarStyle(contextStyle) : normalizeMolstarStyle(foregroundStyle);
   }
@@ -8153,7 +8276,12 @@
       installDockingPoseControls(viewer, prepared);
       return;
     }
+    if (prepared.sdfPoseOverlayAvailable === true && Array.isArray(prepared.collectionSinglePdbs) && prepared.collectionSinglePdbs.length > 1) {
+      await applyDockingSdfPoseVisibility(viewer, prepared, prepared.activePose);
+      return;
+    }
     if (typeof plugin.clear === 'function') {
+      resetDockingSdfPoseState(viewer);
       await plugin.clear();
     }
     if (prepared.trajectoryPair) {
@@ -8369,9 +8497,9 @@
   function nativeTrajectoryControlsRoot() {
     const roots = Array.from(document.querySelectorAll('.msp-viewport-top-left-controls, .msp-animation-viewport-controls'));
     return roots.find(root => {
-      if (/\b(?:Model|Frame)\s+\d+\s*\/\s*\d+/i.test(root.textContent || '')) return true;
+      if (/\b(?:Model|Frame|Pose)\s+\d+\s*\/\s*\d+/i.test(root.textContent || '')) return true;
       return Array.from(root.querySelectorAll('button')).some(button => (
-        /\b(Model|Frame)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
+        /\b(Model|Frame|Pose)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
       ));
     }) || null;
   }
@@ -8390,7 +8518,7 @@
   function readNativeTrajectoryPositionFromDom(expectedCount) {
     const root = nativeTrajectoryControlsRoot();
     const text = root?.textContent || '';
-    const match = text.match(/\b(?:Model|Frame)\s+(\d+)\s*\/\s*(\d+)/i) || text.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+    const match = text.match(/\b(?:Model|Frame|Pose)\s+(\d+)\s*\/\s*(\d+)/i) || text.match(/\b(\d+)\s*\/\s*(\d+)\b/);
     if (!match) return null;
     const index = Number(match[1]) - 1;
     const total = Number(match[2]);
@@ -8463,7 +8591,7 @@
     const root = nativeTrajectoryControlsRoot();
     if (!root) return null;
     const buttons = Array.from(root.querySelectorAll('button')).filter(button => (
-      /\b(Model|Frame)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
+      /\b(Model|Frame|Pose)\b/i.test(`${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`)
     ));
     const named = buttons.find(button => {
       const name = `${button.getAttribute('title') || ''} ${button.getAttribute('aria-label') || ''}`.toLowerCase();
@@ -8958,6 +9086,10 @@
           updateControls();
         } else if (prepared.kind === 'docking' && prepared.dockingSceneMode) {
           await applyDockingSceneVisibility(viewer, activeMolstarPrepared || prepared, nextIndex);
+          activePose = nextIndex;
+          updateControls();
+        } else if (prepared.kind === 'docking' && prepared.sdfPoseOverlayAvailable === true) {
+          await applyDockingSdfPoseVisibility(viewer, activeMolstarPrepared || prepared, nextIndex, { installControls: false });
           activePose = nextIndex;
           updateControls();
         } else {

--- a/plugins/burette-agent/scripts/agent-shell-server.mjs
+++ b/plugins/burette-agent/scripts/agent-shell-server.mjs
@@ -515,7 +515,7 @@ function allowedPathFromFsUrl(url) {
   const filePath = resolve(rawPath);
   if (!isAllowed(filePath)) return null;
   const extension = fileExtension(filePath);
-  if (!TEXT_EXTENSIONS.has(extension)) return null;
+  if (!TEXT_EXTENSIONS.has(extension) && !STATIC_MIME_TYPES.has(`.${extension}`)) return null;
   return filePath;
 }
 

--- a/scripts/agent-shell-server.mjs
+++ b/scripts/agent-shell-server.mjs
@@ -515,7 +515,7 @@ function allowedPathFromFsUrl(url) {
   const filePath = resolve(rawPath);
   if (!isAllowed(filePath)) return null;
   const extension = fileExtension(filePath);
-  if (!TEXT_EXTENSIONS.has(extension)) return null;
+  if (!TEXT_EXTENSIONS.has(extension) && !STATIC_MIME_TYPES.has(`.${extension}`)) return null;
   return filePath;
 }
 

--- a/tests/test-burrete-agent-cli.mjs
+++ b/tests/test-burrete-agent-cli.mjs
@@ -162,6 +162,11 @@ try {
       const viewerRuntimeResponse = await fetch(viewerRuntimeUrl);
       assert.equal(viewerRuntimeResponse.status, 200);
       assert.match(await viewerRuntimeResponse.text(), /window\.BurreteViewerShell/);
+      const wasmUrl = new URL(`/@fs${resolve('PreviewExtension/Web/rdkit/RDKit_minimal.wasm')}`, prebuiltPayload.result.url);
+      const wasmResponse = await fetch(wasmUrl);
+      assert.equal(wasmResponse.status, 200);
+      assert.equal(wasmResponse.headers.get('content-type'), 'application/wasm');
+      assert.equal(Buffer.from(await wasmResponse.arrayBuffer()).subarray(0, 4).toString('hex'), '0061736d');
       if (prebuiltPayload.result.processId) {
         try {
           process.kill(prebuiltPayload.result.processId, 'SIGTERM');

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3839,6 +3839,8 @@ assert.match(viteConfig, /if \(controls\.fieldCmapMin != null && controls\.field
 assert.match(browserDevDocuments, /export async function openBrowserDevDockingDocument\(/);
 assert.match(browserDevDocuments, /const hasCoordinateTrajectory = ligands\.some\(isCoordinateTrajectoryPayload\)/);
 assert.match(browserDevDocuments, /const effectiveSceneMode = hasCoordinateTrajectory \? null : \(options\.sceneMode \?\? null\)/);
+assert.match(browserDevDocuments, /const dockingLigands = ligands/);
+assert.doesNotMatch(browserDevDocuments, /expandBrowserDevDockingLigandPoses/);
 assert.match(browserDevDocuments, /effectiveSceneMode\s*\?\s*`Mol\* scene: \$\{receptor\.title\} \+ \$\{ligands\.length\} more structure/);
 assert.match(browserDevDocuments, /:\s*`Docking: \$\{receptor\.title\} \+ \$\{dockingLigands\.length\} ligand/);
 assert.match(browserDevDocuments, /path: `burrete-docking:\/\/\$\{id\}`/);
@@ -4956,6 +4958,18 @@ assert.match(previewViewer, /function readNativeTrajectoryPosition\(expectedCoun
 assert.match(previewViewer, /function nativeAnimationSelectButton\(\)/);
 assert.match(previewViewer, /function trajectoryControlsForPrepared\(prepared\)/);
 assert.match(previewViewer, /if \(prepared\?\.kind === 'sdf-collection'\) \{/);
+assert.match(previewViewer, /const nativeTrajectorySdfRecords = \[\]/);
+assert.match(previewViewer, /nativeTrajectorySdfRecords\.push\(\.\.\.records\)/);
+assert.match(previewViewer, /nativeTrajectorySdfMolecules\.push\(\.\.\.records\.map\(parseV2000SdfRecord\)\)/);
+assert.match(previewViewer, /sdfMoleculesToPdbCollection\(nativeTrajectorySdfMolecules, 'Ligand poses'\)/);
+assert.match(previewViewer, /data: `\$\{nativeTrajectorySdfRecords\.join\('\\n\$\$\$\$\\n'\)\}\\n\$\$\$\$\\n`/);
+assert.match(previewViewer, /controlLabel: 'Pose'/);
+assert.match(previewViewer, /\?:Model\|Frame\|Pose/);
+assert.match(previewViewer, /entries: \[receptorEntry, \.\.\.poses\]/);
+assert.match(previewViewer, /sdfPoseOverlayAvailable: true/);
+assert.match(previewViewer, /sdfPoseRecordCount: nativeTrajectoryPoseCount/);
+assert.match(previewViewer, /async function applyDockingSdfPoseVisibility\(viewer, prepared, activePose = 0, options = \{\}\)/);
+assert.match(previewViewer, /await applyDockingSdfPoseVisibility\(viewer, prepared, prepared\.activePose\)/);
 assert.match(previewViewer, /prepared\?\.pdbModelMode === 'all'/);
 assert.match(previewViewer, /pdbModelOverlayAvailable: prepared\?\.pdbModelOverlayAvailable === true/);
 assert.match(previewViewer, /if \(prepared\?\.xyzFrameOverlayAvailable === true\) \{[\s\S]*?kind: 'xyz-frame-overlay'[\s\S]*?nativeTrajectoryControls: false/);


### PR DESCRIPTION
## Why

Browser-dev docking regressed after the SDF `All` work: multi-record ligand SDFs were expanded into individual ligand payloads before reaching the viewer, which removed the viewer's ability to treat poses as a single fast pose set. The browser shell could also fail to serve binary runtime assets through `/@fs`, which broke RDKit wasm loading in the agent shell.

## What Changed

- Keep docking ligand files intact in browser-dev so the viewer receives the original multi-record SDF inputs.
- Restore fast docking pose switching by converting parsed SDF poses into Mol* PDB pose layers and swapping only the active ligand pose while keeping the receptor loaded.
- Preserve `All` as an overlay mode for docking SDF poses and keep `Pose` controls wired for `Next`, `Loop`, and individual/all toggling.
- Allow `/@fs` serving of known static binary assets such as wasm in the agent shell server.
- Add contract coverage for non-expanded docking ligands, SDF pose controls, and wasm file serving.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-burrete-agent-cli.mjs`
- `node --check PreviewExtension/Web/viewer.js && node --check plugins/burette-agent/preview-web/viewer.js && node --check scripts/agent-shell-server.mjs && node --check plugins/burette-agent/scripts/agent-shell-server.mjs`
- Browser QA on the 5c01 + 4 SDF ligand docking view: `Next` advanced `Pose 1 / 40` to `Pose 2 / 40`, `Loop` advanced through poses after opening animation controls, and `All` toggled to all-poses overlay and back with no visible issue toast.
- Pre-push `ci-fast` hook passed.
