### PR TITLE
Open workspace chrome in browser demo

### DIFF
--- a/apps/desktop/src/hooks/use-agent-focus-layout.ts
+++ b/apps/desktop/src/hooks/use-agent-focus-layout.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect } from "react";
 
 import { browserDevAgentFocusLayout } from "../lib/browser-dev-startup";
 import { isHostedMcpWidget } from "../lib/hosted-mcp-widget";
+import { isWebDemoWorkspace } from "../lib/web-demo-workspace";
 import { useShellStore } from "../stores/shell-store";
 
 export function useAgentFocusLayout() {
@@ -15,6 +16,13 @@ export function applyAgentFocusLayout(
   isAgentShell?: boolean,
   hostedMcpWidget = isHostedMcpWidget(),
 ) {
+  if (isWebDemoWorkspace()) {
+    const state = useShellStore.getState();
+    if (!state.sidebarOpen) state.toggleSidebar();
+    state.setDockOpen("right", true);
+    state.setDockOpen("bottom", false);
+    return true;
+  }
   if (!hostedMcpWidget && !browserDevAgentFocusLayout(search, isAgentShell)) {
     return false;
   }


### PR DESCRIPTION
## Summary
- keep the real desktop app sidebar open in web-demo mode
- open the real right dock on startup
- keep the bottom dock closed by default

## Validation
- `bun run test && bun run build` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook