### PR TITLE
Enforce safe molecule collection merges

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -3568,11 +3568,11 @@
     const baseName = safeStructureFileStem(label, Number(row?.index));
     const molblock = String(row?.molblock || '').trimEnd();
     if (molblock.trim()) {
-      const text = molblock.includes('$$$$') ? molblock : `${molblock}\n$$$$`;
+      const text = serializeSdfRows([row]);
       return {
         path: `${baseName}.sdf`,
         inputExtension: 'sdf',
-        text: `${text.trimEnd()}\n`
+        text
       };
     }
     const smiles = String(row?.smiles || '').trim();

--- a/apps/desktop/src-tauri/src/commands/documents.rs
+++ b/apps/desktop/src-tauri/src/commands/documents.rs
@@ -1447,7 +1447,7 @@ pub(crate) fn append_to_molecule_collection<R: Runtime>(
 
     let existing = fs::read_to_string(&target_path)
         .map_err(|err| format!("{}: {err}", target_path.display()))?;
-    let merged = merge_collection_text(target_family, &[existing.as_str(), request.text.as_str()]);
+    let merged = merge_collection_text(target_family, &[existing.as_str(), request.text.as_str()])?;
     if merged.trim().is_empty() {
         return Err("Merged collection is empty".to_string());
     }
@@ -1494,7 +1494,7 @@ pub(crate) fn create_molecule_collection<R: Runtime>(
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent).map_err(|err| format!("{}: {err}", parent.display()))?;
     }
-    let merged = merge_collection_text(output_family, &[request.text.as_str()]);
+    let merged = merge_collection_text(output_family, &[request.text.as_str()])?;
     write_text_atomically(&output_path, &merged)?;
     open_document_for_window(&app, window.label(), output_path, &preferences, None)
 }
@@ -2035,7 +2035,7 @@ fn merge_collection_files(paths: &[String]) -> Result<(String, String), String> 
         );
     }
     let texts: Vec<&str> = sources.iter().map(|(_, text)| text.as_str()).collect();
-    let text = merge_collection_text(family, &texts);
+    let text = merge_collection_text(family, &texts)?;
     if text.trim().is_empty() {
         return Err("Merged collection is empty".to_string());
     }
@@ -2071,41 +2071,140 @@ fn collection_family(extension: &str) -> Option<CollectionFamily> {
     }
 }
 
-fn merge_collection_text(family: CollectionFamily, texts: &[&str]) -> String {
+fn merge_collection_text(family: CollectionFamily, texts: &[&str]) -> Result<String, String> {
     match family {
         CollectionFamily::Sdf => {
-            let records: Vec<String> = texts
-                .iter()
-                .flat_map(|text| {
-                    text.split("$$$$")
-                        .map(str::trim)
-                        .filter(|record| !record.is_empty())
-                })
-                .map(|record| format!("{record}\n$$$$"))
-                .collect();
-            format!("{}\n", records.join("\n"))
+            let mut records = Vec::new();
+            for (index, text) in texts.iter().enumerate() {
+                let source_records = split_sdf_collection_records(text);
+                if source_records.is_empty() {
+                    return Err(format!(
+                        "SDF collection source {} does not contain any records",
+                        index + 1
+                    ));
+                }
+                records.extend(source_records);
+            }
+            Ok(format!(
+                "{}\n",
+                records
+                    .iter()
+                    .map(|record| format!("{record}\n$$$$"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ))
         }
         CollectionFamily::Smiles => {
-            let lines: Vec<&str> = texts
-                .iter()
-                .flat_map(|text| text.lines().map(str::trim).filter(|line| !line.is_empty()))
-                .collect();
-            format!("{}\n", lines.join("\n"))
-        }
-        CollectionFamily::Csv | CollectionFamily::Tsv => {
             let mut lines = Vec::new();
             for (index, text) in texts.iter().enumerate() {
-                let mut file_lines = text.lines().filter(|line| !line.trim().is_empty());
-                if index == 0 {
-                    lines.extend(file_lines);
-                } else {
-                    let _ = file_lines.next();
-                    lines.extend(file_lines);
+                let source_lines = text
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .collect::<Vec<_>>();
+                if !source_lines.iter().any(|line| !line.starts_with('#')) {
+                    return Err(format!(
+                        "SMILES collection source {} does not contain any molecule records",
+                        index + 1
+                    ));
                 }
+                lines.extend(source_lines);
             }
-            format!("{}\n", lines.join("\n"))
+            Ok(format!("{}\n", lines.join("\n")))
+        }
+        CollectionFamily::Csv => merge_delimited_collection_text(texts, ',', "CSV"),
+        CollectionFamily::Tsv => merge_delimited_collection_text(texts, '\t', "TSV"),
+    }
+}
+
+fn split_sdf_collection_records(text: &str) -> Vec<String> {
+    let mut records = Vec::new();
+    let mut lines = Vec::new();
+    let finish = |lines: &mut Vec<&str>, records: &mut Vec<String>| {
+        let record = lines.join("\n").trim().to_string();
+        lines.clear();
+        if !record.is_empty() {
+            records.push(record);
+        }
+    };
+    for line in text.lines() {
+        if line.trim() == "$$$$" {
+            finish(&mut lines, &mut records);
+        } else {
+            lines.push(line);
         }
     }
+    finish(&mut lines, &mut records);
+    records
+}
+
+fn merge_delimited_collection_text(
+    texts: &[&str],
+    separator: char,
+    label: &str,
+) -> Result<String, String> {
+    let mut expected_header: Option<Vec<String>> = None;
+    let mut output_lines = Vec::new();
+    for (index, text) in texts.iter().enumerate() {
+        let file_lines = text.lines().collect::<Vec<_>>();
+        let Some(header_index) = file_lines.iter().position(|line| !line.trim().is_empty()) else {
+            return Err(format!("{label} collection source {} is empty", index + 1));
+        };
+        let header_line = file_lines[header_index].trim_start_matches('\u{feff}');
+        let header = parse_delimited_collection_header(header_line, separator);
+        if header.is_empty() || header.iter().all(String::is_empty) {
+            return Err(format!(
+                "{label} collection source {} has an empty header",
+                index + 1
+            ));
+        }
+        if expected_header
+            .as_ref()
+            .is_some_and(|expected| expected != &header)
+        {
+            return Err(format!(
+                "{label} collection headers must use the same columns in the same order"
+            ));
+        }
+        expected_header.get_or_insert(header);
+        let mut data_lines = file_lines[(header_index + 1)..].to_vec();
+        while data_lines.last().is_some_and(|line| line.trim().is_empty()) {
+            data_lines.pop();
+        }
+        if !data_lines.iter().any(|line| !line.trim().is_empty()) {
+            return Err(format!(
+                "{label} collection source {} does not contain any data rows",
+                index + 1
+            ));
+        }
+        if index == 0 {
+            output_lines.push(header_line);
+        }
+        output_lines.extend(data_lines);
+    }
+    Ok(format!("{}\n", output_lines.join("\n")))
+}
+
+fn parse_delimited_collection_header(line: &str, separator: char) -> Vec<String> {
+    let mut cells = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut chars = line.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '"' && chars.peek() == Some(&'"') {
+            current.push('"');
+            chars.next();
+        } else if character == '"' {
+            quoted = !quoted;
+        } else if character == separator && !quoted {
+            cells.push(current.trim().to_lowercase());
+            current.clear();
+        } else {
+            current.push(character);
+        }
+    }
+    cells.push(current.trim().to_lowercase());
+    cells
 }
 
 fn write_text_atomically(path: &Path, text: &str) -> Result<(), String> {
@@ -2705,13 +2804,40 @@ mod tests {
                 "smiles,name\nc1ccccc1,benzene\n",
                 "\nsmiles,name\nCCN,ethylamine\n",
             ],
-        );
+        )
+        .expect("matching CSV headers should merge");
 
         assert_eq!(
             merged,
             "smiles,name\nCCO,ethanol\nc1ccccc1,benzene\nCCN,ethylamine\n"
         );
         assert_eq!(merged.matches("smiles,name").count(), 1);
+    }
+
+    #[test]
+    fn rejects_collection_merge_with_mismatched_delimited_headers() {
+        let error = super::merge_collection_text(
+            super::CollectionFamily::Csv,
+            &["smiles,name\nCCO,ethanol\n", "name,smiles\nwater,O\n"],
+        )
+        .expect_err("reordered CSV columns should fail closed");
+
+        assert!(error.contains("same columns in the same order"));
+    }
+
+    #[test]
+    fn sdf_collection_merge_uses_record_delimiter_lines() {
+        let merged = super::merge_collection_text(
+            super::CollectionFamily::Sdf,
+            &[
+                "First\nM  END\n> <NOTE>\nprice $$$$ marker\n\n$$$$\n",
+                "Second\nM  END\n$$$$\n",
+            ],
+        )
+        .expect("inline dollar text is not an SDF record separator");
+
+        assert_eq!(merged.matches("\n$$$$").count(), 2);
+        assert!(merged.contains("price $$$$ marker"));
     }
 
     #[test]

--- a/apps/desktop/src/hooks/use-app-docking-workflows.ts
+++ b/apps/desktop/src/hooks/use-app-docking-workflows.ts
@@ -144,10 +144,20 @@ export function useAppDockingWorkflows({
   }, [documents]);
 
   const mergeMoleculeCollections = useCallback(async (targetPath: string | null, paths: string[]) => {
-    const sourcePaths = Array.from(new Set([
+    const candidatePaths = Array.from(new Set([
       ...collectionSourcePaths(targetPath),
       ...paths.flatMap((path) => collectionSourcePaths(path)),
-    ].filter(isMoleculeCollectionPath)));
+    ].map((path) => path.trim()).filter(Boolean)));
+    const unsupportedPaths = candidatePaths.filter((path) => !isMoleculeCollectionPath(path));
+    if (unsupportedPaths.length > 0) {
+      pushStatus(
+        "Collection merge accepts only SDF, SMILES, CSV, or TSV inputs.",
+        "error",
+        unsupportedPaths,
+      );
+      return;
+    }
+    const sourcePaths = candidatePaths;
     if (sourcePaths.length < 2) {
       pushStatus("Drop another SDF, SMILES, CSV, or TSV collection to merge it.", "error");
       return;

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -1,4 +1,4 @@
-import { collectionExtension, mergeCollectionSources } from "./collection-documents";
+import { collectionExtension, mergeCollectionSources, parseSdfCollectionRecords } from "./collection-documents";
 import type { DockingDocumentRequest, DockingSceneMode, OpenDocumentsResult, ViewerDocument, ViewerPreferences, ViewerReloadOptions, XyzrenderControls } from "../types";
 import previewFormatRegistry from "../../../../config/preview-formats.json";
 
@@ -294,7 +294,7 @@ export async function openBrowserDevDockingDocument(
   const sdfGridPath = ligands.find((ligand) => (
     ligand.format.molstarFormat === "sdf"
       && !ligand.format.binary
-      && parseSdf(decodeUtf8(ligand.bytes)).length > 1
+      && parseSdfCollectionRecords(decodeUtf8(ligand.bytes)).length > 1
   ))?.path ?? null;
   const config = {
     format: receptor.format.molstarFormat,
@@ -771,7 +771,7 @@ async function openBrowserDevDocumentFromBytes(
 ): Promise<ViewerDocument> {
   const text = await decodeStructureText(bytes, extension);
   const grid = gridPayload(path, extension, text);
-  const sdfRecordCount = isSdfExtension(extension) ? parseSdf(text).length : 0;
+  const sdfRecordCount = isSdfExtension(extension) ? parseSdfCollectionRecords(text).length : 0;
   const requestedMode = normalizeRendererMode(preferences.rendererMode);
   const explicitSdfViewer = isSdfExtension(extension)
     && Boolean(reloadOptions)
@@ -1419,7 +1419,7 @@ async function gridHtml(
 
 function gridPayload(path: string, extension: string, text: string) {
   if (extension === "sdf" || extension === "sd") {
-    const records = parseSdf(text);
+    const records = parseSdfCollectionRecords(text);
     return records.length >= 1 ? { format: "sdf", records } : null;
   }
   if (extension === "smi" || extension === "smiles") {
@@ -1448,38 +1448,6 @@ function parseSmiles(text: string): GridRecord[] {
     });
   }
   return records;
-}
-
-function parseSdf(text: string): GridRecord[] {
-  return text
-    .split(/\$\$\$\$/)
-    .map((record) => record.trim())
-    .filter(Boolean)
-    .map((record, index) => {
-      const lines = record.split(/\r?\n/);
-      return {
-        index,
-        name: lines[0]?.trim() || `Molecule ${index + 1}`,
-        molblock: `${record}\n$$$$\n`,
-        props: parseSdfProps(lines),
-      };
-    });
-}
-
-function parseSdfProps(lines: string[]) {
-  const props: Record<string, string> = {};
-  for (let index = 0; index < lines.length; index += 1) {
-    const match = /^>\s*<([^>]+)>/.exec(lines[index] || "");
-    if (!match) continue;
-    const values: string[] = [];
-    index += 1;
-    while (index < lines.length && lines[index].trim() !== "") {
-      values.push(lines[index]);
-      index += 1;
-    }
-    props[match[1]] = values.join("\n");
-  }
-  return props;
 }
 
 function parseDelimited(text: string, delimiter: "," | "\t"): GridRecord[] {
@@ -1776,7 +1744,7 @@ function ketcherEditConfig(
     atomCount = molfileAtomCount(text);
   } else if (isSdfExtension(normalized)) {
     if (sdfRecordCount !== 1) return null;
-    const record = parseSdf(text)[0]?.molblock ?? text;
+    const record = parseSdfCollectionRecords(text)[0]?.molblock ?? text;
     atomCount = molfileAtomCount(record);
   } else {
     return null;

--- a/apps/desktop/src/lib/collection-documents.ts
+++ b/apps/desktop/src/lib/collection-documents.ts
@@ -14,6 +14,14 @@ export type MergedCollection = {
   sourcePaths: string[];
 };
 
+export type SdfCollectionRecord = {
+  index: number;
+  name: string;
+  smiles?: string;
+  molblock: string;
+  props: Record<string, string>;
+};
+
 const COLLECTION_EXTENSIONS = new Set(["csv", "sd", "sdf", "smi", "smiles", "tsv"]);
 
 export function isMoleculeCollectionPath(path: string) {
@@ -27,10 +35,19 @@ export function collectionExtension(path: string) {
 }
 
 export function mergeCollectionSources(sources: CollectionSource[]): MergedCollection {
-  const cleanSources = sources.filter((source) => isMoleculeCollectionPath(source.path));
-  if (cleanSources.length < 2) {
+  if (sources.length < 2) {
     throw new Error("Drop at least two molecule collections to merge them.");
   }
+
+  const cleanSources = sources.map((source, index) => {
+    if (!isMoleculeCollectionPath(source.path)) {
+      throw new Error(`${source.path || `Collection source ${index + 1}`} is not a supported molecule collection.`);
+    }
+    if (!source.text.trim()) {
+      throw new Error(`${source.path || `Collection source ${index + 1}`} is empty.`);
+    }
+    return source;
+  });
 
   const families = Array.from(new Set(cleanSources.map((source) => collectionFamily(source.extension))));
   if (families.some((family) => family === null) || families.length !== 1) {
@@ -65,23 +82,137 @@ export function collectionFamily(extension: string): CollectionFamily | null {
 
 function mergeCollectionText(family: CollectionFamily, texts: string[]) {
   if (family === "sdf") {
-    const records = texts.flatMap((text) => text
-      .split(/\$\$\$\$/)
-      .map((record) => record.trim())
-      .filter(Boolean));
+    const records = texts.flatMap((text, index) => {
+      const sourceRecords = splitSdfCollectionRecords(text);
+      if (sourceRecords.length === 0) throw new Error(`SDF collection source ${index + 1} does not contain any records.`);
+      return sourceRecords;
+    });
     return records.map((record) => `${record}\n$$$$`).join("\n") + "\n";
   }
   if (family === "smiles") {
-    return texts
-      .flatMap((text) => text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean))
+    return texts.flatMap((text, index) => {
+      const lines = text.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
+      if (!lines.some((line) => !line.startsWith("#"))) {
+        throw new Error(`SMILES collection source ${index + 1} does not contain any molecule records.`);
+      }
+      return lines;
+    })
       .join("\n") + "\n";
   }
 
-  const mergedLines: string[] = [];
-  for (const [index, text] of texts.entries()) {
-    const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
-    if (index === 0) mergedLines.push(...lines);
-    else mergedLines.push(...lines.slice(1));
+  return mergeDelimitedCollectionText(texts, family === "csv" ? "," : "\t", family.toUpperCase());
+}
+
+export function splitSdfCollectionRecords(text: string) {
+  const records: string[] = [];
+  let lines: string[] = [];
+  const finish = () => {
+    const record = lines.join("\n").trim();
+    lines = [];
+    if (record) records.push(record);
+  };
+  for (const line of text.replace(/\r\n?/gu, "\n").split("\n")) {
+    if (/^\s*\$\$\$\$\s*$/u.test(line)) finish();
+    else lines.push(line);
   }
-  return mergedLines.join("\n") + "\n";
+  finish();
+  return records;
+}
+
+export function parseSdfCollectionRecords(text: string): SdfCollectionRecord[] {
+  return splitSdfCollectionRecords(text).map((record, index) => {
+    const lines = record.split("\n");
+    const props = parseSdfProperties(lines);
+    const title = lines[0]?.trim();
+    const name = [props.Name, props.NAME, props.ID, title]
+      .find((value) => value?.trim())
+      ?.trim() ?? `Molecule ${index + 1}`;
+    const smiles = [props.SMILES, props.Smiles, props.smiles]
+      .find((value) => value?.trim())
+      ?.trim();
+    return {
+      index,
+      name,
+      ...(smiles ? { smiles } : {}),
+      molblock: extractSdfMolblock(lines),
+      props,
+    };
+  });
+}
+
+function parseSdfProperties(lines: string[]) {
+  const props: Record<string, string> = {};
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^>\s*<([^>]+)>/u.exec(lines[index] || "");
+    if (!match) continue;
+    const values: string[] = [];
+    index += 1;
+    while (index < lines.length && lines[index].trim() !== "") {
+      values.push(lines[index]);
+      index += 1;
+    }
+    props[match[1].trim()] = values.join("\n");
+  }
+  return props;
+}
+
+function extractSdfMolblock(lines: string[]) {
+  const molEnd = lines.findIndex((line) => line.trim() === "M  END");
+  const propertyStart = lines.findIndex((line) => /^>\s*</u.test(line));
+  const end = molEnd >= 0 ? molEnd + 1 : (propertyStart >= 0 ? propertyStart : lines.length);
+  return lines.slice(0, end).join("\n").trimEnd();
+}
+
+function mergeDelimitedCollectionText(texts: string[], separator: "," | "\t", label: string) {
+  let expectedHeader: string[] | null = null;
+  const outputLines: string[] = [];
+  for (const [index, text] of texts.entries()) {
+    const lines = text.replace(/\r\n?/gu, "\n").split("\n");
+    const headerIndex = lines.findIndex((line) => line.trim().length > 0);
+    if (headerIndex < 0) throw new Error(`${label} collection source ${index + 1} is empty.`);
+    const headerLine = lines[headerIndex].replace(/^\uFEFF/u, "");
+    const header = parseDelimitedHeader(headerLine, separator).map((cell) => cell.trim().toLowerCase());
+    if (header.length === 0 || header.every((cell) => !cell)) {
+      throw new Error(`${label} collection source ${index + 1} has an empty header.`);
+    }
+    if (expectedHeader && !sameHeader(expectedHeader, header)) {
+      throw new Error(`${label} collection headers must use the same columns in the same order.`);
+    }
+    expectedHeader ??= header;
+    const dataLines = lines.slice(headerIndex + 1);
+    while (dataLines.length > 0 && !dataLines[dataLines.length - 1].trim()) dataLines.pop();
+    if (!dataLines.some((line) => line.trim().length > 0)) {
+      throw new Error(`${label} collection source ${index + 1} does not contain any data rows.`);
+    }
+    if (index === 0) outputLines.push(headerLine);
+    outputLines.push(...dataLines);
+  }
+  while (outputLines.length > 0 && !outputLines[outputLines.length - 1].trim()) outputLines.pop();
+  return outputLines.join("\n") + "\n";
+}
+
+function sameHeader(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function parseDelimitedHeader(line: string, separator: "," | "\t") {
+  const cells: string[] = [];
+  let current = "";
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"' && line[index + 1] === '"') {
+      current += '"';
+      index += 1;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (char === separator && !quoted) {
+      cells.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  cells.push(current);
+  return cells;
 }

--- a/plugins/burette-agent/preview-web/grid-viewer.js
+++ b/plugins/burette-agent/preview-web/grid-viewer.js
@@ -3568,11 +3568,11 @@
     const baseName = safeStructureFileStem(label, Number(row?.index));
     const molblock = String(row?.molblock || '').trimEnd();
     if (molblock.trim()) {
-      const text = molblock.includes('$$$$') ? molblock : `${molblock}\n$$$$`;
+      const text = serializeSdfRows([row]);
       return {
         path: `${baseName}.sdf`,
         inputExtension: 'sdf',
-        text: `${text.trimEnd()}\n`
+        text
       };
     }
     const smiles = String(row?.smiles || '').trim();

--- a/tests/test-collection-documents.mjs
+++ b/tests/test-collection-documents.mjs
@@ -6,7 +6,11 @@ const {
   collectionExtension,
   isMoleculeCollectionPath,
   mergeCollectionSources,
+  parseSdfCollectionRecords,
+  splitSdfCollectionRecords,
 } = await import("../apps/desktop/src/lib/collection-documents.ts");
+const { openBrowserDevTextDocument } = await import("../apps/desktop/src/lib/browser-dev-documents.ts");
+const { defaultPreferences } = await import("../apps/desktop/src/stores/settings-store.ts");
 
 assert.equal(collectionExtension("/tmp/a.MAE.GZ"), "gz");
 assert.equal(isMoleculeCollectionPath("/tmp/a.sdf"), true);
@@ -25,6 +29,26 @@ const sdf = mergeCollectionSources([
 assert.equal(sdf.extension, "sdf");
 assert.equal((sdf.text.match(/\$\$\$\$/g) ?? []).length, 2);
 
+const sdfWithInlineDollars = "Named in title\n  CDK\n\nM  END\n> <Name>\nPreferred name\n\n> <NOTE>\nprice $$$$ marker\n\n$$$$\n";
+assert.equal(splitSdfCollectionRecords(sdfWithInlineDollars).length, 1);
+const parsedSdf = parseSdfCollectionRecords(sdfWithInlineDollars);
+assert.equal(parsedSdf.length, 1);
+assert.equal(parsedSdf[0].name, "Preferred name");
+assert.equal(parsedSdf[0].molblock.endsWith("M  END"), true);
+assert.equal(parsedSdf[0].molblock.includes("> <Name>"), false);
+assert.equal(parsedSdf[0].props.NOTE, "price $$$$ marker");
+
+const sampleMultiSdf = await Bun.file(new URL("../samples/collections/sdf/multi.sdf", import.meta.url)).text();
+const browserGridDocument = await openBrowserDevTextDocument("multi.sdf", "sdf", sampleMultiSdf, defaultPreferences);
+assert.equal(browserGridDocument.renderer, "grid2d");
+const browserRecordsMatch = /window\.BurreteGridRecords = (\[[^;]+\]);<\/script>/u.exec(browserGridDocument.runtimePath);
+assert.ok(browserRecordsMatch, "browser-dev grid should embed parsed records");
+const browserRecords = JSON.parse(browserRecordsMatch[1]);
+assert.equal(browserRecords.length, 2);
+assert.equal(browserRecords[0].molblock.endsWith("M  END"), true);
+assert.equal(browserRecords[0].molblock.includes("> <pIC50>"), false);
+assert.equal(browserRecords[0].props.pIC50, "5.1");
+
 const smiles = mergeCollectionSources([
   { path: "/tmp/a.smi", extension: "smi", text: "CCO ethanol\n\n" },
   { path: "/tmp/b.smiles", extension: "smiles", text: "# comment\nO water\n" },
@@ -38,6 +62,14 @@ const csv = mergeCollectionSources([
   { path: "/tmp/b.csv", extension: "csv", text: "SMILES,name\nO,water\n" },
 ]);
 assert.equal(csv.text.trim(), "SMILES,name\nCCO,ethanol\nO,water");
+
+assert.throws(
+  () => mergeCollectionSources([
+    { path: "/tmp/a.csv", extension: "csv", text: "SMILES,name\nCCO,ethanol\n" },
+    { path: "/tmp/b.csv", extension: "csv", text: "name,SMILES\nwater,O\n" },
+  ]),
+  /same columns in the same order/,
+);
 
 const tsv = mergeCollectionSources([
   { path: "/tmp/a.tsv", extension: "tsv", text: "SMILES\tname\nCCO\tethanol\n" },
@@ -59,6 +91,23 @@ assert.throws(
     { path: "/tmp/a.sdf", extension: "sdf", text: "a\n$$$$\n" },
   ]),
   /Drop at least two/,
+);
+
+assert.throws(
+  () => mergeCollectionSources([
+    { path: "/tmp/a.sdf", extension: "sdf", text: "a\n$$$$\n" },
+    { path: "/tmp/empty.sdf", extension: "sdf", text: " \n" },
+  ]),
+  /empty/,
+);
+
+assert.throws(
+  () => mergeCollectionSources([
+    { path: "/tmp/a.sdf", extension: "sdf", text: "a\n$$$$\n" },
+    { path: "/tmp/b.sdf", extension: "sdf", text: "b\n$$$$\n" },
+    { path: "/tmp/notes.txt", extension: "txt", text: "notes" },
+  ]),
+  /not a supported molecule collection/,
 );
 
 console.log("collection document tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3587,6 +3587,8 @@ assert.match(appOpenDropMergeCollectionsHook, /export function useAppOpenDropMer
 assert.match(appOpenDropMergeCollectionsHook, /activeDocument\?\.renderer !== "grid2d"/);
 assert.match(appOpenDropMergeCollectionsHook, /paths\.some\(isMoleculeCollectionPath\)/);
 assert.match(appOpenDropMergeCollectionsHook, /void mergeMoleculeCollections\(activeDocument\.path, paths\)/);
+assert.match(appDockingWorkflowsHook, /const unsupportedPaths = candidatePaths\.filter\(\(path\) => !isMoleculeCollectionPath\(path\)\)/);
+assert.match(appDockingWorkflowsHook, /Collection merge accepts only SDF, SMILES, CSV, or TSV inputs\./);
 assert.match(appOpenDropControllerHook, /useOpenDrop\(openPaths, pushStatus, \{/);
 assert.match(tauriSource, /export function trackTauriListener\(registration: Promise<TauriUnlisten>, label: string\)/);
 assert.match(tauriSource, /if \(disposed\) \{\s*disposeTauriListener\(next, label\);/s);
@@ -6165,6 +6167,7 @@ assert.match(gridCss, /\.buret-card\.buret-card-drop-target\s*\{/);
 assert.match(gridViewer, /function gridDragRecordsForRow\(row\)/);
 assert.match(gridViewer, /state\.selected\.has\(rowIndex\) \|\| state\.selected\.size < 2/);
 assert.match(gridViewer, /function gridDragRecord\(row\)/);
+assert.match(gridViewer, /function gridDragRecord\(row\)[\s\S]*const text = serializeSdfRows\(\[row\]\);/);
 assert.match(gridViewer, /function showMoleculeContextMenu\(event, row\)/);
 assert.match(gridViewer, /if \(!isMoleculeContextTarget\(event\.target\)\) \{/);
 assert.match(gridViewer, /event\.stopImmediatePropagation\?\.\(\);/);


### PR DESCRIPTION
## Why

Collection merges and exports must preserve structure records and fail clearly instead of producing a silently corrupted file.

## What changed

- Enforces one collection family per merge and validates non-empty inputs.
- Preserves SDF record boundaries and requires identical CSV or TSV headers in order.
- Keeps SDF properties when grid records are dragged, copied, or exported.

## Verification

- `bun tests/test-collection-documents.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml commands::documents::tests`
- `git diff --check`