### PR TITLE
Serve the real Burrete viewer at the public URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 apps/burrete-public-plugin/public/molstar/
 apps/burrete-public-plugin/public/burrete-viewer/
 apps/burrete-public-plugin/public/viewer-shell/
+apps/burrete-public-plugin/public/demo/
 apps/desktop/dist/
 apps/desktop/src-tauri/target/
 /target/

--- a/apps/burrete-public-plugin/app/route.ts
+++ b/apps/burrete-public-plugin/app/route.ts
@@ -1,8 +1,22 @@
+import { getAppOrigin } from "@/lib/origin";
+import { createViewerWidgetHtml } from "@/lib/widget";
+
 export const runtime = "nodejs";
 
-export const PLUGIN_DOCUMENTATION_URL =
-  "https://burrete-landing.vercel.app/docs/plugin";
+export const DEMO_STRUCTURE_URL = "/demo/1htb.pdb";
 
 export function GET(): Response {
-  return Response.redirect(PLUGIN_DOCUMENTATION_URL, 308);
+  return new Response(createViewerWidgetHtml(getAppOrigin(), {
+    demoStructure: {
+      format: "pdb",
+      label: "1HTB.pdb",
+      url: DEMO_STRUCTURE_URL,
+    },
+    fullPage: true,
+  }), {
+    headers: {
+      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
 }

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -5,6 +5,15 @@ export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 
+export type ViewerWidgetOptions = {
+  demoStructure?: {
+    format: string;
+    label: string;
+    url: string;
+  };
+  fullPage?: boolean;
+};
+
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
   return new URL(assetPath, `${origin.replace(/\/$/u, "")}/`).toString();
@@ -40,13 +49,28 @@ export function createViewerResourceMeta(appOrigin: string) {
   } as const;
 }
 
-export function createViewerWidgetHtml(assetOrigin = ""): string {
+export function createViewerWidgetHtml(
+  assetOrigin = "",
+  options: ViewerWidgetOptions = {},
+): string {
   const shellScript = assetUrl(assetOrigin, VIEWER_SHELL_SCRIPT_PATH);
   const shellStyles = assetUrl(assetOrigin, VIEWER_SHELL_STYLES_PATH);
   const viewerAssets = assetUrl(assetOrigin, VIEWER_RUNTIME_ASSETS_PATH);
   const bootstrap = serializeForInlineScript({
+    demoStructure: options.demoStructure ? {
+      ...options.demoStructure,
+      url: assetUrl(assetOrigin, options.demoStructure.url),
+    } : null,
     viewerAssets,
   });
+  const documentSizing = options.fullPage
+    ? "html, body, #root { width: 100%; min-height: 100%; height: 100%; }"
+    : "html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }";
+  const compactSizing = options.fullPage
+    ? ""
+    : `@media (max-width: 600px) {
+        html, body, #root { min-height: 420px; height: min(76vh, 680px); }
+      }`;
 
   return `<!doctype html>
 <html lang="en">
@@ -56,13 +80,11 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
     <title>Burrete</title>
     <link rel="stylesheet" crossorigin href="${shellStyles}" />
     <style>
-      html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }
+      ${documentSizing}
       body .app-shell { width: 100%; height: 100%; }
       body { margin: 0; overflow: hidden; background: #f7f7f7; }
       @media (prefers-color-scheme: dark) { body { background: #111315; } }
-      @media (max-width: 600px) {
-        html, body, #root { min-height: 420px; height: min(76vh, 680px); }
-      }
+      ${compactSizing}
     </style>
     <script>
       (() => {
@@ -70,6 +92,38 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         window.__BURRETE_HOSTED_MCP_WIDGET__ = true;
         window.__BURRETE_WEB_ASSETS_BASE__ = config.viewerAssets;
         window.__BURRETE_HOSTED_MCP_RESULTS__ = [];
+        const deliverToolResult = (result) => {
+          if (window.__BURRETE_HOSTED_MCP_BRIDGE_READY__) {
+            window.postMessage({
+              source: "burrete-hosted-mcp-widget",
+              type: "tool-result",
+              result,
+            }, "*");
+            return;
+          }
+          window.__BURRETE_HOSTED_MCP_RESULTS__.push(result);
+        };
+        const loadDemoStructure = async () => {
+          const response = await fetch(config.demoStructure.url, {
+            credentials: "same-origin",
+          });
+          if (!response.ok) {
+            throw new Error(
+              "Demo structure request failed with HTTP " + response.status,
+            );
+          }
+          const data = await response.text();
+          deliverToolResult({
+            structuredContent: { fileName: config.demoStructure.label },
+            _meta: {
+              structure: {
+                data,
+                format: config.demoStructure.format,
+                label: config.demoStructure.label,
+              },
+            },
+          });
+        };
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent) return;
           const message = event.data;
@@ -92,6 +146,11 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
             _meta: globals.toolResponseMetadata,
           });
         }, { passive: true });
+        if (config.demoStructure) {
+          void loadDemoStructure().catch((error) => {
+            console.error("Failed to load the Burrete demo structure", error);
+          });
+        }
       })();
     </script>
   </head>

--- a/apps/burrete-public-plugin/next.config.ts
+++ b/apps/burrete-public-plugin/next.config.ts
@@ -14,7 +14,7 @@ const hostedShellCsp = [
   "frame-src 'self' data: blob:",
   "frame-ancestors 'none'",
   "object-src 'none'",
-  "base-uri 'none'",
+  "base-uri 'self'",
   "form-action 'none'",
 ].join("; ");
 
@@ -29,6 +29,10 @@ const nextConfig: NextConfig = {
   outputFileTracingRoot: path.resolve(appDirectory, "../.."),
   async headers() {
     return [
+      {
+        source: "/",
+        headers: [{ key: "Content-Security-Policy", value: hostedShellCsp }],
+      },
       {
         source: "/viewer-shell/index.html",
         headers: [{ key: "Content-Security-Policy", value: hostedShellCsp }],

--- a/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
+++ b/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
@@ -8,6 +8,11 @@ const REPO_ROOT = path.resolve(APP_ROOT, "../..");
 const SOURCE_VIEWER_ROOT = path.join(REPO_ROOT, "PreviewExtension/Web");
 const OUTPUT_VIEWER_ROOT = path.join(APP_ROOT, "public/burrete-viewer");
 const OUTPUT_SHELL_ROOT = path.join(APP_ROOT, "public/viewer-shell");
+const OUTPUT_DEMO_ROOT = path.join(APP_ROOT, "public/demo");
+const DEMO_STRUCTURE_PATH = path.join(
+  REPO_ROOT,
+  "samples/structures/proteins/1htb.pdb",
+);
 const VIEWER_FILES = [
   "burette-agent.js",
   "viewer-runtime.css",
@@ -18,8 +23,12 @@ const VIEWER_FILES = [
 await Promise.all([
   rm(OUTPUT_VIEWER_ROOT, { recursive: true, force: true }),
   rm(OUTPUT_SHELL_ROOT, { recursive: true, force: true }),
+  rm(OUTPUT_DEMO_ROOT, { recursive: true, force: true }),
 ]);
-await mkdir(OUTPUT_VIEWER_ROOT, { recursive: true });
+await Promise.all([
+  mkdir(OUTPUT_VIEWER_ROOT, { recursive: true }),
+  mkdir(OUTPUT_DEMO_ROOT, { recursive: true }),
+]);
 await Promise.all([
   ...VIEWER_FILES.map((file) => cp(
     path.join(SOURCE_VIEWER_ROOT, file),
@@ -30,6 +39,7 @@ await Promise.all([
     path.join(OUTPUT_VIEWER_ROOT, "rdkit"),
     { recursive: true },
   ),
+  cp(DEMO_STRUCTURE_PATH, path.join(OUTPUT_DEMO_ROOT, "1htb.pdb")),
 ]);
 
 await run("bun", ["run", "build"], {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -16,8 +16,8 @@ import {
   VIEWER_SHELL_STYLES_PATH,
 } from "../lib/widget";
 import {
+  DEMO_STRUCTURE_URL,
   GET as getPluginRoot,
-  PLUGIN_DOCUMENTATION_URL,
 } from "../app/route";
 import nextConfig from "../next.config";
 
@@ -113,15 +113,21 @@ describe("viewer resource contract", () => {
     expect(staticImports.some((specifier) => specifier.includes("ketcher"))).toBe(false);
     expect(source).not.toContain("/private/tmp");
     expect(source).not.toContain("/Users/");
+    expect(existsSync(path.join(publicRoot, DEMO_STRUCTURE_URL.slice(1)))).toBe(true);
   });
 
   test("hardens the directly served shell and enables cross-origin assets", async () => {
     const headers = await nextConfig.headers?.();
     const shellDocument = headers?.find((entry) => entry.source === "/viewer-shell/index.html");
+    const rootDocument = headers?.find((entry) => entry.source === "/");
     const shellAssets = headers?.find((entry) => entry.source === "/viewer-shell/:path*");
     expect(shellDocument?.headers).toContainEqual({
       key: "Content-Security-Policy",
       value: expect.stringContaining("frame-ancestors 'none'"),
+    });
+    expect(rootDocument?.headers).toContainEqual({
+      key: "Content-Security-Policy",
+      value: expect.stringContaining("base-uri 'self'"),
     });
     expect(shellAssets?.headers).toContainEqual({
       key: "Access-Control-Allow-Origin",
@@ -129,9 +135,18 @@ describe("viewer resource contract", () => {
     });
   });
 
-  test("redirects the service root to the public plugin documentation", () => {
+  test("serves the full Burrete viewer with a bundled demo at the service root", async () => {
     const response = getPluginRoot();
-    expect(response.status).toBe(308);
-    expect(response.headers.get("location")).toBe(PLUGIN_DOCUMENTATION_URL);
+    const html = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(html).toContain(VIEWER_SHELL_SCRIPT_PATH);
+    expect(html).toContain(VIEWER_SHELL_STYLES_PATH);
+    expect(html).toContain(DEMO_STRUCTURE_URL);
+    expect(html).toContain("1HTB.pdb");
+    expect(html).toContain("height: 100%");
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toContain("Open full visualizer");
+    expect(html).not.toContain("OpenAI App");
   });
 });

--- a/apps/desktop/src/hooks/use-agent-focus-layout.ts
+++ b/apps/desktop/src/hooks/use-agent-focus-layout.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from "react";
 
 import { browserDevAgentFocusLayout } from "../lib/browser-dev-startup";
+import { isHostedMcpWidget } from "../lib/hosted-mcp-widget";
 import { useShellStore } from "../stores/shell-store";
 
 export function useAgentFocusLayout() {
@@ -9,8 +10,14 @@ export function useAgentFocusLayout() {
   }, []);
 }
 
-export function applyAgentFocusLayout(search?: string, isAgentShell?: boolean) {
-  if (!browserDevAgentFocusLayout(search, isAgentShell)) return false;
+export function applyAgentFocusLayout(
+  search?: string,
+  isAgentShell?: boolean,
+  hostedMcpWidget = isHostedMcpWidget(),
+) {
+  if (!hostedMcpWidget && !browserDevAgentFocusLayout(search, isAgentShell)) {
+    return false;
+  }
   const state = useShellStore.getState();
   state.closeSidebar();
   state.setDockOpen("right", false);

--- a/tests/test-agent-focus-layout.mjs
+++ b/tests/test-agent-focus-layout.mjs
@@ -28,4 +28,9 @@ assert.equal(useShellStore.getState().sidebarOpen, true);
 assert.equal(useShellStore.getState().rightDockOpen, true);
 assert.equal(useShellStore.getState().bottomDockOpen, true);
 
+assert.equal(applyAgentFocusLayout("", false, true), true);
+assert.equal(useShellStore.getState().sidebarOpen, false);
+assert.equal(useShellStore.getState().rightDockOpen, false);
+assert.equal(useShellStore.getState().bottomDockOpen, false);
+
 console.log("agent focus layout tests passed");


### PR DESCRIPTION
## Why

The public Burrete URL redirected to documentation instead of showing the molecular workspace, while the hosted viewer could remain blank because its srcdoc asset base was blocked by CSP.

## What Changed

- serve the real full-page Burrete shell directly at the public root
- preload the bundled 1HTB PDB demo so the page opens with a visible structure
- start hosted surfaces with the outer sidebar and docks closed
- allow the srcdoc viewer to resolve its same-origin runtime asset base
- retain the wrapper-free MCP widget contract

Affected surfaces: hosted public site and plugin/MCP widget shell.

## Verification

- PUBLIC_APP_ORIGIN=http://localhost:3211 bun run --cwd apps/burrete-public-plugin test
- bun run --cwd apps/burrete-public-plugin typecheck
- bun run --cwd apps/burrete-public-plugin build
- bun tests/test-agent-focus-layout.mjs
- pre-push ci-fast hook
- local Browser smoke: 1HTB rendered on a Molstar canvas with sidebar/docks closed and runtime assets loaded from /burrete-viewer/