### PR TITLE
Expose lasso selection to ChatGPT context

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -10483,8 +10483,43 @@
       if (canSelectStructure) selection.fromLoci('add', loci, lassoApplyGranularity);
       selected += 1;
     }
-    if (selected > 0) scheduleMolstarSelectedMoleculePreview();
+    if (selected > 0) {
+      scheduleMolstarSelectedMoleculePreview();
+      notifyMolstarLassoSelection(picks, selected);
+    }
     return selected;
+  }
+
+  function notifyMolstarLassoSelection(picks, selected) {
+    const atoms = [];
+    const atomKeys = new Set();
+    const residues = new Map();
+    for (const pick of picks) {
+      const atom = molstarContextAtomFromLoci(pick?.loci);
+      if (!atom) continue;
+      const chain = String(atom.auth_asym_id || atom.label_asym_id || '').trim();
+      const sequence = atom.auth_seq_id ?? atom.label_seq_id ?? null;
+      const compId = String(atom.auth_comp_id || atom.label_comp_id || '').trim();
+      const atomName = String(atom.auth_atom_id || atom.label_atom_id || '').trim();
+      const atomKey = `${chain}:${sequence ?? ''}:${compId}:${atomName}:${atom.atomIndex ?? ''}`;
+      if (!atomKeys.has(atomKey)) {
+        atomKeys.add(atomKey);
+        atoms.push({ chain, sequence, compId, atomName });
+      }
+      const residueKey = `${chain}:${sequence ?? ''}:${compId}`;
+      if (!residues.has(residueKey) && residues.size < 96) {
+        residues.set(residueKey, { chain, sequence, compId });
+      }
+    }
+    window.__mqlPost?.('selectionChanged', '', {
+      selection: {
+        source: 'lasso',
+        label: `Lasso selection: ${atoms.length} visible atom${atoms.length === 1 ? '' : 's'} across ${residues.size} residue${residues.size === 1 ? '' : 's'}`,
+        atoms: atoms.length,
+        visibleTargets: selected,
+        residues: Array.from(residues.values())
+      }
+    });
   }
 
   function onXyzrenderLassoPointerDown(event) {

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,10 +1,10 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v6.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v7.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-absolute-assets-v1";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-selection-context-v1";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -86,10 +86,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v6.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v7.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-absolute-assets-v1");
+    expect(html).toContain("?v=viewer-selection-context-v1");
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");

--- a/apps/desktop/src/hooks/use-app-viewer-state-messages.ts
+++ b/apps/desktop/src/hooks/use-app-viewer-state-messages.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { StructureOverlayMode, ViewerLigandSelection } from "../components/types";
 import type { ViewerDocument } from "../types";
 import type { DockTabKind } from "../lib/dock";
+import { updateHostedMcpSelectionContext } from "../lib/hosted-mcp-widget";
 
 type ViewerStateMessageBody = Record<string, unknown> | null | undefined;
 type SetViewerLigandSelections = (
@@ -72,6 +73,7 @@ export function useAppViewerStateMessages({
       const selection = body.selection && typeof body.selection === "object"
         ? body.selection as Record<string, unknown>
         : null;
+      updateHostedMcpSelectionContext(selection, documentId);
       setViewerLigandSelections((previous) => ({
         ...previous,
         [documentId]: selection?.selector ? {

--- a/apps/desktop/src/lib/hosted-mcp-widget.ts
+++ b/apps/desktop/src/lib/hosted-mcp-widget.ts
@@ -3,7 +3,9 @@ export const HOSTED_MCP_WIDGET_MESSAGE_SOURCE = "burrete-hosted-mcp-widget";
 
 const MAX_HOSTED_STRUCTURE_BYTES = 3 * 1024 * 1024;
 const MAX_HOSTED_LABEL_LENGTH = 255;
+const MAX_HOSTED_SELECTION_RESIDUES = 96;
 const HOSTED_STRUCTURE_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
+let hostedSelectionRequestId = 0;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -11,6 +13,12 @@ export type HostedMcpStructure = {
   data: string;
   format: string;
   label: string;
+};
+
+type HostedMcpSelectionResidue = {
+  chain: string;
+  compId: string;
+  sequence: number | string | null;
 };
 
 function record(value: unknown): UnknownRecord | null {
@@ -42,6 +50,63 @@ function nestedResultMetadata(value: unknown) {
 function boundedLabel(value: unknown, fallback: string) {
   const label = typeof value === "string" ? value.trim() : "";
   return (label || fallback).slice(0, MAX_HOSTED_LABEL_LENGTH);
+}
+
+function selectionResidue(value: unknown): HostedMcpSelectionResidue | null {
+  const residue = record(value);
+  if (!residue) return null;
+  const sequence = typeof residue.sequence === "number" || typeof residue.sequence === "string"
+    ? residue.sequence
+    : null;
+  return {
+    chain: boundedLabel(residue.chain, ""),
+    compId: boundedLabel(residue.compId, ""),
+    sequence,
+  };
+}
+
+export function createHostedMcpSelectionContext(value: unknown, documentId: string) {
+  const selection = record(value);
+  if (!selection || selection.source !== "lasso") return null;
+  const residues = Array.isArray(selection.residues)
+    ? selection.residues
+      .slice(0, MAX_HOSTED_SELECTION_RESIDUES)
+      .map(selectionResidue)
+      .filter((residue): residue is HostedMcpSelectionResidue => residue !== null)
+    : [];
+  const atoms = Math.max(0, Math.trunc(Number(selection.atoms) || 0));
+  const label = boundedLabel(
+    selection.label,
+    `Lasso selection with ${atoms} visible atoms across ${residues.length} residues`,
+  );
+  const activeSelection = {
+    source: "lasso",
+    documentId: boundedLabel(documentId, "active-structure"),
+    label,
+    atoms,
+    residues,
+  };
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Current Burrete selection: ${label}. Treat this as the user's active molecular selection for their next request.`,
+    }],
+    structuredContent: { burrete: { activeSelection } },
+  };
+}
+
+export function updateHostedMcpSelectionContext(value: unknown, documentId: string) {
+  if (!isHostedMcpWidget() || !window.parent) return false;
+  const params = createHostedMcpSelectionContext(value, documentId);
+  if (!params) return false;
+  hostedSelectionRequestId += 1;
+  window.parent.postMessage({
+    jsonrpc: "2.0",
+    id: `burrete-selection-context-${hostedSelectionRequestId}`,
+    method: "ui/update-model-context",
+    params,
+  }, "*");
+  return true;
 }
 
 export function isHostedMcpWidgetLocation(location: Pick<Location, "search">) {

--- a/tests/test-hosted-mcp-widget.mjs
+++ b/tests/test-hosted-mcp-widget.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   HOSTED_MCP_WIDGET_MESSAGE_SOURCE,
+  createHostedMcpSelectionContext,
   isHostedMcpWidgetLocation,
   isHostedMcpToolResultMessage,
   parseHostedMcpStructureMessage,
@@ -146,5 +147,22 @@ const initialStructure = selectHostedMcpInitialStructure([
 });
 assert.equal(initialStructure?.label, "latest.pdb");
 assert.equal(initialStructure?.data, "LATEST");
+
+const selectionContext = createHostedMcpSelectionContext({
+  source: "lasso",
+  label: "Lasso selection: 4 visible atoms across 2 residues",
+  atoms: 4,
+  residues: [
+    { chain: "A", sequence: 12, compId: "CYS" },
+    { chain: "A", sequence: 13, compId: "ARG" },
+  ],
+}, "document-1");
+assert.equal(selectionContext?.structuredContent.burrete.activeSelection.atoms, 4);
+assert.deepEqual(selectionContext?.structuredContent.burrete.activeSelection.residues, [
+  { chain: "A", sequence: 12, compId: "CYS" },
+  { chain: "A", sequence: 13, compId: "ARG" },
+]);
+assert.match(selectionContext?.content[0].text ?? "", /active molecular selection/);
+assert.equal(createHostedMcpSelectionContext({ source: "click" }, "document-1"), null);
 
 console.log("Hosted MCP widget contract tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1552,6 +1552,8 @@ for (const runtimeSource of [viewer]) {
   assert.match(runtimeSource, /const lassoApplyGranularity = false;/);
   assert.match(runtimeSource, /selects\.select\(\{ loci \}, lassoApplyGranularity\)/);
   assert.match(runtimeSource, /selection\.fromLoci\('add', loci, lassoApplyGranularity\)/);
+  assert.match(runtimeSource, /function notifyMolstarLassoSelection\(picks, selected\)/);
+  assert.match(runtimeSource, /window\.__mqlPost\?\.\('selectionChanged'/);
   assert.match(runtimeSource, /function xyzrenderAtomIndexFromElement\(element\)/);
   assert.match(runtimeSource, /const atomNodes = xyzrenderAtomNodes\(item\)/);
   assert.doesNotMatch(runtimeSource, /const selectedAtomElements = new Set\(\)/);


### PR DESCRIPTION
## Summary

- emit bounded residue and atom summaries after Mol* lasso selection
- forward validated hosted selection state through `ui/update-model-context`
- version the hosted widget resource as v7
- keep context payloads bounded to 96 residues

## Verification

- public plugin typecheck
- hosted MCP widget contract tests
- UI shell contract tests
- repository `ci-fast` pre-push suite
- production MCP exposes `ui://burrete/molecular-viewer-v7.html`