### PR TITLE
Keep legacy samples in browser demo

### DIFF
--- a/apps/desktop/src/lib/web-demo-workspace.ts
+++ b/apps/desktop/src/lib/web-demo-workspace.ts
@@ -24,6 +24,15 @@ const MAX_FILE_BYTES = 3 * 1024 * 1024;
 const listeners = new Set<() => void>();
 const files = new Map<string, SidebarProjectStructure>();
 
+const methaneXyz = `5
+Methane
+C 0 0 0
+H 0.629 0.629 0.629
+H -0.629 -0.629 0.629
+H -0.629 0.629 -0.629
+H 0.629 -0.629 -0.629
+`;
+
 const DEMO_STRUCTURES = [
   ["proteins/1HTB.pdb", oneHtb],
   ["proteins/paired.pdb", pairedPdb],
@@ -42,6 +51,8 @@ const DEMO_STRUCTURES = [
   ["formats/mini.cif", miniCif],
   ["formats/mini.sdf", miniSdf],
   ["formats/mini.xyz", miniXyz],
+  ["structures/mini-protein.pdb", miniPdb],
+  ["structures/ligands/methane.xyz", methaneXyz],
 ] as const;
 
 export function isWebDemoWorkspace() {


### PR DESCRIPTION
## Summary
- keep the original mini protein and methane browser examples
- make the expanded demo consistently expose 20 files including README for new and returning visitors

## Validation
- `bun run test && bun run build` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook