### PR TITLE
Collapse hosted MCP toolbar by default

### DIFF
--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -1000,9 +1000,6 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
     0 8px 22px rgba(0, 0, 0, 0.22),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
-body.burette-hosted-mcp-viewer #buret-toolbar .buret-grip {
-  display: none;
-}
 .buret-button {
   position: relative;
   min-width: 30px; height: 30px; border: 0; border-radius: 8px; padding: 0 7px;

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3785,7 +3785,7 @@
 
   function restoreToolbarCollapsed(toolbar, viewer) {
     if (window.BurreteConfig?.hostedMcpWidgetBootstrap === true) {
-      setToolbarCollapsed(toolbar, false, viewer, false);
+      setToolbarCollapsed(toolbar, true, viewer, false);
       return;
     }
     let collapsed = false;

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,10 +1,10 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v8.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v9.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-toolbar-v1";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-toolbar-v2";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -86,10 +86,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v8.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v9.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-toolbar-v1");
+    expect(html).toContain("?v=viewer-hosted-toolbar-v2");
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -1208,7 +1208,7 @@ function viewerHtml(
   <title>Burrete - ${escapeHtml(label)}</title>
   <link rel="stylesheet" href="${viewerAsset("viewer-runtime.css")}?v=${runtimeAssetVersion}" />
 </head>
-<body class="${visuals.transparentBackground ? "burette-transparent-background" : "burette-opaque-background"}${hostedMcpBootstrap ? " burette-hosted-mcp-viewer" : ""}">
+<body class="${visuals.transparentBackground ? "burette-transparent-background" : "burette-opaque-background"}">
   <div id="app"></div>
   <script src="${viewerAsset("viewer-shell.js")}?v=${runtimeAssetVersion}"></script>
   <div id="status" class="hidden">Loading ${escapeHtml(label)}...</div>

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -571,7 +571,6 @@ assert.match(previewRuntimeCss, /#buret-toolbar\[data-active-renderer="xyzrender
 assert.match(previewRuntimeCss, /#buret-toolbar\[data-active-renderer="xyzrender-external"\] \[data-buret-toggle="log"\] \{\s*display: none;/);
 assert.match(previewRuntimeCss, /\.buret-slider-row/);
 assert.match(previewRuntimeCss, /\.buret-slider\[data-auto\]/);
-assert.match(previewRuntimeCss, /body\.burette-hosted-mcp-viewer #buret-toolbar \.buret-grip \{\s*display: none;/);
 assert.match(previewShell, /data-buret-xyzrender-field/);
 assert.match(previewShell, /min="0\.01" max="2" step="0\.01" value="0\.3" data-buret-xctrl-slider="fieldIso"/);
 assert.match(previewShell, /data-buret-xctrl-slider="fieldIso"/);
@@ -593,7 +592,6 @@ assert.match(browserDevDocuments, /if \(normalized === "xyzrender-external"\) re
 assert.match(browserDevDocuments, /requestedRenderer: normalizeRendererMode\(preferences\.rendererMode\)/);
 assert.match(browserDevDocuments, /sourcePath: path/);
 assert.match(browserDevDocuments, /xyzrenderEndpoint: "\/__burette\/xyzrender"/);
-assert.match(browserDevDocuments, /hostedMcpBootstrap \? " burette-hosted-mcp-viewer" : ""/);
 assert.match(browserDevDocuments, /vdwAtoms: null/);
 assert.match(browserDevDocuments, /hullMode: null/);
 assert.match(browserDevDocuments, /hullAtoms: null/);
@@ -603,7 +601,7 @@ assert.match(browserDevDocuments, /const trajectoryFrameCount = Math\.max\(xyzFr
 assert.match(browserDevDocuments, /const shouldOpenTrajectoryInMolstar = trajectoryFrameCount > 1 && requestedMode === "auto";/);
 assert.match(browserDevDocuments, /function countXyzFrames\(text: string\)/);
 assert.match(browserDevDocuments, /function countPdbModels\(text: string\)/);
-assert.match(viewer, /window\.BurreteConfig\?\.hostedMcpWidgetBootstrap === true\) \{\s*setToolbarCollapsed\(toolbar, false, viewer, false\);\s*return;/);
+assert.match(viewer, /window\.BurreteConfig\?\.hostedMcpWidgetBootstrap === true\) \{\s*setToolbarCollapsed\(toolbar, true, viewer, false\);\s*return;/);
 assert.match(browserDevDocuments, /requestBrowserDevDesmondPreview/);
 assert.match(browserDevDocuments, /\/__burette\/desmond-preview\?path=/);
 assert.match(browserDevDocuments, /`\$\{path\}\.desmond-preview\.pdb`/);


### PR DESCRIPTION
## Summary
- keep the toolbar grip visible in hosted MCP widgets
- start hosted MCP controls collapsed so only the expand button is shown
- preserve local viewer toolbar behavior
- bump the widget resource to v9

## Validation
- hosted MCP and UI shell contract tests
- TypeScript and hosted viewer asset build
- focused public plugin contract test
- pre-push `ci-fast`