### PR TITLE
Fix PDB Quick Look routing

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -454,7 +454,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -479,7 +479,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -504,7 +504,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -548,7 +548,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -27,6 +27,7 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>com.local.burrete10.pdb</string>
+				<string>public.pdb</string>
 				<string>com.local.burrete10.cif</string>
 				<string>public.cif</string>
 				<string>com.local.burrete10.mmcif</string>

--- a/PreviewExtension/ThumbnailInfo.plist
+++ b/PreviewExtension/ThumbnailInfo.plist
@@ -27,6 +27,7 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>com.local.burrete10.pdb</string>
+				<string>public.pdb</string>
 				<string>com.local.burrete10.cif</string>
 				<string>public.cif</string>
 				<string>com.local.burrete10.mmcif</string>

--- a/apps/desktop/src-tauri/AppMetadata.plist
+++ b/apps/desktop/src-tauri/AppMetadata.plist
@@ -143,6 +143,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.local.burrete10.pdb</string>
+				<string>public.pdb</string>
 				<string>com.local.burrete10.cif</string>
 				<string>public.cif</string>
 				<string>com.local.burrete10.mmcif</string>

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "1.0.7"
+version = "1.0.8"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "bin": "bin/burrete.mjs",
     },
   },

--- a/config/preview-formats.json
+++ b/config/preview-formats.json
@@ -3,6 +3,7 @@
     {
       "id": "pdb",
       "contentType": "com.local.burrete10.pdb",
+      "contentTypeAliases": ["public.pdb"],
       "extensions": ["pdb", "ent", "pdbqt", "pqr", "xpdb"],
       "mimeTypes": ["chemical/x-pdb", "chemical/x-pdbqt"],
       "conformsTo": ["public.plain-text", "public.data"],
@@ -449,6 +450,7 @@
     ],
     "contentTypes": [
       "com.local.burrete10.pdb",
+      "public.pdb",
       "com.local.burrete10.cif",
       "public.cif",
       "com.local.burrete10.mmcif",

--- a/ios/BurreteMobile/Info.plist
+++ b/ios/BurreteMobile/Info.plist
@@ -149,6 +149,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.local.burrete10.pdb</string>
+				<string>public.pdb</string>
 				<string>com.local.burrete10.cif</string>
 				<string>public.cif</string>
 				<string>com.local.burrete10.mmcif</string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/scripts/check-preview-format-registry.mjs
+++ b/scripts/check-preview-format-registry.mjs
@@ -85,6 +85,7 @@ const allowedSystemQuickLookContentTypes = new Set([
   'net.sourceforge.openbabel.xyz',
   'public.cif',
   'public.comma-separated-values-text',
+  'public.pdb',
   'public.tab-separated-values-text',
 ]);
 for (const contentType of registry.quickLook.contentTypes) {


### PR DESCRIPTION
## Why

Finder reports ordinary `.pdb` files as the system `public.pdb` content type, while Burrete only advertised its own `com.local.burrete10.pdb` type. That left common PDB samples outside the Burrete Quick Look extension and made preview coverage look inconsistent next to formats like CIF, SDF, XYZ, and FDF.

## What Changed

- Added `public.pdb` to the preview format registry and Quick Look/thumbnail supported content types.
- Kept desktop, iOS, and registry metadata aligned for PDB document handling.
- Allowed `public.pdb` in the preview format registry contract check.
- Bumped release metadata to `1.0.8` so the merged fix can be published immediately.

## Verification

- `bun scripts/check-preview-format-registry.mjs`
- `bun tests/test-preview-format-matrix.mjs`
- `bun tests/test-cross-platform-preview-contract.mjs`
- `bun run check:release`
- `./scripts/release.sh --dry-run`
- `bun run ci:fast`
- pre-push `ci-fast`

## Notes / Follow-Up

The local machine also had stale dev Quick Look registrations from an older build path. Installing the release bundle will unregister old Burrete/MolstarQuickLook extensions and reset Quick Look caches through the existing installer path.