### PR TITLE
Add software citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use Burrete in your research, please cite it using the metadata from this file."
+title: "Burrete: local-first molecular file inspection for macOS, Quick Look, and agent workflows"
+type: software
+authors:
+  - family-names: "Nikolenko"
+    given-names: "Sergei A."
+    orcid: "https://orcid.org/0000-0003-1150-9390"
+version: "1.0.22"
+date-released: "2026-07-08"
+license: "MIT"
+repository-code: "https://github.com/SergeiNikolenko/Burrete"
+url: "https://github.com/SergeiNikolenko/Burrete"
+abstract: "Burrete is an open-source molecular file inspection workspace for macOS Finder Quick Look previews, a Tauri desktop workspace, molecular renderer routing, molecule collection triage, and typed agent workflows."

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Burrete contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Licence.txt
+++ b/Licence.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Burrete contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 1.0.5" src="https://img.shields.io/badge/version-1.0.5-0f8f72.svg?style=flat-square" />
+  <img alt="Version 1.0.22" src="https://img.shields.io/badge/version-1.0.22-0f8f72.svg?style=flat-square" />
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square" /></a>
   <img alt="macOS 12+" src="https://img.shields.io/badge/macOS-12%2B-blue.svg?style=flat-square" />
   <img alt="iOS source app" src="https://img.shields.io/badge/iOS-source%20app-blue.svg?style=flat-square" />


### PR DESCRIPTION
## Why

SoftwareX expects normal repository-level citation and license metadata for the software distribution. The manuscript and all submission files remain outside this application repository.

## What Changed

- adds schema-valid `CITATION.cff` metadata for Burrete v1.0.22 and ORCID 0000-0003-1150-9390
- adds exact `LICENSE.txt` and `Licence.txt` aliases requested by the current SoftwareX guide/template while preserving the existing MIT `LICENSE`
- updates the README version badge from v1.0.5 to v1.0.22

Affected surface: repository metadata and documentation only. No manuscript, PDF, figure, submission package, or application runtime file is included.

## Verification

- validated `CITATION.cff` against schema 1.2.0
- confirmed `LICENSE`, `LICENSE.txt`, and `Licence.txt` are byte-identical
- ran `bun scripts/check-release-version.mjs`
- passed repository pre-commit checks for plists, JavaScript syntax, and Rust formatting
- passed `git diff --check`
