### PR TITLE
Fix hosted viewer on mobile ChatGPT

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -13940,7 +13940,9 @@
       ...(pickScale !== undefined ? { pickScale } : {}),
       ...(resolutionMode !== undefined ? { resolutionMode } : {}),
       viewportBackgroundColor: transparentBackground ? undefined : canvasBackgroundCSS(),
-      powerPreference: isQuickLookHost() ? 'default' : 'high-performance'
+      powerPreference: String(activeConfig?.molstarPowerPreference || '') === 'default' || isQuickLookHost()
+        ? 'default'
+        : 'high-performance'
     };
   }
 

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -28,7 +28,7 @@ The production Streamable HTTP endpoint is
 
 Both tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v9.html` with MIME type
+`ui://burrete/molecular-viewer-v10.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The model receives only bounded structure summaries. Original molecular text

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -1,0 +1,217 @@
+(() => {
+  "use strict";
+
+  const MAX_STRUCTURE_BYTES = 3 * 1024 * 1024;
+  const MAX_SELECTION_RESIDUES = 96;
+  const SUPPORTED_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
+  const assetsBase = String(window.__BURRETE_WEB_ASSETS_BASE__ || "/burrete-viewer/").replace(/\/$/u, "");
+  let started = false;
+  let selectionRequestId = 0;
+
+  const record = (value) => value && typeof value === "object" ? value : null;
+  const bounded = (value, fallback = "") => {
+    const text = typeof value === "string" ? value.trim() : "";
+    return (text || fallback).slice(0, 255);
+  };
+  const normalizedFormat = (value) => {
+    const format = typeof value === "string" ? value.trim().toLowerCase() : "";
+    if (format === "cif" || format === "mcif") return "mmcif";
+    if (format === "sd") return "sdf";
+    return SUPPORTED_FORMATS.has(format) ? format : null;
+  };
+  const nestedMetadata = (value) => {
+    const envelope = record(value);
+    const result = record(envelope?.result);
+    return record(result?._meta) || record(envelope?._meta);
+  };
+  const resultMetadata = (result) => {
+    const metadata = record(result?._meta) || record(result?.meta);
+    return record(metadata?._meta)
+      || nestedMetadata(metadata?.mcp_tool_result)
+      || nestedMetadata(metadata?.call_tool_result)
+      || metadata;
+  };
+  const structureFromResult = (value) => {
+    const result = record(value);
+    const structure = record(resultMetadata(result)?.structure);
+    const data = typeof structure?.data === "string" ? structure.data : "";
+    const format = normalizedFormat(structure?.format);
+    const byteCount = new TextEncoder().encode(data).length;
+    if (!data || !format || byteCount > MAX_STRUCTURE_BYTES) return null;
+    return {
+      data,
+      format,
+      byteCount,
+      label: bounded(structure?.label, bounded(record(result?.structuredContent)?.fileName, "Molecular structure")),
+    };
+  };
+  const base64Utf8 = (text) => {
+    const bytes = new TextEncoder().encode(text);
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+      binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+    }
+    return btoa(binary);
+  };
+  const addStylesheet = (name) => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.crossOrigin = "anonymous";
+    link.href = `${assetsBase}/${name}`;
+    document.head.appendChild(link);
+  };
+  const loadScript = (name) => new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.crossOrigin = "anonymous";
+    script.src = `${assetsBase}/${name}`;
+    script.addEventListener("load", resolve, { once: true });
+    script.addEventListener("error", () => reject(new Error(`Failed to load ${name}`)), { once: true });
+    document.body.appendChild(script);
+  });
+  const jsonElement = (id, value) => {
+    const element = document.createElement("script");
+    element.id = id;
+    element.type = "application/json";
+    element.textContent = JSON.stringify(value).replaceAll("<", "\\u003c");
+    document.head.appendChild(element);
+  };
+
+  function updateSelectionContext(body) {
+    const selection = record(body?.selection);
+    if (body?.type !== "selectionChanged" || selection?.source !== "lasso") return;
+    const residues = Array.isArray(selection.residues)
+      ? selection.residues.slice(0, MAX_SELECTION_RESIDUES).map((value) => {
+        const residue = record(value) || {};
+        return {
+          chain: bounded(residue.chain),
+          compId: bounded(residue.compId),
+          sequence: typeof residue.sequence === "number" || typeof residue.sequence === "string"
+            ? residue.sequence
+            : null,
+        };
+      })
+      : [];
+    const atoms = Math.max(0, Math.trunc(Number(selection.atoms) || 0));
+    const label = bounded(selection.label, `Lasso selection with ${atoms} visible atoms across ${residues.length} residues`);
+    selectionRequestId += 1;
+    window.parent.postMessage({
+      jsonrpc: "2.0",
+      id: `burrete-selection-context-${selectionRequestId}`,
+      method: "ui/update-model-context",
+      params: {
+        content: [{
+          type: "text",
+          text: `Current Burrete selection: ${label}. Treat this as the user's active molecular selection for their next request.`,
+        }],
+        structuredContent: {
+          burrete: {
+            activeSelection: {
+              source: "lasso",
+              documentId: bounded(body.documentId, "active-structure"),
+              label,
+              atoms,
+              residues,
+            },
+          },
+        },
+      },
+    }, "*");
+  }
+
+  async function start(structure) {
+    if (started) return;
+    started = true;
+    const root = document.getElementById("root");
+    if (!root) throw new Error("Hosted viewer root is unavailable");
+    root.id = "app";
+    root.insertAdjacentHTML("afterend", '<div id="status" class="hidden">Loading structure...</div>');
+    document.body.className = "burette-opaque-background";
+    document.documentElement.classList.add("buret-hosted-mobile-direct");
+
+    addStylesheet("viewer-runtime.css");
+    addStylesheet("molstar.css");
+    const documentId = `hosted-${Date.now()}`;
+    jsonElement("burrete-runtime-config", {
+      format: structure.format,
+      molstarFormat: structure.format,
+      binary: false,
+      renderer: "molstar",
+      requestedRenderer: "molstar",
+      allowMolstarFallback: false,
+      label: structure.label,
+      byteCount: structure.byteCount,
+      previewByteCount: structure.byteCount,
+      quickLookBuild: "burrete-hosted-mobile-direct",
+      debug: false,
+      theme: "auto",
+      canvasBackground: "auto",
+      documentId,
+      uiScale: 0.9,
+      overlayOpacity: 0.9,
+      transparentBackground: false,
+      appViewer: true,
+      tauriViewer: false,
+      molstarStyle: "illustrative",
+      molstarPreferWebgl1: true,
+      molstarDisableAntialiasing: true,
+      molstarPixelScale: 0.75,
+      molstarPickScale: 0.75,
+      molstarResolutionMode: "scaled",
+      molstarPowerPreference: "default",
+      waterRepresentation: "line",
+      xyzrenderViewer: false,
+      xyzrenderAvailable: false,
+      molstarAvailable: true,
+      showPanelControls: true,
+      defaultLayoutState: { left: "hidden", right: "hidden", top: "hidden", bottom: "hidden" },
+    });
+    jsonElement("burrete-runtime-data", base64Utf8(structure.data));
+
+    await loadScript("viewer-shell.js");
+    await loadScript("viewer-bootstrap.js");
+    window.__mqlPost = (type, message, payload = {}) => {
+      updateSelectionContext({ type, message, ...payload, documentId });
+    };
+    await loadScript("molstar.js");
+    await loadScript("burette-agent.js");
+    await loadScript("trajectory-smoothing.js");
+    await loadScript("viewer.js");
+  }
+
+  function acceptResult(value) {
+    if (started) return;
+    const structure = structureFromResult(value);
+    if (!structure) return;
+    start(structure).catch((error) => {
+      const status = document.getElementById("status");
+      if (status) {
+        status.className = "error";
+        status.textContent = `[web] Burrete mobile renderer failed to start.\n\n${error?.message || String(error)}`;
+      }
+    });
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window.parent) return;
+    const message = record(event.data);
+    if (message?.jsonrpc === "2.0" && message.method === "ui/notifications/tool-result") {
+      acceptResult(message.params);
+    }
+  }, { passive: true });
+  window.addEventListener("openai:set_globals", (event) => {
+    const globals = event.detail?.globals;
+    if (globals?.toolOutput === undefined) return;
+    acceptResult({ structuredContent: globals.toolOutput, _meta: globals.toolResponseMetadata });
+  }, { passive: true });
+
+  const queued = Array.isArray(window.__BURRETE_HOSTED_MCP_RESULTS__)
+    ? window.__BURRETE_HOSTED_MCP_RESULTS__
+    : [];
+  if (queued.length > 0) acceptResult(queued[queued.length - 1]);
+  if (!started && window.openai?.toolOutput !== undefined) {
+    acceptResult({
+      structuredContent: window.openai.toolOutput,
+      _meta: window.openai.toolResponseMetadata,
+    });
+  }
+})();

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,10 +1,11 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v9.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v10.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-toolbar-v2";
+export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v1";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -45,6 +46,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
   const shellScript = `${assetUrl(assetOrigin, VIEWER_SHELL_SCRIPT_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const shellStyles = `${assetUrl(assetOrigin, VIEWER_SHELL_STYLES_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const viewerAssets = assetUrl(assetOrigin, VIEWER_RUNTIME_ASSETS_PATH);
+  const mobileScript = `${assetUrl(assetOrigin, VIEWER_MOBILE_SCRIPT_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const bootstrap = serializeForInlineScript({
     viewerAssets,
   });
@@ -98,7 +100,16 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" crossorigin src="${shellScript}"></script>
+    <script>
+      (() => {
+        const mobile = window.matchMedia("(max-width: 600px)").matches;
+        const script = document.createElement("script");
+        script.src = mobile ? ${serializeForInlineScript(mobileScript)} : ${serializeForInlineScript(shellScript)};
+        if (!mobile) script.type = "module";
+        script.crossOrigin = "anonymous";
+        document.body.appendChild(script);
+      })();
+    </script>
   </body>
 </html>`;
 }

--- a/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
+++ b/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
@@ -9,6 +9,8 @@ const SOURCE_VIEWER_ROOT = path.join(REPO_ROOT, "PreviewExtension/Web");
 const OUTPUT_VIEWER_ROOT = path.join(APP_ROOT, "public/burrete-viewer");
 const OUTPUT_SHELL_ROOT = path.join(APP_ROOT, "public/viewer-shell");
 const LEGACY_DEMO_ROOT = path.join(APP_ROOT, "public/demo");
+const MOBILE_VIEWER_SOURCE = path.join(APP_ROOT, "assets/burrete-hosted-mobile.js");
+const MOBILE_VIEWER_OUTPUT = path.join(APP_ROOT, "public/burrete-hosted-mobile.js");
 const VIEWER_FILES = [
   "burette-agent.js",
   "viewer-runtime.css",
@@ -36,6 +38,7 @@ await Promise.all([
     path.join(OUTPUT_VIEWER_ROOT, "rdkit"),
     { recursive: true },
   ),
+  cp(MOBILE_VIEWER_SOURCE, MOBILE_VIEWER_OUTPUT),
 ]);
 
 await run("bun", ["run", "build"], {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -12,6 +12,7 @@ import {
   createViewerResourceMeta,
   createViewerWidgetHtml,
   VIEWER_RESOURCE_URI,
+  VIEWER_MOBILE_SCRIPT_PATH,
   VIEWER_SHELL_SCRIPT_PATH,
   VIEWER_SHELL_STYLES_PATH,
 } from "../lib/widget";
@@ -86,10 +87,12 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v9.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v10.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-toolbar-v2");
+    expect(html).toContain("?v=viewer-hosted-mobile-v1");
+    expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
+    expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");
@@ -101,6 +104,20 @@ describe("viewer resource contract", () => {
     expect(html).not.toContain("molstar.Viewer");
     expect(html).not.toContain('class="metrics"');
     expect(html).not.toContain('class="header"');
+  });
+
+  test("uses a direct mobile viewer without a second iframe", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../assets/burrete-hosted-mobile.js",
+    ), "utf8");
+    expect(source).toContain('root.id = "app"');
+    expect(source).toContain('quickLookBuild: "burrete-hosted-mobile-direct"');
+    expect(source).toContain('molstarPowerPreference: "default"');
+    expect(source).toContain('molstarResolutionMode: "scaled"');
+    expect(source).toContain('method: "ui/update-model-context"');
+    expect(source).not.toContain("<iframe");
+    expect(source).not.toContain("srcdoc");
   });
 
   test("builds the stable hosted shell entry assets", () => {

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -1213,4 +1213,4 @@ assert.match(viewerJS, /M  V30 BEGIN CTAB/);
 assert.doesNotMatch(viewerJS, /BurreteXyzFastURL|xyz-fast\.js/);
 assert.match(previewRuntimeViewer, /window\.__mqlPost = \(type, message, payload\) => postToParent\(\{ type, message: message \|\| '', \.\.\.\(payload \|\| \{\}\) \}\);/);
 assert.match(viewerJS, /function isQuickLookHost\(\)/);
-assert.match(viewerJS, /powerPreference: isQuickLookHost\(\) \? 'default' : 'high-performance'/);
+assert.match(viewerJS, /powerPreference: String\(activeConfig\?\.molstarPowerPreference \|\| ''\) === 'default' \|\| isQuickLookHost\(\)/);


### PR DESCRIPTION
## Summary
- render Mol* directly in the ChatGPT app iframe on narrow mobile viewports
- remove the nested `srcdoc` WebGL boundary that fails in ChatGPT on iOS
- use a conservative mobile GPU profile and preserve lasso model-context updates
- version the widget resource as `molecular-viewer-v10.html`

## Verification
- `bun run --cwd apps/burrete-public-plugin test`
- `bun run --cwd apps/burrete-public-plugin typecheck`
- `bun run --cwd apps/burrete-public-plugin build`
- `bun tests/test-hosted-mcp-widget.mjs`
- `bun tests/test-viewer-bridge-message-contract.mjs`
- `bun tests/test-tauri-structure.mjs`
- pre-push `ci-fast`
- direct Mol*/WebGL rendering verified on the connected physical iPhone 13 Pro