### PR TITLE
Update Cargo lock for 1.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.16"
+version = "1.0.18"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",


### PR DESCRIPTION
## Summary
- align Cargo.lock package version with the 1.0.18 release bump already merged in #354

## Checks
- bun run check:release
- pre-push ci-fast