### PR TITLE
Use true black hosted viewer background

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -28,7 +28,7 @@ The production Streamable HTTP endpoint is
 
 Both tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v12.html` with MIME type
+`ui://burrete/molecular-viewer-v13.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The model receives only bounded structure summaries. Original molecular text

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -144,7 +144,7 @@
       quickLookBuild: "burrete-hosted-mobile-direct",
       debug: false,
       theme: "auto",
-      canvasBackground: "auto",
+      canvasBackground: "black",
       documentId,
       uiScale: 0.9,
       overlayOpacity: 0.9,

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,11 +1,11 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v12.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v13.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v3";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v4";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -62,7 +62,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
       html, body, #root { width: 100%; min-height: 480px; height: min(80vh, 760px); }
       body .app-shell { width: 100%; height: 100%; }
       body { margin: 0; overflow: hidden; background: #f7f7f7; }
-      @media (prefers-color-scheme: dark) { body { background: #111315; } }
+      @media (prefers-color-scheme: dark) { body { background: #000000; } }
       @media (max-width: 600px) {
         html, body, #root { min-height: 420px; height: min(76vh, 680px); }
       }

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -87,10 +87,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v12.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v13.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-mobile-v3");
+    expect(html).toContain("?v=viewer-hosted-mobile-v4");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
     expect(html).toContain("navigator.userAgent");
@@ -121,9 +121,16 @@ describe("viewer resource contract", () => {
     expect(source).toContain('molstarPixelScale: 1');
     expect(source).toContain('molstarPickScale: 1');
     expect(source).toContain('molstarResolutionMode: "native"');
+    expect(source).toContain('canvasBackground: "black"');
     expect(source).toContain('method: "ui/update-model-context"');
     expect(source).not.toContain("<iframe");
     expect(source).not.toContain("srcdoc");
+  });
+
+  test("uses a true black MCP widget background in dark mode", () => {
+    const html = createViewerWidgetHtml("https://burrete.example");
+    expect(html).toContain("background: #000000;");
+    expect(html).not.toContain("background: #111315;");
   });
 
   test("builds the stable hosted shell entry assets", () => {

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -384,6 +384,10 @@ export async function openBrowserDevMolstarContextDocument(
   contextDocument: BrowserDevMolstarContextDocument,
   preferences: ViewerPreferences,
 ): Promise<ViewerDocument> {
+  const hostedMcpWidget = contextDocument.context?.hostedMcpWidget === true;
+  const contextPreferences = hostedMcpWidget
+    ? { ...preferences, canvasBackground: "black" as const }
+    : preferences;
   const entries = (contextDocument.entries ?? [])
     .filter((entry): entry is Required<Pick<BrowserDevMolstarContextEntry, "data">> & BrowserDevMolstarContextEntry => (
       typeof entry?.data === "string" && entry.data.length > 0
@@ -402,14 +406,14 @@ export async function openBrowserDevMolstarContextDocument(
         `${label}.sdf`,
         "sdf",
         decodeUtf8(entry.bytes),
-        { ...preferences, rendererMode: "molstar" },
+        { ...contextPreferences, rendererMode: "molstar" },
         {},
       );
       return { ...document, title: label };
     }
     const config = {
-      ...browserDevContextConfig(label, entry.format, entry.bytes.length, preferences, id),
-      hostedMcpWidgetBootstrap: contextDocument.context?.hostedMcpWidget === true,
+      ...browserDevContextConfig(label, entry.format, entry.bytes.length, contextPreferences, id),
+      hostedMcpWidgetBootstrap: hostedMcpWidget,
       molstarContextFocus: contextFocus,
     };
     const virtualPath = `burrete-context://${id}`;
@@ -420,7 +424,7 @@ export async function openBrowserDevMolstarContextDocument(
       "molstar",
       entry.bytes,
       entry.bytes.length,
-      preferences,
+      contextPreferences,
       false,
       false,
       undefined,
@@ -444,9 +448,13 @@ export async function openBrowserDevMolstarContextDocument(
 
   const receptor = entries.find((entry) => entry.role === "receptor") ?? entries[0];
   const ligands = entries.filter((entry) => entry !== receptor);
-  if (ligands.length === 0) return openBrowserDevMolstarContextDocument({ label, entries: [contextDocument.entries?.[0] ?? {}] }, preferences);
+  if (ligands.length === 0) return openBrowserDevMolstarContextDocument({
+    label,
+    entries: [contextDocument.entries?.[0] ?? {}],
+    context: contextDocument.context,
+  }, contextPreferences);
   const byteCount = receptor.bytes.length + ligands.reduce((total, ligand) => total + ligand.bytes.length, 0);
-  const visuals = resolvePreviewVisuals(preferences);
+  const visuals = resolvePreviewVisuals(contextPreferences);
   const config = {
     format: receptor.format.molstarFormat,
     molstarFormat: receptor.format.molstarFormat,
@@ -460,7 +468,7 @@ export async function openBrowserDevMolstarContextDocument(
     quickLookBuild: "burrete-browser-dev-context-docking",
     debug: false,
     theme: visuals.theme,
-    themeTokens: previewThemeTokens(preferences),
+    themeTokens: previewThemeTokens(contextPreferences),
     canvasBackground: visuals.canvasBackground,
     documentId: id,
     uiScale: 0.9,
@@ -470,7 +478,7 @@ export async function openBrowserDevMolstarContextDocument(
     sdfPosePager: false,
     appViewer: true,
     tauriViewer: false,
-    molstarStyle: preferences.molstarStyle,
+    molstarStyle: contextPreferences.molstarStyle,
     waterRepresentation: "line",
     xyzrenderViewer: false,
     xyzrenderAvailable: false,
@@ -495,7 +503,7 @@ export async function openBrowserDevMolstarContextDocument(
     "molstar",
     new Uint8Array([10]),
     byteCount,
-    preferences,
+    contextPreferences,
     false,
     false,
     undefined,

--- a/tests/test-hosted-mcp-widget.mjs
+++ b/tests/test-hosted-mcp-widget.mjs
@@ -81,6 +81,19 @@ assert.equal(
 deleteBrowserDevVirtualTextDocument(contextDocument.path);
 assert.equal(readBrowserDevVirtualTextDocument(contextDocument.path), null);
 
+const hostedContextDocument = await openBrowserDevMolstarContextDocument({
+  label: "hosted-inline.pdb",
+  context: { hostedMcpWidget: true },
+  entries: [{
+    role: "structure",
+    label: "hosted-inline.pdb",
+    format: "pdb",
+    data: "ATOM      1  C   MOL A   1       0.000   0.000   0.000  1.00  0.00           C\nEND\n",
+  }],
+}, defaultPreferences);
+assert.match(hostedContextDocument.runtimePath, /"canvasBackground":"black"/);
+deleteBrowserDevVirtualTextDocument(hostedContextDocument.path);
+
 const replacementDocument = await openBrowserDevMolstarContextDocument({
   label: "inline.pdb",
   entries: [{

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5275,8 +5275,10 @@ assert.match(previewViewController, /private func presentJavaScriptExportSavePan
 assert.match(previewViewController, /let panel = NSSavePanel\(\)/);
 assert.match(previewViewController, /try data\.write\(to: url, options: \[\.atomic\]\)/);
 assert.match(browserDevDocuments, /export async function openBrowserDevMolstarContextDocument/);
+assert.match(browserDevDocuments, /const hostedMcpWidget = contextDocument\.context\?\.hostedMcpWidget === true;/);
+assert.match(browserDevDocuments, /\? \{ \.\.\.preferences, canvasBackground: "black" as const \}/);
 assert.match(browserDevDocuments, /entry\.role === "ligand" && entry\.extension === "sdf" && entry\.format\.molstarFormat === "sdf"/);
-assert.match(browserDevDocuments, /openBrowserDevTextDocument\([\s\S]*?\{ \.\.\.preferences, rendererMode: "molstar" \},[\s\S]*?\{\},[\s\S]*?\)/);
+assert.match(browserDevDocuments, /openBrowserDevTextDocument\([\s\S]*?\{ \.\.\.contextPreferences, rendererMode: "molstar" \},[\s\S]*?\{\},[\s\S]*?\)/);
 assert.match(browserDevDocuments, /return \{ \.\.\.document, title: label \};/);
 assert.match(browserDevDocuments, /molstarContextFocus: contextFocus/);
 assert.match(previewViewer, /async function applyMolstarContextFocus\(config\)/);


### PR DESCRIPTION
## Summary
- force hosted MCP viewers to use a true black Mol* canvas
- make the dark widget shell background black on web and iPhone
- version the widget resource and add regression coverage for both hosted paths

## Verification
- `bun tests/test-hosted-mcp-widget.mjs`
- `bun run --cwd apps/burrete-public-plugin test`
- `bun run --cwd apps/burrete-public-plugin typecheck`
- `bun run ci:fast`