### PR TITLE
Document the local plugin as the local-first path

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -98,7 +98,9 @@ use Vercel-provided deployment origins, while production should set
 
 The local Burrete desktop app remains the primary workspace. The hosted service
 only supplies the public MCP endpoint, widget assets, and one isolated
-structure result at a time inside the user's chat.
+structure result at a time inside the user's chat. The separate packaged local
+plugin remains the preferred path for local files and installed-app control on
+the same Mac through the local MCP and CLI bridge.
 
 `bun run build` first copies the reviewed viewer runtime assets and builds the
 real desktop React shell in hosted MCP mode with stable component entry files.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -42,9 +42,11 @@ directly and passes the tool result into its existing inline-document path. The
 root deployment URL redirects to the public plugin documentation; it is not a
 second standalone product or a persistent web workspace. The local desktop app
 remains the primary Burrete workspace, while each hosted widget receives only
-the current MCP tool result inside the user's chat. The bundle, submission
-metadata, review tests, and directory skill live together under
-`apps/burrete-public-plugin`; the main repository remains the source of truth.
+the current MCP tool result inside the user's chat. The packaged local plugin
+continues to use the local MCP and CLI bridge for local files and installed-app
+control on the same Mac. The bundle, submission metadata, review tests, and
+directory skill live together under `apps/burrete-public-plugin`; the main
+repository remains the source of truth.
 
 ## CLI And Skill Map
 


### PR DESCRIPTION
## Why

The public Directory app and the packaged local plugin are complementary surfaces. The local plugin should remain the preferred path for local files and installed Burrete control on the same Mac; the hosted service is limited to the public MCP endpoint and isolated chat widgets.

## What Changed

- documented the packaged local plugin's local MCP and CLI bridge
- marked local app control as the preferred local-first workflow
- kept the hosted plugin description scoped to one isolated MCP result in the user's chat

Affected surfaces: plugin/MCP documentation only. Runtime behavior is unchanged.

## Verification

- `git diff --check`
- repository pre-push `ci-fast`
