### PR TITLE
Stabilize embedded demo startup

### DIFF
--- a/apps/desktop/src/lib/web-demo-workspace.ts
+++ b/apps/desktop/src/lib/web-demo-workspace.ts
@@ -60,11 +60,13 @@ export function isWebDemoWorkspace() {
 }
 
 export function initializeWebDemoWorkspace() {
-  if (!WEB_DEMO_ENABLED || files.size > 0) return [];
-  for (const [relativePath, text] of DEMO_STRUCTURES) {
-    registerText(`${WEB_DEMO_ROOT}/${relativePath}`, text);
+  if (!WEB_DEMO_ENABLED) return [];
+  if (files.size === 0) {
+    for (const [relativePath, text] of DEMO_STRUCTURES) {
+      registerText(`${WEB_DEMO_ROOT}/${relativePath}`, text);
+    }
+    registerText(`${WEB_DEMO_ROOT}/notes/README.md`, "# Burrete browser workspace\n\nOpen a structure or choose a local project folder.\n");
   }
-  registerText(`${WEB_DEMO_ROOT}/notes/README.md`, "# Burrete browser workspace\n\nOpen a structure or choose a local project folder.\n");
   return [`${WEB_DEMO_ROOT}/proteins/1HTB.pdb`];
 }
 


### PR DESCRIPTION
## Summary
- always return the default 1HTB sample after the demo registry has initialized
- remove the startup race between sidebar registration and initial document opening

## Validation
- `bun run test && bun run build` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook