### PR TITLE
Fix text-to-Molstar range selection

### DIFF
--- a/PreviewExtension/Web/burette-agent.js
+++ b/PreviewExtension/Web/burette-agent.js
@@ -1120,7 +1120,7 @@
 
   function schemasForSelector(selector, atoms, warnings) {
     const direct = directSchema(selector);
-    if (direct) return [direct];
+    if (direct) return expandSchemaArrays(direct);
     const residueMap = new Map();
     for (const atom of atoms) {
       residueMap.set(residueIdentity(atom), ligandToSelector(residueSummary(atom)));
@@ -1130,6 +1130,16 @@
       warnings?.push(`Selector expands to more than ${MAX_SCHEMA_RESIDUES} residues; Mol* visual application is capped.`);
     }
     return Array.from(residueMap.values()).slice(0, MAX_SCHEMA_RESIDUES).map(directSchema).filter(Boolean);
+  }
+
+  function expandSchemaArrays(schema) {
+    const arrayEntries = Object.entries(schema).filter(([, value]) => Array.isArray(value));
+    if (arrayEntries.length === 0) return [schema];
+    if (arrayEntries.length > 1) {
+      return [schema];
+    }
+    const [[field, values]] = arrayEntries;
+    return values.map(value => ({ ...schema, [field]: value }));
   }
 
   function directSchema(selector = {}) {

--- a/apps/desktop/src/components/text-file-viewer.tsx
+++ b/apps/desktop/src/components/text-file-viewer.tsx
@@ -27,7 +27,6 @@ export function TextFileViewer({
   const parentRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
   const selectionTimeoutRef = useRef<number | null>(null);
-  const hoverTimeoutRef = useRef<number | null>(null);
   const onStructureSelectionRef = useRef(onStructureSelection);
   const lastStructureSelectionKeyRef = useRef<string | null>(null);
   const lineDragStartRef = useRef<{ from: number; to: number } | null>(null);
@@ -100,22 +99,6 @@ export function TextFileViewer({
       const structureSelection = textStructureSelectionFromRange(document, from, to);
       if (structureSelection) emitStructureSelection(structureSelection);
     };
-    const emitHoveredStructureLine = (lineElement: HTMLElement | null) => {
-      if (hoverTimeoutRef.current !== null) {
-        window.clearTimeout(hoverTimeoutRef.current);
-        hoverTimeoutRef.current = null;
-      }
-      if (!lineElement) return;
-      hoverTimeoutRef.current = window.setTimeout(() => {
-        hoverTimeoutRef.current = null;
-        try {
-          const line = lineRangeFromElement(lineElement);
-          emitStructureRange(line.from, line.to);
-        } catch (_) {
-          // CodeMirror can recycle virtualized line nodes between pointermove and debounce flush.
-        }
-      }, 80);
-    };
     const emitLineDragStructureSelection = (lineElement: HTMLElement) => {
       try {
         const line = lineRangeFromElement(lineElement);
@@ -174,9 +157,7 @@ export function TextFileViewer({
         } else if (target) {
           emitLineDragStructureSelection(target);
         }
-        return;
       }
-      emitHoveredStructureLine(target);
     };
     const onPointerUp = (event: PointerEvent) => {
       const target = lineElementFromEvent(event);
@@ -188,10 +169,7 @@ export function TextFileViewer({
       lineDragStartRef.current = null;
     };
     const onPointerLeave = () => {
-      if (hoverTimeoutRef.current !== null) {
-        window.clearTimeout(hoverTimeoutRef.current);
-        hoverTimeoutRef.current = null;
-      }
+      lineDragStartRef.current = null;
     };
     parent.addEventListener("pointerdown", onPointerDown);
     parent.addEventListener("pointermove", onPointerMove);
@@ -202,10 +180,6 @@ export function TextFileViewer({
       if (selectionTimeoutRef.current !== null) {
         window.clearTimeout(selectionTimeoutRef.current);
         selectionTimeoutRef.current = null;
-      }
-      if (hoverTimeoutRef.current !== null) {
-        window.clearTimeout(hoverTimeoutRef.current);
-        hoverTimeoutRef.current = null;
       }
       lineDragStartRef.current = null;
       window.document.removeEventListener("selectionchange", emitNativeStructureSelection);

--- a/plugins/burette-agent/preview-web/burette-agent.js
+++ b/plugins/burette-agent/preview-web/burette-agent.js
@@ -1120,7 +1120,7 @@
 
   function schemasForSelector(selector, atoms, warnings) {
     const direct = directSchema(selector);
-    if (direct) return [direct];
+    if (direct) return expandSchemaArrays(direct);
     const residueMap = new Map();
     for (const atom of atoms) {
       residueMap.set(residueIdentity(atom), ligandToSelector(residueSummary(atom)));
@@ -1130,6 +1130,16 @@
       warnings?.push(`Selector expands to more than ${MAX_SCHEMA_RESIDUES} residues; Mol* visual application is capped.`);
     }
     return Array.from(residueMap.values()).slice(0, MAX_SCHEMA_RESIDUES).map(directSchema).filter(Boolean);
+  }
+
+  function expandSchemaArrays(schema) {
+    const arrayEntries = Object.entries(schema).filter(([, value]) => Array.isArray(value));
+    if (arrayEntries.length === 0) return [schema];
+    if (arrayEntries.length > 1) {
+      return [schema];
+    }
+    const [[field, values]] = arrayEntries;
+    return values.map(value => ({ ...schema, [field]: value }));
   }
 
   function directSchema(selector = {}) {

--- a/tests/test-burette-agent.mjs
+++ b/tests/test-burette-agent.mjs
@@ -166,6 +166,19 @@ assert.equal(selected.result.counts.residues, 2);
 assert.ok(selected.result.selectionId.startsWith('sel-'));
 assert.ok(interactions.some(x => x.action === 'select'));
 
+interactions.length = 0;
+const selectedAtomRange = await context.window.BurreteAgent.run({
+  command: 'selectResidues',
+  args: { selector: { atom_index: [1, 2, 3] }, granularity: 'atom' }
+});
+assert.equal(selectedAtomRange.ok, true);
+assert.equal(selectedAtomRange.result.counts.atoms, 3);
+assert.deepEqual(
+  interactions.filter(x => x.action === 'select' && x.elements).map(x => x.elements.atom_index),
+  [1, 2, 3],
+);
+assert.ok(interactions.every(x => !Array.isArray(x.elements?.atom_index)));
+
 const focus = await context.window.BurreteAgent.run({ command: 'focusSelection', args: { selection: 'last' } });
 assert.equal(focus.ok, true);
 assert.ok(interactions.some(x => x.action === 'focus'));

--- a/tests/test-text-file-viewer-contract.mjs
+++ b/tests/test-text-file-viewer-contract.mjs
@@ -96,6 +96,8 @@ assert.match(textViewer, /range\.intersectsNode\(lineElement\)/);
 assert.match(textViewer, /textStructureSelectionFromRange\(document, from, to\)/);
 assert.doesNotMatch(textViewer, /textStructureSelectionFromRange\(document, line\.from, line\.to, \{ preferAtom: true \}\)/);
 assert.match(textViewer, /lineDragStartRef/);
+assert.doesNotMatch(textViewer, /hoverTimeoutRef/);
+assert.doesNotMatch(textViewer, /emitHoveredStructureLine/);
 assert.match(textViewer, /parent\.addEventListener\("pointerdown", onPointerDown\)/);
 assert.match(textViewer, /parent\.addEventListener\("pointermove", onPointerMove\)/);
 assert.match(textViewer, /parent\.addEventListener\("pointerup", onPointerUp\)/);


### PR DESCRIPTION
## Summary
- stop passive text hover from replacing an existing structure selection
- expand atom-index array selectors into scalar Mol* interactivity selections so text ranges highlight all matching atoms
- cover the text viewer contract and Burrete agent visual selection bridge

## Root cause
Text ranges were correctly converted to atom_index arrays, but the Mol* visual bridge forwarded the array as a single schema payload. Mol* did not visually apply that as a multi-atom selection. A separate hover path also replaced existing text selections with the single atom under the cursor.

## Validation
- node tests/test-burette-agent.mjs
- node tests/test-text-file-viewer-contract.mjs
- node tests/test-text-structure-selection.mjs
- pre-push ci-fast hook passed during push