### PR TITLE
Fix xyzrender atom selection hiding

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6292,6 +6292,26 @@
     return parts.join(',');
   }
 
+  function xyzrenderAtomSetFromSelector(selector) {
+    const atoms = new Set();
+    String(selector || '').split(',').forEach(part => {
+      const trimmed = part.trim();
+      if (!trimmed) return;
+      const [startValue, endValue] = trimmed.split('-').map(value => Number(value.trim()));
+      if (!Number.isInteger(startValue) || startValue <= 0) return;
+      const end = Number.isInteger(endValue) && endValue >= startValue ? endValue : startValue;
+      for (let atom = startValue; atom <= end; atom += 1) atoms.add(atom);
+    });
+    return atoms;
+  }
+
+  function xyzrenderAtomSetsIntersect(left, right) {
+    for (const atom of left || []) {
+      if (right?.has?.(atom)) return true;
+    }
+    return false;
+  }
+
   function requestSelectedXyzrenderSheetItemsUpdate(options = {}) {
     const selectedItems = selectedXyzrenderSheetItems().filter(item => item.querySelector('.buret-xyzrender-sheet-item-body'));
     const frontmostItem = selectedItems.length === 0 ? frontmostXyzrenderSheetItem() : null;
@@ -10489,25 +10509,26 @@
   function selectXyzrenderElementsInLasso(item, points, additive) {
     if (!additive) clearXyzrenderSelection();
     const atomNodes = xyzrenderAtomNodes(item);
-    const selectedAtomElements = new Set();
     let selectedAtoms = 0;
     if (atomNodes.length > 0) {
       for (const atom of atomNodes) {
         if (!xyzrenderAtomIntersectsLasso(atom, points)) continue;
         markXyzrenderElementSelected(atom.element);
-        selectedAtomElements.add(atom.element);
         selectedAtoms += 1;
       }
     }
-    let selected = selectedAtoms;
+    if (selectedAtoms > 0) {
+      updateXyzrenderSelectionRoots();
+      return { count: selectedAtoms, kind: 'atom' };
+    }
+    let selected = 0;
     for (const element of xyzrenderSelectableElements(item)) {
-      if (selectedAtomElements.has(element)) continue;
       if (!svgElementIntersectsLasso(element, points, item)) continue;
       markXyzrenderElementSelected(element);
       selected += 1;
     }
     updateXyzrenderSelectionRoots();
-    return { count: selected, kind: selectedAtoms > 0 ? 'atom' : 'graphic' };
+    return { count: selected, kind: 'graphic' };
   }
 
   function xyzrenderAtomIntersectsLasso(atom, points) {
@@ -11017,7 +11038,7 @@
   }
 
   function hideSelectedXyzrenderElements() {
-    const elements = Array.from(xyzrenderSelectedElements).filter(element => element.isConnected);
+    const elements = selectedXyzrenderElementsForHide();
     if (!elements.length) {
       clearXyzrenderSelection();
       return;
@@ -11026,8 +11047,27 @@
       ensureXyzrenderOriginalStyle(element);
       element.setAttribute('display', 'none');
     }
+    clearXyzrenderSelection();
     setStatus(`[web] Hid ${elements.length} selected xyzrender graphic${elements.length === 1 ? '' : 's'}.`);
     setTimeout(hideStatus, 900);
+  }
+
+  function selectedXyzrenderElementsForHide() {
+    const elements = new Set();
+    const groups = xyzrenderSelectionGroups();
+    for (const group of groups) {
+      const atomSelector = xyzrenderAtomSelectorForElements(group.item, group.elements);
+      const selectedAtoms = xyzrenderAtomSetFromSelector(atomSelector);
+      if (selectedAtoms.size === 0) {
+        group.elements.filter(element => element.isConnected).forEach(element => elements.add(element));
+        continue;
+      }
+      for (const element of xyzrenderSelectableElements(group.item)) {
+        const elementAtoms = xyzrenderAtomSetFromSelector(xyzrenderAtomSelectorForElements(group.item, [element]));
+        if (xyzrenderAtomSetsIntersect(selectedAtoms, elementAtoms)) elements.add(element);
+      }
+    }
+    return Array.from(elements).filter(element => element.isConnected);
   }
 
   function applyXyzrenderSelectionControls(controls) {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1532,9 +1532,9 @@ assert.doesNotMatch(viewer, /appendXyzrenderMenuButton\(actions, 'Redo'/);
 assert.match(viewer, /function setXyzrenderLassoEnabled\(enabled\)/);
 assert.match(viewer, /function selectXyzrenderElementsInLasso\(item, points, additive\)/);
 assert.match(viewer, /const atomNodes = xyzrenderAtomNodes\(item\)/);
-assert.match(viewer, /const selectedAtomElements = new Set\(\)/);
-assert.match(viewer, /if \(selectedAtomElements\.has\(element\)\) continue/);
-assert.match(viewer, /return \{ count: selected, kind: selectedAtoms > 0 \? 'atom' : 'graphic' \}/);
+assert.doesNotMatch(viewer, /const selectedAtomElements = new Set\(\)/);
+assert.match(viewer, /if \(selectedAtoms > 0\) \{\s*updateXyzrenderSelectionRoots\(\);\s*return \{ count: selectedAtoms, kind: 'atom' \};\s*\}/);
+assert.match(viewer, /return \{ count: selected, kind: 'graphic' \}/);
 assert.match(viewer, /function showXyzrenderSelectionContextMenu\(item, bounds\)/);
 for (const runtimeSource of [viewer]) {
   const initStaticRendererToolbarBody = runtimeSource.match(/function initStaticRendererToolbar\(\) \{([\s\S]*?)\n  \}/)?.[1] || "";
@@ -1544,10 +1544,10 @@ for (const runtimeSource of [viewer]) {
   assert.match(initStaticRendererToolbarBody, /installMolstarToolbarActionDelegates\(\)/);
   assert.match(runtimeSource, /function xyzrenderAtomIndexFromElement\(element\)/);
   assert.match(runtimeSource, /const atomNodes = xyzrenderAtomNodes\(item\)/);
-  assert.match(runtimeSource, /const selectedAtomElements = new Set\(\)/);
-  assert.match(runtimeSource, /if \(selectedAtomElements\.has\(element\)\) continue/);
+  assert.doesNotMatch(runtimeSource, /const selectedAtomElements = new Set\(\)/);
+  assert.match(runtimeSource, /if \(selectedAtoms > 0\) \{\s*updateXyzrenderSelectionRoots\(\);\s*return \{ count: selectedAtoms, kind: 'atom' \};\s*\}/);
   assert.match(runtimeSource, /function xyzrenderAtomIntersectsLasso\(atom, points\)/);
-  assert.match(runtimeSource, /return \{ count: selected, kind: selectedAtoms > 0 \? 'atom' : 'graphic' \}/);
+  assert.match(runtimeSource, /return \{ count: selected, kind: 'graphic' \}/);
   assert.match(runtimeSource, /const xyzrenderSelectionFilterIds = new WeakMap\(\)/);
   assert.match(runtimeSource, /const xyzrenderSelectionHaloClones = new WeakMap\(\)/);
   assert.match(runtimeSource, /let xyzrenderSelectionFilterSerial = 0/);
@@ -1605,6 +1605,11 @@ assert.doesNotMatch(viewer, /function applyXyzrenderElementPresentation\(targetE
 assert.match(viewer, /bodyHtml: body \? body\.innerHTML : null/);
 assert.match(viewer, /restoreNullableAttribute\(snapshot\.item, 'data-buret-xyzrender-regions', snapshot\.regions\)/);
 assert.match(viewer, /function hideSelectedXyzrenderElements\(\)/);
+assert.match(viewer, /const elements = selectedXyzrenderElementsForHide\(\)/);
+assert.match(viewer, /function selectedXyzrenderElementsForHide\(\)/);
+assert.match(viewer, /const selectedAtoms = xyzrenderAtomSetFromSelector\(atomSelector\)/);
+assert.match(viewer, /if \(xyzrenderAtomSetsIntersect\(selectedAtoms, elementAtoms\)\) elements\.add\(element\)/);
+assert.match(viewer, /clearXyzrenderSelection\(\);\n    setStatus\(`\[web\] Hid \$\{elements\.length\} selected xyzrender graphic/);
 assert.match(viewer, /function showHiddenXyzrenderElements\(item\)/);
 assert.match(viewer, /function pushXyzrenderActionHistory\(item, label\)/);
 assert.match(viewer, /function undoXyzrenderLastAction\(options = \{\}\)/);


### PR DESCRIPTION
## Summary
- make xyzrender lasso prefer atom hits over mixed SVG graphic hits
- hide all SVG graphics associated with selected atom indices for the right-click Hide Selected action
- keep the packaged preview runtime and agent preview runtime in sync

## Root cause
The xyzrender lasso kept both atom circles and overlapping bond/path SVG graphics in the active selection. Right-click hiding then operated on that mixed graphic selection instead of a stable atom-derived region, so selected pieces could be incomplete or fail after runtime updates.

## Validation
- node tests/test-ui-shell-contract.mjs
- bun scripts/check-js-syntax.mjs PreviewExtension/Web/viewer.js plugins/burette-agent/preview-web/viewer.js
- pre-push ci-fast