### PR TITLE
Fix browser agent shell static runtime

### DIFF
--- a/apps/desktop/src/lib/build-info.ts
+++ b/apps/desktop/src/lib/build-info.ts
@@ -44,7 +44,7 @@ export const defaultBuildInfo = buildInfoFromValues(
   "Burrete",
   packageInfo.version,
   buildIdentifier ?? (import.meta.env.DEV ? "browser-dev" : RELEASE_IDENTIFIER),
-  import.meta.env.DEV,
+  import.meta.env.DEV || isAgentShell,
   buildFlavor,
 );
 

--- a/plugins/burette-agent/scripts/agent-shell-server.mjs
+++ b/plugins/burette-agent/scripts/agent-shell-server.mjs
@@ -41,6 +41,24 @@ const STATIC_MIME_TYPES = new Map([
   ['.woff', 'font/woff'],
   ['.woff2', 'font/woff2'],
 ]);
+const RUNTIME_ASSET_NAMES = new Set([
+  'viewer-runtime.css',
+  'viewer-shell.js',
+  'molstar.css',
+  'molstar.js',
+  'burette-agent.js',
+  'viewer.js',
+]);
+const APP_ICONS = {
+  finder: '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns',
+  maestro: '/Applications/SchrodingerSuites2026-1/Maestro.app/Contents/Resources/Maestro.icns',
+  chimerax: '/Applications/ChimeraX-1.10.app/Contents/Resources/chimerax-icon.icns',
+  pymol: '/Applications/PyMOL.app/Contents/Resources/pymol.icns',
+  avogadro2: '/Applications/Avogadro2.app/Contents/Resources/avogadro.icns',
+  datawarrior: '/Applications/DataWarrior.app/Contents/Resources/datawarrior.icns',
+  vesta: '/Applications/VESTA.app/Contents/Resources/VESTA.icns',
+};
+const runtimeAssetRoots = runtimeAssetRootCandidates();
 
 function usage() {
   console.error(`Usage:
@@ -149,6 +167,10 @@ async function handleRequest(req, res) {
     await handleAgentSession(req, res, method, url);
     return;
   }
+  if (url.pathname.startsWith('/__burette/app-icon/')) {
+    await handleAppIcon(res, method, url);
+    return;
+  }
   if (url.pathname === '/__burette/read-file') {
     await handleReadFile(res, method, url);
     return;
@@ -167,10 +189,6 @@ async function handleRequest(req, res) {
   }
   if (url.pathname === '/__burette/dev-files') {
     await handleDevFiles(res, method, url);
-    return;
-  }
-  if (url.pathname === '/@fs' || url.pathname.startsWith('/@fs/')) {
-    await handleFsFile(res, method, url);
     return;
   }
   await handleStatic(res, method, url);
@@ -225,6 +243,30 @@ async function handleAgentSession(req, res, method, url) {
     return;
   }
   sendJson(res, 405, { error: 'Method not allowed' });
+}
+
+async function handleAppIcon(res, method, url) {
+  if (method !== 'GET' && method !== 'HEAD') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+  const iconId = decodeURIComponent(url.pathname.replace('/__burette/app-icon/', '').replace(/^\/+/, '')).replace(/\.png$/u, '');
+  const iconPath = APP_ICONS[iconId];
+  if (!iconPath || !existsSync(iconPath)) {
+    sendJson(res, 404, { error: 'Icon not found' });
+    return;
+  }
+  const cacheDir = resolve(sessionDir, 'app-icons');
+  const outputPath = resolve(cacheDir, `${iconId}.png`);
+  if (!existsSync(outputPath)) {
+    await mkdir(cacheDir, { recursive: true });
+    const result = spawnSync('/usr/bin/sips', ['-s', 'format', 'png', iconPath, '--out', outputPath], { encoding: 'utf8' });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error((result.stderr || result.stdout || '').trim() || `sips exited with status ${result.status}`);
+    }
+  }
+  await sendStaticFile(res, method, outputPath, true);
 }
 
 async function handleReadFile(res, method, url) {
@@ -434,13 +476,31 @@ async function handleDevFiles(res, method, url) {
   sendJson(res, 200, { files: Array.from(new Set(files)).sort((left, right) => left.localeCompare(right)) });
 }
 
-async function handleFsFile(res, method, url) {
+async function handleStatic(res, method, url) {
   if (method !== 'GET' && method !== 'HEAD') {
     sendJson(res, 405, { error: 'Method not allowed' });
     return;
   }
-  const filePath = allowedPathFromFsUrl(url);
-  if (!filePath) {
+  const cleanPath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+  if (cleanPath.startsWith('@fs/')) {
+    await handleFsStatic(res, method, cleanPath);
+    return;
+  }
+  const candidate = resolve(distRoot, cleanPath || 'index.html');
+  const filePath = isWithin(candidate, distRoot) && existsSync(candidate)
+    ? candidate
+    : indexPath;
+  await sendStaticFile(res, method, filePath, filePath === indexPath);
+}
+
+async function handleFsStatic(res, method, cleanPath) {
+  const runtimeAssetPath = findRuntimeAssetPath(cleanPath);
+  if (runtimeAssetPath) {
+    await sendStaticFile(res, method, runtimeAssetPath, false);
+    return;
+  }
+  const filePath = resolve(`/${cleanPath.slice('@fs/'.length)}`);
+  if (!isAllowed(filePath)) {
     sendJson(res, 403, { error: 'Forbidden' });
     return;
   }
@@ -449,25 +509,11 @@ async function handleFsFile(res, method, url) {
     sendJson(res, 404, { error: 'Not found' });
     return;
   }
-  const bytes = await readFile(filePath);
-  res.statusCode = 200;
-  res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
-  res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', 'no-cache');
-  res.end(method === 'HEAD' ? undefined : bytes);
+  await sendStaticFile(res, method, filePath, false, info);
 }
 
-async function handleStatic(res, method, url) {
-  if (method !== 'GET' && method !== 'HEAD') {
-    sendJson(res, 405, { error: 'Method not allowed' });
-    return;
-  }
-  const cleanPath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
-  const candidate = resolve(distRoot, cleanPath || 'index.html');
-  const filePath = isWithin(candidate, distRoot) && existsSync(candidate)
-    ? candidate
-    : indexPath;
-  const info = await stat(filePath);
+async function sendStaticFile(res, method, filePath, noCache, knownInfo = null) {
+  const info = knownInfo ?? await stat(filePath);
   if (!info.isFile()) {
     sendJson(res, 404, { error: 'Not found' });
     return;
@@ -476,32 +522,28 @@ async function handleStatic(res, method, url) {
   res.statusCode = 200;
   res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
   res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', filePath === indexPath ? 'no-cache' : 'public, max-age=31536000, immutable');
+  res.setHeader('Cache-Control', noCache ? 'no-cache' : 'public, max-age=31536000, immutable');
   res.end(method === 'HEAD' ? undefined : bytes);
 }
 
-async function handleFsFile(res, method, url) {
-  if (method !== 'GET' && method !== 'HEAD') {
-    sendJson(res, 405, { error: 'Method not allowed' });
-    return;
+function runtimeAssetRootCandidates() {
+  return Array.from(new Set([
+    resolve(scriptDir, '..', 'PreviewExtension', 'Web'),
+    resolve(scriptDir, '..', 'preview-web'),
+    resolve(scriptDir, '..', '..', 'PreviewExtension', 'Web'),
+    resolve(scriptDir, '..', '..', '..', 'PreviewExtension', 'Web'),
+  ]));
+}
+
+function findRuntimeAssetPath(cleanPath) {
+  if (!cleanPath.includes('/PreviewExtension/Web/')) return null;
+  const assetName = basename(cleanPath);
+  if (!RUNTIME_ASSET_NAMES.has(assetName)) return null;
+  for (const root of runtimeAssetRoots) {
+    const candidate = resolve(root, assetName);
+    if (isWithin(candidate, root) && existsSync(candidate)) return candidate;
   }
-  const rawPath = decodeURIComponent(url.pathname).replace(/^\/@fs\/+/u, '/');
-  const filePath = resolve(rawPath);
-  if (!isAllowed(filePath)) {
-    sendJson(res, 403, { error: 'Forbidden' });
-    return;
-  }
-  const info = await stat(filePath).catch(() => null);
-  if (!info?.isFile()) {
-    sendJson(res, 404, { error: 'Not found' });
-    return;
-  }
-  const bytes = await readFile(filePath);
-  res.statusCode = 200;
-  res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
-  res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', 'no-cache');
-  res.end(method === 'HEAD' ? undefined : bytes);
+  return null;
 }
 
 async function collectDevFiles(path, files) {
@@ -530,16 +572,6 @@ function allowedPathFromQuery(url, options = {}) {
   if (!isAllowed(filePath)) return null;
   const extension = fileExtension(filePath);
   if (options.allowText ? !TEXT_EXTENSIONS.has(extension) : !STRUCTURE_EXTENSIONS.has(extension)) return null;
-  return filePath;
-}
-
-function allowedPathFromFsUrl(url) {
-  const rawPath = decodeURIComponent(url.pathname.slice('/@fs'.length));
-  if (!rawPath.startsWith('/')) return null;
-  const filePath = resolve(rawPath);
-  if (!isAllowed(filePath)) return null;
-  const extension = fileExtension(filePath);
-  if (!TEXT_EXTENSIONS.has(extension) && !STATIC_MIME_TYPES.has(`.${extension}`)) return null;
   return filePath;
 }
 

--- a/scripts/agent-shell-server.mjs
+++ b/scripts/agent-shell-server.mjs
@@ -41,6 +41,24 @@ const STATIC_MIME_TYPES = new Map([
   ['.woff', 'font/woff'],
   ['.woff2', 'font/woff2'],
 ]);
+const RUNTIME_ASSET_NAMES = new Set([
+  'viewer-runtime.css',
+  'viewer-shell.js',
+  'molstar.css',
+  'molstar.js',
+  'burette-agent.js',
+  'viewer.js',
+]);
+const APP_ICONS = {
+  finder: '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns',
+  maestro: '/Applications/SchrodingerSuites2026-1/Maestro.app/Contents/Resources/Maestro.icns',
+  chimerax: '/Applications/ChimeraX-1.10.app/Contents/Resources/chimerax-icon.icns',
+  pymol: '/Applications/PyMOL.app/Contents/Resources/pymol.icns',
+  avogadro2: '/Applications/Avogadro2.app/Contents/Resources/avogadro.icns',
+  datawarrior: '/Applications/DataWarrior.app/Contents/Resources/datawarrior.icns',
+  vesta: '/Applications/VESTA.app/Contents/Resources/VESTA.icns',
+};
+const runtimeAssetRoots = runtimeAssetRootCandidates();
 
 function usage() {
   console.error(`Usage:
@@ -149,6 +167,10 @@ async function handleRequest(req, res) {
     await handleAgentSession(req, res, method, url);
     return;
   }
+  if (url.pathname.startsWith('/__burette/app-icon/')) {
+    await handleAppIcon(res, method, url);
+    return;
+  }
   if (url.pathname === '/__burette/read-file') {
     await handleReadFile(res, method, url);
     return;
@@ -167,10 +189,6 @@ async function handleRequest(req, res) {
   }
   if (url.pathname === '/__burette/dev-files') {
     await handleDevFiles(res, method, url);
-    return;
-  }
-  if (url.pathname === '/@fs' || url.pathname.startsWith('/@fs/')) {
-    await handleFsFile(res, method, url);
     return;
   }
   await handleStatic(res, method, url);
@@ -225,6 +243,30 @@ async function handleAgentSession(req, res, method, url) {
     return;
   }
   sendJson(res, 405, { error: 'Method not allowed' });
+}
+
+async function handleAppIcon(res, method, url) {
+  if (method !== 'GET' && method !== 'HEAD') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+  const iconId = decodeURIComponent(url.pathname.replace('/__burette/app-icon/', '').replace(/^\/+/, '')).replace(/\.png$/u, '');
+  const iconPath = APP_ICONS[iconId];
+  if (!iconPath || !existsSync(iconPath)) {
+    sendJson(res, 404, { error: 'Icon not found' });
+    return;
+  }
+  const cacheDir = resolve(sessionDir, 'app-icons');
+  const outputPath = resolve(cacheDir, `${iconId}.png`);
+  if (!existsSync(outputPath)) {
+    await mkdir(cacheDir, { recursive: true });
+    const result = spawnSync('/usr/bin/sips', ['-s', 'format', 'png', iconPath, '--out', outputPath], { encoding: 'utf8' });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error((result.stderr || result.stdout || '').trim() || `sips exited with status ${result.status}`);
+    }
+  }
+  await sendStaticFile(res, method, outputPath, true);
 }
 
 async function handleReadFile(res, method, url) {
@@ -434,13 +476,31 @@ async function handleDevFiles(res, method, url) {
   sendJson(res, 200, { files: Array.from(new Set(files)).sort((left, right) => left.localeCompare(right)) });
 }
 
-async function handleFsFile(res, method, url) {
+async function handleStatic(res, method, url) {
   if (method !== 'GET' && method !== 'HEAD') {
     sendJson(res, 405, { error: 'Method not allowed' });
     return;
   }
-  const filePath = allowedPathFromFsUrl(url);
-  if (!filePath) {
+  const cleanPath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+  if (cleanPath.startsWith('@fs/')) {
+    await handleFsStatic(res, method, cleanPath);
+    return;
+  }
+  const candidate = resolve(distRoot, cleanPath || 'index.html');
+  const filePath = isWithin(candidate, distRoot) && existsSync(candidate)
+    ? candidate
+    : indexPath;
+  await sendStaticFile(res, method, filePath, filePath === indexPath);
+}
+
+async function handleFsStatic(res, method, cleanPath) {
+  const runtimeAssetPath = findRuntimeAssetPath(cleanPath);
+  if (runtimeAssetPath) {
+    await sendStaticFile(res, method, runtimeAssetPath, false);
+    return;
+  }
+  const filePath = resolve(`/${cleanPath.slice('@fs/'.length)}`);
+  if (!isAllowed(filePath)) {
     sendJson(res, 403, { error: 'Forbidden' });
     return;
   }
@@ -449,25 +509,11 @@ async function handleFsFile(res, method, url) {
     sendJson(res, 404, { error: 'Not found' });
     return;
   }
-  const bytes = await readFile(filePath);
-  res.statusCode = 200;
-  res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
-  res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', 'no-cache');
-  res.end(method === 'HEAD' ? undefined : bytes);
+  await sendStaticFile(res, method, filePath, false, info);
 }
 
-async function handleStatic(res, method, url) {
-  if (method !== 'GET' && method !== 'HEAD') {
-    sendJson(res, 405, { error: 'Method not allowed' });
-    return;
-  }
-  const cleanPath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
-  const candidate = resolve(distRoot, cleanPath || 'index.html');
-  const filePath = isWithin(candidate, distRoot) && existsSync(candidate)
-    ? candidate
-    : indexPath;
-  const info = await stat(filePath);
+async function sendStaticFile(res, method, filePath, noCache, knownInfo = null) {
+  const info = knownInfo ?? await stat(filePath);
   if (!info.isFile()) {
     sendJson(res, 404, { error: 'Not found' });
     return;
@@ -476,32 +522,28 @@ async function handleStatic(res, method, url) {
   res.statusCode = 200;
   res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
   res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', filePath === indexPath ? 'no-cache' : 'public, max-age=31536000, immutable');
+  res.setHeader('Cache-Control', noCache ? 'no-cache' : 'public, max-age=31536000, immutable');
   res.end(method === 'HEAD' ? undefined : bytes);
 }
 
-async function handleFsFile(res, method, url) {
-  if (method !== 'GET' && method !== 'HEAD') {
-    sendJson(res, 405, { error: 'Method not allowed' });
-    return;
+function runtimeAssetRootCandidates() {
+  return Array.from(new Set([
+    resolve(scriptDir, '..', 'PreviewExtension', 'Web'),
+    resolve(scriptDir, '..', 'preview-web'),
+    resolve(scriptDir, '..', '..', 'PreviewExtension', 'Web'),
+    resolve(scriptDir, '..', '..', '..', 'PreviewExtension', 'Web'),
+  ]));
+}
+
+function findRuntimeAssetPath(cleanPath) {
+  if (!cleanPath.includes('/PreviewExtension/Web/')) return null;
+  const assetName = basename(cleanPath);
+  if (!RUNTIME_ASSET_NAMES.has(assetName)) return null;
+  for (const root of runtimeAssetRoots) {
+    const candidate = resolve(root, assetName);
+    if (isWithin(candidate, root) && existsSync(candidate)) return candidate;
   }
-  const rawPath = decodeURIComponent(url.pathname).replace(/^\/@fs\/+/u, '/');
-  const filePath = resolve(rawPath);
-  if (!isAllowed(filePath)) {
-    sendJson(res, 403, { error: 'Forbidden' });
-    return;
-  }
-  const info = await stat(filePath).catch(() => null);
-  if (!info?.isFile()) {
-    sendJson(res, 404, { error: 'Not found' });
-    return;
-  }
-  const bytes = await readFile(filePath);
-  res.statusCode = 200;
-  res.setHeader('Content-Type', STATIC_MIME_TYPES.get(extname(filePath).toLowerCase()) || 'application/octet-stream');
-  res.setHeader('Content-Length', String(bytes.length));
-  res.setHeader('Cache-Control', 'no-cache');
-  res.end(method === 'HEAD' ? undefined : bytes);
+  return null;
 }
 
 async function collectDevFiles(path, files) {
@@ -530,16 +572,6 @@ function allowedPathFromQuery(url, options = {}) {
   if (!isAllowed(filePath)) return null;
   const extension = fileExtension(filePath);
   if (options.allowText ? !TEXT_EXTENSIONS.has(extension) : !STRUCTURE_EXTENSIONS.has(extension)) return null;
-  return filePath;
-}
-
-function allowedPathFromFsUrl(url) {
-  const rawPath = decodeURIComponent(url.pathname.slice('/@fs'.length));
-  if (!rawPath.startsWith('/')) return null;
-  const filePath = resolve(rawPath);
-  if (!isAllowed(filePath)) return null;
-  const extension = fileExtension(filePath);
-  if (!TEXT_EXTENSIONS.has(extension) && !STATIC_MIME_TYPES.has(`.${extension}`)) return null;
   return filePath;
 }
 

--- a/tests/test-burrete-agent-cli.mjs
+++ b/tests/test-burrete-agent-cli.mjs
@@ -2,9 +2,24 @@
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { createServer } from 'node:http';
+import { createServer, get as httpGet } from 'node:http';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+
+function get(url) {
+  return new Promise((resolveRequest, rejectRequest) => {
+    httpGet(new URL(url), (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', chunk => { body += chunk; });
+      response.on('end', () => resolveRequest({
+        statusCode: response.statusCode,
+        headers: response.headers,
+        body,
+      }));
+    }).on('error', rejectRequest);
+  });
+}
 
 async function freePort() {
   const server = createServer();
@@ -167,10 +182,40 @@ try {
       assert.equal(wasmResponse.status, 200);
       assert.equal(wasmResponse.headers.get('content-type'), 'application/wasm');
       assert.equal(Buffer.from(await wasmResponse.arrayBuffer()).subarray(0, 4).toString('hex'), '0061736d');
+      const miniFsPath = resolve('samples/mini.pdb').split('/').map(encodeURIComponent).join('/');
+      const miniFs = await get(`${prebuiltPayload.result.url.split('?')[0]}@fs/${miniFsPath}`);
+      assert.equal(miniFs.statusCode, 200);
+      assert.match(miniFs.body, /^HEADER\s+MINI GLY-ALA PEPTIDE/u);
+      assert.doesNotMatch(miniFs.body, /Burrete Agent Shell/);
+      const finderIcon = await get(`${prebuiltPayload.result.url.split('?')[0]}__burette/app-icon/finder.png`);
+      assert.equal(finderIcon.statusCode, 200);
+      assert.match(finderIcon.headers['content-type'] ?? '', /^image\/png\b/u);
+      assert.doesNotMatch(finderIcon.body, /Burrete Agent Shell/);
       if (prebuiltPayload.result.processId) {
         try {
           process.kill(prebuiltPayload.result.processId, 'SIGTERM');
         } catch {}
+      }
+      const staleAssetDist = await mkdtemp(resolve(tmpdir(), 'burrete-agent-stale-shell-dist-'));
+      try {
+        await writeFile(resolve(staleAssetDist, 'index.html'), '<!doctype html><script src="/@fs/tmp/stale/Burette/PreviewExtension/Web/viewer.js"></script>');
+        const staleAssetShell = runCliWithEnv(['open', '--mode', 'browser-agent-shell', 'samples/mini.pdb'], {
+          BURRETE_AGENT_SHELL_DIST_DIR: staleAssetDist,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        });
+        assert.equal(staleAssetShell.status, 0, staleAssetShell.stderr);
+        const staleAssetPayload = JSON.parse(staleAssetShell.stdout);
+        const staleAsset = await get(`${staleAssetPayload.result.url.split('?')[0]}@fs/tmp/stale/Burette/PreviewExtension/Web/viewer.js`);
+        assert.equal(staleAsset.statusCode, 200);
+        assert.match(staleAsset.body, /BurreteAgent|BurreteDataBase64|molstar/u);
+        assert.doesNotMatch(staleAsset.body, /Burrete Agent Shell/);
+        if (staleAssetPayload.result.processId) {
+          try {
+            process.kill(staleAssetPayload.result.processId, 'SIGTERM');
+          } catch {}
+        }
+      } finally {
+        await rm(staleAssetDist, { recursive: true, force: true });
       }
     } finally {
       await rm(prebuiltDist, { recursive: true, force: true });

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -149,6 +149,7 @@ const [
   windowTitle,
   componentFormat,
   instance,
+  buildInfoLib,
   tauriSource,
   settingsSections,
   browserDevStartup,
@@ -344,6 +345,7 @@ const [
   source('apps/desktop/src/components/window-title/index.tsx'),
   source('apps/desktop/src/components/format.ts'),
   source('apps/desktop/src/lib/instance.ts'),
+  source('apps/desktop/src/lib/build-info.ts'),
   source('apps/desktop/src/lib/tauri.ts'),
   source('apps/desktop/src/lib/settings-sections.ts'),
   source('apps/desktop/src/lib/browser-dev-startup.ts'),
@@ -3860,6 +3862,8 @@ assert.match(instance, /VITE_BURRETE_AGENT_SHELL/);
 assert.match(instance, /"Burette Agent"/);
 assert.match(instance, /Burette Dev \$\{devInstanceSuffix\}/);
 assert.match(instance, /"8a18"/);
+assert.match(buildInfoLib, /import\.meta\.env\.DEV \|\| isAgentShell/);
+assert.match(buildInfoLib, /isAgentShell: isBrowserDev && isAgentShell/);
 assert.match(browserDevDocuments, /function browserRendererPlan/);
 assert.match(browserDevDocuments, /export function browserDevRuntimeNeedsRefresh/);
 assert.match(browserDevDocuments, /const GRID_ASSET_VERSION = "grid-ui-v138"/);


### PR DESCRIPTION
## Summary
- serve allowed @fs files and remap stale PreviewExtension runtime asset paths in the prebuilt browser agent shell
- classify browser-agent-shell builds as browser/dev shells so update prompts stay disabled
- serve app icon PNGs from the static shell server so Open In menus do not show broken images

## Validation
- node tests/test-burrete-agent-cli.mjs
- node tests/test-ui-shell-contract.mjs
- bun scripts/check-js-syntax.mjs scripts/agent-shell-server.mjs plugins/burette-agent/scripts/agent-shell-server.mjs tests/test-burrete-agent-cli.mjs
- bun run build:agent-shell
- bun plugins/burette-agent/scripts/install-local.mjs --skip-build
- pre-push ci-fast
- manual prebuilt shell checks: /@fs 1htb.pdb, stale viewer.js, /__burette/app-icon/{finder,maestro,chimerax,pymol,avogadro2,vesta}.png return 200 image/png