### PR TITLE
Route iOS widgets to direct viewer

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -28,7 +28,7 @@ The production Streamable HTTP endpoint is
 
 Both tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v11.html` with MIME type
+`ui://burrete/molecular-viewer-v12.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The model receives only bounded structure summaries. Original molecular text

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,11 +1,11 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v11.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v12.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v2";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v3";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -102,7 +102,8 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
     <div id="root"></div>
     <script>
       (() => {
-        const mobile = window.matchMedia("(max-width: 600px)").matches;
+        const mobile = window.matchMedia("(max-width: 600px)").matches
+          || /iPhone|iPad|iPod/iu.test(navigator.userAgent);
         const script = document.createElement("script");
         script.src = mobile ? ${serializeForInlineScript(mobileScript)} : ${serializeForInlineScript(shellScript)};
         if (!mobile) script.type = "module";

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -87,12 +87,14 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v11.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v12.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-mobile-v2");
+    expect(html).toContain("?v=viewer-hosted-mobile-v3");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
+    expect(html).toContain("navigator.userAgent");
+    expect(html).toContain("iPhone|iPad|iPod");
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");


### PR DESCRIPTION
## Summary
- detect iPhone, iPad, and iPod environments independently of iframe CSS width
- route ChatGPT iOS to the direct Mol* viewer instead of the desktop shell
- bump the Apps SDK resource and asset versions to avoid stale iframe caches

## Verification
- `bun run --cwd apps/burrete-public-plugin test` (27 passed)
- `bun run --cwd apps/burrete-public-plugin typecheck`
- physical iPhone screenshot reproduced the desktop-shell placeholder before the fix