### PR TITLE
Enable embedded browser demo and Ketcher

### DIFF
--- a/apps/burrete-public-plugin/next.config.ts
+++ b/apps/burrete-public-plugin/next.config.ts
@@ -18,6 +18,21 @@ const hostedShellCsp = [
   "form-action 'none'",
 ].join("; ");
 
+const webDemoCsp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "worker-src 'self' blob:",
+  "frame-src 'self' data: blob:",
+  "frame-ancestors 'self' https://burrete-landing.vercel.app http://127.0.0.1:* http://localhost:*",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'none'",
+].join("; ");
+
 const crossOriginAssetHeaders = [
   { key: "Access-Control-Allow-Origin", value: "*" },
   { key: "Cross-Origin-Resource-Policy", value: "cross-origin" },
@@ -35,7 +50,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/web-demo/index.html",
-        headers: [{ key: "Content-Security-Policy", value: hostedShellCsp }],
+        headers: [{ key: "Content-Security-Policy", value: webDemoCsp }],
       },
       {
         source: "/viewer-shell/:path*",

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -170,6 +170,7 @@ describe("viewer resource contract", () => {
   test("hardens the directly served shell and enables cross-origin assets", async () => {
     const headers = await nextConfig.headers?.();
     const shellDocument = headers?.find((entry) => entry.source === "/viewer-shell/index.html");
+    const webDemoDocument = headers?.find((entry) => entry.source === "/web-demo/index.html");
     const shellAssets = headers?.find((entry) => entry.source === "/viewer-shell/:path*");
     expect(shellDocument?.headers).toContainEqual({
       key: "Content-Security-Policy",
@@ -178,6 +179,14 @@ describe("viewer resource contract", () => {
     expect(shellAssets?.headers).toContainEqual({
       key: "Access-Control-Allow-Origin",
       value: "*",
+    });
+    expect(webDemoDocument?.headers).toContainEqual({
+      key: "Content-Security-Policy",
+      value: expect.stringContaining("'unsafe-eval'"),
+    });
+    expect(webDemoDocument?.headers).toContainEqual({
+      key: "Content-Security-Policy",
+      value: expect.stringContaining("frame-ancestors 'self' https://burrete-landing.vercel.app"),
     });
   });
 

--- a/apps/desktop/src/hooks/use-agent-focus-layout.ts
+++ b/apps/desktop/src/hooks/use-agent-focus-layout.ts
@@ -18,8 +18,10 @@ export function applyAgentFocusLayout(
 ) {
   if (isWebDemoWorkspace()) {
     const state = useShellStore.getState();
+    const heroEmbed = typeof window !== "undefined"
+      && new URLSearchParams(window.location.search).get("embed") === "hero";
     if (!state.sidebarOpen) state.toggleSidebar();
-    state.setDockOpen("right", true);
+    state.setDockOpen("right", !heroEmbed);
     state.setDockOpen("bottom", false);
     return true;
   }


### PR DESCRIPTION
## Summary
- allow Ketcher-required evaluation only on the public web-demo CSP
- allow the web demo to be framed by the Burrete landing page
- add a compact hero embed layout with sidebar open and right dock closed

## Validation
- `bun run test && bun run build` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook