### PR TITLE
Open LAMMPS data files as structures

### DIFF
--- a/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_viewer.rs
@@ -660,7 +660,16 @@ fn should_use_converted_molstar_data(
         && !format.is_binary
         && matches!(
             format.molstar_format.as_str(),
-            "gro" | "mmcif" | "cifCore" | "lammpstrj" | "dump" | "pos" | "cfg"
+            "gro"
+                | "mmcif"
+                | "cifCore"
+                | "lammpstrj"
+                | "dump"
+                | "pos"
+                | "cfg"
+                | "data"
+                | "lammps"
+                | "lmp"
         )
 }
 


### PR DESCRIPTION
## Summary
- route LAMMPS data/topology formats through converted Mol* preview data in the desktop runtime
- keeps the existing text fallback while allowing .data/.lammps/.lmp files with parsed coordinates to open as structures

## Tests
- cargo test preview::text_xyz::tests::converts_lammps_data_atoms_to_pdb_for_molstar
- bun tests/test-ui-shell-contract.mjs
- bun tests/test-text-file-viewer-contract.mjs
- pre-push ci-fast