### PR TITLE
Fix hosted widget viewport sizing

### DIFF
--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -57,6 +57,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
     <link rel="stylesheet" crossorigin href="${shellStyles}" />
     <style>
       html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }
+      body .app-shell { width: 100%; height: 100%; }
       body { margin: 0; overflow: hidden; background: #f7f7f7; }
       @media (prefers-color-scheme: dark) { body { background: #111315; } }
       @media (max-width: 600px) {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -93,6 +93,7 @@ describe("viewer resource contract", () => {
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");
     expect(html).toContain('<div id="root"></div>');
+    expect(html).toContain("body .app-shell { width: 100%; height: 100%; }");
     expect(html).not.toContain("<iframe");
     expect(html).not.toContain("Open full viewer");
     expect(html).not.toContain("OpenAI App");


### PR DESCRIPTION
## Summary

- bound the hosted Burrete shell to the Apps SDK resource container
- prevent the 80vh widget viewport from clipping the 100vh desktop shell
- cover the hosted sizing contract in the public plugin tests

## Validation

- bun test tests/contracts.test.ts
- bun run typecheck
- bash scripts/ci-fast.sh
- in-app browser production shell smoke with a 1HTB structure