### PR TITLE
Keep the public plugin scoped to MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ dist/
 apps/burrete-public-plugin/public/molstar/
 apps/burrete-public-plugin/public/burrete-viewer/
 apps/burrete-public-plugin/public/viewer-shell/
-apps/burrete-public-plugin/public/demo/
 apps/desktop/dist/
 apps/desktop/src-tauri/target/
 /target/

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -78,9 +78,8 @@ bun run dev
 
 The production server exposes:
 
-- `/` — empty full-page Burrete shell for direct runtime diagnostics; molecular
-  structures arrive only through MCP tool results and are not shared between
-  visitors;
+- `/` — permanent redirect to the public plugin documentation; the hosted
+  service is not a standalone web workspace;
 - `/mcp` — stateless Streamable HTTP MCP endpoint;
 - `/api/health` — no-store health response;
 - `/.well-known/openai-apps-challenge` — exact domain-verification token when
@@ -96,6 +95,10 @@ The production server exposes:
 Do not change the production origin after publication. Preview deployments can
 use Vercel-provided deployment origins, while production should set
 `PUBLIC_APP_ORIGIN` explicitly.
+
+The local Burrete desktop app remains the primary workspace. The hosted service
+only supplies the public MCP endpoint, widget assets, and one isolated
+structure result at a time inside the user's chat.
 
 `bun run build` first copies the reviewed viewer runtime assets and builds the
 real desktop React shell in hosted MCP mode with stable component entry files.

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -78,7 +78,9 @@ bun run dev
 
 The production server exposes:
 
-- `/` — permanent redirect to the public plugin documentation;
+- `/` — empty full-page Burrete shell for direct runtime diagnostics; molecular
+  structures arrive only through MCP tool results and are not shared between
+  visitors;
 - `/mcp` — stateless Streamable HTTP MCP endpoint;
 - `/api/health` — no-store health response;
 - `/.well-known/openai-apps-challenge` — exact domain-verification token when

--- a/apps/burrete-public-plugin/app/route.ts
+++ b/apps/burrete-public-plugin/app/route.ts
@@ -3,15 +3,8 @@ import { createViewerWidgetHtml } from "@/lib/widget";
 
 export const runtime = "nodejs";
 
-export const DEMO_STRUCTURE_URL = "/demo/1htb.pdb";
-
 export function GET(): Response {
   return new Response(createViewerWidgetHtml(getAppOrigin(), {
-    demoStructure: {
-      format: "pdb",
-      label: "1HTB.pdb",
-      url: DEMO_STRUCTURE_URL,
-    },
     fullPage: true,
   }), {
     headers: {

--- a/apps/burrete-public-plugin/app/route.ts
+++ b/apps/burrete-public-plugin/app/route.ts
@@ -1,15 +1,8 @@
-import { getAppOrigin } from "@/lib/origin";
-import { createViewerWidgetHtml } from "@/lib/widget";
-
 export const runtime = "nodejs";
 
+export const PLUGIN_DOCUMENTATION_URL =
+  "https://burrete-landing.vercel.app/docs/plugin";
+
 export function GET(): Response {
-  return new Response(createViewerWidgetHtml(getAppOrigin(), {
-    fullPage: true,
-  }), {
-    headers: {
-      "Cache-Control": "public, max-age=0, must-revalidate",
-      "Content-Type": "text/html; charset=utf-8",
-    },
-  });
+  return Response.redirect(PLUGIN_DOCUMENTATION_URL, 308);
 }

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -6,11 +6,6 @@ export const VIEWER_SHELL_STYLES_PATH =
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 
 export type ViewerWidgetOptions = {
-  demoStructure?: {
-    format: string;
-    label: string;
-    url: string;
-  };
   fullPage?: boolean;
 };
 
@@ -57,10 +52,6 @@ export function createViewerWidgetHtml(
   const shellStyles = assetUrl(assetOrigin, VIEWER_SHELL_STYLES_PATH);
   const viewerAssets = assetUrl(assetOrigin, VIEWER_RUNTIME_ASSETS_PATH);
   const bootstrap = serializeForInlineScript({
-    demoStructure: options.demoStructure ? {
-      ...options.demoStructure,
-      url: assetUrl(assetOrigin, options.demoStructure.url),
-    } : null,
     viewerAssets,
   });
   const documentSizing = options.fullPage
@@ -92,38 +83,6 @@ export function createViewerWidgetHtml(
         window.__BURRETE_HOSTED_MCP_WIDGET__ = true;
         window.__BURRETE_WEB_ASSETS_BASE__ = config.viewerAssets;
         window.__BURRETE_HOSTED_MCP_RESULTS__ = [];
-        const deliverToolResult = (result) => {
-          if (window.__BURRETE_HOSTED_MCP_BRIDGE_READY__) {
-            window.postMessage({
-              source: "burrete-hosted-mcp-widget",
-              type: "tool-result",
-              result,
-            }, "*");
-            return;
-          }
-          window.__BURRETE_HOSTED_MCP_RESULTS__.push(result);
-        };
-        const loadDemoStructure = async () => {
-          const response = await fetch(config.demoStructure.url, {
-            credentials: "same-origin",
-          });
-          if (!response.ok) {
-            throw new Error(
-              "Demo structure request failed with HTTP " + response.status,
-            );
-          }
-          const data = await response.text();
-          deliverToolResult({
-            structuredContent: { fileName: config.demoStructure.label },
-            _meta: {
-              structure: {
-                data,
-                format: config.demoStructure.format,
-                label: config.demoStructure.label,
-              },
-            },
-          });
-        };
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent) return;
           const message = event.data;
@@ -146,11 +105,6 @@ export function createViewerWidgetHtml(
             _meta: globals.toolResponseMetadata,
           });
         }, { passive: true });
-        if (config.demoStructure) {
-          void loadDemoStructure().catch((error) => {
-            console.error("Failed to load the Burrete demo structure", error);
-          });
-        }
       })();
     </script>
   </head>

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -5,10 +5,6 @@ export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 
-export type ViewerWidgetOptions = {
-  fullPage?: boolean;
-};
-
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
   return new URL(assetPath, `${origin.replace(/\/$/u, "")}/`).toString();
@@ -44,24 +40,13 @@ export function createViewerResourceMeta(appOrigin: string) {
   } as const;
 }
 
-export function createViewerWidgetHtml(
-  assetOrigin = "",
-  options: ViewerWidgetOptions = {},
-): string {
+export function createViewerWidgetHtml(assetOrigin = ""): string {
   const shellScript = assetUrl(assetOrigin, VIEWER_SHELL_SCRIPT_PATH);
   const shellStyles = assetUrl(assetOrigin, VIEWER_SHELL_STYLES_PATH);
   const viewerAssets = assetUrl(assetOrigin, VIEWER_RUNTIME_ASSETS_PATH);
   const bootstrap = serializeForInlineScript({
     viewerAssets,
   });
-  const documentSizing = options.fullPage
-    ? "html, body, #root { width: 100%; min-height: 100%; height: 100%; }"
-    : "html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }";
-  const compactSizing = options.fullPage
-    ? ""
-    : `@media (max-width: 600px) {
-        html, body, #root { min-height: 420px; height: min(76vh, 680px); }
-      }`;
 
   return `<!doctype html>
 <html lang="en">
@@ -71,11 +56,13 @@ export function createViewerWidgetHtml(
     <title>Burrete</title>
     <link rel="stylesheet" crossorigin href="${shellStyles}" />
     <style>
-      ${documentSizing}
+      html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }
       body .app-shell { width: 100%; height: 100%; }
       body { margin: 0; overflow: hidden; background: #f7f7f7; }
       @media (prefers-color-scheme: dark) { body { background: #111315; } }
-      ${compactSizing}
+      @media (max-width: 600px) {
+        html, body, #root { min-height: 420px; height: min(76vh, 680px); }
+      }
     </style>
     <script>
       (() => {

--- a/apps/burrete-public-plugin/next.config.ts
+++ b/apps/burrete-public-plugin/next.config.ts
@@ -30,10 +30,6 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/",
-        headers: [{ key: "Content-Security-Policy", value: hostedShellCsp }],
-      },
-      {
         source: "/viewer-shell/index.html",
         headers: [{ key: "Content-Security-Policy", value: hostedShellCsp }],
       },

--- a/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
+++ b/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
@@ -8,11 +8,7 @@ const REPO_ROOT = path.resolve(APP_ROOT, "../..");
 const SOURCE_VIEWER_ROOT = path.join(REPO_ROOT, "PreviewExtension/Web");
 const OUTPUT_VIEWER_ROOT = path.join(APP_ROOT, "public/burrete-viewer");
 const OUTPUT_SHELL_ROOT = path.join(APP_ROOT, "public/viewer-shell");
-const OUTPUT_DEMO_ROOT = path.join(APP_ROOT, "public/demo");
-const DEMO_STRUCTURE_PATH = path.join(
-  REPO_ROOT,
-  "samples/structures/proteins/1htb.pdb",
-);
+const LEGACY_DEMO_ROOT = path.join(APP_ROOT, "public/demo");
 const VIEWER_FILES = [
   "burette-agent.js",
   "viewer-runtime.css",
@@ -23,11 +19,10 @@ const VIEWER_FILES = [
 await Promise.all([
   rm(OUTPUT_VIEWER_ROOT, { recursive: true, force: true }),
   rm(OUTPUT_SHELL_ROOT, { recursive: true, force: true }),
-  rm(OUTPUT_DEMO_ROOT, { recursive: true, force: true }),
+  rm(LEGACY_DEMO_ROOT, { recursive: true, force: true }),
 ]);
 await Promise.all([
   mkdir(OUTPUT_VIEWER_ROOT, { recursive: true }),
-  mkdir(OUTPUT_DEMO_ROOT, { recursive: true }),
 ]);
 await Promise.all([
   ...VIEWER_FILES.map((file) => cp(
@@ -39,7 +34,6 @@ await Promise.all([
     path.join(OUTPUT_VIEWER_ROOT, "rdkit"),
     { recursive: true },
   ),
-  cp(DEMO_STRUCTURE_PATH, path.join(OUTPUT_DEMO_ROOT, "1htb.pdb")),
 ]);
 
 await run("bun", ["run", "build"], {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -15,7 +15,10 @@ import {
   VIEWER_SHELL_SCRIPT_PATH,
   VIEWER_SHELL_STYLES_PATH,
 } from "../lib/widget";
-import { GET as getPluginRoot } from "../app/route";
+import {
+  GET as getPluginRoot,
+  PLUGIN_DOCUMENTATION_URL,
+} from "../app/route";
 import nextConfig from "../next.config";
 
 describe("submission tool contract", () => {
@@ -116,15 +119,10 @@ describe("viewer resource contract", () => {
   test("hardens the directly served shell and enables cross-origin assets", async () => {
     const headers = await nextConfig.headers?.();
     const shellDocument = headers?.find((entry) => entry.source === "/viewer-shell/index.html");
-    const rootDocument = headers?.find((entry) => entry.source === "/");
     const shellAssets = headers?.find((entry) => entry.source === "/viewer-shell/:path*");
     expect(shellDocument?.headers).toContainEqual({
       key: "Content-Security-Policy",
       value: expect.stringContaining("frame-ancestors 'none'"),
-    });
-    expect(rootDocument?.headers).toContainEqual({
-      key: "Content-Security-Policy",
-      value: expect.stringContaining("base-uri 'self'"),
     });
     expect(shellAssets?.headers).toContainEqual({
       key: "Access-Control-Allow-Origin",
@@ -132,19 +130,9 @@ describe("viewer resource contract", () => {
     });
   });
 
-  test("serves an empty full-page Burrete shell at the service root", async () => {
+  test("redirects the service root to the public plugin documentation", () => {
     const response = getPluginRoot();
-    const html = await response.text();
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(html).toContain(VIEWER_SHELL_SCRIPT_PATH);
-    expect(html).toContain(VIEWER_SHELL_STYLES_PATH);
-    expect(html).toContain("height: 100%");
-    expect(html).not.toContain("<iframe");
-    expect(html).not.toContain("Open full visualizer");
-    expect(html).not.toContain("OpenAI App");
-    expect(html).not.toContain("demoStructure");
-    expect(html).not.toContain("1HTB.pdb");
-    expect(html).not.toContain("/demo/");
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(PLUGIN_DOCUMENTATION_URL);
   });
 });

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -15,10 +15,7 @@ import {
   VIEWER_SHELL_SCRIPT_PATH,
   VIEWER_SHELL_STYLES_PATH,
 } from "../lib/widget";
-import {
-  DEMO_STRUCTURE_URL,
-  GET as getPluginRoot,
-} from "../app/route";
+import { GET as getPluginRoot } from "../app/route";
 import nextConfig from "../next.config";
 
 describe("submission tool contract", () => {
@@ -113,7 +110,7 @@ describe("viewer resource contract", () => {
     expect(staticImports.some((specifier) => specifier.includes("ketcher"))).toBe(false);
     expect(source).not.toContain("/private/tmp");
     expect(source).not.toContain("/Users/");
-    expect(existsSync(path.join(publicRoot, DEMO_STRUCTURE_URL.slice(1)))).toBe(true);
+    expect(existsSync(path.join(publicRoot, "demo/1htb.pdb"))).toBe(false);
   });
 
   test("hardens the directly served shell and enables cross-origin assets", async () => {
@@ -135,18 +132,19 @@ describe("viewer resource contract", () => {
     });
   });
 
-  test("serves the full Burrete viewer with a bundled demo at the service root", async () => {
+  test("serves an empty full-page Burrete shell at the service root", async () => {
     const response = getPluginRoot();
     const html = await response.text();
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(html).toContain(VIEWER_SHELL_SCRIPT_PATH);
     expect(html).toContain(VIEWER_SHELL_STYLES_PATH);
-    expect(html).toContain(DEMO_STRUCTURE_URL);
-    expect(html).toContain("1HTB.pdb");
     expect(html).toContain("height: 100%");
     expect(html).not.toContain("<iframe");
     expect(html).not.toContain("Open full visualizer");
     expect(html).not.toContain("OpenAI App");
+    expect(html).not.toContain("demoStructure");
+    expect(html).not.toContain("1HTB.pdb");
+    expect(html).not.toContain("/demo/");
   });
 });

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -39,10 +39,12 @@ The hosted plugin is a separate runtime boundary from the local desktop bridge:
 
 The MCP widget mounts the production build of the real Burrete browser shell
 directly and passes the tool result into its existing inline-document path. The
-root deployment URL redirects to the public plugin documentation; it is not a
-second standalone product. The bundle, submission metadata, review tests, and
-directory skill live together under `apps/burrete-public-plugin`; the main
-repository remains the source of truth.
+root deployment URL serves the same shell without a preloaded molecule for
+direct diagnostics; structures arrive only from the current MCP tool result and
+are not shared between visitors. It is not a second standalone product. The
+bundle, submission metadata, review tests, and directory skill live together
+under `apps/burrete-public-plugin`; the main repository remains the source of
+truth.
 
 ## CLI And Skill Map
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -39,12 +39,12 @@ The hosted plugin is a separate runtime boundary from the local desktop bridge:
 
 The MCP widget mounts the production build of the real Burrete browser shell
 directly and passes the tool result into its existing inline-document path. The
-root deployment URL serves the same shell without a preloaded molecule for
-direct diagnostics; structures arrive only from the current MCP tool result and
-are not shared between visitors. It is not a second standalone product. The
-bundle, submission metadata, review tests, and directory skill live together
-under `apps/burrete-public-plugin`; the main repository remains the source of
-truth.
+root deployment URL redirects to the public plugin documentation; it is not a
+second standalone product or a persistent web workspace. The local desktop app
+remains the primary Burrete workspace, while each hosted widget receives only
+the current MCP tool result inside the user's chat. The bundle, submission
+metadata, review tests, and directory skill live together under
+`apps/burrete-public-plugin`; the main repository remains the source of truth.
 
 ## CLI And Skill Map
 


### PR DESCRIPTION
## Why

The public plugin host was behaving like a standalone web workspace and preloading the same bundled 1HTB structure for every visitor. Burrete is local-first: the desktop app remains the primary workspace, while the hosted service should exist only for the public MCP endpoint and the isolated viewer result inside each user's chat.

## What Changed

- removed the bundled 1HTB asset and every demo autoload path
- restored the service root redirect to the public plugin documentation
- kept the real Burrete shell as the MCP widget, populated only by the current tool result
- added a contract that rejects a regenerated `public/demo/1htb.pdb`
- documented the local desktop versus hosted MCP boundary

Affected surfaces: plugin/MCP and docs. The desktop app's local behavior is unchanged.

## Verification

- `bun run --cwd apps/burrete-public-plugin test` (23 passed)
- `bun run --cwd apps/burrete-public-plugin typecheck`
- `bun run --cwd apps/burrete-public-plugin build`
- repository pre-push `ci-fast`
