### PR TITLE
Restore bottom dock Jobs tab

### DIFF
--- a/apps/desktop/src/lib/dock.ts
+++ b/apps/desktop/src/lib/dock.ts
@@ -95,6 +95,7 @@ export const RIGHT_DOCK_DEFAULT_TABS: DockTabKind[] = [
 
 export const BOTTOM_DOCK_DEFAULT_TABS: DockTabKind[] = [
   "files",
+  "jobs",
 ];
 
 const RIGHT_DOCK_TAB_CATALOG: DockTabKind[] = [
@@ -106,6 +107,7 @@ const RIGHT_DOCK_TAB_CATALOG: DockTabKind[] = [
 
 const BOTTOM_DOCK_TAB_CATALOG: DockTabKind[] = [
   "files",
+  "jobs",
   "folding",
   "spectrum",
   "logs",

--- a/apps/desktop/src/stores/shell-store.ts
+++ b/apps/desktop/src/stores/shell-store.ts
@@ -204,14 +204,22 @@ export const useShellStore = create<ShellState>()(
                 rightDockTabs: ensureDefaultDockTabs("right", state.rightDockTabs),
               }),
             }
-          : { bottomDockOpen: !state.bottomDockOpen }
+          : {
+              bottomDockOpen: !state.bottomDockOpen,
+              ...(state.bottomDockOpen ? {} : {
+                bottomDockTabs: ensureDefaultDockTabs("bottom", state.bottomDockTabs),
+              }),
+            }
       )),
       setDockOpen: (area, open) => set((state) => area === "right"
         ? {
             rightDockOpen: open,
             ...(open ? { rightDockTabs: ensureDefaultDockTabs("right", state.rightDockTabs) } : {}),
           }
-        : { bottomDockOpen: open }),
+        : {
+            bottomDockOpen: open,
+            ...(open ? { bottomDockTabs: ensureDefaultDockTabs("bottom", state.bottomDockTabs) } : {}),
+          }),
       setDockSize: (area, size) => set(area === "right"
         ? { rightDockWidth: normalizeRightDockWidth(size) }
         : { bottomDockHeight: normalizeBottomDockHeight(size) }),
@@ -242,13 +250,25 @@ export const useShellStore = create<ShellState>()(
             : { bottomDockActiveTab: kind };
         }),
       setDockDocument: (area, documentId) =>
-        set(area === "right"
+        set((state) => area === "right"
           ? { rightDockOpen: true, rightDockDocumentId: documentId, rightDockTool: null, rightDockActiveTab: "files" }
-          : { bottomDockOpen: true, bottomDockDocumentId: documentId, bottomDockTool: null, bottomDockActiveTab: "files" }),
+          : {
+              bottomDockOpen: true,
+              bottomDockTabs: ensureDefaultDockTabs("bottom", state.bottomDockTabs),
+              bottomDockDocumentId: documentId,
+              bottomDockTool: null,
+              bottomDockActiveTab: "files",
+            }),
       setDockTool: (area, tool) =>
-        set(area === "right"
+        set((state) => area === "right"
           ? { rightDockOpen: true, rightDockDocumentId: null, rightDockTool: tool, rightDockActiveTab: "files" }
-          : { bottomDockOpen: true, bottomDockDocumentId: null, bottomDockTool: tool, bottomDockActiveTab: "files" }),
+          : {
+              bottomDockOpen: true,
+              bottomDockTabs: ensureDefaultDockTabs("bottom", state.bottomDockTabs),
+              bottomDockDocumentId: null,
+              bottomDockTool: tool,
+              bottomDockActiveTab: "files",
+            }),
       addDockDrop: (input) =>
         set((state) => {
           if (!dockTabCatalog(input.area).includes(input.tabKind)) return state;
@@ -394,6 +414,9 @@ export const useShellStore = create<ShellState>()(
         const rightDockOpen = stored?.rightDockOpen ?? current.rightDockOpen;
         const normalizedRightDockTabs = normalizeDockTabs("right", stored?.rightDockTabs ?? current.rightDockTabs);
         const rightDockTabs = rightDockOpen ? ensureDefaultDockTabs("right", normalizedRightDockTabs) : normalizedRightDockTabs;
+        const bottomDockOpen = stored?.bottomDockOpen ?? current.bottomDockOpen;
+        const normalizedBottomDockTabs = persistentDockTabs("bottom", stored?.bottomDockTabs ?? current.bottomDockTabs);
+        const bottomDockTabs = bottomDockOpen ? ensureDefaultDockTabs("bottom", normalizedBottomDockTabs) : normalizedBottomDockTabs;
         const projectRoots = persistentRoots(stored?.projectRoots ?? current.projectRoots);
         const pinnedProjectRoots = persistentRoots(stored?.pinnedProjectRoots ?? current.pinnedProjectRoots)
           .filter((root) => projectRoots.includes(root));
@@ -411,12 +434,12 @@ export const useShellStore = create<ShellState>()(
             rightDockTabs,
             stored?.rightDockActiveTab ?? current.rightDockActiveTab,
           ),
-          bottomDockOpen: stored?.bottomDockOpen ?? current.bottomDockOpen,
+          bottomDockOpen,
           bottomDockHeight: normalizeBottomDockHeight(stored?.bottomDockHeight ?? current.bottomDockHeight),
-          bottomDockTabs: persistentDockTabs("bottom", stored?.bottomDockTabs ?? current.bottomDockTabs),
+          bottomDockTabs,
           bottomDockActiveTab: normalizeDockActiveTab(
             "bottom",
-            persistentDockTabs("bottom", stored?.bottomDockTabs ?? current.bottomDockTabs),
+            bottomDockTabs,
             stored?.bottomDockActiveTab ?? current.bottomDockActiveTab,
           ),
           projectsOpen: stored?.projectsOpen ?? current.projectsOpen,

--- a/tests/test-dock-file-entries.mjs
+++ b/tests/test-dock-file-entries.mjs
@@ -91,7 +91,9 @@ assert.deepEqual(activeTextWithDroppedStructureEntries.map((entry) => entry.key)
 assert.ok(activeTextWithDroppedStructureEntries.some((entry) => entry.key === "text-document:text-1"));
 
 assert.deepEqual(defaultDockTabs("right").map((tab) => tab.kind), ["inspector", "text", "files"]);
+assert.deepEqual(defaultDockTabs("bottom").map((tab) => tab.kind), ["files", "jobs"]);
 assert.deepEqual(dockTabCatalog("right"), ["xyzrender", "inspector", "text", "files"]);
+assert.deepEqual(dockTabCatalog("bottom"), ["files", "jobs", "folding", "spectrum", "logs"]);
 assert.deepEqual(
   ensureDefaultDockTabs("right", [{ id: "dock-inspector", kind: "inspector" }, { id: "dock-files", kind: "files" }])
     .map((tab) => tab.kind),
@@ -110,7 +112,7 @@ assert.deepEqual(
 assert.deepEqual(
   persistentDockTabs("bottom", [{ id: "dock-folding", kind: "folding" }])
     .map((tab) => tab.kind),
-  ["files"],
+  ["files", "jobs"],
 );
 
 console.log("dock file entry tests passed");

--- a/tests/test-shell-store-behavior.mjs
+++ b/tests/test-shell-store-behavior.mjs
@@ -29,11 +29,25 @@ assert.deepEqual(initial.rightDockTabs.map((tab) => tab.kind), [
   "text",
   "files",
 ]);
+assert.deepEqual(initial.bottomDockTabs.map((tab) => tab.kind), [
+  "files",
+  "jobs",
+]);
 useShellStore.getState().openDockTab("right", "descriptors");
 assert.deepEqual(useShellStore.getState().rightDockTabs.map((tab) => tab.kind), [
   "inspector",
   "text",
   "files",
+]);
+
+useShellStore.setState({
+  bottomDockOpen: false,
+  bottomDockTabs: [{ id: "dock-files", kind: "files" }],
+});
+useShellStore.getState().setDockOpen("bottom", true);
+assert.deepEqual(useShellStore.getState().bottomDockTabs.map((tab) => tab.kind), [
+  "files",
+  "jobs",
 ]);
 
 useShellStore.setState({


### PR DESCRIPTION
## Why

The bottom dock Jobs tab existed as a panel, but it was removed from the bottom dock default tabs and add-tab catalog. Existing persisted layouts with only Files also kept hiding Jobs after reload.

## What Changed

- Restored Jobs to the bottom dock default tab list.
- Restored Jobs to the bottom dock add-tab catalog.
- Ensured opening or rehydrating the bottom dock adds missing default tabs, so older saved layouts regain Jobs.
- Added store and dock catalog tests for the behavior.

## Verification

- `bun scripts/check-js-syntax.mjs apps/desktop/src/lib/dock.ts apps/desktop/src/stores/shell-store.ts tests/test-dock-file-entries.mjs tests/test-shell-store-behavior.mjs`
- `bun tests/test-dock-file-entries.mjs`
- `bun tests/test-shell-store-behavior.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- Browser-dev visual check at `http://127.0.0.1:1420/` with old persisted bottom tabs containing only Files; bottom dock rendered Files and Jobs.
- pre-commit: plist, js-syntax, rust-fmt
- pre-push: `ci-fast`