### PR TITLE
Restore XYZ all overlay toggle

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2185,6 +2185,11 @@
     }
     const format = normalizeFormat(config?.molstarFormat || config?.format);
     if (format !== 'sdf' && format !== 'xyz') return 'single';
+    const storageKey = poseModeStorageKey(config);
+    try {
+      const stored = window.localStorage?.getItem(storageKey);
+      if (stored === 'all' || stored === 'single') return stored;
+    } catch (_) {}
     return 'single';
   }
 
@@ -2240,8 +2245,6 @@
 
   function structureOverlayToggleAvailable(prepared = activeMolstarPrepared) {
     if (!structureOverlayAvailable(prepared)) return false;
-    const sourceFormat = normalizeFormat(activeConfig?.sourceExtension || activeConfig?.molstarFormat || activeConfig?.format);
-    if (prepared?.xyzFrameOverlayAvailable === true || sourceFormat === 'xyz' || sourceFormat === 'extxyz') return false;
     return true;
   }
 

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -1095,6 +1095,7 @@ assert.match(viewerJS, /function requestStructureDataFromNative\(\)/);
 assert.match(viewerJS, /const fallbackKey = format === 'xyz' \? XYZ_FRAME_MODE_STORAGE_KEY : SDF_POSE_MODE_STORAGE_KEY/);
 assert.match(viewerJS, /const storageKey = String\(config\?\.sdfPoseModeStorageKey \|\| fallbackKey\)/);
 assert.match(viewerJS, /const defaultMode = sceneMode === 'structureAll' \? 'all' : 'single'/);
+assert.match(viewerJS, /const stored = window\.localStorage\?\.getItem\(storageKey\);[\s\S]*if \(stored === 'all' \|\| stored === 'single'\) return stored;[\s\S]*return 'single';/);
 assert.match(viewerJS, /window\.__mqlPost\('requestData', 'requestData', \{ requestToken \}\);/);
 assert.match(viewerJS, /function loadArrayBufferViaXHR\(url\)/);
 assert.match(viewerJS, /fetch preview-data\.bin failed, falling back to XMLHttpRequest/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5178,8 +5178,8 @@ for (const runtimeSource of [previewViewer]) {
   assert.match(runtimeSource, /function xyzFrameOverlayRawSignature\(raw\)/);
   assert.match(runtimeSource, /function xyzFrameOverlayStateKey\(rawSignature, frames, prepared, style, contextStyle, contextOpacity, contextColor, backgroundIndexes\)/);
   assert.match(runtimeSource, /function structureOverlayToggleAvailable\(prepared = activeMolstarPrepared\)/);
-  assert.match(runtimeSource, /const sourceFormat = normalizeFormat\(activeConfig\?\.sourceExtension \|\| activeConfig\?\.molstarFormat \|\| activeConfig\?\.format\)/);
-  assert.match(runtimeSource, /if \(prepared\?\.xyzFrameOverlayAvailable === true \|\| sourceFormat === 'xyz' \|\| sourceFormat === 'extxyz'\) return false;/);
+  assert.match(runtimeSource, /function structureOverlayToggleAvailable\(prepared = activeMolstarPrepared\) \{\s*if \(!structureOverlayAvailable\(prepared\)\) return false;\s*return true;\s*\}/);
+  assert.doesNotMatch(runtimeSource, /sourceFormat === 'xyz' \|\| sourceFormat === 'extxyz'/);
   assert.match(runtimeSource, /const overlayToggleAvailable = structureOverlayToggleAvailable\(prepared\);[\s\S]*?const all = overlayToggleAvailable \? createStructureOverlayToggleButton\(prepared\) : null;/);
   assert.match(runtimeSource, /function xyzFrameRepresentationStyle\(style\)/);
   assert.match(runtimeSource, /if \(normalized === 'line' \|\| normalized === 'ball-and-stick' \|\| normalized === 'spacefill' \|\| normalized === 'molecular-surface'\) return normalized;\s*return 'line';/);


### PR DESCRIPTION
## Summary
- show the structure overlay `All` toggle for XYZ frame overlays again
- honor the stored `buret.xyz.frameMode` value so XYZ can reopen in `all` mode
- update runtime contracts that previously asserted XYZ should hide the toggle

## Verification
- bun tests/test-tauri-structure.mjs
- bun tests/test-ui-shell-contract.mjs
- bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js
- git diff --check
- pre-push ci-fast
