### PR TITLE
Fix Ketcher export format panel switching

### DIFF
--- a/apps/desktop/src/components/ketcher-page.tsx
+++ b/apps/desktop/src/components/ketcher-page.tsx
@@ -534,18 +534,12 @@ export function KetcherPage({
     });
   }, [collectionTargets]);
 
-  const showExport = useCallback(async (format: KetcherTextFormat) => {
+  const showExport = useCallback((format: KetcherTextFormat) => {
     if (!ketcher) return;
     const label = KETCHER_FORMAT_LABELS[format];
     setStatus(`Exporting ${label}`);
-    try {
-      const text = await withKetcherTimeout(exportKetcherText(ketcher, format), `${label} export`);
-      setOutput(text || "");
-      setPanelMode({ purpose: "export", format });
-      setStatus(`Exported ${label}`);
-    } catch (error) {
-      setStatus(ketcherExportErrorMessage(error));
-    }
+    setOutput("");
+    setPanelMode({ purpose: "export", format });
   }, [ketcher]);
 
   useEffect(() => {
@@ -591,7 +585,7 @@ export function KetcherPage({
 
   const selectExportFormat = useCallback((format: KetcherTextFormat) => {
     actions.setDockTool("bottom", "ketcher");
-    void showExport(format);
+    showExport(format);
   }, [actions, showExport]);
 
   const selectImportFormat = useCallback((format: KetcherTextFormat) => {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2993,7 +2993,9 @@ assert.match(ketcherPage, /const \[liveSmilesImportDirty, setLiveSmilesImportDir
 assert.match(ketcherPage, /const liveSmilesImportSerialRef = useRef\(0\)/);
 assert.match(ketcherPage, /const locallySavedDraftRef = useRef\(""\)/);
 assert.match(ketcherPage, /if \(!draftKet\.trim\(\) && draftMolfile\.trimEnd\(\) === locallySavedDraftRef\.current\) return Promise\.resolve\(false\);/);
-assert.match(ketcherPage, /const showExport = useCallback\(async \(format: KetcherTextFormat\) =>/);
+assert.match(ketcherPage, /const showExport = useCallback\(\(format: KetcherTextFormat\) =>/);
+assert.match(ketcherPage, /setStatus\(`Exporting \$\{label\}`\);\s*setOutput\(""\);\s*setPanelMode\(\{ purpose: "export", format \}\);/);
+assert.doesNotMatch(ketcherPage, /const showExport = useCallback\(async/);
 assert.match(ketcherPage, /const refreshExport = \(\) => \{/);
 assert.match(ketcherPage, /const unsubscribe = ketcher\.subscribeChange\(scheduleRefresh\)/);
 assert.match(ketcherPage, /const startImport = useCallback\(\(format: KetcherTextFormat\) =>/);


### PR DESCRIPTION
## Why

Right-clicking the Ketcher Export button and choosing another output format could leave the dock panel showing stale export text or status from the previous format. The selection handler exported asynchronously before switching panel state, so older exports could race with the new format.

## What Changed

- Switch the export panel format synchronously when a menu item is selected.
- Clear stale export text before the current-format refresh runs.
- Keep export generation in the existing panel-mode effect, which cancels stale refreshes.
- Added a UI shell contract assertion for the synchronous format switch.

## Verification

- `bun scripts/check-js-syntax.mjs apps/desktop/src/components/ketcher-page.tsx tests/test-ui-shell-contract.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `git diff --check`
- pre-commit: plist, js-syntax, rust-fmt
- pre-push: `ci-fast`