### PR TITLE
Fix Molstar 2D molecule preview

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -474,7 +474,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -524,7 +524,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -545,7 +545,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -568,7 +568,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -12781,7 +12781,7 @@
     const sdfEntry = molstarMoleculePreviewSdfEntry(target);
     if (sdfEntry) return sdfEntry;
     const entry = target.selectedEntry || target.ligand || null;
-    return molstarStandaloneMoleculePreviewEntryForTarget(target, entry) || entry;
+    return molstarStandaloneMoleculePreviewEntryForTarget(target, entry);
   }
 
   function molstarMoleculePreviewSdfEntry(target) {
@@ -12804,7 +12804,7 @@
 
   function molstarStandaloneMoleculePreviewEntryForTarget(target, entry = null) {
     if (!target || (target.scope !== 'ligand' && target.scope !== 'ion')) return null;
-    if (entry) return null;
+    if (normalizeFormat(entry?.format) === 'sdf') return null;
     const preview = molstarStandaloneMoleculePreviewTarget(activeConfig);
     const ligand = preview?.ligand || null;
     return normalizeFormat(ligand?.format) === 'sdf' ? ligand : null;
@@ -13253,6 +13253,33 @@
       });
   }
 
+  function molstarSelectionMoleculePreviewTarget() {
+    const structures = molstarContextStructures();
+    if (!structures.length) return null;
+    const sourceEntry = molstarContextSourceEntryForActiveConfig();
+    for (const structureRef of structures) {
+      const structure = molstarStructureFromRef(structureRef) || structureRef;
+      const loci = molstarContextSelectionLociForStructure(structureRef);
+      const atom = molstarContextAtomFromLoci(loci);
+      const scope = molstarContextScopeForAtom(atom);
+      if (scope !== 'ligand' && scope !== 'ion') continue;
+      const selectedEntry = sourceEntry ? pdbEntryForResidue(sourceEntry, atom) : null;
+      return {
+        structures: [structureRef],
+        structure: structureRef,
+        loci,
+        atomLoci: molstarContextAtomLociForStructure(structure || loci?.structure, atom),
+        atom,
+        selectionBased: true,
+        label: selectedEntry?.label || molstarContextResidueLabel(atom),
+        scope,
+        sourceEntry,
+        selectedEntry
+      };
+    }
+    return null;
+  }
+
   function molstarSelectedMoleculePreviewTarget(target = null) {
     const resolved = target || molstarContextTarget();
     if (resolved?.scope === 'ligand' || resolved?.scope === 'ion') return resolved;
@@ -13266,6 +13293,7 @@
         };
       }
     }
+    if (!target) return molstarSelectionMoleculePreviewTarget();
     return null;
   }
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "1.0.19"
+version = "1.0.20"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "bin": "bin/burrete.mjs",
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5056,6 +5056,11 @@ assert.match(previewViewer, /if \(resolved\?\.scope === 'ligand' \|\| resolved\?
 assert.match(previewViewer, /if \(resolved\?\.selectionBased && resolved\.atom\) \{/);
 assert.match(previewViewer, /const scope = molstarContextScopeForAtom\(resolved\.atom\);/);
 assert.match(previewViewer, /label: resolved\.selectedEntry\?\.label \|\| molstarContextResidueLabel\(resolved\.atom\) \|\| resolved\.label/);
+assert.match(previewViewer, /function molstarSelectionMoleculePreviewTarget\(\)/);
+assert.match(previewViewer, /const loci = molstarContextSelectionLociForStructure\(structureRef\);/);
+assert.match(previewViewer, /const scope = molstarContextScopeForAtom\(atom\);/);
+assert.match(previewViewer, /if \(scope !== 'ligand' && scope !== 'ion'\) continue;/);
+assert.match(previewViewer, /if \(!target\) return molstarSelectionMoleculePreviewTarget\(\);/);
 assert.match(previewViewer, /MOLSTAR_STANDALONE_PREVIEW_MAX_ATOMS = 300/);
 assert.match(previewViewer, /function molstarStandaloneMoleculePreviewTarget\(config\)/);
 assert.match(previewViewer, /format === 'pdb' \|\| format === 'pdbqt' \|\| format === 'mmcif' \|\| format === 'cifCore' \|\| format === 'xyz'/);
@@ -5069,8 +5074,9 @@ assert.match(previewViewer, /function molstarMoleculePreviewSdfEntry\(target\)/)
 assert.match(previewViewer, /pdbLigandSdfEntryForResidue\(target\.receptor, target\.atom\)/);
 assert.match(previewViewer, /pdbLigandSdfEntryForResidue\(target\.sourceEntry, target\.atom\)/);
 assert.match(previewViewer, /function molstarStandaloneMoleculePreviewEntryForTarget\(target, entry = null\)/);
-assert.match(previewViewer, /if \(entry\) return null;/);
-assert.match(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target, entry\) \|\| entry;/);
+assert.match(previewViewer, /if \(normalizeFormat\(entry\?\.format\) === 'sdf'\) return null;/);
+assert.match(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target, entry\);/);
+assert.doesNotMatch(previewViewer, /return molstarStandaloneMoleculePreviewEntryForTarget\(target, entry\) \|\| entry;/);
 assert.doesNotMatch(previewViewer, /sourceFormat !== 'xyz'/);
 assert.match(previewViewer, /if \(normalizeFormat\(entry\?\.format\) !== 'sdf'\) \{\s*hideMolstarMoleculePreview\(\);\s*return;\s*\}/);
 assert.match(previewViewer, /const image = molstarPreviewSvgCache\.get\(key\) \|\| ''/);


### PR DESCRIPTION
## Why

Mol* molecule selections could fail to show the lower-left 2D preview because the preview path could hand a PDB/non-SDF entry to the RDKit renderer, which immediately hid the popover. Selection-driven updates such as lasso also had no context-menu target to recover the ligand preview target from.

## What Changed

- Keep the Mol* 2D molecule preview on SDF inputs only, using the standalone SDF fallback instead of passing non-SDF entries through to the renderer.
- Let Mol* rebuild a ligand/ion preview target from the active selection so lasso/selection sync can show the RDKit preview without an open context menu.
- Bump release metadata to 1.0.20.

## Verification

- bun tests/test-ui-shell-contract.mjs
- bun run check:release
- ./scripts/release.sh --dry-run
- pre-push ci-fast

## Notes

In-app Browser control timed out while trying to load the local preview, so visual Browser confirmation was not completed in this turn.