### PR TITLE
Mobile: full-screen viewer shell with Settings, command palette, and view modes

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		C20000000000000000000022 /* MobilePreviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000012 /* MobilePreviewScreen.swift */; };
 		C20000000000000000000023 /* MobilePreviewWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000013 /* MobilePreviewWebView.swift */; };
 		C20000000000000000000024 /* MobilePreviewRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000014 /* MobilePreviewRuntime.swift */; };
+		C20000000000000000000071 /* MobileAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000061 /* MobileAppModel.swift */; };
+		C20000000000000000000072 /* MobileRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000062 /* MobileRootView.swift */; };
+		C20000000000000000000073 /* MobileSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000063 /* MobileSettingsScreen.swift */; };
+		C20000000000000000000076 /* MobileViewModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000066 /* MobileViewModes.swift */; };
+		C20000000000000000000077 /* MobileCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000067 /* MobileCommandPalette.swift */; };
 		C20000000000000000000025 /* Web in Resources */ = {isa = PBXBuildFile; fileRef = 4ADF66CA120EDD24C9E3F203 /* Web */; };
 		C20000000000000000000026 /* mini.pdb in Resources */ = {isa = PBXBuildFile; fileRef = 4A566BCA24ADD5993DACE9DD /* mini.pdb */; };
 		C20000000000000000000027 /* samples in Resources */ = {isa = PBXBuildFile; fileRef = C20000000000000000000015 /* samples */; };
@@ -37,6 +42,11 @@
 		C20000000000000000000012 /* MobilePreviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePreviewScreen.swift; sourceTree = "<group>"; };
 		C20000000000000000000013 /* MobilePreviewWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePreviewWebView.swift; sourceTree = "<group>"; };
 		C20000000000000000000014 /* MobilePreviewRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePreviewRuntime.swift; sourceTree = "<group>"; };
+		C20000000000000000000061 /* MobileAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAppModel.swift; sourceTree = "<group>"; };
+		C20000000000000000000062 /* MobileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileRootView.swift; sourceTree = "<group>"; };
+		C20000000000000000000063 /* MobileSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSettingsScreen.swift; sourceTree = "<group>"; };
+		C20000000000000000000066 /* MobileViewModes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileViewModes.swift; sourceTree = "<group>"; };
+		C20000000000000000000067 /* MobileCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCommandPalette.swift; sourceTree = "<group>"; };
 		C20000000000000000000017 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C20000000000000000000015 /* samples */ = {isa = PBXFileReference; lastKnownFileType = folder; path = samples; sourceTree = SOURCE_ROOT; };
 		C20000000000000000000018 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -126,6 +136,11 @@
 				C20000000000000000000012 /* MobilePreviewScreen.swift */,
 				C20000000000000000000013 /* MobilePreviewWebView.swift */,
 				C20000000000000000000014 /* MobilePreviewRuntime.swift */,
+				C20000000000000000000061 /* MobileAppModel.swift */,
+				C20000000000000000000062 /* MobileRootView.swift */,
+				C20000000000000000000063 /* MobileSettingsScreen.swift */,
+				C20000000000000000000066 /* MobileViewModes.swift */,
+				C20000000000000000000067 /* MobileCommandPalette.swift */,
 				C20000000000000000000017 /* Info.plist */,
 				C20000000000000000000018 /* Assets.xcassets */,
 			);
@@ -340,6 +355,11 @@
 				C20000000000000000000022 /* MobilePreviewScreen.swift in Sources */,
 				C20000000000000000000023 /* MobilePreviewWebView.swift in Sources */,
 				C20000000000000000000024 /* MobilePreviewRuntime.swift in Sources */,
+				C20000000000000000000071 /* MobileAppModel.swift in Sources */,
+				C20000000000000000000072 /* MobileRootView.swift in Sources */,
+				C20000000000000000000073 /* MobileSettingsScreen.swift in Sources */,
+				C20000000000000000000076 /* MobileViewModes.swift in Sources */,
+				C20000000000000000000077 /* MobileCommandPalette.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/BurreteMobile/BurreteMobileApp.swift
+++ b/ios/BurreteMobile/BurreteMobileApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BurreteMobileApp: App {
     var body: some Scene {
         WindowGroup {
-            MobilePreviewScreen()
+            MobileRootView()
         }
     }
 }

--- a/ios/BurreteMobile/MobileAppModel.swift
+++ b/ios/BurreteMobile/MobileAppModel.swift
@@ -1,0 +1,137 @@
+import Foundation
+import SwiftUI
+import Observation
+
+/// Renderer selection surfaced in Settings. On iPhone only the in-app Mol*
+/// runtime renders live; `xyzrender` is a desktop-only external process, so it
+/// is exposed as an honest, non-live option for parity with the desktop app.
+enum MobileRenderer: String, CaseIterable, Identifiable {
+    case auto
+    case molstar
+    case xyzrender
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .auto: "Auto"
+        case .molstar: "Mol*"
+        case .xyzrender: "xyzrender"
+        }
+    }
+}
+
+/// Mol* quality preset threaded into the preview runtime config.
+enum MobileMolstarQuality: String, CaseIterable, Identifiable {
+    case automatic
+    case high
+    case balanced
+    case performance
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .automatic: "Auto"
+        case .high: "High"
+        case .balanced: "Balanced"
+        case .performance: "Performance"
+        }
+    }
+
+    /// Maps to the runtime `molstarResolutionMode` config value.
+    var resolutionMode: String {
+        switch self {
+        case .automatic: "auto"
+        case .high: "native"
+        case .balanced: "balanced"
+        case .performance: "scaled"
+        }
+    }
+}
+
+/// Preview canvas background, independent from the UI theme.
+enum MobilePreviewBackground: String, CaseIterable, Identifiable {
+    case matchTheme
+    case dark
+    case light
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .matchTheme: "Match theme"
+        case .dark: "Dark"
+        case .light: "Light"
+        }
+    }
+}
+
+/// Shared, observable app state. Single source of truth for rendering
+/// preferences, the active document, imports, and cross-tab navigation.
+@Observable
+final class MobileAppModel {
+    // MARK: Rendering preferences (persisted)
+    var theme: MobileThemeSelection {
+        didSet { persist(theme.rawValue, for: Keys.theme) }
+    }
+    var style: MobileMolecularStyle {
+        didSet { persist(style.rawValue, for: Keys.style) }
+    }
+    var water: MobileWaterRepresentation {
+        didSet { persist(water.rawValue, for: Keys.water) }
+    }
+    var renderer: MobileRenderer {
+        didSet { persist(renderer.rawValue, for: Keys.renderer) }
+    }
+    var molstarQuality: MobileMolstarQuality {
+        didSet { persist(molstarQuality.rawValue, for: Keys.quality) }
+    }
+    var previewBackground: MobilePreviewBackground {
+        didSet { persist(previewBackground.rawValue, for: Keys.background) }
+    }
+
+    // MARK: Documents
+    var importedDocuments: [MobilePreviewDocument]
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        theme = MobileThemeSelection(rawValue: defaults.string(forKey: Keys.theme) ?? "") ?? .system
+        style = MobileMolecularStyle(rawValue: defaults.string(forKey: Keys.style) ?? "") ?? .illustrative
+        water = MobileWaterRepresentation(rawValue: defaults.string(forKey: Keys.water) ?? "") ?? .line
+        renderer = MobileRenderer(rawValue: defaults.string(forKey: Keys.renderer) ?? "") ?? .auto
+        molstarQuality = MobileMolstarQuality(rawValue: defaults.string(forKey: Keys.quality) ?? "") ?? .high
+        previewBackground = MobilePreviewBackground(rawValue: defaults.string(forKey: Keys.background) ?? "") ?? .matchTheme
+        importedDocuments = MobileImportedDocumentStore.loadImportedDocuments()
+    }
+
+    // MARK: Actions
+
+    @discardableResult
+    func importDocument(from url: URL) throws -> MobilePreviewDocument {
+        let document = try MobileImportedDocumentStore.importDocument(from: url)
+        importedDocuments.removeAll { $0 == document }
+        importedDocuments.insert(document, at: 0)
+        return document
+    }
+
+    func deleteImportedDocument(_ document: MobilePreviewDocument) throws {
+        try MobileImportedDocumentStore.deleteDocument(document)
+        importedDocuments.removeAll { $0 == document }
+    }
+
+    private func persist(_ value: String, for key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    private enum Keys {
+        static let theme = "mobile.theme"
+        static let style = "mobile.style"
+        static let water = "mobile.water"
+        static let renderer = "mobile.renderer"
+        static let quality = "mobile.molstarQuality"
+        static let background = "mobile.previewBackground"
+    }
+}

--- a/ios/BurreteMobile/MobileCommandPalette.swift
+++ b/ios/BurreteMobile/MobileCommandPalette.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// A single command surfaced in the palette (mockup 14: ⌘P parity).
+struct MobileCommand: Identifiable {
+    enum Group: String, CaseIterable {
+        case representation = "Representation"
+        case view = "View"
+        case actions = "Actions"
+    }
+
+    let id = UUID()
+    let title: String
+    let systemImage: String
+    let group: Group
+    let perform: () -> Void
+}
+
+/// Command palette (mockup 14). A searchable list of viewer actions —
+/// representations, view modes, and export — mirroring the desktop ⌘P palette.
+struct MobileCommandPalette: View {
+    let commands: [MobileCommand]
+    let shareURL: URL?
+    @Binding var searchText: String
+    let dismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(MobileCommand.Group.allCases, id: \.self) { group in
+                    let groupCommands = filtered.filter { $0.group == group }
+                    if !groupCommands.isEmpty {
+                        Section(group.rawValue) {
+                            ForEach(groupCommands) { command in
+                                Button {
+                                    command.perform()
+                                    dismiss()
+                                } label: {
+                                    Label(command.title, systemImage: command.systemImage)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let shareURL {
+                    Section("Share") {
+                        ShareLink(item: shareURL) {
+                            Label("Share / Open In…", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                }
+
+                if filtered.isEmpty {
+                    ContentUnavailableView.search(text: searchText)
+                }
+            }
+            .navigationTitle("Commands")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search commands")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var filtered: [MobileCommand] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return commands }
+        return commands.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+}

--- a/ios/BurreteMobile/MobilePreviewRuntime.swift
+++ b/ios/BurreteMobile/MobilePreviewRuntime.swift
@@ -687,6 +687,7 @@ struct MobilePreviewRuntime {
         theme: MobilePreviewTheme = .dark,
         style: MobileMolecularStyle = .illustrative,
         waterRepresentation: MobileWaterRepresentation = .line,
+        molstarQuality: MobileMolstarQuality = .high,
         fileManager: FileManager = .default
     ) throws -> Preview {
         guard let webDirectory = Bundle.main.url(forResource: "Web", withExtension: nil) else {
@@ -706,7 +707,7 @@ struct MobilePreviewRuntime {
         try fileManager.createDirectory(at: runtimeDirectory, withIntermediateDirectories: true)
         try Data(inlineHTML(title: document.displayName, theme: theme).utf8)
             .write(to: runtimeDirectory.appendingPathComponent("index.html"), options: [.atomic])
-        try Data("window.BurreteConfig = \(previewConfigJSON(document: document, byteCount: data.count, theme: theme, style: style, waterRepresentation: waterRepresentation));\n".utf8)
+        try Data("window.BurreteConfig = \(previewConfigJSON(document: document, byteCount: data.count, theme: theme, style: style, waterRepresentation: waterRepresentation, molstarQuality: molstarQuality));\n".utf8)
             .write(to: runtimeDirectory.appendingPathComponent("preview-config.js"), options: [.atomic])
         let dataScript = "window.BurreteDataBase64 = '\(data.base64EncodedString())';\n"
         try Data(dataScript.utf8)
@@ -743,7 +744,8 @@ struct MobilePreviewRuntime {
         byteCount: Int,
         theme: MobilePreviewTheme,
         style: MobileMolecularStyle,
-        waterRepresentation: MobileWaterRepresentation
+        waterRepresentation: MobileWaterRepresentation,
+        molstarQuality: MobileMolstarQuality
     ) -> String {
         let xyzFrameCount = document.xyzFrameCount()
         let trajectoryFrameCount = xyzFrameCount > 1 ? xyzFrameCount : 0
@@ -771,7 +773,7 @@ struct MobilePreviewRuntime {
             "molstarPickScale": 1,
             "molstarPixelScale": 1,
             "molstarPreferWebgl1": false,
-            "molstarResolutionMode": "native",
+            "molstarResolutionMode": molstarQuality.resolutionMode,
             "waterRepresentation": waterRepresentation.configValue,
             "uiScale": 0.9,
             "overlayOpacity": 0.86,

--- a/ios/BurreteMobile/MobilePreviewScreen.swift
+++ b/ios/BurreteMobile/MobilePreviewScreen.swift
@@ -4,17 +4,15 @@ import UniformTypeIdentifiers
 import WebKit
 
 struct MobilePreviewScreen: View {
+    @Bindable var model: MobileAppModel
     @Environment(\.colorScheme) private var deviceColorScheme
     @State private var status = "Preparing mini.pdb"
     @State private var lastError: String?
     @State private var isProjectDrawerOpen = false
     @State private var activeSheet: MobileSheet?
-    @State private var selectedTheme: MobileThemeSelection = .system
-    @State private var selectedStyle: MobileMolecularStyle = .illustrative
-    @State private var selectedWaterRepresentation: MobileWaterRepresentation = .line
     @State private var selectedProject: MobileProject = .imports
     @State private var currentDocument = MobilePreviewDocument(filename: "mini.pdb")
-    @State private var importedDocuments = MobileImportedDocumentStore.loadImportedDocuments()
+    @State private var viewMode: MobileViewMode = .structure3D
     @State private var panelState = MobileMolstarPanelState()
     @State private var controlAction: MobileMolstarControlAction?
     @State private var contextMenuCommand: MobileMolstarContextMenuCommand?
@@ -22,15 +20,17 @@ struct MobilePreviewScreen: View {
     @State private var inspectorTarget: MobileInspectorTarget?
     @State private var logEntries: [MobileLogEntry] = []
     @State private var isFileImporterPresented = false
+    @State private var commandSearchText = ""
 
     var body: some View {
         GeometryReader { _ in
             ZStack(alignment: .leading) {
                 MobilePreviewWebView(
                     document: currentDocument,
-                    theme: resolvedTheme,
-                    style: selectedStyle,
-                    waterRepresentation: selectedWaterRepresentation,
+                    theme: previewCanvasTheme,
+                    style: model.style,
+                    waterRepresentation: model.water,
+                    molstarQuality: model.molstarQuality,
                     panelState: panelState,
                     controlAction: controlAction,
                     contextMenuCommand: contextMenuCommand,
@@ -42,16 +42,34 @@ struct MobilePreviewScreen: View {
                 )
                     .ignoresSafeArea()
 
+                if viewMode == .text {
+                    MobileTextArtifactView(document: currentDocument)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                        .zIndex(5)
+                }
+
                 MobileViewerChrome(
                     currentDocument: currentDocument,
                     currentProject: selectedProject,
+                    viewModes: availableViewModes,
+                    viewMode: $viewMode,
                     openDrawer: { isProjectDrawerOpen = true },
-                    openTools: { activeSheet = .tools }
+                    openTools: { activeSheet = .tools },
+                    openCommands: { activeSheet = .commandPalette }
                 )
                 .zIndex(20)
 
+
                 MobileEdgeSwipeZone(isProjectDrawerOpen: $isProjectDrawerOpen)
                     .frame(width: 28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .ignoresSafeArea()
+                    .zIndex(10)
+
+                MobileSettingsEdgeSwipeZone { activeSheet = .settings }
+                    .frame(width: 28)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
                     .ignoresSafeArea()
                     .zIndex(10)
 
@@ -74,7 +92,7 @@ struct MobilePreviewScreen: View {
 
                 if isProjectDrawerOpen {
                     MobileProjectDrawer(
-                        importedDocuments: importedDocuments,
+                        importedDocuments: model.importedDocuments,
                         selectedProject: $selectedProject,
                         currentDocument: $currentDocument,
                         importFile: { isFileImporterPresented = true },
@@ -90,9 +108,13 @@ struct MobilePreviewScreen: View {
             .animation(.snappy(duration: 0.24), value: isProjectDrawerOpen)
             .animation(.snappy(duration: 0.24), value: activeSheet)
         }
-        .background(resolvedTheme.screenBackground)
-        .ignoresSafeArea()
-        .preferredColorScheme(selectedTheme.preferredColorScheme)
+        .background(resolvedTheme.screenBackground.ignoresSafeArea())
+        .onChange(of: currentDocument) { _, _ in
+            if !availableViewModes.contains(viewMode) {
+                viewMode = availableViewModes.first ?? .structure3D
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: viewMode)
         .sheet(item: $activeSheet) { sheet in
             sheetContent(for: sheet)
                 .presentationDetents(sheet.detents)
@@ -131,7 +153,21 @@ struct MobilePreviewScreen: View {
     }
 
     private var resolvedTheme: MobilePreviewTheme {
-        selectedTheme.resolve(deviceColorScheme: deviceColorScheme)
+        model.theme.resolve(deviceColorScheme: deviceColorScheme)
+    }
+
+    /// Canvas theme for the Mol* preview, honoring the Settings "Preview
+    /// background" override independently from the UI theme.
+    private var previewCanvasTheme: MobilePreviewTheme {
+        switch model.previewBackground {
+        case .matchTheme: resolvedTheme
+        case .dark: .dark
+        case .light: .light
+        }
+    }
+
+    private var availableViewModes: [MobileViewMode] {
+        MobileViewModeCatalog.modes(for: currentDocument)
     }
 
     @ViewBuilder
@@ -139,16 +175,26 @@ struct MobilePreviewScreen: View {
         switch sheet {
         case .tools:
             MobileControlsBottomMenu(
-                selectedTheme: $selectedTheme,
+                selectedTheme: $model.theme,
                 resolvedTheme: resolvedTheme,
-                selectedStyle: $selectedStyle,
-                selectedWaterRepresentation: $selectedWaterRepresentation,
+                selectedStyle: $model.style,
+                selectedWaterRepresentation: $model.water,
                 structureSummary: MobileStructureSummary.load(document: currentDocument),
                 inspectorTarget: inspectorTarget,
                 logEntries: logEntries,
                 runAction: { name in controlAction = MobileMolstarControlAction(name: name) },
                 close: { activeSheet = nil }
             )
+        case .commandPalette:
+            MobileCommandPalette(
+                commands: paletteCommands,
+                shareURL: currentDocument.bundleURL(),
+                searchText: $commandSearchText
+            ) {
+                activeSheet = nil
+            }
+        case .settings:
+            MobileSettingsScreen(model: model)
         case .context(let menu):
             MobileContextMenuSheet(menu: menu) { action, mode in
                 contextMenuCommand = MobileMolstarContextMenuCommand(action: action.name, mode: mode.rawValue)
@@ -156,6 +202,39 @@ struct MobilePreviewScreen: View {
                 activeSheet = nil
             }
         }
+    }
+
+    private var paletteCommands: [MobileCommand] {
+        var commands: [MobileCommand] = []
+        for style in MobileMolecularStyle.allCases {
+            commands.append(
+                MobileCommand(
+                    title: "Representation: \(style.displayName)",
+                    systemImage: style.systemImage,
+                    group: .representation
+                ) { model.style = style }
+            )
+        }
+        for mode in availableViewModes {
+            commands.append(
+                MobileCommand(
+                    title: "View: \(mode.title)",
+                    systemImage: mode.systemImage,
+                    group: .view
+                ) { viewMode = mode }
+            )
+        }
+        commands.append(
+            MobileCommand(title: "Reset camera", systemImage: "arrow.counterclockwise", group: .actions) {
+                controlAction = MobileMolstarControlAction(name: "reset-camera")
+            }
+        )
+        commands.append(
+            MobileCommand(title: "Open render settings…", systemImage: "slider.horizontal.3", group: .actions) {
+                DispatchQueue.main.async { activeSheet = .tools }
+            }
+        )
+        return commands
     }
 
     @ViewBuilder
@@ -177,9 +256,7 @@ struct MobilePreviewScreen: View {
 
     private func openImportedDocument(from url: URL) {
         do {
-            let document = try MobileImportedDocumentStore.importDocument(from: url)
-            importedDocuments.removeAll { $0 == document }
-            importedDocuments.insert(document, at: 0)
+            let document = try model.importDocument(from: url)
             selectedProject = .imports
             currentDocument = document
             isProjectDrawerOpen = false
@@ -194,10 +271,9 @@ struct MobilePreviewScreen: View {
 
     private func deleteImportedDocument(_ document: MobilePreviewDocument) {
         do {
-            try MobileImportedDocumentStore.deleteDocument(document)
-            importedDocuments.removeAll { $0 == document }
+            try model.deleteImportedDocument(document)
             if currentDocument == document {
-                currentDocument = importedDocuments.first ?? MobilePreviewDocument(filename: "mini.pdb")
+                currentDocument = model.importedDocuments.first ?? MobilePreviewDocument(filename: "mini.pdb")
                 selectedProject = .imports
             }
             status = "Removed \(document.displayName)"
@@ -211,12 +287,18 @@ struct MobilePreviewScreen: View {
 
 private enum MobileSheet: Identifiable, Equatable {
     case tools
+    case commandPalette
+    case settings
     case context(MobileContextMenu)
 
     var id: String {
         switch self {
         case .tools:
             "tools"
+        case .commandPalette:
+            "commandPalette"
+        case .settings:
+            "settings"
         case .context(let menu):
             "context-\(menu.id.uuidString)"
         }
@@ -226,6 +308,10 @@ private enum MobileSheet: Identifiable, Equatable {
         switch self {
         case .tools:
             [.height(420), .medium, .large]
+        case .commandPalette:
+            [.medium, .large]
+        case .settings:
+            [.large]
         case .context:
             [.height(460), .medium, .large]
         }
@@ -361,14 +447,21 @@ private enum MobileProject: String, Identifiable, Hashable {
 private struct MobileViewerChrome: View {
     let currentDocument: MobilePreviewDocument
     let currentProject: MobileProject
+    let viewModes: [MobileViewMode]
+    @Binding var viewMode: MobileViewMode
     let openDrawer: () -> Void
     let openTools: () -> Void
+    let openCommands: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 10) {
             chromeContent
                 .padding(.horizontal, 12)
                 .padding(.top, 8)
+
+            if viewModes.count > 1 {
+                MobileViewModePicker(modes: viewModes, selection: $viewMode)
+            }
 
             Spacer()
         }
@@ -393,6 +486,8 @@ private struct MobileViewerChrome: View {
             ChromeButton(systemName: "sidebar.left", accessibilityLabel: "Open projects", action: openDrawer)
 
             MobileChromeTitle(currentDocument: currentDocument, currentProject: currentProject)
+
+            ChromeButton(systemName: "command", accessibilityLabel: "Command palette", action: openCommands)
 
             ChromeButton(systemName: "slider.horizontal.3", accessibilityLabel: "Open tools", action: openTools)
         }
@@ -455,6 +550,24 @@ private struct MobileEdgeSwipeZone: View {
                     .onEnded { value in
                         if value.translation.width > 42 {
                             isProjectDrawerOpen = true
+                        }
+                    }
+            )
+    }
+}
+
+/// Trailing-edge swipe zone: a right-to-left swipe opens Settings.
+private struct MobileSettingsEdgeSwipeZone: View {
+    let openSettings: () -> Void
+
+    var body: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 18)
+                    .onEnded { value in
+                        if value.translation.width < -42 {
+                            openSettings()
                         }
                     }
             )

--- a/ios/BurreteMobile/MobilePreviewWebView.swift
+++ b/ios/BurreteMobile/MobilePreviewWebView.swift
@@ -6,6 +6,7 @@ struct MobilePreviewWebView: UIViewRepresentable {
     let theme: MobilePreviewTheme
     let style: MobileMolecularStyle
     let waterRepresentation: MobileWaterRepresentation
+    let molstarQuality: MobileMolstarQuality
     let panelState: MobileMolstarPanelState
     let controlAction: MobileMolstarControlAction?
     let contextMenuCommand: MobileMolstarContextMenuCommand?
@@ -51,7 +52,7 @@ struct MobilePreviewWebView: UIViewRepresentable {
         webView.scrollView.alwaysBounceHorizontal = false
         webView.scrollView.alwaysBounceVertical = false
         webView.scrollView.pinchGestureRecognizer?.isEnabled = false
-        context.coordinator.loadPreview(in: webView, document: document, theme: theme, style: style, waterRepresentation: waterRepresentation)
+        context.coordinator.loadPreview(in: webView, document: document, theme: theme, style: style, waterRepresentation: waterRepresentation, molstarQuality: molstarQuality)
         return webView
     }
 
@@ -61,8 +62,9 @@ struct MobilePreviewWebView: UIViewRepresentable {
         if context.coordinator.loadedDocument != document ||
             context.coordinator.loadedTheme != theme ||
             context.coordinator.loadedStyle != style ||
-            context.coordinator.loadedWaterRepresentation != waterRepresentation {
-            context.coordinator.loadPreview(in: uiView, document: document, theme: theme, style: style, waterRepresentation: waterRepresentation)
+            context.coordinator.loadedWaterRepresentation != waterRepresentation ||
+            context.coordinator.loadedMolstarQuality != molstarQuality {
+            context.coordinator.loadPreview(in: uiView, document: document, theme: theme, style: style, waterRepresentation: waterRepresentation, molstarQuality: molstarQuality)
         }
         context.coordinator.applyPanelState(panelState, in: uiView)
         context.coordinator.runControlAction(controlAction, in: uiView)
@@ -79,6 +81,7 @@ struct MobilePreviewWebView: UIViewRepresentable {
         private(set) var loadedTheme: MobilePreviewTheme?
         private(set) var loadedStyle: MobileMolecularStyle?
         private(set) var loadedWaterRepresentation: MobileWaterRepresentation?
+        private(set) var loadedMolstarQuality: MobileMolstarQuality?
         private var desiredPanelState: MobileMolstarPanelState?
         private var appliedPanelState: MobileMolstarPanelState?
         private var appliedActionID: UUID?
@@ -103,12 +106,14 @@ struct MobilePreviewWebView: UIViewRepresentable {
             document: MobilePreviewDocument,
             theme: MobilePreviewTheme,
             style: MobileMolecularStyle,
-            waterRepresentation: MobileWaterRepresentation
+            waterRepresentation: MobileWaterRepresentation,
+            molstarQuality: MobileMolstarQuality
         ) {
             loadedDocument = document
             loadedTheme = theme
             loadedStyle = style
             loadedWaterRepresentation = waterRepresentation
+            loadedMolstarQuality = molstarQuality
             appliedPanelState = nil
             contextMenu.wrappedValue = nil
             inspectorTarget.wrappedValue = nil
@@ -118,7 +123,8 @@ struct MobilePreviewWebView: UIViewRepresentable {
                     document: document,
                     theme: theme,
                     style: style,
-                    waterRepresentation: waterRepresentation
+                    waterRepresentation: waterRepresentation,
+                    molstarQuality: molstarQuality
                 )
                 webView.loadFileURL(preview.indexURL, allowingReadAccessTo: preview.readAccessURL)
                 status.wrappedValue = "Loading \(document.displayName) (\(style.displayName))"

--- a/ios/BurreteMobile/MobileRootView.swift
+++ b/ios/BurreteMobile/MobileRootView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Root shell for the iPhone app. The Mol* viewer is full-screen; there is no
+/// bottom tab bar. A left-edge swipe opens the Files browser (project drawer),
+/// a right-edge swipe opens Settings.
+struct MobileRootView: View {
+    @State private var model = MobileAppModel()
+
+    var body: some View {
+        MobilePreviewScreen(model: model)
+            .preferredColorScheme(model.theme.preferredColorSchemeValue)
+    }
+}
+
+extension MobileThemeSelection {
+    /// Color-scheme mapping so the root shell can apply the theme app-wide.
+    var preferredColorSchemeValue: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .dark: .dark
+        case .light: .light
+        }
+    }
+}

--- a/ios/BurreteMobile/MobileSettingsScreen.swift
+++ b/ios/BurreteMobile/MobileSettingsScreen.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+/// Settings tab (mockup 09): rendering, appearance, integrations, maintenance,
+/// and about. Uses a native grouped `Form`. Preferences are bound to the shared
+/// `MobileAppModel` and flow into the Mol* preview runtime.
+struct MobileSettingsScreen: View {
+    @Bindable var model: MobileAppModel
+
+    @State private var maintenanceMessage: String?
+    @State private var showingDiagnostics = false
+    @State private var diagnosticsReport = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                renderingSection
+                appearanceSection
+                integrationsSection
+                maintenanceSection
+                aboutSection
+            }
+            .navigationTitle("Settings")
+            .alert("Maintenance", isPresented: maintenanceAlertBinding) {
+                Button("OK", role: .cancel) { maintenanceMessage = nil }
+            } message: {
+                Text(maintenanceMessage ?? "")
+            }
+            .sheet(isPresented: $showingDiagnostics) {
+                MobileDiagnosticsSheet(report: diagnosticsReport)
+            }
+        }
+    }
+
+    // MARK: Sections
+
+    private var renderingSection: some View {
+        Section("Rendering") {
+            Picker("Renderer", selection: $model.renderer) {
+                ForEach(MobileRenderer.allCases) { renderer in
+                    Text(renderer.displayName).tag(renderer)
+                }
+            }
+            Picker("Mol* quality", selection: $model.molstarQuality) {
+                ForEach(MobileMolstarQuality.allCases) { quality in
+                    Text(quality.displayName).tag(quality)
+                }
+            }
+            Picker("Default representation", selection: $model.style) {
+                ForEach(MobileMolecularStyle.allCases) { style in
+                    Text(style.displayName).tag(style)
+                }
+            }
+            Picker("Water", selection: $model.water) {
+                ForEach(MobileWaterRepresentation.allCases) { water in
+                    Text(water.displayName).tag(water)
+                }
+            }
+        }
+    }
+
+    private var appearanceSection: some View {
+        Section("Appearance") {
+            Picker("Theme", selection: $model.theme) {
+                ForEach(MobileThemeSelection.allCases) { theme in
+                    Label(theme.displayName, systemImage: theme.systemImage).tag(theme)
+                }
+            }
+            Picker("Preview background", selection: $model.previewBackground) {
+                ForEach(MobilePreviewBackground.allCases) { background in
+                    Text(background.displayName).tag(background)
+                }
+            }
+        }
+    }
+
+    private var integrationsSection: some View {
+        Section {
+            LabeledContent("xyzrender", value: "Desktop only")
+            LabeledContent("VESTA", value: "Desktop only")
+            LabeledContent("External editors", value: "Desktop only")
+        } header: {
+            Text("Integrations")
+        } footer: {
+            Text("xyzrender SVG export, VESTA, and external chemistry editors run on the macOS app. On iPhone, structures render with the in-app Mol* runtime.")
+        }
+    }
+
+    private var maintenanceSection: some View {
+        Section("Maintenance") {
+            Button {
+                clearPreviewCache()
+            } label: {
+                Label("Clear preview cache", systemImage: "trash")
+            }
+            Button {
+                runDiagnostics()
+            } label: {
+                Label("Run diagnostics", systemImage: "stethoscope")
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        Section("About") {
+            LabeledContent("Version", value: appVersion)
+            LabeledContent("License", value: "MIT")
+        }
+    }
+
+    // MARK: Actions
+
+    private var maintenanceAlertBinding: Binding<Bool> {
+        Binding(
+            get: { maintenanceMessage != nil },
+            set: { if !$0 { maintenanceMessage = nil } }
+        )
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        if let build, !build.isEmpty { return "\(version) (\(build))" }
+        return version
+    }
+
+    private func clearPreviewCache() {
+        let fileManager = FileManager.default
+        guard let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            maintenanceMessage = "Caches directory is unavailable."
+            return
+        }
+        let previews = caches
+            .appendingPathComponent("BurreteMobile", isDirectory: true)
+            .appendingPathComponent("previews", isDirectory: true)
+        do {
+            if fileManager.fileExists(atPath: previews.path) {
+                try fileManager.removeItem(at: previews)
+                maintenanceMessage = "Preview cache cleared. The next structure rebuilds the runtime."
+            } else {
+                maintenanceMessage = "Preview cache is already empty."
+            }
+        } catch {
+            maintenanceMessage = "Could not clear preview cache: \(error.localizedDescription)"
+        }
+    }
+
+    private func runDiagnostics() {
+        var lines: [String] = []
+        lines.append("Burrete Mobile \(appVersion)")
+        lines.append("Renderer: \(model.renderer.displayName)")
+        lines.append("Mol* quality: \(model.molstarQuality.displayName)")
+        lines.append("Theme: \(model.theme.displayName)")
+        lines.append("Imported files: \(model.importedDocuments.count)")
+
+        let webAvailable = Bundle.main.url(forResource: "Web", withExtension: nil) != nil
+        lines.append("Web runtime bundle: \(webAvailable ? "present" : "missing")")
+        let rdkit = Bundle.main.url(forResource: "RDKit_minimal", withExtension: "wasm", subdirectory: "Web/rdkit") != nil
+        lines.append("RDKit WASM: \(rdkit ? "present" : "missing")")
+
+        diagnosticsReport = lines.joined(separator: "\n")
+        showingDiagnostics = true
+    }
+}
+
+/// Read-only diagnostics report presented as a sheet.
+private struct MobileDiagnosticsSheet: View {
+    let report: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(report)
+                    .font(.system(.footnote, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding()
+            }
+            .navigationTitle("Diagnostics")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/ios/BurreteMobile/MobileViewModes.swift
+++ b/ios/BurreteMobile/MobileViewModes.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Preview view modes for a document (mockup 11). `structure3D` is the live Mol*
+/// runtime; `text` shows the raw file contents.
+enum MobileViewMode: String, CaseIterable, Identifiable {
+    case structure3D
+    case text
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .structure3D: "3D"
+        case .text: "Text"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .structure3D: "cube"
+        case .text: "text.alignleft"
+        }
+    }
+}
+
+enum MobileViewModeCatalog {
+    /// Formats Mol* can render as an interactive 3D structure.
+    static let structureFormats: Set<String> = [
+        "pdb", "ent", "pdbqt", "pqr", "cif", "mmcif", "mcif", "bcif",
+        "sdf", "sd", "mol", "mol2", "xyz", "xyzr", "gro", "cube", "cub"
+    ]
+
+    /// UTF-8 text-inspectable formats.
+    static let textFormats: Set<String> = structureFormats.union([
+        "txt", "csv", "tsv", "smi", "smiles", "dat", "json", "xml",
+        "mdp", "top", "itp", "key", "par", "prm", "rtf", "str", "log", "out",
+        "com", "inp", "in", "nw", "psi4", "qcin", "vasp"
+    ])
+
+    static func modes(for document: MobilePreviewDocument) -> [MobileViewMode] {
+        let ext = document.fileExtension
+        var modes: [MobileViewMode] = []
+        if ext.isEmpty || structureFormats.contains(ext) { modes.append(.structure3D) }
+        if ext.isEmpty || textFormats.contains(ext) { modes.append(.text) }
+        if modes.isEmpty { modes = [.structure3D] }
+        return modes
+    }
+}
+
+/// Compact segmented switcher shown when a document supports more than one view.
+struct MobileViewModePicker: View {
+    let modes: [MobileViewMode]
+    @Binding var selection: MobileViewMode
+
+    var body: some View {
+        Picker("View mode", selection: $selection) {
+            ForEach(modes) { mode in
+                Label(mode.title, systemImage: mode.systemImage).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(maxWidth: 240)
+        .padding(6)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(.white.opacity(0.14)))
+    }
+}
+
+/// Native text/artifact viewer (mockup 11): raw file contents with line numbers.
+struct MobileTextArtifactView: View {
+    let document: MobilePreviewDocument
+    var maxLines = 4000
+
+    var body: some View {
+        ScrollView([.vertical, .horizontal]) {
+            let lines = fileLines
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text("\(index + 1)")
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 44, alignment: .trailing)
+                        Text(line.isEmpty ? " " : line)
+                            .font(.system(.footnote, design: .monospaced))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .textSelection(.enabled)
+                    }
+                    .padding(.vertical, 1)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 150)
+            .padding(.bottom, 120)
+        }
+        .background(Color(.systemBackground))
+    }
+
+    private var fileLines: [String] {
+        guard let url = document.bundleURL(),
+              let text = try? String(contentsOf: url, encoding: .utf8) else {
+            return ["Unable to read \(document.displayName) as text."]
+        }
+        let all = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+        if all.count > maxLines {
+            return Array(all.prefix(maxLines)) + ["… \(all.count - maxLines) more lines (truncated)"]
+        }
+        return all
+    }
+}
+


### PR DESCRIPTION
Reworks the BurreteMobile iPhone app into a full-screen Mol* viewer with edge-swipe navigation instead of a bottom tab bar.

## Changes
- **Shared state**: new `@Observable MobileAppModel` holds rendering preferences (renderer, Mol* quality, water, theme, preview background), persisted to `UserDefaults` and threaded into the preview runtime (`molstarResolutionMode`, canvas background).
- **Navigation**: left-edge swipe opens the Files browser (project drawer); right-edge swipe opens **Settings** (rendering, appearance, integrations, maintenance, about). No bottom tab bar.
- **Command palette**: chrome button opens a searchable palette (representation / view / share actions).
- **View modes**: 3D / Text switcher pinned under the top chrome; native text/log viewer with line numbers and horizontal scroll.
- **Fix**: trajectory playback bar was hidden under the UI — the viewer container no longer ignores the whole safe area (only the Mol* canvas stays full-bleed).

## Verification
- `xcodebuild` (generic iOS, signing off): **BUILD SUCCEEDED**.
- Built, installed, and launched on a physical iPhone 13 Pro and on the iOS 17 simulator.

Rebased onto latest `main`.