### PR TITLE
Document runtime contracts and RCA guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,20 @@ Burrete is a macOS desktop app, Finder Quick Look extension, and source-built
 iPhone preview app for molecular structure files. Keep this file as a
 dispatcher; load the focused doc for the surface you are changing.
 
+## Project Contracts
+
+- Product name: `Burrete`
+- Package name: `burrete`
+- Tauri app identifier: `com.local.BurreteV10`
+- Package manager: `bun@1.3.8`
+- Stable agent CLIs: `scripts/burrete-agent.mjs` and
+  `scripts/agent-preview.mjs`
+- Packaged agent plugin root: `plugins/burette-agent`
+- Quick Look base bundle identifiers:
+  `com.local.BurreteV10.Preview` and `com.local.BurreteV10.Thumbnail`
+- Development installs must use `BURRETE_DEV_FLAVOR` so local app, extension,
+  container, and forced-content-type namespaces do not collide.
+
 ## Documentation Graph
 
 - User-facing overview: [README.md](README.md)
@@ -32,6 +46,18 @@ dispatcher; load the focused doc for the surface you are changing.
 - iOS mobile app: [ios/BurreteMobile/AGENTS.md](ios/BurreteMobile/AGENTS.md)
 - Agent plugin: [plugins/burette-agent/AGENTS.md](plugins/burette-agent/AGENTS.md)
 - Repository scripts: [scripts/README.md](scripts/README.md)
+
+## Runtime Boundaries
+
+| Boundary | Primary paths | First doc to read |
+| --- | --- | --- |
+| Desktop app shell | `apps/desktop/src`, `apps/desktop/src-tauri` | `docs/architecture.md` |
+| Browser-dev runtime | `apps/desktop/vite`, `apps/desktop/src/hooks` | `docs/tools/testing-surfaces.md` |
+| Finder Quick Look | `PreviewExtension`, `PreviewExtension/Web` | `PreviewExtension/AGENTS.md` |
+| iPhone source app | `ios/BurreteMobile` | `ios/BurreteMobile/AGENTS.md` |
+| Agent CLI and sessions | `scripts/burrete-agent.mjs`, `scripts/agent-preview.mjs` | `docs/agent-platform.md` |
+| Packaged MCP plugin | `plugins/burette-agent` | `plugins/burette-agent/AGENTS.md` |
+| Release and repository tooling | `scripts`, `.codex/skills` | `docs/tools/index.md` |
 
 ## Common Routing
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -69,6 +69,17 @@ state channel.
 - Screenshot interpretation must not replace typed `observe`, validation
   output, or CLI/MCP errors.
 
+## Agent RCA
+
+| Symptom | Likely cause | Where to look first |
+| --- | --- | --- |
+| Skill opens the wrong surface | Router chose `browser-preview`, `browser-dev-shell`, or `desktop-app` incorrectly. | `plugins/burette-agent/skills/index/SKILL.md`, CLI `open` arguments |
+| MCP tool succeeds but the panel is empty | Widget snapshot is unbounded, malformed, or missing the expected artifact shape. | MCP registration output, `plugins/burette-agent/mcp/widget-assets/*`, `render-panel` payload |
+| `observe` returns no active document | Wrong session directory, closed Browser tab, or desktop session not attached. | CLI `sessionDir`, shell logs, `apps/desktop/src/hooks/use-agent-session.ts` |
+| `act` times out | Action was sent to the shell when the active Mol* viewer was not ready, or the action contract changed. | Last `observe` result, `apps/desktop/src/hooks/use-agent-session.ts`, viewer bridge tests |
+| Plugin preflight fails | Packaged plugin paths, CLI availability, or local runtime capabilities are out of sync. | `plugins/burette-agent/scripts/burette_agent_preflight.mjs`, `plugins/burette-agent/AGENTS.md` |
+| Browser screenshot disagrees with typed state | Visual QA inspected the wrong tab or stale runtime while `observe` targeted another session. | Browser URL, CLI JSON metadata, `observe` output |
+
 ## Plugin Contract
 
 - Run `node plugins/burette-agent/scripts/burette_agent_preflight.mjs` before

--- a/docs/quicklook-debugging.md
+++ b/docs/quicklook-debugging.md
@@ -153,6 +153,17 @@ between desktop previews and Finder previews are documented in
 - Launch Services is still pointing at an older app bundle.
 - The selected file type is not registered to the expected forced content type.
 
+## Quick Look RCA
+
+| Symptom | Likely cause | Where to look first |
+| --- | --- | --- |
+| `quicklook-preview-smoke.sh` reports `NO_REQUEST` | Finder did not launch the extension, or Launch Services selected another generator. | Recent unified logs, `qlmanage -m plugins`, installed app path |
+| Smoke reports `Quick Look extension launch failure` | macOS rejected the ad-hoc signed extension before renderer code ran. | Smoke output, unified-log AMFI entries, installed `BurretePreview` signature |
+| Runtime directory is missing `manifest.json` | Preview runtime generation failed before web rendering. | Quick Look log, `preview-trace.jsonl`, `PreviewExtension/Platform/PreviewViewController.swift` |
+| Manifest exists but preview is blank | Generated web assets or renderer-specific assets are missing or stale. | `PreviewExtension/Web/`, `vendor-assets.lock.json`, runtime `manifest.json` |
+| Browser Quick Look succeeds but native Quick Look is blank | Browser-dev URL bypasses native extension registration, sandbox, and Launch Services. | `docs/tools/testing-surfaces.md`, extension container logs |
+| Only `.csv` or `.tsv` normal preview is missing | macOS may route public table UTIs to the system generator. | Forced preview scripts, browser-dev grid rendering |
+
 ## Required Checks After Migration Changes
 
 Run these after changes to `PreviewExtension/`, `Burrete.xcodeproj`,

--- a/docs/tools/testing-surfaces.md
+++ b/docs/tools/testing-surfaces.md
@@ -19,6 +19,20 @@ app, and native Finder Quick Look are different runtimes.
 - Browser success does not prove packaged desktop app or Finder Quick Look
   success. Native checks still need the packaged app and Quick Look scripts.
 
+## Surface RCA
+
+When behavior differs between surfaces, identify the runtime first instead of
+debugging the renderer generically.
+
+| Symptom | Likely cause | Where to look first |
+| --- | --- | --- |
+| Browser-dev works but packaged desktop fails | Tauri bundle resources, asset protocol scope, or generated frontend bundle differs from dev server state. | `apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/dist`, `scripts/build.sh` |
+| Browser Quick Look works but Finder Quick Look fails | Native extension registration, Launch Services, app install location, or Quick Look cache is stale. | `docs/quicklook-debugging.md`, `PreviewExtension/AGENTS.md`, `scripts/quicklook-preview-smoke.sh` |
+| Native forced preview works but normal Spacebar preview does not | Launch Services routed the public file type to another generator. | `config/preview-formats.json`, `PreviewExtension/Info.plist`, `scripts/force-preview.sh` |
+| Agent session opens but observe returns stale or empty state | Wrong session directory, old dev server, or missing browser shell agent endpoint. | CLI JSON `sessionDir`, `logPath`, `processId`; `apps/desktop/vite/browser-dev/agent-session.ts` |
+| Tokenized preview works but full browser shell actions fail | Preview transport and shell session contracts are different surfaces. | `scripts/agent-preview.mjs`, `scripts/burrete-agent.mjs`, `apps/desktop/src/hooks/use-agent-session.ts` |
+| External file fails only in browser-dev | Dev server file allowlist excludes the file path. | `BURRETE_DEV_FS_ALLOW`, Vite server logs, CLI `logPath` |
+
 ## Dev Server: Full Browser Shell
 
 For agent-owned Browser shell testing, prefer the CLI. It allocates a fresh


### PR DESCRIPTION
## Summary

- Add root project contract facts and runtime boundary routing to `AGENTS.md`.
- Add symptom-to-cause RCA tables for testing surfaces, Quick Look, and the agent platform.
- Keep detailed debugging guidance in the owning docs instead of expanding the root dispatcher with surface-specific details.

## Validation

- `git diff --check`
- pre-commit: `plist`, `js-syntax`, `rust-fmt`
- pre-push: `scripts/ci-fast.sh`