### PR TITLE
Fix hosted preview controls and iPhone loading

### DIFF
--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -839,7 +839,7 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
   outline: none;
   background: var(--buret-menu-input-background);
 }
-body.burette-mobile-host #status {
+body.burette-mobile-host #status.hidden {
   display: none !important;
 }
 body.burette-mobile-host .buret-molecule-context-menu {

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -143,6 +143,29 @@
       <aside class="buret-preview-dock buret-preview-dock-right" data-buret-preview-dock="right" aria-label="Right dock" aria-hidden="true"></aside>
       <section class="buret-preview-dock buret-preview-dock-bottom" data-buret-preview-dock="bottom" aria-label="Bottom dock" aria-hidden="true"></section>
     `);
+    if (window.__BURRETE_HOSTED_MCP_WIDGET__ === true) {
+      const toolbar = document.getElementById('buret-toolbar');
+      const grip = toolbar?.querySelector('[data-drag-handle]');
+      if (toolbar && grip) {
+        toolbar.classList.add('collapsed');
+        document.body?.classList.add('buret-toolbar-collapsed');
+        grip.setAttribute('aria-expanded', 'false');
+        grip.setAttribute('aria-label', 'Expand controls');
+        grip.setAttribute('title', 'Expand controls');
+        const fallbackGripClick = event => {
+          event.preventDefault();
+          event.stopPropagation();
+          const collapsed = !toolbar.classList.contains('collapsed');
+          toolbar.classList.toggle('collapsed', collapsed);
+          document.body?.classList.toggle('buret-toolbar-collapsed', collapsed);
+          grip.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+          grip.setAttribute('aria-label', collapsed ? 'Expand controls' : 'Collapse controls');
+          grip.setAttribute('title', collapsed ? 'Expand controls' : 'Collapse controls');
+        };
+        window.__BURRETE_HOSTED_GRIP_FALLBACK__ = fallbackGripClick;
+        grip.addEventListener('click', fallbackGripClick);
+      }
+    }
   }
 
   window.BurreteViewerShell = { mountToolbar };

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -3883,6 +3883,10 @@
     let drag = null;
     let ignoreNextGripClick = false;
     const grip = toolbar.querySelector('[data-drag-handle]');
+    if (grip && window.__BURRETE_HOSTED_GRIP_FALLBACK__) {
+      grip.removeEventListener('click', window.__BURRETE_HOSTED_GRIP_FALLBACK__);
+      delete window.__BURRETE_HOSTED_GRIP_FALLBACK__;
+    }
     grip?.addEventListener('click', event => {
       event.preventDefault();
       event.stopPropagation();

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -28,7 +28,7 @@ The production Streamable HTTP endpoint is
 
 Both tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v14.html` with MIME type
+`ui://burrete/molecular-viewer-v15.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The model receives only bounded structure summaries. Original molecular text

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -3,6 +3,7 @@
 
   const MAX_STRUCTURE_BYTES = 3 * 1024 * 1024;
   const MAX_SELECTION_RESIDUES = 96;
+  const ASSET_LOAD_TIMEOUT_MS = 30_000;
   const SUPPORTED_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
   const assetsBase = String(window.__BURRETE_WEB_ASSETS_BASE__ || "/burrete-viewer/").replace(/\/$/u, "");
   let started = false;
@@ -53,21 +54,37 @@
     }
     return btoa(binary);
   };
+  const waitForAsset = (element, name) => new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(
+      () => reject(new Error(`Timed out loading ${name}`)),
+      ASSET_LOAD_TIMEOUT_MS,
+    );
+    element.addEventListener("load", () => {
+      window.clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+    element.addEventListener("error", () => {
+      window.clearTimeout(timeout);
+      reject(new Error(`Failed to load ${name}`));
+    }, { once: true });
+  });
   const addStylesheet = (name) => {
     const link = document.createElement("link");
     link.rel = "stylesheet";
     link.crossOrigin = "anonymous";
     link.href = `${assetsBase}/${name}`;
+    const loaded = waitForAsset(link, name);
     document.head.appendChild(link);
+    return loaded;
   };
-  const loadScript = (name) => new Promise((resolve, reject) => {
+  const loadScript = (name) => {
     const script = document.createElement("script");
     script.crossOrigin = "anonymous";
     script.src = `${assetsBase}/${name}`;
-    script.addEventListener("load", resolve, { once: true });
-    script.addEventListener("error", () => reject(new Error(`Failed to load ${name}`)), { once: true });
+    const loaded = waitForAsset(script, name);
     document.body.appendChild(script);
-  });
+    return loaded;
+  };
   const jsonElement = (id, value) => {
     const element = document.createElement("script");
     element.id = id;
@@ -124,12 +141,14 @@
     const root = document.getElementById("root");
     if (!root) throw new Error("Hosted viewer root is unavailable");
     root.id = "app";
-    root.insertAdjacentHTML("afterend", '<div id="status" class="hidden">Loading structure...</div>');
-    document.body.className = "burette-opaque-background";
+    root.insertAdjacentHTML("afterend", '<div id="status" class="loading">Loading structure...</div>');
+    document.body.className = "burette-opaque-background burette-mobile-host";
     document.documentElement.classList.add("buret-hosted-mobile-direct");
 
-    addStylesheet("viewer-runtime.css");
-    addStylesheet("molstar.css");
+    await Promise.all([
+      addStylesheet("viewer-runtime.css"),
+      addStylesheet("molstar.css"),
+    ]);
     const documentId = `hosted-${Date.now()}`;
     jsonElement("burrete-runtime-config", {
       format: structure.format,
@@ -152,18 +171,22 @@
       appViewer: true,
       tauriViewer: false,
       molstarStyle: "illustrative",
-      molstarPreferWebgl1: false,
-      molstarDisableAntialiasing: false,
-      molstarPixelScale: 1,
-      molstarPickScale: 1,
-      molstarResolutionMode: "native",
+      molstarPreferWebgl1: true,
+      molstarDisableAntialiasing: true,
+      molstarPixelScale: 0.75,
+      molstarPickScale: 0.75,
+      molstarResolutionMode: "scaled",
       molstarPowerPreference: "default",
       waterRepresentation: "line",
       xyzrenderViewer: false,
       xyzrenderAvailable: false,
       molstarAvailable: true,
-      showPanelControls: true,
-      defaultLayoutState: { left: "hidden", right: "hidden", top: "hidden", bottom: "hidden" },
+      showPanelControls: false,
+      layoutShowControls: false,
+      layoutShowSequence: false,
+      layoutShowLog: false,
+      layoutShowLeftPanel: false,
+      defaultLayoutState: { left: "hidden", right: "hidden", sequence: "hidden", log: "hidden" },
     });
     jsonElement("burrete-runtime-data", base64Utf8(structure.data));
 
@@ -186,6 +209,7 @@
       const status = document.getElementById("status");
       if (status) {
         status.className = "error";
+        status.style.setProperty("display", "block", "important");
         status.textContent = `[web] Burrete mobile renderer failed to start.\n\n${error?.message || String(error)}`;
       }
     });

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,11 +1,11 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v14.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v15.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v5";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v6";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -64,7 +64,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
       body { margin: 0; overflow: hidden; background: #f7f7f7; }
       @media (prefers-color-scheme: dark) { body { background: #000000; } }
       @media (max-width: 600px) {
-        html, body, #root { min-height: 420px; height: min(76vh, 680px); }
+        html, body, #root, #app { min-height: 0; height: 100%; }
       }
     </style>
     <script>

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -87,10 +87,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v14.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v15.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-mobile-v5");
+    expect(html).toContain("?v=viewer-hosted-mobile-v6");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
     expect(html).toContain("navigator.userAgent");
@@ -115,12 +115,18 @@ describe("viewer resource contract", () => {
     ), "utf8");
     expect(source).toContain('root.id = "app"');
     expect(source).toContain('quickLookBuild: "burrete-hosted-mobile-direct"');
+    expect(source).toContain('document.body.className = "burette-opaque-background burette-mobile-host"');
     expect(source).toContain('molstarPowerPreference: "default"');
-    expect(source).toContain('molstarPreferWebgl1: false');
-    expect(source).toContain('molstarDisableAntialiasing: false');
-    expect(source).toContain('molstarPixelScale: 1');
-    expect(source).toContain('molstarPickScale: 1');
-    expect(source).toContain('molstarResolutionMode: "native"');
+    expect(source).toContain('molstarPreferWebgl1: true');
+    expect(source).toContain('molstarDisableAntialiasing: true');
+    expect(source).toContain('molstarPixelScale: 0.75');
+    expect(source).toContain('molstarPickScale: 0.75');
+    expect(source).toContain('molstarResolutionMode: "scaled"');
+    expect(source).toContain('layoutShowControls: false');
+    expect(source).toContain('layoutShowSequence: false');
+    expect(source).toContain('layoutShowLog: false');
+    expect(source).toContain('layoutShowLeftPanel: false');
+    expect(source).toContain('await Promise.all([\n      addStylesheet("viewer-runtime.css"),\n      addStylesheet("molstar.css"),\n    ])');
     expect(source).toContain('canvasBackground: "black"');
     expect(source).toContain('method: "ui/update-model-context"');
     expect(source).not.toContain("<iframe");
@@ -130,6 +136,7 @@ describe("viewer resource contract", () => {
   test("uses a true black MCP widget background in dark mode", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
     expect(html).toContain("background: #000000;");
+    expect(html).toContain("html, body, #root, #app { min-height: 0; height: 100%; }");
     expect(html).not.toContain("background: #111315;");
   });
 

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -96,7 +96,7 @@ export function AppLayout({
       onPaste={hostedMcpWidget ? undefined : onPaste}
       style={shellStyle}
     >
-      <div className="drag-region" data-tauri-drag-region />
+      {!hostedMcpWidget && <div className="drag-region" data-tauri-drag-region />}
       {chromeVisible && (
         <>
           {!hostedMcpWidget ? (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -519,6 +519,10 @@ button:focus-visible > .shortcut-tooltip {
   border-radius: 0;
   box-shadow: none;
 }
+.app-shell[data-hosted-mcp-widget="true"] .workbench {
+  border-radius: 0;
+  box-shadow: none;
+}
 .workbench-main {
   min-width: 0;
   min-height: 0;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -505,6 +505,9 @@ assert.doesNotMatch(viewer, /message: 'open-burrete'/);
 assert.doesNotMatch(previewViewController, /open-burrete/);
 assert.doesNotMatch(previewViewController, /BurreteLauncher/);
 assert.doesNotMatch(viewerShell, /data-buret-action="open-burrete"/);
+assert.match(viewerShell, /window\.__BURRETE_HOSTED_MCP_WIDGET__ === true/);
+assert.match(viewerShell, /window\.__BURRETE_HOSTED_GRIP_FALLBACK__ = fallbackGripClick/);
+assert.match(viewer, /grip\.removeEventListener\('click', window\.__BURRETE_HOSTED_GRIP_FALLBACK__\)/);
 assert.doesNotMatch(viewerShell, /data-buret-action="xyzrender-apply"/);
 assert.match(viewerShell, /data-buret-action="xyzrender-reset"/);
 assert.match(viewerShell, /data-buret-action="xyzrender-reset-orientation"/);
@@ -1259,6 +1262,7 @@ assert.match(notificationPopup, /aria-live=\{notice\.kind === "error" \? "assert
 assert.match(notificationPopup, /compactNotificationMessage/);
 assert.match(appLayout, /const sidebarVisible = settingsMode \|\| \(!hostedMcpWidget && state\.sidebarOpen\)/);
 assert.match(appLayout, /const chromeVisible = !settingsMode && !hostedMcpWidget/);
+assert.match(appLayout, /\{!hostedMcpWidget && <div className="drag-region" data-tauri-drag-region \/>\}/);
 assert.match(appLayout, /const sidebarLayoutWidth = sidebarVisible \? sidebarWidth : 0/);
 assert.match(appLayout, /const rightDockWidth = clampRightDockWidth\(state\.rightDockWidth, viewportWidth, sidebarLayoutWidth\)/);
 assert.doesNotMatch(appLayout, /Math\.max\(360, clampedSidebarWidth\)/);
@@ -1983,6 +1987,7 @@ assert.match(styles, /\.sidebar::after \{[^}]*background: var\(--sidebar-divider
 assert.doesNotMatch(styles, /\.splitter::after \{ background: var\(--sidebar-divider-right\); \}/);
 assert.match(styles, /\.workbench \{[^}]*background: var\(--bg-base\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;[^}]*box-shadow: -12px 0 28px var\(--workspace-edge-shadow\);/s);
 assert.match(styles, /\.app-shell\[data-settings-mode="true"\] \.workbench \{[^}]*border-radius: 0;[^}]*box-shadow: none;[^}]*\}/s);
+assert.match(styles, /\.app-shell\[data-hosted-mcp-widget="true"\] \.workbench \{[^}]*border-radius: 0;[^}]*box-shadow: none;[^}]*\}/s);
 assert.doesNotMatch(styles, /\.main-stage \{[^}]*border-radius: 20px 0 0 20px;/s);
 assert.match(styles, /\.app-shell\[data-theme="auto"\] \{[^}]*color-scheme: light dark/s);
 assert.match(styles, /@media \(prefers-color-scheme: light\) \{[\s\S]*\.app-shell\[data-theme="auto"\]/);


### PR DESCRIPTION
## Summary
- remove hosted preview rounding and the invisible desktop drag layer that blocked the top edge
- keep the hosted toolbar grip interactive before Mol* finishes booting
- restore the iPhone-safe WebGL profile, wait for CSS, apply mobile layout styles, and bound asset loading
- bump the MCP widget resource to v15

## Verification
- bun tests/test-ui-shell-contract.mjs
- bun tests/test-hosted-mcp-widget.mjs
- bun run --cwd apps/burrete-public-plugin typecheck
- bun run --cwd apps/burrete-public-plugin test (28 passed)