### PR TITLE
Release 1.0.14 with MLIP and QE previews

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -454,7 +454,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -479,7 +479,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -504,7 +504,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -548,7 +548,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.13;
+				MARKETING_VERSION = 1.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -4402,7 +4402,7 @@ private enum PreviewStructureTextConverter {
         case "lammpstrj", "dump", "pos":
             return parseLammpsDump(lines)
         case "cfg":
-            return parseAtomeyeCFG(lines)
+            return parseAtomeyeCFG(lines) ?? parseMLIPCFG(lines)
         case "data", "lammps", "lmp":
             return parseLammpsData(lines)
         case "crd":
@@ -5860,6 +5860,66 @@ private enum PreviewStructureTextConverter {
             ))
         }
         return atoms.count == atomCount ? atoms : nil
+    }
+
+    private static func parseMLIPCFG(_ lines: [String]) -> [Atom]? {
+        guard let begin = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "begin_cfg" }) else {
+            return nil
+        }
+        let end = lines[(begin + 1)..<lines.count].firstIndex(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "end_cfg" }) ?? lines.count
+        let block = Array(lines[(begin + 1)..<end])
+        guard let atomCount = mlipCFGSize(block),
+              let atomDataIndex = block.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("AtomData:") }) else {
+            return nil
+        }
+        let header = fields(block[atomDataIndex])
+        func column(_ name: String) -> Int? {
+            guard let index = header.firstIndex(where: { $0.lowercased() == name.lowercased() }), index > 0 else {
+                return nil
+            }
+            return index - 1
+        }
+        guard let xIndex = column("cartes_x"),
+              let yIndex = column("cartes_y"),
+              let zIndex = column("cartes_z") else {
+            return nil
+        }
+        let typeIndex = column("type")
+        var atoms: [Atom] = []
+        for line in block.dropFirst(atomDataIndex + 1) {
+            let parts = fields(line)
+            guard parts.count > max(xIndex, max(yIndex, zIndex)) else {
+                if !atoms.isEmpty { break }
+                continue
+            }
+            guard let x = Double(parts[xIndex]),
+                  let y = Double(parts[yIndex]),
+                  let z = Double(parts[zIndex]) else {
+                if !atoms.isEmpty { break }
+                continue
+            }
+            let symbol = typeIndex.flatMap { parts.indices.contains($0) ? mlipCFGSymbol(for: parts[$0]) : nil } ?? "C"
+            atoms.append(Atom(symbol: symbol, x: x, y: y, z: z))
+            if atoms.count == atomCount { break }
+        }
+        return atoms.count == atomCount ? atoms : nil
+    }
+
+    private static func mlipCFGSize(_ lines: [String]) -> Int? {
+        guard lines.count >= 2 else { return nil }
+        for index in 0..<(lines.count - 1) {
+            guard lines[index].trimmingCharacters(in: .whitespaces).lowercased() == "size" else { continue }
+            if let value = fields(lines[index + 1]).first.flatMap(Int.init), value > 0 {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func mlipCFGSymbol(for value: String) -> String {
+        let normalized = normalizeElementSymbol(value)
+        if isElementSymbol(normalized) { return normalized }
+        return value.trimmingCharacters(in: .whitespaces) == "1" ? "H" : "C"
     }
 
     private static func atomeyeCFGAtomCount(_ lines: [String]) -> Int? {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "1.0.13"
+version = "1.0.14"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/preview/text_xyz.rs
+++ b/apps/desktop/src-tauri/src/preview/text_xyz.rs
@@ -131,14 +131,14 @@ fn atoms_from_text(data: &[u8], extension: &str) -> Option<Vec<Atom>> {
     match extension {
         "cub" | "cube" => parse_cube_atoms(&lines),
         "vasp" => parse_vasp_atoms(&lines),
-        "in" => parse_quantum_espresso_atoms(&lines),
+        "in" | "inp" => parse_quantum_espresso_atoms(&lines),
         "out" => parse_orca_atoms(&lines),
         "abi" => parse_abinit_atoms(&lines),
         "fdf" => parse_fdf_atoms(&lines),
         "cif" | "mmcif" | "mcif" => parse_cif_core_atoms(&lines),
         "inpcrd" | "rst7" | "restrt" => parse_amber_restart_atoms(&lines),
         "lammpstrj" | "dump" | "pos" => parse_lammps_dump_atoms(&lines),
-        "cfg" => parse_atomeye_cfg_atoms(&lines),
+        "cfg" => parse_atomeye_cfg_atoms(&lines).or_else(|| parse_mlip_cfg_atoms(&lines)),
         "data" | "lammps" | "lmp" => parse_lammps_data_atoms(&lines),
         "crd" => parse_charmm_coordinate_atoms(&lines),
         "rst" => {
@@ -877,6 +877,83 @@ fn parse_atomeye_cfg_atoms(lines: &[&str]) -> Option<Vec<Atom>> {
         atoms.push(Atom { symbol, x, y, z });
     }
     (atoms.len() == atom_count).then_some(atoms)
+}
+
+fn parse_mlip_cfg_atoms(lines: &[&str]) -> Option<Vec<Atom>> {
+    let begin = lines
+        .iter()
+        .position(|line| line.trim().eq_ignore_ascii_case("BEGIN_CFG"))?;
+    let end = lines[begin + 1..]
+        .iter()
+        .position(|line| line.trim().eq_ignore_ascii_case("END_CFG"))
+        .map(|offset| begin + 1 + offset)
+        .unwrap_or(lines.len());
+    let block = &lines[begin + 1..end];
+    let atom_count = parse_mlip_cfg_size(block)?;
+    let atom_data_index = block
+        .iter()
+        .position(|line| line.trim_start().starts_with("AtomData:"))?;
+    let header = fields(block[atom_data_index]);
+    let column = |name: &str| -> Option<usize> {
+        header
+            .iter()
+            .position(|value| value.eq_ignore_ascii_case(name))
+            .and_then(|index| index.checked_sub(1))
+    };
+    let type_index = column("type");
+    let x_index = column("cartes_x")?;
+    let y_index = column("cartes_y")?;
+    let z_index = column("cartes_z")?;
+    let mut atoms = Vec::with_capacity(atom_count);
+    for line in &block[atom_data_index + 1..] {
+        let parts = fields(line);
+        if parts.len() <= x_index.max(y_index).max(z_index) {
+            if !atoms.is_empty() {
+                break;
+            }
+            continue;
+        }
+        let x = parts[x_index].parse::<f64>().ok();
+        let y = parts[y_index].parse::<f64>().ok();
+        let z = parts[z_index].parse::<f64>().ok();
+        let (Some(x), Some(y), Some(z)) = (x, y, z) else {
+            if !atoms.is_empty() {
+                break;
+            }
+            continue;
+        };
+        let symbol = type_index
+            .and_then(|index| parts.get(index))
+            .map(|value| mlip_cfg_symbol_for_type(value))
+            .unwrap_or_else(|| "C".to_string());
+        atoms.push(Atom { symbol, x, y, z });
+        if atoms.len() == atom_count {
+            break;
+        }
+    }
+    (atoms.len() == atom_count).then_some(atoms)
+}
+
+fn parse_mlip_cfg_size(lines: &[&str]) -> Option<usize> {
+    lines.windows(2).find_map(|pair| {
+        pair[0]
+            .trim()
+            .eq_ignore_ascii_case("Size")
+            .then(|| fields(pair[1]).first()?.parse::<usize>().ok())
+            .flatten()
+    })
+}
+
+fn mlip_cfg_symbol_for_type(value: &str) -> String {
+    let normalized = normalize_element_symbol(value);
+    if is_element_symbol(&normalized) {
+        return normalized;
+    }
+    match value.trim() {
+        "0" => "C".to_string(),
+        "1" => "H".to_string(),
+        _ => "C".to_string(),
+    }
 }
 
 fn parse_atomeye_cfg_atom_count(lines: &[&str]) -> Option<usize> {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -1833,7 +1833,8 @@ function fileExtension(path: string) {
   const name = fileTitle(path);
   if (name.toLowerCase().endsWith(".mae.gz")) return "maegz";
   const index = name.lastIndexOf(".");
-  return index >= 0 ? name.slice(index + 1).toLowerCase() : "";
+  if (index >= 0) return name.slice(index + 1).toLowerCase();
+  return /^in(?:_|$)/iu.test(name) ? "in" : "";
 }
 
 function isMaestroPreviewExtension(extension: string) {
@@ -2245,7 +2246,7 @@ function atomsFromText(text: string, extension: string) {
     atoms = parseCubeAtoms(lines);
   } else if (extension === "vasp") {
     atoms = parseVaspAtoms(lines);
-  } else if (extension === "in") {
+  } else if (extension === "in" || extension === "inp") {
     atoms = parseQuantumEspressoAtoms(lines);
   } else if (extension === "out") {
     atoms = parseOrcaAtoms(lines);
@@ -2260,7 +2261,7 @@ function atomsFromText(text: string, extension: string) {
   } else if (extension === "lammpstrj" || extension === "dump" || extension === "pos") {
     atoms = parseLammpsDumpAtoms(lines);
   } else if (extension === "cfg") {
-    atoms = parseAtomeyeCfgAtoms(lines);
+    atoms = parseAtomeyeCfgAtoms(lines) ?? parseMlipCfgAtoms(lines);
   } else if (extension === "data" || extension === "lammps" || extension === "lmp") {
     atoms = parseLammpsDataAtoms(lines);
   } else if (extension === "crd") {
@@ -3301,6 +3302,66 @@ function parseAtomeyeCfgAtoms(lines: string[]) {
     });
   }
   return atoms.length === atomCount ? atoms : null;
+}
+
+function parseMlipCfgAtoms(lines: string[]) {
+  const begin = lines.findIndex((line) => line.trim().toLowerCase() === "begin_cfg");
+  if (begin < 0) return null;
+  const relativeEnd = lines.slice(begin + 1).findIndex((line) => line.trim().toLowerCase() === "end_cfg");
+  const end = relativeEnd >= 0 ? begin + 1 + relativeEnd : lines.length;
+  const block = lines.slice(begin + 1, end);
+  const atomCount = parseMlipCfgSize(block);
+  const atomDataIndex = block.findIndex((line) => line.trimStart().startsWith("AtomData:"));
+  if (!atomCount || atomDataIndex < 0) return null;
+  const header = fields(block[atomDataIndex]);
+  const column = (name: string) => {
+    const index = header.findIndex((value) => value.toLowerCase() === name.toLowerCase());
+    return index > 0 ? index - 1 : -1;
+  };
+  const typeIndex = column("type");
+  const xIndex = column("cartes_x");
+  const yIndex = column("cartes_y");
+  const zIndex = column("cartes_z");
+  if (xIndex < 0 || yIndex < 0 || zIndex < 0) return null;
+  const atoms: Atom[] = [];
+  for (const line of block.slice(atomDataIndex + 1)) {
+    const parts = fields(line);
+    if (parts.length <= Math.max(xIndex, yIndex, zIndex)) {
+      if (atoms.length) break;
+      continue;
+    }
+    const x = Number(parts[xIndex]);
+    const y = Number(parts[yIndex]);
+    const z = Number(parts[zIndex]);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      if (atoms.length) break;
+      continue;
+    }
+    atoms.push({
+      symbol: typeIndex >= 0 ? mlipCfgSymbolForType(parts[typeIndex] ?? "") : "C",
+      x,
+      y,
+      z,
+    });
+    if (atoms.length === atomCount) break;
+  }
+  return atoms.length === atomCount ? atoms : null;
+}
+
+function parseMlipCfgSize(lines: string[]) {
+  for (let index = 0; index + 1 < lines.length; index += 1) {
+    if (lines[index].trim().toLowerCase() !== "size") continue;
+    const value = Number.parseInt(fields(lines[index + 1])[0] ?? "", 10);
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+  return null;
+}
+
+function mlipCfgSymbolForType(value: string) {
+  const normalized = normalizeElementSymbol(value);
+  if (isElementSymbol(normalized)) return normalized;
+  if (value.trim() === "1") return "H";
+  return "C";
 }
 
 function parseAtomeyeCfgAtomCount(lines: string[]) {

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "bin": "bin/burrete.mjs",
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/plugins/burette-agent/mcp/lib/structure-summary.mjs
+++ b/plugins/burette-agent/mcp/lib/structure-summary.mjs
@@ -48,6 +48,18 @@ export async function summarizeStructureFile(file) {
   if (extension === "cif" || extension === "mmcif") {
     return summarizeCif(base, text);
   }
+  if (extension === "cfg") {
+    return summarizeMlipCfg(base, text);
+  }
+  if (extension === "in" || extension === "inp") {
+    return summarizeCoordinateAtoms(base, parseQuantumEspressoAtoms(text), "QE", "Quantum ESPRESSO input");
+  }
+  if (extension === "log" || extension === "out") {
+    return summarizeCoordinateAtoms(base, parseBestCoordinateBlock(text), extension.toUpperCase(), "Text coordinate output");
+  }
+  if (extension === "data" || extension === "lammps" || extension === "lmp") {
+    return summarizeCoordinateAtoms(base, parseLammpsDataAtoms(text), "LAMMPS", "LAMMPS data");
+  }
   return {
     ...base,
     format: extension ? extension.toUpperCase() : "FILE",
@@ -317,6 +329,48 @@ function summarizeCif(base, text) {
   };
 }
 
+function summarizeMlipCfg(base, text) {
+  const atoms = parseMlipCfgAtoms(text);
+  const configs = (text.match(/\bBEGIN_CFG\b/g) || []).length;
+  const summary = summarizeCoordinateAtoms(base, atoms, "CFG", "MLIP configuration");
+  return {
+    ...summary,
+    summaryLine: atoms.length > 0
+      ? `CFG MLIP configuration, ${formatInteger(configs || 1)} ${plural(configs || 1, "configuration")}, ${formatInteger(atoms.length)} atoms in first configuration`
+      : summary.summaryLine,
+    counts: { ...summary.counts, configurations: configs || 0 },
+    rows: [
+      { label: "Configurations", value: configs > 0 ? formatInteger(configs) : "Not detected" },
+      ...summary.rows,
+    ],
+    notes: [
+      "MLIP CFG summary reads the first BEGIN_CFG block for coordinates.",
+    ],
+  };
+}
+
+function summarizeCoordinateAtoms(base, atoms, format, kind) {
+  if (atoms.length === 0) return emptyParsedSummary(base, format, kind, "No supported coordinate block was detected.");
+  const elements = new Map();
+  for (const atom of atoms) {
+    increment(elements, atom.element || "X", 1);
+  }
+  return {
+    ...base,
+    format,
+    kind,
+    summaryLine: `${format} ${kind.toLowerCase()}, ${formatInteger(atoms.length)} atoms`,
+    counts: { atoms: atoms.length, elements: elements.size },
+    rows: [
+      { label: "Atoms", value: formatInteger(atoms.length) },
+      { label: "Elements", value: formatNameCounts(elements, 8) },
+      { label: "Lines", value: formatInteger(base.lineCount) },
+    ],
+    components: { elements: Object.fromEntries(elements) },
+    notes: ["Coordinate summary is element-level because this format has no residue or chain records."],
+  };
+}
+
 function emptyParsedSummary(base, format, kind, note) {
   return {
     ...base,
@@ -347,6 +401,174 @@ function parseMolCounts(block) {
     atoms: Number.parseInt(countsLine.slice(0, 3).trim(), 10) || 0,
     bonds: Number.parseInt(countsLine.slice(3, 6).trim(), 10) || 0,
   };
+}
+
+function parseQuantumEspressoAtoms(text) {
+  const lines = text.split(/\r?\n/);
+  const atoms = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^ATOMIC_POSITIONS\b/i.test(lines[index].trim())) continue;
+    for (let atomLineIndex = index + 1; atomLineIndex < lines.length; atomLineIndex += 1) {
+      const parsed = parseElementCoordinateLine(lines[atomLineIndex]);
+      if (!parsed) {
+        if (atoms.length > 0) return atoms;
+        break;
+      }
+      atoms.push(parsed);
+    }
+  }
+  return atoms;
+}
+
+function parseBestCoordinateBlock(text) {
+  const lines = text.split(/\r?\n/);
+  let best = [];
+  for (let start = 0; start < lines.length; start += 1) {
+    const block = [];
+    for (let index = start; index < lines.length; index += 1) {
+      const parsed = parseElementCoordinateLine(lines[index]);
+      if (!parsed) {
+        if (block.length >= 3) break;
+        if (block.length > 0) break;
+        continue;
+      }
+      block.push(parsed);
+    }
+    if (block.length > best.length) best = block;
+  }
+  return best;
+}
+
+function parseMlipCfgAtoms(text) {
+  const lines = text.split(/\r?\n/);
+  const begin = lines.findIndex((line) => line.trim() === "BEGIN_CFG");
+  if (begin < 0) return [];
+  const end = lines.findIndex((line, index) => index > begin && line.trim() === "END_CFG");
+  const block = lines.slice(begin, end > begin ? end : undefined);
+  const size = parseMlipCfgSize(block);
+  const atomDataIndex = block.findIndex((line) => line.trim().startsWith("AtomData:"));
+  if (atomDataIndex < 0) return [];
+  const header = block[atomDataIndex].trim().split(/\s+/).slice(1);
+  const typeIndex = header.indexOf("type");
+  const xIndex = header.indexOf("cartes_x");
+  const yIndex = header.indexOf("cartes_y");
+  const zIndex = header.indexOf("cartes_z");
+  if (xIndex < 0 || yIndex < 0 || zIndex < 0) return [];
+  const atoms = [];
+  for (let index = atomDataIndex + 1; index < block.length; index += 1) {
+    const values = block[index].trim().split(/\s+/);
+    if (values.length < header.length) break;
+    const x = Number.parseFloat(values[xIndex]);
+    const y = Number.parseFloat(values[yIndex]);
+    const z = Number.parseFloat(values[zIndex]);
+    if (![x, y, z].every(Number.isFinite)) break;
+    const type = typeIndex >= 0 ? values[typeIndex] : "";
+    atoms.push({ element: mlipCfgSymbolForType(type), x, y, z });
+    if (size > 0 && atoms.length >= size) break;
+  }
+  return atoms;
+}
+
+function parseMlipCfgSize(block) {
+  const sizeIndex = block.findIndex((line) => line.trim() === "Size");
+  if (sizeIndex < 0 || sizeIndex + 1 >= block.length) return 0;
+  const size = Number.parseInt(block[sizeIndex + 1].trim(), 10);
+  return Number.isFinite(size) ? size : 0;
+}
+
+function mlipCfgSymbolForType(type) {
+  const normalized = normalizeElement(type);
+  if (normalized) return normalized;
+  if (type === "1") return "H";
+  if (/^\d+$/.test(type)) return "C";
+  return "X";
+}
+
+function parseLammpsDataAtoms(text) {
+  const lines = text.split(/\r?\n/);
+  const masses = parseLammpsMasses(lines);
+  const atoms = [];
+  const atomsIndex = lines.findIndex((line) => /^Atoms\b/i.test(line.trim()));
+  if (atomsIndex < 0) return atoms;
+  for (let index = atomsIndex + 1; index < lines.length; index += 1) {
+    const line = stripInlineComment(lines[index]).trim();
+    if (!line) continue;
+    if (/^[A-Za-z]/.test(line)) break;
+    const values = line.split(/\s+/);
+    if (values.length < 5) continue;
+    const atom = lammpsDataAtom(values, masses);
+    if (!atom) continue;
+    atoms.push(atom);
+  }
+  return atoms;
+}
+
+function parseLammpsMasses(lines) {
+  const masses = new Map();
+  const massesIndex = lines.findIndex((line) => /^Masses\b/i.test(line.trim()));
+  if (massesIndex < 0) return masses;
+  for (let index = massesIndex + 1; index < lines.length; index += 1) {
+    const line = stripInlineComment(lines[index]).trim();
+    if (!line) continue;
+    if (/^[A-Za-z]/.test(line)) break;
+    const values = line.split(/\s+/);
+    const type = values[0];
+    const symbol = normalizeElement(values[2]) || lammpsSymbolFromMass(values[1]);
+    if (type && symbol) masses.set(type, symbol);
+  }
+  return masses;
+}
+
+function lammpsDataAtom(values, masses) {
+  const starts = [];
+  if (masses.has(values[2])) starts.push({ coordinateIndex: 4, typeIndex: 2 });
+  if (masses.has(values[1])) starts.push({ coordinateIndex: 3, typeIndex: 1 }, { coordinateIndex: 2, typeIndex: 1 });
+  starts.push(
+    { coordinateIndex: 3, typeIndex: 1 },
+    { coordinateIndex: 4, typeIndex: 2 },
+    { coordinateIndex: 2, typeIndex: 1 },
+  );
+  for (const start of starts) {
+    const x = Number.parseFloat(values[start.coordinateIndex]);
+    const y = Number.parseFloat(values[start.coordinateIndex + 1]);
+    const z = Number.parseFloat(values[start.coordinateIndex + 2]);
+    if ([x, y, z].every(Number.isFinite)) {
+      return { element: lammpsDataAtomSymbol(values, masses, start.typeIndex), x, y, z };
+    }
+  }
+  return null;
+}
+
+function lammpsDataAtomSymbol(values, masses, typeIndex) {
+  return masses.get(values[typeIndex])
+    || normalizeElement(values[typeIndex])
+    || "X";
+}
+
+function lammpsSymbolFromMass(value) {
+  const mass = Number(value);
+  if (!Number.isFinite(mass)) return "";
+  if (Math.abs(mass - 1.008) < 0.25) return "H";
+  if (Math.abs(mass - 12.011) < 0.5) return "C";
+  if (Math.abs(mass - 14.007) < 0.5) return "N";
+  if (Math.abs(mass - 15.999) < 0.5) return "O";
+  if (Math.abs(mass - 32.06) < 1) return "S";
+  return "";
+}
+
+function parseElementCoordinateLine(line) {
+  const values = stripInlineComment(line).trim().split(/\s+/);
+  if (values.length < 4) return null;
+  const element = normalizeElement(values[0]);
+  const x = Number.parseFloat(values[1]);
+  const y = Number.parseFloat(values[2]);
+  const z = Number.parseFloat(values[3]);
+  if (!element || ![x, y, z].every(Number.isFinite)) return null;
+  return { element, x, y, z };
+}
+
+function stripInlineComment(line) {
+  return String(line || "").replace(/[#;!].*$/, "");
 }
 
 function ligandLabel(residue) {
@@ -403,7 +625,10 @@ function plural(count, noun) {
 }
 
 function extensionForPath(file) {
-  return path.extname(file).replace(/^\./, "").toLowerCase();
+  const extension = path.extname(file).replace(/^\./, "").toLowerCase();
+  if (extension) return extension;
+  const basename = path.basename(file);
+  return /^in(?:_|$)/iu.test(basename) ? "in" : "";
 }
 
 function lineCount(text) {

--- a/scripts/agent-preview.mjs
+++ b/scripts/agent-preview.mjs
@@ -16,7 +16,7 @@ const agentControlApiVersion = 'burette-agent-control/v1';
 const renderPanelReadLimit = 512 * 1024;
 const mvsReadLimit = 25 * 1024 * 1024;
 const amberNcPreviewFrameLimit = 100;
-const coordinateArtifactExtensions = new Set(['xml', 'inpcrd', 'rst7', 'restrt', 'crd', 'rst', 'state', 'lammpstrj', 'dump', 'pos', 'cfg']);
+const coordinateArtifactExtensions = new Set(['xml', 'inpcrd', 'rst7', 'restrt', 'crd', 'rst', 'state', 'lammpstrj', 'dump', 'pos', 'cfg', 'in', 'inp', 'log', 'out', 'data', 'lammps', 'lmp']);
 const textArtifactExtensions = new Set(['par', 'prm', 'rtf', 'str', 'key', 'chk', 'checkpoint']);
 const amberNetcdfExtensions = new Set(['nc', 'ncdf', 'netcdf', 'ncrst']);
 const topologyPreviewExtensions = new Set(['pdb', 'ent', 'pdbqt', 'pqr', 'xpdb']);
@@ -83,7 +83,7 @@ function isAmberNetcdfFile(file) {
 }
 
 function preparePreviewPayload(file, bytes) {
-  const extension = extname(file).toLowerCase().replace(/^\./, '');
+  const extension = previewExtension(file);
   if (isPreferredTextArtifact(file)) {
     return { bytes, format: 'text', binary: looksBinary(bytes), textPreview: true };
   }
@@ -98,6 +98,12 @@ function preparePreviewPayload(file, bytes) {
   const converted = maestroPdbDataFromText(bytes.toString('utf8'));
   if (!converted) return { bytes, format: inferFormat(file), binary: isBinaryFormat(file) };
   return { bytes: Buffer.from(converted, 'utf8'), format: 'pdb', binary: false };
+}
+
+function previewExtension(file) {
+  const explicit = extname(file).toLowerCase().replace(/^\./, '');
+  if (explicit) return explicit;
+  return /^in(?:_|$)/iu.test(basename(file)) ? 'in' : '';
 }
 
 function isPreferredTextArtifact(file) {
@@ -205,12 +211,47 @@ function genericPdbDataFromText(text, extension, label) {
 function atomsFromCoordinateText(text, extension) {
   const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
   if (extension === 'inpcrd' || extension === 'rst7' || extension === 'restrt') return parseAmberRestartAtoms(lines);
+  if (extension === 'in' || extension === 'inp') return parseQuantumEspressoAtoms(lines) ?? parseBestCoordinateBlock(lines);
+  if (extension === 'log' || extension === 'out') return parseBestCoordinateBlock(lines);
   if (extension === 'lammpstrj' || extension === 'dump' || extension === 'pos') return parseLammpsDumpAtoms(lines);
-  if (extension === 'cfg') return parseAtomeyeCfgAtoms(lines);
+  if (extension === 'cfg') return parseAtomeyeCfgAtoms(lines) ?? parseMlipCfgAtoms(lines);
+  if (extension === 'data' || extension === 'lammps' || extension === 'lmp') return parseLammpsDataAtoms(lines);
   if (extension === 'crd') return parseCharmmCoordinateAtoms(lines);
   if (extension === 'rst') return parseCharmmCoordinateAtoms(lines) ?? parseAmberRestartAtoms(lines);
   if (extension === 'state' || extension === 'xml') return parseXmlPositionAtoms(text) ?? parseHoomdXmlAtoms(text);
   return null;
+}
+
+function parseQuantumEspressoAtoms(lines) {
+  const start = lines.findIndex((line) => line.trim().toLowerCase().startsWith('atomic_positions')) + 1;
+  if (start <= 0) return null;
+  const atoms = [];
+  for (const line of lines.slice(start)) {
+    const parts = fields(line);
+    if (parts.length < 4) break;
+    const x = Number(parts[1]);
+    const y = Number(parts[2]);
+    const z = Number(parts[3]);
+    if (!isElementSymbol(parts[0]) || !Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) break;
+    atoms.push({ symbol: normalizeElementSymbol(parts[0]), x, y, z });
+  }
+  return atoms.length ? atoms : null;
+}
+
+function parseBestCoordinateBlock(lines) {
+  let best = [];
+  let current = [];
+  const finishBlock = () => {
+    if (current.length > best.length) best = current;
+    current = [];
+  };
+  for (const line of lines) {
+    const atom = parseElementCoordinateLine(line);
+    if (atom) current.push(atom);
+    else finishBlock();
+  }
+  finishBlock();
+  return best.length >= 2 ? best : null;
 }
 
 function parseAmberRestartAtoms(lines) {
@@ -317,6 +358,148 @@ function parseAtomeyeCfgAtoms(lines) {
     });
   }
   return atoms.length === atomCount ? atoms : null;
+}
+
+function parseMlipCfgAtoms(lines) {
+  const begin = lines.findIndex((line) => line.trim().toLowerCase() === 'begin_cfg');
+  if (begin < 0) return null;
+  const relativeEnd = lines.slice(begin + 1).findIndex((line) => line.trim().toLowerCase() === 'end_cfg');
+  const end = relativeEnd >= 0 ? begin + 1 + relativeEnd : lines.length;
+  const block = lines.slice(begin + 1, end);
+  const atomCount = parseMlipCfgSize(block);
+  const atomDataIndex = block.findIndex((line) => line.trimStart().startsWith('AtomData:'));
+  if (!atomCount || atomDataIndex < 0) return null;
+  const header = fields(block[atomDataIndex]);
+  const column = (name) => {
+    const index = header.findIndex((value) => value.toLowerCase() === name.toLowerCase());
+    return index > 0 ? index - 1 : -1;
+  };
+  const typeIndex = column('type');
+  const xIndex = column('cartes_x');
+  const yIndex = column('cartes_y');
+  const zIndex = column('cartes_z');
+  if (xIndex < 0 || yIndex < 0 || zIndex < 0) return null;
+  const atoms = [];
+  for (const line of block.slice(atomDataIndex + 1)) {
+    const parts = fields(line);
+    if (parts.length <= Math.max(xIndex, yIndex, zIndex)) {
+      if (atoms.length) break;
+      continue;
+    }
+    const x = Number(parts[xIndex]);
+    const y = Number(parts[yIndex]);
+    const z = Number(parts[zIndex]);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      if (atoms.length) break;
+      continue;
+    }
+    atoms.push({
+      symbol: typeIndex >= 0 ? mlipCfgSymbolForType(parts[typeIndex] ?? '') : 'C',
+      x,
+      y,
+      z
+    });
+    if (atoms.length === atomCount) break;
+  }
+  return atoms.length === atomCount ? atoms : null;
+}
+
+function parseLammpsDataAtoms(lines) {
+  const masses = parseLammpsMasses(lines);
+  let inAtoms = false;
+  const atoms = [];
+  for (const line of lines) {
+    const parts = fields(stripInlineComment(line));
+    const first = parts[0];
+    if (!first) continue;
+    if (first.toLowerCase() === 'atoms') {
+      inAtoms = true;
+      continue;
+    }
+    if (inAtoms && /^[A-Za-z]/u.test(first)) break;
+    if (!inAtoms || parts.length < 5) continue;
+    const coordinates = lammpsDataCoordinates(parts, masses);
+    if (!coordinates) continue;
+    atoms.push({
+      symbol: lammpsDataAtomSymbol(parts, masses),
+      x: coordinates[0],
+      y: coordinates[1],
+      z: coordinates[2]
+    });
+  }
+  return atoms.length ? atoms : null;
+}
+
+function parseLammpsMasses(lines) {
+  let inMasses = false;
+  const masses = new Map();
+  for (const line of lines) {
+    const parts = fields(stripInlineComment(line));
+    const first = parts[0];
+    if (!first) continue;
+    if (first.toLowerCase() === 'masses') {
+      inMasses = true;
+      continue;
+    }
+    if (inMasses && /^[A-Za-z]/u.test(first)) break;
+    if (!inMasses || parts.length < 2) continue;
+    const symbol = elementSymbolFromAtomName(parts[2] ?? '') ?? lammpsSymbolFromMass(parts[1] ?? '');
+    if (symbol) masses.set(parts[0], symbol);
+  }
+  return masses;
+}
+
+function lammpsDataCoordinates(parts, masses) {
+  const starts = [];
+  if (masses.has(parts[2])) starts.push(4);
+  if (masses.has(parts[1])) starts.push(3, 2);
+  starts.push(3, 4, 2);
+  for (const start of starts) {
+    const x = Number(parts[start]);
+    const y = Number(parts[start + 1]);
+    const z = Number(parts[start + 2]);
+    if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) return [x, y, z];
+  }
+  return null;
+}
+
+function lammpsDataAtomSymbol(parts, masses) {
+  return masses.get(parts[1])
+    ?? masses.get(parts[2])
+    ?? elementSymbolFromAtomName(parts[1] ?? '')
+    ?? elementSymbolFromAtomName(parts[2] ?? '')
+    ?? 'C';
+}
+
+function lammpsSymbolFromMass(value) {
+  const mass = Number(value);
+  if (!Number.isFinite(mass)) return null;
+  const candidates = [
+    [1.008, 'H'], [12.011, 'C'], [14.007, 'N'], [15.999, 'O'], [18.998, 'F'],
+    [22.99, 'Na'], [24.305, 'Mg'], [30.974, 'P'], [32.06, 'S'], [35.45, 'Cl']
+  ];
+  const match = candidates.find(([candidate]) => Math.abs(candidate - mass) < 0.15);
+  return match?.[1] ?? null;
+}
+
+function stripInlineComment(line) {
+  return line.split('#')[0] ?? '';
+}
+
+function parseMlipCfgSize(lines) {
+  for (let index = 0; index + 1 < lines.length; index += 1) {
+    if (lines[index].trim().toLowerCase() !== 'size') continue;
+    const value = Number.parseInt(fields(lines[index + 1])[0] ?? '', 10);
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+  return null;
+}
+
+function mlipCfgSymbolForType(value) {
+  const normalized = normalizeElementSymbol(value);
+  if (isElementSymbol(normalized)) return normalized;
+  if (value.trim() === '1') return 'H';
+  return 'C';
 }
 
 function parseAtomeyeCfgAtomCount(lines) {
@@ -441,6 +624,19 @@ function elementSymbolFromAtomName(value) {
   if (isElementSymbol(two)) return two;
   const one = normalizeElementSymbol(clean.slice(0, 1));
   return isElementSymbol(one) ? one : null;
+}
+
+function parseElementCoordinateLine(line) {
+  const parts = fields(line);
+  if (parts.length < 4) return null;
+  const symbol = elementSymbolFromAtomName(parts[0]);
+  if (!symbol) return null;
+  const x = Number(parts[1]);
+  const y = Number(parts[2]);
+  const z = Number(parts[3]);
+  return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)
+    ? { symbol, x, y, z }
+    : null;
 }
 
 function maestroPdbDataFromText(text) {

--- a/tests/test-agent-preview-server.mjs
+++ b/tests/test-agent-preview-server.mjs
@@ -206,6 +206,9 @@ f_m_ct {
   const lammpsPath = join(coordinateTempDir, 'dump.lammpstrj');
   const posPath = join(coordinateTempDir, 'c60.0.pos');
   const cfgPath = join(coordinateTempDir, 'c60.0.cfg');
+  const mlipCfgPath = join(coordinateTempDir, 'mlip.cfg');
+  const qeInputPath = join(coordinateTempDir, 'in_md');
+  const lammpsDataPath = join(coordinateTempDir, 'benz.data');
   const lammpsLogPath = join(coordinateTempDir, 'log.lammps');
   await writeFile(amberPath, `Amber restart
 3
@@ -279,11 +282,53 @@ C
 C
 0.839378 0.431559 0.52349
 `);
+  await writeFile(mlipCfgPath, `BEGIN_CFG
+ Size
+    2
+ Supercell
+    8.000000    0.000000    0.000000
+    0.000000    8.000000    0.000000
+    0.000000    0.000000    8.000000
+ AtomData:  id type       cartes_x      cartes_y      cartes_z           fx          fy          fz
+    1    1       5.418134    4.868009    1.987250   -0.828945    0.379492    0.424787
+    2    0       4.784862    4.549671    2.873289   -1.023257   -0.334575   -0.435610
+ Energy
+    -1593.0524513859514
+END_CFG
+`);
+  await writeFile(qeInputPath, `&control
+    calculation = 'md'
+ /
+ATOMIC_POSITIONS angstrom
+  H   5.609150 4.376960 2.305480
+  C   4.769440 4.232290 2.954480
+K_POINTS {automatic}
+ 1 1 1 0 0 0
+`);
+  await writeFile(lammpsDataPath, `# Molecules
+
+      2     atoms
+      2     atom types
+
+    0.0000   8.0000 xlo xhi
+    0.0000   8.0000 ylo yhi
+    0.0000   8.0000 zlo zhi
+
+Masses
+
+         1          12.01
+         2          1.007
+
+Atoms
+
+    1    2       5.418134    4.868009    1.987250
+    2    1       4.784862    4.549671    2.873289
+`);
   await writeFile(lammpsLogPath, `LAMMPS (22 Jul 2025 - Update 4)
 thermo_style custom step time temp pe ke etotal
 Loop time of 1.30065 on 1 procs for 200 steps with 60 atoms
 `);
-  for (const coordinatePath of [amberPath, charmmPath, statePath, hoomdPath, lammpsPath, posPath, cfgPath]) {
+  for (const coordinatePath of [amberPath, charmmPath, statePath, hoomdPath, lammpsPath, posPath, cfgPath, mlipCfgPath, qeInputPath, lammpsDataPath]) {
     const coordinatePort = await freePort();
     const coordinateChild = spawn(process.execPath, ['scripts/agent-preview.mjs', coordinatePath, '--port', String(coordinatePort)], {
       stdio: ['ignore', 'pipe', 'pipe']

--- a/tests/test-burette-agent-structure-summary.mjs
+++ b/tests/test-burette-agent-structure-summary.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { summarizeStructureFile } from "../plugins/burette-agent/mcp/lib/structure-summary.mjs";
 
 const miniPdb = await summarizeStructureFile("samples/mini.pdb");
@@ -29,5 +32,68 @@ assert.match(oneHtbPdb.summaryLine, /4 ligand instances/);
 const miniCif = await summarizeStructureFile("samples/mini.cif");
 assert.equal(miniCif.format, "CIF");
 assert.ok(miniCif.counts.atomSiteRows > 0);
+
+const fixtureDir = await mkdtemp(path.join(tmpdir(), "burrete-summary-"));
+
+const mlipCfgPath = path.join(fixtureDir, "mlip.cfg");
+await writeFile(mlipCfgPath, `BEGIN_CFG
+ Size
+    3
+ AtomData:  id type       cartes_x      cartes_y      cartes_z           fx          fy          fz
+      1    1        0.0           0.0           0.0             0.0         0.0         0.0
+      2    6        1.0           0.0           0.0             0.0         0.0         0.0
+      3    6        0.0           1.0           0.0             0.0         0.0         0.0
+ Energy
+    -1.0
+END_CFG
+BEGIN_CFG
+END_CFG
+`);
+const mlipCfg = await summarizeStructureFile(mlipCfgPath);
+assert.equal(mlipCfg.format, "CFG");
+assert.equal(mlipCfg.kind, "MLIP configuration");
+assert.equal(mlipCfg.counts.atoms, 3);
+assert.equal(mlipCfg.counts.configurations, 2);
+assert.match(mlipCfg.summaryLine, /MLIP configuration/);
+
+const qeInputPath = path.join(fixtureDir, "in_md");
+await writeFile(qeInputPath, `&CONTROL
+ calculation = 'md'
+/
+ATOMIC_POSITIONS angstrom
+C 0.0 0.0 0.0
+H 0.0 0.0 1.1
+H 1.0 0.0 0.0
+`);
+const qeInput = await summarizeStructureFile(qeInputPath);
+assert.equal(qeInput.format, "QE");
+assert.equal(qeInput.kind, "Quantum ESPRESSO input");
+assert.equal(qeInput.counts.atoms, 3);
+assert.equal(qeInput.extension, "in");
+
+const lammpsDataPath = path.join(fixtureDir, "benz.data");
+await writeFile(lammpsDataPath, `LAMMPS data
+
+3 atoms
+2 atom types
+
+Masses
+
+1 12.011
+2 1.008
+
+Atoms # full
+
+1 1 1 0.0 0.0 0.0 0.0
+2 1 2 0.0 1.0 0.0 0.0
+3 1 2 0.0 0.0 1.0 0.0
+`);
+const lammpsData = await summarizeStructureFile(lammpsDataPath);
+assert.equal(lammpsData.format, "LAMMPS");
+assert.equal(lammpsData.kind, "LAMMPS data");
+assert.equal(lammpsData.counts.atoms, 3);
+assert.match(lammpsData.rows.find((row) => row.label === "Elements")?.value ?? "", /H 2/);
+
+await rm(fixtureDir, { recursive: true, force: true });
 
 console.log("burette-agent structure summary tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4177,10 +4177,14 @@ assert.match(browserDevDocuments, /extension === "cfg" && converted\.molstarForm
 assert.match(browserDevDocuments, /function pdbDataFromText\(text: string, extension: string, label: string\)/);
 assert.match(browserDevDocuments, /function lammpsDumpXyzDataFromText\(text: string, label: string\)/);
 assert.match(browserDevDocuments, /function parseAtomeyeCfgAtoms\(lines: string\[\]\)/);
+assert.match(browserDevDocuments, /parseAtomeyeCfgAtoms\(lines\) \?\? parseMlipCfgAtoms\(lines\)/);
+assert.match(browserDevDocuments, /function parseMlipCfgAtoms\(lines: string\[\]\)/);
 assert.match(browserDevDocuments, /function parseLammpsDataAtoms\(lines: string\[\]\)/);
 assert.match(browserDevDocuments, /function lammpsDataCoordinates\(parts: string\[\], masses: Map<string, string>\)/);
 assert.match(previewViewController, /case "data", "lammps", "lmp":[\s\S]*return parseLammpsData\(lines\)/);
 assert.match(previewViewController, /case "cfg":[\s\S]*return parseAtomeyeCFG\(lines\)/);
+assert.match(previewViewController, /case "cfg":[\s\S]*return parseAtomeyeCFG\(lines\) \?\? parseMLIPCFG\(lines\)/);
+assert.match(previewViewController, /private static func parseMLIPCFG\(_ lines: \[String\]\) -> \[Atom\]\?/);
 assert.match(previewViewController, /shouldUseTextArtifactPreview\(url: url, fileExtension: pathExtension, previewPlan: previewPlan\)/);
 assert.match(previewViewController, /private static func isPreferredTextArtifact\(url: URL\) -> Bool \{[\s\S]*url\.lastPathComponent\.lowercased\(\) == "log\.lammps"/);
 assert.match(previewViewController, /private static func parseLammpsData\(_ lines: \[String\]\) -> \[Atom\]\?/);
@@ -4191,9 +4195,12 @@ assert.match(browserDevDocuments, /extension === "fdf"[\s\S]*parseFdfAtoms\(line
 assert.match(browserDevDocuments, /function parseAbinitAtoms\(lines: string\[\]\)/);
 assert.match(browserDevDocuments, /function parseFdfAtoms\(lines: string\[\]\)/);
 assert.match(browserDevDocuments, /function fdfBlockRows\(blockName: string, lines: string\[\]\)/);
+assert.match(browserDevDocuments, /return \/\^in\(\?:_\|\$\)\/iu\.test\(name\) \? "in" : "";/);
 assert.match(previewTextXyz, /"abi" => parse_abinit_atoms\(&lines\)/);
 assert.match(previewTextXyz, /"data" \| "lammps" \| "lmp" => parse_lammps_data_atoms\(&lines\)/);
 assert.match(previewTextXyz, /"cfg" => parse_atomeye_cfg_atoms\(&lines\)/);
+assert.match(previewTextXyz, /"cfg" => parse_atomeye_cfg_atoms\(&lines\)\.or_else\(\|\| parse_mlip_cfg_atoms\(&lines\)\)/);
+assert.match(previewTextXyz, /fn parse_mlip_cfg_atoms\(lines: &\[&str\]\) -> Option<Vec<Atom>>/);
 assert.match(previewTextXyz, /"lammpstrj" \| "dump" \| "pos" => parse_lammps_dump_atoms\(&lines\)/);
 assert.match(previewTextXyz, /"fdf" => parse_fdf_atoms\(&lines\)/);
 assert.match(previewTextXyz, /fn parse_lammps_data_atoms\(lines: &\[&str\]\) -> Option<Vec<Atom>>/);


### PR DESCRIPTION
## Why

MD and MLIP tutorial folders contain useful coordinate data in formats that Burrete previously treated as plain text or unsupported structure summaries. This made `.cfg`, Quantum ESPRESSO input/output, and LAMMPS data files harder to inspect in the browser, Quick Look, and agent workflows.

## What Changed

- Added MLIP `BEGIN_CFG` coordinate parsing for desktop/Tauri preview, browser-dev documents, Quick Look, tokenized agent preview, and MCP structure summaries.
- Added Quantum ESPRESSO `ATOMIC_POSITIONS` support for `.in`, `.inp`, and extensionless `in_*` files such as `in_md`.
- Added text-coordinate extraction for QE-style `.log`/`.out` files in the agent preview and structure summary path.
- Added LAMMPS `.data`/`.lammps`/`.lmp` coordinate handling with `Masses`/`Atoms` inference for agent preview and summaries.
- Bumped release metadata from `1.0.13` to `1.0.14` across package, Tauri, Rust, Xcode, and lock metadata.
- Extended focused tests for MLIP CFG, QE input, extensionless `in_*`, LAMMPS data, and cross-surface parser contracts.

## Verification

- `bun run ci:fast`
- `bun run check:release`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main bun run check:release`
- `./scripts/release.sh --dry-run`
- Real-file smoke against the MLIP tutorial files: `dataset.cfg`, `QE_md/in_md`, `test_MTP/benz.data`, and `QE_md/_output_empl/md.log` all summarize as 12-atom C/H structures.

## Notes / Follow-Up

- MLIP CFG preview and summary currently read coordinates from the first `BEGIN_CFG` block; the summary still reports the total configuration count.