### PR TITLE
Fix RDKit 2D molecule previews

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -11528,7 +11528,7 @@
         const record = splitSdfRecords(text)[0] || String(text || '');
         if (!record.trim()) return null;
         data = `${record.trimEnd()}\n$$$$\n`;
-      } else if (format === 'pdb' || format === 'pdbqt' || format === 'mmcif' || format === 'cifCore') {
+      } else if (format === 'pdb' || format === 'pdbqt' || format === 'mmcif' || format === 'cifCore' || format === 'xyz') {
         const frame = orientationFrameFromConfig({ ...config, format, binary: false });
         data = standalonePreviewSdfFromAtoms(frame?.atoms, config.label || 'Molecule');
         if (!data) return null;
@@ -12681,7 +12681,18 @@
       const sdfEntry = molstarContextSdfEntryForExport(target);
       if (sdfEntry) return sdfEntry;
     }
-    return target.selectedEntry || target.ligand || null;
+    const entry = target.selectedEntry || target.ligand || null;
+    if (normalizeFormat(entry?.format) === 'sdf') return entry;
+    return molstarStandaloneMoleculePreviewEntryForTarget(target) || entry;
+  }
+
+  function molstarStandaloneMoleculePreviewEntryForTarget(target) {
+    if (!target || (target.scope !== 'ligand' && target.scope !== 'ion')) return null;
+    const sourceFormat = normalizeFormat(activeConfig?.sourceExtension || activeConfig?.molstarFormat || activeConfig?.format);
+    if (sourceFormat !== 'xyz') return null;
+    const preview = molstarStandaloneMoleculePreviewTarget(activeConfig);
+    const ligand = preview?.ligand || null;
+    return normalizeFormat(ligand?.format) === 'sdf' ? ligand : null;
   }
 
   function molstarMoleculePreviewTargetForAction(action) {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -12677,19 +12677,33 @@
 
   function molstarMoleculePreviewEntry(target) {
     if (!target || (target.scope !== 'ligand' && target.scope !== 'ion')) return null;
-    if (target.scope === 'ligand') {
-      const sdfEntry = molstarContextSdfEntryForExport(target);
-      if (sdfEntry) return sdfEntry;
-    }
+    const sdfEntry = molstarMoleculePreviewSdfEntry(target);
+    if (sdfEntry) return sdfEntry;
     const entry = target.selectedEntry || target.ligand || null;
-    if (normalizeFormat(entry?.format) === 'sdf') return entry;
-    return molstarStandaloneMoleculePreviewEntryForTarget(target) || entry;
+    return molstarStandaloneMoleculePreviewEntryForTarget(target, entry) || entry;
   }
 
-  function molstarStandaloneMoleculePreviewEntryForTarget(target) {
+  function molstarMoleculePreviewSdfEntry(target) {
     if (!target || (target.scope !== 'ligand' && target.scope !== 'ion')) return null;
-    const sourceFormat = normalizeFormat(activeConfig?.sourceExtension || activeConfig?.molstarFormat || activeConfig?.format);
-    if (sourceFormat !== 'xyz') return null;
+    if (target.atom && target.receptor) {
+      const ligandEntry = pdbLigandSdfEntryForResidue(target.receptor, target.atom);
+      if (ligandEntry) return ligandEntry;
+    }
+    if (target.atom && target.sourceEntry) {
+      const ligandEntry = pdbLigandSdfEntryForResidue(target.sourceEntry, target.atom);
+      if (ligandEntry) return ligandEntry;
+    }
+    if (target.scope === 'ligand') {
+      const ligandEntry = molstarContextSdfEntryForExport(target);
+      if (ligandEntry) return ligandEntry;
+    }
+    const entry = target.selectedEntry || target.ligand || null;
+    return normalizeFormat(entry?.format) === 'sdf' ? entry : null;
+  }
+
+  function molstarStandaloneMoleculePreviewEntryForTarget(target, entry = null) {
+    if (!target || (target.scope !== 'ligand' && target.scope !== 'ion')) return null;
+    if (entry) return null;
     const preview = molstarStandaloneMoleculePreviewTarget(activeConfig);
     const ligand = preview?.ligand || null;
     return normalizeFormat(ligand?.format) === 'sdf' ? ligand : null;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4989,9 +4989,13 @@ assert.match(previewViewer, /normalizedAtoms\.length > MOLSTAR_STANDALONE_PREVIE
 assert.match(previewViewer, /function inferStandalonePreviewBonds\(atoms\)/);
 assert.match(previewViewer, /function standalonePreviewBondLimit\(a, b\)/);
 assert.match(previewViewer, /function showMolstarMoleculePreview\(target\)/);
-assert.match(previewViewer, /function molstarStandaloneMoleculePreviewEntryForTarget\(target\)/);
-assert.match(previewViewer, /sourceFormat !== 'xyz'/);
-assert.match(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target\) \|\| entry;/);
+assert.match(previewViewer, /function molstarMoleculePreviewSdfEntry\(target\)/);
+assert.match(previewViewer, /pdbLigandSdfEntryForResidue\(target\.receptor, target\.atom\)/);
+assert.match(previewViewer, /pdbLigandSdfEntryForResidue\(target\.sourceEntry, target\.atom\)/);
+assert.match(previewViewer, /function molstarStandaloneMoleculePreviewEntryForTarget\(target, entry = null\)/);
+assert.match(previewViewer, /if \(entry\) return null;/);
+assert.match(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target, entry\) \|\| entry;/);
+assert.doesNotMatch(previewViewer, /sourceFormat !== 'xyz'/);
 assert.match(previewViewer, /if \(normalizeFormat\(entry\?\.format\) !== 'sdf'\) \{\s*hideMolstarMoleculePreview\(\);\s*return;\s*\}/);
 assert.match(previewViewer, /const image = molstarPreviewSvgCache\.get\(key\) \|\| ''/);
 assert.match(previewViewer, /function molstarPreviewParseMolblock2D\(data\)/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4982,13 +4982,16 @@ assert.match(previewViewer, /const scope = molstarContextScopeForAtom\(resolved\
 assert.match(previewViewer, /label: resolved\.selectedEntry\?\.label \|\| molstarContextResidueLabel\(resolved\.atom\) \|\| resolved\.label/);
 assert.match(previewViewer, /MOLSTAR_STANDALONE_PREVIEW_MAX_ATOMS = 300/);
 assert.match(previewViewer, /function molstarStandaloneMoleculePreviewTarget\(config\)/);
-assert.match(previewViewer, /format === 'pdb' \|\| format === 'pdbqt' \|\| format === 'mmcif' \|\| format === 'cifCore'/);
+assert.match(previewViewer, /format === 'pdb' \|\| format === 'pdbqt' \|\| format === 'mmcif' \|\| format === 'cifCore' \|\| format === 'xyz'/);
 assert.match(previewViewer, /standalonePreviewSdfFromAtoms\(frame\?\.atoms, config\.label \|\| 'Molecule'\)/);
 assert.match(previewViewer, /function standalonePreviewSdfFromAtoms\(atoms, label\)/);
 assert.match(previewViewer, /normalizedAtoms\.length > MOLSTAR_STANDALONE_PREVIEW_MAX_ATOMS/);
 assert.match(previewViewer, /function inferStandalonePreviewBonds\(atoms\)/);
 assert.match(previewViewer, /function standalonePreviewBondLimit\(a, b\)/);
 assert.match(previewViewer, /function showMolstarMoleculePreview\(target\)/);
+assert.match(previewViewer, /function molstarStandaloneMoleculePreviewEntryForTarget\(target\)/);
+assert.match(previewViewer, /sourceFormat !== 'xyz'/);
+assert.match(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target\) \|\| entry;/);
 assert.match(previewViewer, /if \(normalizeFormat\(entry\?\.format\) !== 'sdf'\) \{\s*hideMolstarMoleculePreview\(\);\s*return;\s*\}/);
 assert.match(previewViewer, /const image = molstarPreviewSvgCache\.get\(key\) \|\| ''/);
 assert.match(previewViewer, /function molstarPreviewParseMolblock2D\(data\)/);


### PR DESCRIPTION
## Summary
- route Mol* molecule preview cards through RDKit-backed SDF data when available
- add standalone SDF fallback for supported preview formats, including XYZ/PDB/mmCIF-style previews
- keep PreviewExtension and plugin viewer runtime mirrors in sync

## Validation
- bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js plugins/burette-agent/preview-web/viewer.js
- bun tests/test-ui-shell-contract.mjs
- git diff --check
- RDKit JS SVG generation smoke for SDF, XYZ, PDB, and the reported cluster_001.xyz sample
- pre-push ci-fast