### PR TITLE
Add Open as Text context menu items

### DIFF
--- a/apps/desktop/src/components/editor-area/editor-tabs.tsx
+++ b/apps/desktop/src/components/editor-area/editor-tabs.tsx
@@ -530,6 +530,16 @@ export function EditorTabs({ state, actions }: { state: ShellViewState; actions:
                 ? [
                     {
                       kind: "item" as const,
+                      id: "open-tab-document-as-text",
+                      text: "Open as Text",
+                      disabled: tabDocument.virtual === true,
+                      action: () => {
+                        if (tabDocument.virtual) return;
+                        void actions.openTextPaths([tabDocument.path]);
+                      },
+                    },
+                    {
+                      kind: "item" as const,
                       id: "reveal-tab-document",
                       text: "Reveal in Finder",
                       action: () => {

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -633,6 +633,14 @@ export function ProjectItem({
       },
       {
         kind: "item" as const,
+        id: "open-structure-as-text",
+        text: "Open as Text",
+        action: () => {
+          void actions.openTextPaths([item.path]);
+        },
+      },
+      {
+        kind: "item" as const,
         id: "copy-structure-path",
         text: "Copy Path",
         action: () => {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1300,6 +1300,9 @@ assert.match(editorTabs, /const canSaveAs = tabDocument && isMoleculeCollectionP
 assert.match(editorTabs, /const tabMolstarScenePaths = tabDocument\?\.renderer === "molstar"/);
 assert.match(editorTabs, /id: "save-as"/);
 assert.match(editorTabs, /text: "Save As\.\.\."/);
+assert.match(editorTabs, /id: "open-tab-document-as-text"/);
+assert.match(editorTabs, /text: "Open as Text"/);
+assert.match(editorTabs, /actions\.openTextPaths\(\[tabDocument\.path\]\)/);
 assert.match(editorTabs, /id: "open-tab-folder-molstar-scene"/);
 assert.match(editorTabs, /text: "Open all in Mol\* scene"/);
 assert.match(editorTabs, /disabled: tabMolstarScenePaths\.length < 2/);
@@ -3170,6 +3173,9 @@ assert.match(sidebarSurface, /disabled: !project\.rootPath,\s*action: \(\) => \{
 assert.doesNotMatch(sidebarSurface, /!project\.rootPath \|\| !project\.isExplicit/);
 assert.match(sidebarSurface, /Pin structure/);
 assert.match(sidebarSurface, /Unpin structure/);
+assert.match(sidebarSurface, /id: "open-structure-as-text"/);
+assert.match(sidebarSurface, /text: "Open as Text"/);
+assert.match(sidebarSurface, /actions\.openTextPaths\(\[item\.path\]\)/);
 assert.match(sidebarSurface, /id: "copy-structure-path"/);
 assert.match(sidebarSurface, /text: "Copy Path"/);
 assert.match(sidebarSurface, /actions\.copyPath\(item\.path, "structure"\)/);


### PR DESCRIPTION
## Why

Structure files can already be opened as text, but that path was not available from the right-click menus users reach most often.

## What Changed

- Added `Open as Text` to structure tab context menus in the desktop app.
- Added `Open as Text` to sidebar structure item context menus.
- Covered both menu entries in the UI shell contract test.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-text-file-viewer-contract.mjs`
- `git diff --check`
- pre-commit hooks
- pre-push `ci-fast`