### PR TITLE
Catch Quick Look text fallback regressions

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -454,7 +454,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -479,7 +479,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -504,7 +504,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -548,7 +548,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.15;
+				MARKETING_VERSION = 1.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/PreviewExtension/Platform/PreviewViewController.swift
+++ b/PreviewExtension/Platform/PreviewViewController.swift
@@ -4142,6 +4142,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController, WKN
         if message.hasPrefix("elapsed.") { return true }
         if message.hasPrefix("[build] detected.format=") { return true }
         if message.hasPrefix("[build] detected.previewMode=") { return true }
+        if message.hasPrefix("[build] textFallback.originalError=") { return true }
         if message.hasPrefix("[build] trajectory.frames=") { return true }
         if message.hasPrefix("[build] elapsed.") { return true }
         if message.hasPrefix("[build] runtimeDirectory=") { return true }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "1.0.15"
+version = "1.0.16"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "bin": "bin/burrete.mjs",
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/scripts/quicklook-semantic-check.mjs
+++ b/scripts/quicklook-semantic-check.mjs
@@ -114,13 +114,11 @@ if (/native build error|JS message type=error|render timeout/u.test(blockText)) 
 
 const evidence = parseEvidence(lines);
 const readyEvidence = evidence.filter((record) => record.type === "ready" || record.mode || record.renderer);
-const textFallbackDetected = lineWith(lines, "detected.previewMode=text-fallback");
-if (textFallbackDetected) {
-  const textFallbackReady = hasEvidence(readyEvidence, (record) =>
-    record.mode === "text" && record.renderer === "text-fallback"
-  );
-  if (!textFallbackReady) fail("text fallback preview reached no ready evidence");
-  pass("text fallback ready");
+const textFallbackLine = lineWith(lines, "detected.previewMode=text-fallback");
+if (textFallbackLine) {
+  const originalError = lineWith(lines, "textFallback.originalError=");
+  const suffix = originalError ? `: ${originalError.slice(originalError.indexOf("textFallback.originalError="))}` : "";
+  fail(`rich Quick Look preview fell back to text${suffix}`);
 }
 const strategy = format.preview?.strategy ?? "direct";
 const renderer = format.preview?.renderer ?? format.viewer?.molstarFormat ?? "";

--- a/tests/test-quicklook-semantic-check.mjs
+++ b/tests/test-quicklook-semantic-check.mjs
@@ -55,10 +55,12 @@ assert.match(xyzrenderNativeError.stderr, /contains an error or timeout/);
 const xyzrenderTextFallback = await runCase("xyzrender-text-fallback", xyzrenderFile, [
   `[CCCC0002] file.path=${xyzrenderFile}`,
   "[CCCC0002] [build] detected.previewMode=text-fallback",
+  "[CCCC0002] [build] textFallback.originalError=Molstar assets were unavailable",
   "[CCCC0002] preview.evidence type=ready mode=text renderer=text-fallback sourceExtension=com",
 ]);
-assert.equal(xyzrenderTextFallback.status, 0);
-assert.match(xyzrenderTextFallback.stdout, /text fallback ready/);
+assert.equal(xyzrenderTextFallback.status, 1);
+assert.match(xyzrenderTextFallback.stderr, /fell back to text/);
+assert.match(xyzrenderTextFallback.stderr, /Molstar assets were unavailable/);
 
 const gridSuccess = await runCase("grid-success", sdfFile, [
   `[DDDD0001] file.path=${sdfFile}`,

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -788,6 +788,7 @@ assert.match(quickLookPreviewController, /score: " \+ String\(format: "%\.3f", \
 assert.match(quickLookPreviewController, /shouldUseTextArtifactPreview\(url: URL, fileExtension: String, previewPlan: BurretePreviewPlan\?\)/);
 assert.match(quickLookPreviewController, /private static func isPreferredTextArtifact\(url: URL\) -> Bool \{[\s\S]*url\.lastPathComponent\.lowercased\(\) == "log\.lammps"/);
 assert.match(quickLookPreviewController, /detected\.previewMode=text-artifact/);
+assert.match(quickLookPreviewController, /textFallback\.originalError=/);
 assert.doesNotMatch(installLocalScript, /broadPublicTypes/);
 assert.match(installLocalScript, /let contentTypes = documentTypes\.flatMap/);
 assert.match(installLocalScript, /for contentType in Set\(contentTypes\)/);


### PR DESCRIPTION
## Why

Quick Look could show a text fallback for an XYZ preview and still be treated as a successful rich preview. That hid the underlying renderer failure and let regressions pass smoke checks.

## What Changed

- Treat `detected.previewMode=text-fallback` as a semantic Quick Look failure.
- Preserve `textFallback.originalError` in filtered Quick Look logs so the next failure points at the real cause.
- Add a regression test for text fallback evidence.
- Bump Burrete release metadata to `1.0.16`.

## Verification

- `bun tests/test-quicklook-semantic-check.mjs`
- `bun tests/test-tauri-structure.mjs`
- `bun run check:release`
- `./scripts/release.sh --dry-run`
- `bun run ci:fast`
- pre-push `ci-fast` hook

## Notes / Follow-Up

The local `caffeine_cell.xyz` smoke no longer passes silently when macOS routes to a bad/stale release extension; it now fails with the launch or semantic error instead of reporting success.