### PR TITLE
Add model-aware hosted viewer actions

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -115,6 +115,9 @@
   let molstarLassoEnabled = false;
   let molstarLassoStroke = null;
   let molstarLassoOverlay = null;
+  const molstarLassoSelectionAtoms = new Map();
+  const molstarLassoSelectionAtomKeys = new Set();
+  const molstarLassoSelectionResidueKeys = new Set();
   let xyzrenderLassoEnabled = false;
   let xyzrenderLassoStroke = null;
   let xyzrenderLassoOverlay = null;
@@ -588,7 +591,13 @@
       return setSdfPoseIndexFromAction(action);
     }
     if (type === 'focus_selection') {
-      return window.BurreteAgent.run({ command: 'focusSelection', args: action.args || {} });
+      return window.BurreteAgent.run({
+        command: 'focusSelection',
+        args: {
+          ...(action.args || {}),
+          selector: action.selector || action.args?.selector || 'last'
+        }
+      });
     }
     if (type === 'label_selection') {
       return window.BurreteAgent.run({
@@ -757,6 +766,72 @@
       }, '*');
     })();
   });
+
+  window.BurreteViewerActions = { run: executeBurreteAgentAction };
+
+  let hostedMcpActionsApplied = false;
+  function hostedMcpSelectionFromResults(actions, results) {
+    let selection = null;
+    for (let index = 0; index < actions.length; index++) {
+      const action = actions[index];
+      const result = results[index];
+      if (action?.type === 'clear_selection' && result?.ok !== false) selection = null;
+      if (action?.type !== 'select_residues' || result?.ok === false) continue;
+      const details = result?.result || {};
+      const residues = Array.isArray(details.residuesPreview)
+        ? details.residuesPreview.slice(0, 96).map(residue => ({
+          chain: String(residue.auth_asym_id || residue.label_asym_id || ''),
+          sequence: residue.auth_seq_id ?? residue.label_seq_id ?? null,
+          compId: String(residue.auth_comp_id || residue.label_comp_id || '')
+        }))
+        : [];
+      selection = {
+        source: 'agent',
+        label: String(action.label || `Agent selection: ${Number(details.counts?.atoms) || 0} atoms across ${residues.length} residues`),
+        atoms: Math.max(0, Number(details.counts?.atoms) || 0),
+        residues,
+        atomIdentities: []
+      };
+    }
+    return selection;
+  }
+
+  async function applyHostedMcpActions() {
+    if (hostedMcpActionsApplied) return;
+    const requestedActions = Array.isArray(window.BurreteConfig?.hostedMcpActions)
+      ? window.BurreteConfig.hostedMcpActions.slice(0, 8)
+      : [];
+    if (!requestedActions.length) return;
+    hostedMcpActionsApplied = true;
+    try {
+      await window.BurreteHostedAppBridge?.ready;
+      const actions = window.BurreteHostedAppBridge?.sanitizeViewerActions?.(requestedActions) || [];
+      if (actions.length !== requestedActions.length) {
+        throw new Error('Hosted scene contained an action outside the public Burrete allowlist.');
+      }
+      await window.BurreteAgent?.ready;
+      const results = [];
+      for (const action of actions) results.push(await executeBurreteAgentAction(action));
+      window.__mqlPost?.('sceneActionsApplied', '', {
+        report: {
+          revision: Date.now(),
+          documentId: String(window.BurreteConfig?.documentId || 'active-structure'),
+          selection: hostedMcpSelectionFromResults(actions, results),
+          results
+        }
+      });
+    } catch (error) {
+      window.__mqlPost?.('sceneActionsApplied', '', {
+        report: {
+          revision: Date.now(),
+          results: [agentActionFailure('hosted_scene', 'ACTION_ERROR', error?.message || String(error))]
+        }
+      });
+    }
+  }
+
+  window.addEventListener('burette-agent-ready', () => { void applyHostedMcpActions(); }, { once: true });
+  void applyHostedMcpActions();
 
   function agentActionFailure(command, code, message) {
     return {
@@ -8613,6 +8688,12 @@
     if (!cleared) {
       return sceneActionFailure('clear_selection', 'NOT_IMPLEMENTED', 'Mol* selection managers are unavailable.');
     }
+    molstarLassoSelectionAtoms.clear();
+    molstarLassoSelectionAtomKeys.clear();
+    molstarLassoSelectionResidueKeys.clear();
+    window.__mqlPost?.('selectionChanged', '', {
+      selection: { source: 'viewer', cleared: true, atoms: 0, residues: [], atomIdentities: [] }
+    });
     return { ok: true, command: 'clear_selection', result: { cleared: true } };
   }
 
@@ -10626,6 +10707,9 @@
     if (!additive) {
       selects?.deselectAll?.();
       selection?.clear?.();
+      molstarLassoSelectionAtoms.clear();
+      molstarLassoSelectionAtomKeys.clear();
+      molstarLassoSelectionResidueKeys.clear();
     }
     let selected = 0;
     for (const pick of picks) {
@@ -10643,9 +10727,6 @@
   }
 
   function notifyMolstarLassoSelection(picks, selected) {
-    const atoms = [];
-    const atomKeys = new Set();
-    const residues = new Map();
     for (const pick of picks) {
       const atom = molstarContextAtomFromLoci(pick?.loci);
       if (!atom) continue;
@@ -10654,10 +10735,16 @@
       const compId = String(atom.auth_comp_id || atom.label_comp_id || '').trim();
       const atomName = String(atom.auth_atom_id || atom.label_atom_id || '').trim();
       const atomKey = `${chain}:${sequence ?? ''}:${compId}:${atomName}:${atom.atomIndex ?? ''}`;
-      if (!atomKeys.has(atomKey)) {
-        atomKeys.add(atomKey);
-        atoms.push({ chain, sequence, compId, atomName });
+      molstarLassoSelectionAtomKeys.add(atomKey);
+      molstarLassoSelectionResidueKeys.add(`${chain}:${sequence ?? ''}:${compId}`);
+      if (!molstarLassoSelectionAtoms.has(atomKey) && molstarLassoSelectionAtoms.size < 96) {
+        molstarLassoSelectionAtoms.set(atomKey, { chain, sequence, compId, atomName });
       }
+    }
+    const atoms = Array.from(molstarLassoSelectionAtoms.values());
+    const residues = new Map();
+    for (const atom of atoms) {
+      const { chain, sequence, compId } = atom;
       const residueKey = `${chain}:${sequence ?? ''}:${compId}`;
       if (!residues.has(residueKey) && residues.size < 96) {
         residues.set(residueKey, { chain, sequence, compId });
@@ -10666,10 +10753,12 @@
     window.__mqlPost?.('selectionChanged', '', {
       selection: {
         source: 'lasso',
-        label: `Lasso selection: ${atoms.length} visible atom${atoms.length === 1 ? '' : 's'} across ${residues.size} residue${residues.size === 1 ? '' : 's'}`,
-        atoms: atoms.length,
+        label: `Lasso selection: ${molstarLassoSelectionAtomKeys.size} visible atom${molstarLassoSelectionAtomKeys.size === 1 ? '' : 's'} across ${molstarLassoSelectionResidueKeys.size} residue${molstarLassoSelectionResidueKeys.size === 1 ? '' : 's'}`,
+        atoms: molstarLassoSelectionAtomKeys.size,
+        residueCount: molstarLassoSelectionResidueKeys.size,
         visibleTargets: selected,
-        residues: Array.from(residues.values())
+        residues: Array.from(residues.values()),
+        atomIdentities: atoms
       }
     });
   }

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -19,17 +19,24 @@ the root URL redirects to the public plugin documentation.
 ## MCP contract
 
 The production Streamable HTTP endpoint is
-<https://burrete-plugin.vercel.app/mcp>. It exposes two no-auth tools:
+<https://burrete-plugin.vercel.app/mcp>. It exposes three no-auth tools:
 
 | Tool | Behavior |
 | --- | --- |
 | `preview_molecular_file` | Reads one ChatGPT-authorized PDB, ENT, PDBQT, CIF, mmCIF, SDF, SD, XYZ, or extXYZ attachment. |
 | `preview_pdb_structure` | Retrieves one public RCSB structure from an explicit four-character PDB ID. |
+| `render_molecular_scene` | Re-renders one PDB entry or authorized attachment with bounded select, focus, clear, reset, and component visibility actions. |
 
-Both tools are read-only, idempotent, non-destructive, and cannot write to the
+All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v15.html` with MIME type
+`ui://burrete/molecular-viewer-v16.html` with MIME type
 `text/html;profile=mcp-app`.
+
+The widget uses the MCP Apps handshake before publishing bounded selection or
+scene state through `ui/update-model-context`. Lasso selection includes up to
+96 atom identities and residues, and clearing the selection explicitly clears
+the model-visible state. Viewer actions run client-side in the isolated widget;
+the server does not persist a shared molecular workspace.
 
 The model receives only bounded structure summaries. Original molecular text
 is placed in tool-result `_meta`, which is delivered to the viewer but hidden

--- a/apps/burrete-public-plugin/app/mcp/route.ts
+++ b/apps/burrete-public-plugin/app/mcp/route.ts
@@ -8,6 +8,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { z } from "zod/v4";
 import {
   fileReferenceSchema,
+  molecularSceneInputSchema,
   exposeNoauthSecuritySchemes,
   NOAUTH_SECURITY_SCHEMES,
   NOAUTH_TOOL_SECURITY,
@@ -110,7 +111,57 @@ function createServer(): McpServer {
             },
           ],
           structuredContent: prepared.summary,
-          _meta: { structure: prepared.viewer },
+          _meta: {
+            structure: prepared.viewer,
+            scene: {
+              source: { kind: "attachment", fileName: prepared.summary.fileName },
+              actions: [],
+            },
+          },
+        };
+      } catch (error) {
+        return toolError(error);
+      }
+    },
+  );
+
+  registerAppTool(
+    server,
+    "render_molecular_scene",
+    {
+      title: "Render a molecular scene",
+      description:
+        "Use this when the user asks to select or focus part of a structure, clear the selection, reset the camera, or hide/show polymers, ligands, ions, or water. Re-render the PDB entry or authorized attachment with up to eight allowlisted viewer actions.",
+      inputSchema: molecularSceneInputSchema,
+      outputSchema: publicStructureOutputSchema,
+      annotations: TOOL_ANNOTATIONS,
+      ...NOAUTH_TOOL_SECURITY,
+      _meta: {
+        ...viewerToolMeta("Preparing molecular scene…", "Molecular scene ready"),
+        "openai/fileParams": ["structureFile"],
+      },
+    },
+    async (input) => {
+      try {
+        const prepared = input.source === "pdb"
+          ? await preparePdbStructure(input.pdbId)
+          : await prepareAttachedStructure(input.structureFile);
+        const sourceDescriptor = input.source === "pdb"
+          ? { kind: "pdb", pdbId: input.pdbId.toUpperCase() }
+          : {
+              kind: "attachment",
+              fileName: input.structureFile.file_name ?? prepared.summary.fileName,
+            };
+        return {
+          content: [{
+            type: "text" as const,
+            text: `${prepared.summary.summaryLine} ${input.actions.length} viewer action${input.actions.length === 1 ? " was" : "s were"} requested; the widget will report which actions were applied.`,
+          }],
+          structuredContent: prepared.summary,
+          _meta: {
+            structure: prepared.viewer,
+            scene: { source: sourceDescriptor, actions: input.actions },
+          },
         };
       } catch (error) {
         return toolError(error);
@@ -148,7 +199,13 @@ function createServer(): McpServer {
             },
           ],
           structuredContent: prepared.summary,
-          _meta: { structure: prepared.viewer },
+          _meta: {
+            structure: prepared.viewer,
+            scene: {
+              source: { kind: "pdb", pdbId: pdbId.toUpperCase() },
+              actions: [],
+            },
+          },
         };
       } catch (error) {
         return toolError(error);

--- a/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
@@ -1,0 +1,67 @@
+import { App, type McpUiUpdateModelContextRequest } from "@modelcontextprotocol/ext-apps";
+import {
+  createSceneContext,
+  createSelectionContext,
+  sanitizeViewerActions,
+} from "../lib/hosted-context";
+
+declare global {
+  interface Window {
+    BurreteHostedAppBridge?: {
+      ready: Promise<boolean>;
+      setSource: (source: unknown) => void;
+      updateSelection: (selection: unknown, documentId: string) => Promise<boolean>;
+      updateScene: (report: unknown) => Promise<boolean>;
+      sanitizeViewerActions: (actions: unknown) => Record<string, unknown>[];
+    };
+    __BURRETE_HOSTED_APP_QUEUE__?: Array<{ method: string; args: unknown[] }>;
+    __BURRETE_HOSTED_APP_READY__?: (ready: boolean) => void;
+  }
+}
+
+const app = new App(
+  { name: "burrete-molecular-viewer", version: "0.1.0" },
+  {},
+  { autoResize: true, strict: true },
+);
+
+let sourceDescriptor: unknown;
+let connected = false;
+const ready = app.connect().then(() => {
+  connected = true;
+  return app.getHostCapabilities()?.updateModelContext !== undefined;
+}).catch((error) => {
+  console.error("Burrete Apps bridge initialization failed", error);
+  return false;
+});
+
+async function updateModelContext(params: McpUiUpdateModelContextRequest["params"]) {
+  if (!(await ready) || !connected) return false;
+  await app.updateModelContext(params);
+  return true;
+}
+
+const queuedCalls = Array.isArray(window.__BURRETE_HOSTED_APP_QUEUE__)
+  ? window.__BURRETE_HOSTED_APP_QUEUE__.splice(0)
+  : [];
+const bridge = {
+  setSource(source: unknown) {
+    sourceDescriptor = source;
+  },
+  updateSelection(selection: unknown, documentId: string) {
+    return updateModelContext(createSelectionContext(selection, documentId, sourceDescriptor));
+  },
+  updateScene(report: unknown) {
+    return updateModelContext(createSceneContext(report, sourceDescriptor));
+  },
+  sanitizeViewerActions,
+  ready,
+};
+window.BurreteHostedAppBridge = bridge;
+for (const call of queuedCalls) {
+  if (call.method === "setSource") bridge.setSource(call.args[0]);
+  else if (call.method === "updateSelection") {
+    void bridge.updateSelection(call.args[0], String(call.args[1] || "active-structure"));
+  } else if (call.method === "updateScene") void bridge.updateScene(call.args[0]);
+}
+window.__BURRETE_HOSTED_APP_READY__?.(true);

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -2,12 +2,10 @@
   "use strict";
 
   const MAX_STRUCTURE_BYTES = 3 * 1024 * 1024;
-  const MAX_SELECTION_RESIDUES = 96;
   const ASSET_LOAD_TIMEOUT_MS = 30_000;
   const SUPPORTED_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
   const assetsBase = String(window.__BURRETE_WEB_ASSETS_BASE__ || "/burrete-viewer/").replace(/\/$/u, "");
   let started = false;
-  let selectionRequestId = 0;
 
   const record = (value) => value && typeof value === "object" ? value : null;
   const bounded = (value, fallback = "") => {
@@ -34,7 +32,9 @@
   };
   const structureFromResult = (value) => {
     const result = record(value);
-    const structure = record(resultMetadata(result)?.structure);
+    const metadata = resultMetadata(result);
+    const structure = record(metadata?.structure);
+    const scene = record(metadata?.scene);
     const data = typeof structure?.data === "string" ? structure.data : "";
     const format = normalizedFormat(structure?.format);
     const byteCount = new TextEncoder().encode(data).length;
@@ -44,6 +44,10 @@
       format,
       byteCount,
       label: bounded(structure?.label, bounded(record(result?.structuredContent)?.fileName, "Molecular structure")),
+      source: record(scene?.source),
+      actions: Array.isArray(scene?.actions)
+        ? scene.actions.slice(0, 8).map(record).filter(Boolean)
+        : [],
     };
   };
   const base64Utf8 = (text) => {
@@ -93,46 +97,15 @@
     document.head.appendChild(element);
   };
 
-  function updateSelectionContext(body) {
-    const selection = record(body?.selection);
-    if (body?.type !== "selectionChanged" || selection?.source !== "lasso") return;
-    const residues = Array.isArray(selection.residues)
-      ? selection.residues.slice(0, MAX_SELECTION_RESIDUES).map((value) => {
-        const residue = record(value) || {};
-        return {
-          chain: bounded(residue.chain),
-          compId: bounded(residue.compId),
-          sequence: typeof residue.sequence === "number" || typeof residue.sequence === "string"
-            ? residue.sequence
-            : null,
-        };
-      })
-      : [];
-    const atoms = Math.max(0, Math.trunc(Number(selection.atoms) || 0));
-    const label = bounded(selection.label, `Lasso selection with ${atoms} visible atoms across ${residues.length} residues`);
-    selectionRequestId += 1;
-    window.parent.postMessage({
-      jsonrpc: "2.0",
-      id: `burrete-selection-context-${selectionRequestId}`,
-      method: "ui/update-model-context",
-      params: {
-        content: [{
-          type: "text",
-          text: `Current Burrete selection: ${label}. Treat this as the user's active molecular selection for their next request.`,
-        }],
-        structuredContent: {
-          burrete: {
-            activeSelection: {
-              source: "lasso",
-              documentId: bounded(body.documentId, "active-structure"),
-              label,
-              atoms,
-              residues,
-            },
-          },
-        },
-      },
-    }, "*");
+  function updateHostedContext(body) {
+    const bridge = window.BurreteHostedAppBridge;
+    if (!bridge) return;
+    if (body?.type === "selectionChanged") {
+      void bridge.updateSelection(record(body.selection), bounded(body.documentId, "active-structure"));
+    }
+    if (body?.type === "sceneActionsApplied") {
+      void bridge.updateScene(record(body.report));
+    }
   }
 
   async function start(structure) {
@@ -186,14 +159,17 @@
       layoutShowSequence: false,
       layoutShowLog: false,
       layoutShowLeftPanel: false,
+      hostedMcpActions: structure.actions,
       defaultLayoutState: { left: "hidden", right: "hidden", sequence: "hidden", log: "hidden" },
     });
     jsonElement("burrete-runtime-data", base64Utf8(structure.data));
 
     await loadScript("viewer-shell.js");
     await loadScript("viewer-bootstrap.js");
+    window.BurreteHostedAppBridge?.setSource(structure.source);
+    void window.BurreteHostedAppBridge?.updateSelection(null, documentId);
     window.__mqlPost = (type, message, payload = {}) => {
-      updateSelectionContext({ type, message, ...payload, documentId });
+      updateHostedContext({ type, message, ...payload, documentId });
     };
     await loadScript("molstar.js");
     await loadScript("burette-agent.js");

--- a/apps/burrete-public-plugin/chatgpt-app-submission.json
+++ b/apps/burrete-public-plugin/chatgpt-app-submission.json
@@ -31,6 +31,18 @@
         "open_world_justification": "Reads public structure data without writing to RCSB or any other external system.",
         "destructive_justification": "Cannot delete, overwrite, send, revoke, or perform another irreversible action."
       }
+    },
+    "render_molecular_scene": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Only re-renders one explicitly supplied structure with bounded client-side viewer actions and does not save a workspace.",
+        "open_world_justification": "Viewer actions affect only the isolated result widget and do not write to RCSB or another external system.",
+        "destructive_justification": "Cannot modify the source file, persist a molecular edit, or perform an irreversible external action."
+      }
     }
   },
   "test_cases": [
@@ -65,13 +77,11 @@
       "expected_output_url": null
     },
     {
-      "description": "Preview an attached XYZ geometry.",
-      "user_prompt": "Visualize this XYZ geometry and report its atom and element counts.",
-      "file_attachment_urls": [
-        "https://raw.githubusercontent.com/SergeiNikolenko/Burrete/main/samples/mini.xyz"
-      ],
-      "tools_triggered": "preview_molecular_file",
-      "expected_output": "Returns bounded XYZ atom and element counts and opens the geometry in the interactive viewer.",
+      "description": "Select and focus a residue range in a public PDB scene.",
+      "user_prompt": "Open PDB 1CRN, select residues 10 through 20 in chain A, focus that selection, and hide water.",
+      "file_attachment_urls": null,
+      "tools_triggered": "render_molecular_scene",
+      "expected_output": "Re-renders 1CRN, selects and focuses the requested chain A residue range, hides water, and reports the bounded client-side action results.",
       "expected_output_url": null
     },
     {

--- a/apps/burrete-public-plugin/lib/contracts.ts
+++ b/apps/burrete-public-plugin/lib/contracts.ts
@@ -100,6 +100,61 @@ export const fileReferenceSchema = z.object({
   file_name: z.string().min(1).max(255).optional(),
 });
 
+export const viewerSelectorSchema = z.object({
+  kind: z.enum(["all", "polymer", "protein", "nucleic", "ligand", "ion", "water"]).optional(),
+  auth_asym_id: z.string().trim().min(1).max(32).optional(),
+  label_asym_id: z.string().trim().min(1).max(32).optional(),
+  auth_comp_id: z.string().trim().min(1).max(16).optional(),
+  label_comp_id: z.string().trim().min(1).max(16).optional(),
+  auth_seq_id: z.number().int().optional(),
+  label_seq_id: z.number().int().optional(),
+  beg_auth_seq_id: z.number().int().optional(),
+  end_auth_seq_id: z.number().int().optional(),
+  beg_label_seq_id: z.number().int().optional(),
+  end_label_seq_id: z.number().int().optional(),
+}).strict();
+
+const selectActionSchema = z.object({
+  type: z.literal("select_residues"),
+  selector: viewerSelectorSchema,
+  mode: z.literal("replace").optional(),
+  granularity: z.enum(["atom", "residue", "chain"]).optional(),
+  label: z.string().trim().max(128).optional(),
+}).strict();
+
+const focusActionSchema = z.object({
+  type: z.literal("focus_selection"),
+  selector: viewerSelectorSchema.optional(),
+}).strict();
+
+const visibilityActionSchema = z.object({
+  type: z.enum(["hide_components", "show_components"]),
+  kind: z.enum(["polymer", "ligand", "ion", "water"]),
+}).strict();
+
+export const viewerActionSchema = z.discriminatedUnion("type", [
+  selectActionSchema,
+  focusActionSchema,
+  visibilityActionSchema,
+  z.object({ type: z.literal("clear_selection") }).strict(),
+  z.object({ type: z.literal("reset_camera") }).strict(),
+]);
+
+const sceneActionsSchema = z.array(viewerActionSchema).min(1).max(8);
+
+export const molecularSceneInputSchema = z.discriminatedUnion("source", [
+  z.object({
+    source: z.literal("pdb"),
+    pdbId: z.string().trim().regex(/^[0-9][A-Za-z0-9]{3}$/u),
+    actions: sceneActionsSchema,
+  }).strict(),
+  z.object({
+    source: z.literal("attachment"),
+    structureFile: fileReferenceSchema,
+    actions: sceneActionsSchema,
+  }).strict(),
+]);
+
 export function viewerToolMeta(invoking: string, invoked: string) {
   return {
     securitySchemes: NOAUTH_SECURITY_SCHEMES,

--- a/apps/burrete-public-plugin/lib/hosted-context.ts
+++ b/apps/burrete-public-plugin/lib/hosted-context.ts
@@ -1,0 +1,189 @@
+const MAX_ITEMS = 96;
+const MAX_TEXT = 255;
+
+type UnknownRecord = Record<string, unknown>;
+
+function record(value: unknown): UnknownRecord | null {
+  return value && typeof value === "object" ? value as UnknownRecord : null;
+}
+
+function bounded(value: unknown, fallback = ""): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  return (text || fallback).slice(0, MAX_TEXT);
+}
+
+function boundedSource(value: unknown) {
+  const source = record(value);
+  if (source?.kind === "pdb") {
+    return { kind: "pdb", pdbId: bounded(source.pdbId).slice(0, 4) };
+  }
+  if (source?.kind === "attachment") {
+    return { kind: "attachment", fileName: bounded(source.fileName) };
+  }
+  return null;
+}
+
+const SELECTOR_STRING_KEYS = new Set([
+  "kind", "auth_asym_id", "label_asym_id", "auth_comp_id", "label_comp_id",
+]);
+const SELECTOR_NUMBER_KEYS = new Set([
+  "auth_seq_id", "label_seq_id", "beg_auth_seq_id", "end_auth_seq_id",
+  "beg_label_seq_id", "end_label_seq_id",
+]);
+const SELECTOR_KINDS = new Set(["all", "polymer", "protein", "nucleic", "ligand", "ion", "water"]);
+const COMPONENT_KINDS = new Set(["polymer", "ligand", "ion", "water"]);
+
+function sanitizedSelector(value: unknown) {
+  const selector = record(value);
+  if (!selector) return null;
+  const keys = Object.keys(selector);
+  if (keys.some((key) => !SELECTOR_STRING_KEYS.has(key) && !SELECTOR_NUMBER_KEYS.has(key))) return null;
+  const out: UnknownRecord = {};
+  for (const key of keys) {
+    const field = selector[key];
+    if (SELECTOR_STRING_KEYS.has(key)) {
+      const text = bounded(field);
+      if (!text || (key === "kind" && !SELECTOR_KINDS.has(text))) return null;
+      out[key] = text;
+    } else {
+      const number = Number(field);
+      if (!Number.isSafeInteger(number)) return null;
+      out[key] = number;
+    }
+  }
+  return out;
+}
+
+export function sanitizeViewerActions(value: unknown): UnknownRecord[] {
+  if (!Array.isArray(value)) return [];
+  const actions: UnknownRecord[] = [];
+  for (const item of value.slice(0, 8)) {
+    const action = record(item);
+    const type = typeof action?.type === "string" ? action.type : "";
+    if ((type === "clear_selection" || type === "reset_camera") && Object.keys(action ?? {}).length === 1) {
+      actions.push({ type });
+      continue;
+    }
+    if (type === "hide_components" || type === "show_components") {
+      if (Object.keys(action ?? {}).some((key) => key !== "type" && key !== "kind")) continue;
+      const kind = typeof action?.kind === "string" ? action.kind : "";
+      if (COMPONENT_KINDS.has(kind)) actions.push({ type, kind });
+      continue;
+    }
+    if (type === "select_residues") {
+      if (Object.keys(action ?? {}).some((key) => !["type", "selector", "mode", "granularity", "label"].includes(key))) continue;
+      const selector = sanitizedSelector(action?.selector);
+      const granularity = action?.granularity;
+      if (
+        !selector
+        || (action?.mode != null && action.mode !== "replace")
+        || (granularity != null && !["atom", "residue", "chain"].includes(String(granularity)))
+      ) continue;
+      actions.push({
+        type,
+        selector,
+        mode: "replace",
+        ...(granularity == null ? {} : { granularity: String(granularity) }),
+        ...(typeof action?.label === "string" ? { label: bounded(action.label).slice(0, 128) } : {}),
+      });
+      continue;
+    }
+    if (type === "focus_selection") {
+      if (Object.keys(action ?? {}).some((key) => key !== "type" && key !== "selector")) continue;
+      const selector = action?.selector == null ? undefined : sanitizedSelector(action.selector);
+      if (action?.selector != null && !selector) continue;
+      actions.push({ type, ...(selector ? { selector } : {}) });
+    }
+  }
+  return actions;
+}
+
+function boundedIdentity(value: unknown) {
+  const atom = record(value) ?? {};
+  return {
+    chain: bounded(atom.chain),
+    sequence: typeof atom.sequence === "number"
+      ? atom.sequence
+      : typeof atom.sequence === "string"
+        ? bounded(atom.sequence)
+        : null,
+    compId: bounded(atom.compId),
+    atomName: bounded(atom.atomName),
+  };
+}
+
+export function createSelectionContext(value: unknown, documentId: string, source?: unknown) {
+  const selection = record(value);
+  const sourceDescriptor = boundedSource(source);
+  if (!selection || selection.cleared === true) {
+    return {
+      content: [{ type: "text" as const, text: "The active Burrete molecular selection is empty." }],
+      structuredContent: { burrete: { source: sourceDescriptor, activeSelection: null } },
+    };
+  }
+  const residues = Array.isArray(selection.residues)
+    ? selection.residues.slice(0, MAX_ITEMS).map(boundedIdentity).map(({ atomName: _, ...residue }) => residue)
+    : [];
+  const atomIdentities = Array.isArray(selection.atomIdentities)
+    ? selection.atomIdentities.slice(0, MAX_ITEMS).map(boundedIdentity)
+    : [];
+  const atoms = Math.max(0, Math.trunc(Number(selection.atoms) || atomIdentities.length));
+  const label = bounded(selection.label, `Selection with ${atoms} visible atoms across ${residues.length} residues`);
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Current Burrete selection: ${label}. Treat this as the user's active molecular selection for their next request.`,
+    }],
+    structuredContent: {
+      burrete: {
+        source: sourceDescriptor,
+        activeSelection: {
+          source: bounded(selection.source, "viewer"),
+          documentId: bounded(documentId, "active-structure"),
+          label,
+          atoms,
+          residueCount: Math.max(0, Math.trunc(Number(selection.residueCount) || residues.length)),
+          visibleTargets: Math.max(0, Math.trunc(Number(selection.visibleTargets) || 0)),
+          residues,
+          atomIdentities,
+        },
+      },
+    },
+  };
+}
+
+export function createSceneContext(value: unknown, source?: unknown) {
+  const report = record(value) ?? {};
+  const selectionContext = createSelectionContext(
+    report.selection,
+    bounded(report.documentId, "active-structure"),
+    source,
+  );
+  const results = Array.isArray(report.results)
+    ? report.results.slice(0, 8).map((entry) => {
+      const result = record(entry) ?? {};
+      const error = record(result.error);
+      return {
+        ok: result.ok === true,
+        command: bounded(result.command, "unknown"),
+        error: error ? bounded(error.message, "Action failed") : null,
+      };
+    })
+    : [];
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Burrete applied ${results.filter((result) => result.ok).length} of ${results.length} requested viewer actions.`,
+    }],
+    structuredContent: {
+      burrete: {
+        source: boundedSource(source),
+        activeSelection: selectionContext.structuredContent.burrete.activeSelection,
+        scene: {
+          revision: Math.max(0, Math.trunc(Number(report.revision) || 0)),
+          results,
+        },
+      },
+    },
+  };
+}

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,11 +1,12 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v15.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v16.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.css";
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-mobile-v6";
+export const VIEWER_APP_BRIDGE_SCRIPT_PATH = "/burrete-hosted-app.js";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-state-v1";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -47,6 +48,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
   const shellStyles = `${assetUrl(assetOrigin, VIEWER_SHELL_STYLES_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const viewerAssets = assetUrl(assetOrigin, VIEWER_RUNTIME_ASSETS_PATH);
   const mobileScript = `${assetUrl(assetOrigin, VIEWER_MOBILE_SCRIPT_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
+  const appBridgeScript = `${assetUrl(assetOrigin, VIEWER_APP_BRIDGE_SCRIPT_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const bootstrap = serializeForInlineScript({
     viewerAssets,
   });
@@ -73,6 +75,22 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         window.__BURRETE_HOSTED_MCP_WIDGET__ = true;
         window.__BURRETE_WEB_ASSETS_BASE__ = config.viewerAssets;
         window.__BURRETE_HOSTED_MCP_RESULTS__ = [];
+        const appQueue = [];
+        const appReady = new Promise((resolve) => { window.__BURRETE_HOSTED_APP_READY__ = resolve; });
+        window.__BURRETE_HOSTED_APP_QUEUE__ = appQueue;
+        window.BurreteHostedAppBridge = {
+          ready: appReady,
+          setSource: (...args) => { appQueue.push({ method: "setSource", args }); },
+          updateSelection: (...args) => {
+            appQueue.push({ method: "updateSelection", args });
+            return appReady;
+          },
+          updateScene: (...args) => {
+            appQueue.push({ method: "updateScene", args });
+            return appReady;
+          },
+          sanitizeViewerActions: () => [],
+        };
         window.addEventListener("message", (event) => {
           if (event.source !== window.parent) return;
           const message = event.data;
@@ -97,6 +115,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         }, { passive: true });
       })();
     </script>
+    <script type="module" crossorigin src="${appBridgeScript}"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
+++ b/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
@@ -12,6 +12,8 @@ const OUTPUT_WEB_DEMO_ROOT = path.join(APP_ROOT, "public/web-demo");
 const LEGACY_DEMO_ROOT = path.join(APP_ROOT, "public/demo");
 const MOBILE_VIEWER_SOURCE = path.join(APP_ROOT, "assets/burrete-hosted-mobile.js");
 const MOBILE_VIEWER_OUTPUT = path.join(APP_ROOT, "public/burrete-hosted-mobile.js");
+const HOSTED_APP_SOURCE = path.join(APP_ROOT, "assets/burrete-hosted-app.ts");
+const HOSTED_APP_OUTPUT = path.join(APP_ROOT, "public/burrete-hosted-app.js");
 const VIEWER_FILES = [
   "burette-agent.js",
   "viewer-runtime.css",
@@ -42,6 +44,18 @@ await Promise.all([
   ),
   cp(MOBILE_VIEWER_SOURCE, MOBILE_VIEWER_OUTPUT),
 ]);
+
+await run("bun", [
+  "build",
+  HOSTED_APP_SOURCE,
+  "--outfile",
+  HOSTED_APP_OUTPUT,
+  "--target",
+  "browser",
+  "--format",
+  "iife",
+  "--minify",
+], { cwd: REPO_ROOT, env: process.env });
 
 await run("bun", ["run", "build"], {
   cwd: path.join(REPO_ROOT, "apps/desktop"),

--- a/apps/burrete-public-plugin/submission/skills/preview-molecular-structures/SKILL.md
+++ b/apps/burrete-public-plugin/submission/skills/preview-molecular-structures/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preview-molecular-structures
-description: Preview supported molecular attachments or an explicit public PDB ID in Burrete's interactive 3D viewer. Use when the user asks to inspect a molecular structure visually.
+description: Preview and inspect supported molecular attachments or an explicit public PDB ID in Burrete's interactive 3D viewer. Use when the user asks to view, select, focus, hide, or show molecular structure components.
 ---
 
 # Preview molecular structures
@@ -13,6 +13,10 @@ Use Burrete for read-only molecular structure inspection.
   structure attachment.
 - Use `preview_pdb_structure` only when the user explicitly names a
   four-character PDB ID or clearly asks to open that public PDB entry.
+- Use `render_molecular_scene` when the user asks to select or focus a typed
+  chain, residue range, or component; clear a selection; reset the camera; or
+  hide/show polymers, ligands, ions, or water. Pass the same PDB ID or authorized
+  attachment again because the public server does not retain widget sessions.
 - If several supported attachments are present and the target is unclear, ask
   which single structure to open.
 
@@ -25,6 +29,9 @@ Use Burrete for read-only molecular structure inspection.
    The user can rotate, zoom, select residues, inspect the sequence, change
    representations, and use measurements directly in the result.
 4. State format limitations or parser notes when the result includes them.
+5. Treat `burrete.activeSelection` from widget context as the user's current
+   selection. Do not claim an action succeeded until the widget reports its
+   bounded scene result.
 
 ## Boundaries
 
@@ -38,3 +45,5 @@ Use Burrete for read-only molecular structure inspection.
   other sensitive identifiers.
 - Files larger than 3 MiB or unsupported formats need a smaller supported
   structure file.
+- Arbitrary residue isolation and persistent representation overpaint are not
+  available in the hosted action allowlist.

--- a/apps/burrete-public-plugin/tests/apps-bridge.test.ts
+++ b/apps/burrete-public-plugin/tests/apps-bridge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { App } from "@modelcontextprotocol/ext-apps";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+describe("MCP Apps bridge", () => {
+  test("completes initialization before acknowledging model context updates", async () => {
+    const [appTransport, hostTransport] = InMemoryTransport.createLinkedPair();
+    const methods: string[] = [];
+    hostTransport.onmessage = (message) => {
+      if (!("id" in message) || typeof message.id !== "number" || !("method" in message)) return;
+      methods.push(message.method);
+      if (message.method === "ui/initialize") {
+        const params = message.params as { protocolVersion: string };
+        void hostTransport.send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: params.protocolVersion,
+            hostInfo: { name: "test-host", version: "1.0.0" },
+            hostCapabilities: { updateModelContext: { structuredContent: {} } },
+            hostContext: {},
+          },
+        });
+      } else if (message.method === "ui/update-model-context") {
+        void hostTransport.send({ jsonrpc: "2.0", id: message.id, result: {} });
+      }
+    };
+    await hostTransport.start();
+
+    const app = new App(
+      { name: "burrete-test", version: "1.0.0" },
+      {},
+      { autoResize: false, strict: true },
+    );
+    await app.connect(appTransport);
+    expect(app.getHostCapabilities()?.updateModelContext).toBeDefined();
+    await app.updateModelContext({
+      structuredContent: { burrete: { activeSelection: null } },
+    });
+    expect(methods).toEqual(["ui/initialize", "ui/update-model-context"]);
+    await app.close();
+    await hostTransport.close();
+  });
+});

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { z } from "zod/v4";
 import {
   publicStructureOutputSchema,
+  molecularSceneInputSchema,
   PUBLIC_OUTPUT_LIMITS,
   TOOL_ANNOTATIONS,
   viewerToolMeta,
@@ -13,6 +14,7 @@ import {
   createViewerWidgetHtml,
   VIEWER_RESOURCE_URI,
   VIEWER_MOBILE_SCRIPT_PATH,
+  VIEWER_APP_BRIDGE_SCRIPT_PATH,
   VIEWER_SHELL_SCRIPT_PATH,
   VIEWER_SHELL_STYLES_PATH,
 } from "../lib/widget";
@@ -21,6 +23,11 @@ import {
   PLUGIN_DOCUMENTATION_URL,
 } from "../app/route";
 import nextConfig from "../next.config";
+import {
+  createSceneContext,
+  createSelectionContext,
+  sanitizeViewerActions,
+} from "../lib/hosted-context";
 
 describe("submission tool contract", () => {
   test("sets every required action hint explicitly", () => {
@@ -69,6 +76,29 @@ describe("submission tool contract", () => {
     expect(meta["openai/outputTemplate"]).toBe(VIEWER_RESOURCE_URI);
     expect(meta["openai/widgetAccessible"]).toBe(false);
   });
+
+  test("bounds molecular scene actions and selector fields", () => {
+    const schema = molecularSceneInputSchema;
+    expect(schema.parse({
+      source: "pdb",
+      pdbId: "1CRN",
+      actions: [{
+        type: "select_residues",
+        selector: { auth_asym_id: "A", beg_auth_seq_id: 10, end_auth_seq_id: 20 },
+        mode: "replace",
+      }],
+    }).actions).toHaveLength(1);
+    expect(() => schema.parse({
+      source: "pdb",
+      pdbId: "1CRN",
+      actions: Array.from({ length: 9 }, () => ({ type: "reset_camera" })),
+    })).toThrow();
+    expect(() => schema.parse({
+      source: "pdb",
+      pdbId: "1CRN",
+      actions: [{ type: "select_residues", selector: { arbitrary: "javascript" } }],
+    })).toThrow();
+  });
 });
 
 describe("viewer resource contract", () => {
@@ -87,11 +117,12 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v15.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-mobile-v6");
+    expect(html).toContain("?v=viewer-hosted-state-v1");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
+    expect(html).toContain(`https://burrete.example${VIEWER_APP_BRIDGE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
     expect(html).toContain("navigator.userAgent");
     expect(html).toContain("iPhone|iPad|iPod");
@@ -128,9 +159,55 @@ describe("viewer resource contract", () => {
     expect(source).toContain('layoutShowLeftPanel: false');
     expect(source).toContain('await Promise.all([\n      addStylesheet("viewer-runtime.css"),\n      addStylesheet("molstar.css"),\n    ])');
     expect(source).toContain('canvasBackground: "black"');
-    expect(source).toContain('method: "ui/update-model-context"');
+    expect(source).toContain("BurreteHostedAppBridge");
     expect(source).not.toContain("<iframe");
     expect(source).not.toContain("srcdoc");
+  });
+
+  test("initializes the Apps bridge before publishing bounded viewer state", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../assets/burrete-hosted-app.ts",
+    ), "utf8");
+    expect(source).toContain("new App(");
+    expect(source).toContain("app.connect()");
+    expect(source).toContain("getHostCapabilities()?.updateModelContext");
+    expect(source).toContain("await app.updateModelContext(params)");
+
+    const selection = createSelectionContext({
+      source: "lasso",
+      atoms: 1,
+      residues: [{ chain: "A", sequence: 12, compId: "CYS" }],
+      atomIdentities: [{ chain: "A", sequence: 12, compId: "CYS", atomName: "CA" }],
+    }, "document-1", { kind: "pdb", pdbId: "1CRN" });
+    expect(selection.structuredContent.burrete.activeSelection?.atomIdentities).toEqual([
+      { chain: "A", sequence: 12, compId: "CYS", atomName: "CA" },
+    ]);
+    expect(selection.structuredContent.burrete.source).toEqual({ kind: "pdb", pdbId: "1CRN" });
+    expect(createSelectionContext(null, "document-1", {
+      kind: "attachment",
+      fileName: "example.pdb",
+      nested: { unbounded: "x".repeat(10_000) },
+    }).structuredContent.burrete.source).toEqual({
+      kind: "attachment",
+      fileName: "example.pdb",
+    });
+    expect(createSelectionContext(null, "document-1").structuredContent.burrete.activeSelection).toBeNull();
+
+    expect(sanitizeViewerActions([
+      { type: "hide_components", kind: "water" },
+      { type: "raw_burrete_agent", command: "loadMVS" },
+      { type: "select_residues", selector: { auth_asym_id: "A" }, mode: "add" },
+    ])).toEqual([{ type: "hide_components", kind: "water" }]);
+
+    const scene = createSceneContext({
+      revision: 2,
+      selection: null,
+      results: [{ ok: true, command: "hide_components" }],
+    }, { kind: "pdb", pdbId: "1CRN" });
+    expect(scene.structuredContent.burrete.scene.results).toEqual([
+      { ok: true, command: "hide_components", error: null },
+    ]);
   });
 
   test("uses a true black MCP widget background in dark mode", () => {

--- a/apps/burrete-public-plugin/tests/submission.test.ts
+++ b/apps/burrete-public-plugin/tests/submission.test.ts
@@ -26,6 +26,7 @@ const submission = JSON.parse(
 const publicToolNames = [
   "preview_molecular_file",
   "preview_pdb_structure",
+  "render_molecular_scene",
 ] as const;
 
 describe("plugin submission bundle", () => {
@@ -53,12 +54,15 @@ describe("plugin submission bundle", () => {
         testCase.tools_triggered,
       );
     }
+    for (const toolName of publicToolNames) {
+      expect(submission.test_cases.map((testCase) => testCase.tools_triggered)).toContain(toolName);
+    }
     for (const testCase of submission.negative_test_cases) {
       expect(testCase.tools_triggered).toBeNull();
     }
   });
 
-  test("ships a narrowly scoped skill that names both public tools", () => {
+  test("ships a narrowly scoped skill that names every public tool", () => {
     const skill = readFileSync(
       resolve(
         packageRoot,

--- a/apps/desktop/src/hooks/use-app-viewer-state-messages.ts
+++ b/apps/desktop/src/hooks/use-app-viewer-state-messages.ts
@@ -95,6 +95,11 @@ export function useAppViewerStateMessages({
       return true;
     }
 
+    if (sourceName === "burrete-viewer" && body?.type === "sceneActionsApplied") {
+      void window.BurreteHostedAppBridge?.updateScene(body.report);
+      return true;
+    }
+
     if (sourceName === "burrete-viewer" && body?.type === "structureOverlayModeChanged") {
       const documentId = bodyString(body.documentId);
       if (!documentId) return true;

--- a/apps/desktop/src/hooks/use-hosted-mcp-widget.ts
+++ b/apps/desktop/src/hooks/use-hosted-mcp-widget.ts
@@ -54,16 +54,23 @@ export function useHostedMcpWidget({
         opened?.label === structure.label
         && opened.format === structure.format
         && opened.data === structure.data
+        && JSON.stringify(opened.source) === JSON.stringify(structure.source)
+        && JSON.stringify(opened.actions) === JSON.stringify(structure.actions)
       ) return;
 
       openedStructureRef.current = structure;
+      window.BurreteHostedAppBridge?.setSource(structure.source);
+      void window.BurreteHostedAppBridge?.updateSelection(null, "active-structure");
       openSequenceRef.current += 1;
       const sequence = openSequenceRef.current;
       forgetOpenedDocument();
       closeAllDocuments();
       void openBrowserDevMolstarContextDocument({
         label: structure.label,
-        context: { hostedMcpWidget: true },
+        context: {
+          hostedMcpWidget: true,
+          hostedMcpActions: structure.actions,
+        },
         entries: [{
           role: "structure",
           label: structure.label,

--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -414,6 +414,9 @@ export async function openBrowserDevMolstarContextDocument(
     const config = {
       ...browserDevContextConfig(label, entry.format, entry.bytes.length, contextPreferences, id),
       hostedMcpWidgetBootstrap: hostedMcpWidget,
+      hostedMcpActions: hostedMcpWidget && Array.isArray(contextDocument.context?.hostedMcpActions)
+        ? contextDocument.context.hostedMcpActions.slice(0, 8)
+        : [],
       molstarContextFocus: contextFocus,
     };
     const virtualPath = `burrete-context://${id}`;

--- a/apps/desktop/src/lib/hosted-mcp-widget.ts
+++ b/apps/desktop/src/lib/hosted-mcp-widget.ts
@@ -3,9 +3,7 @@ export const HOSTED_MCP_WIDGET_MESSAGE_SOURCE = "burrete-hosted-mcp-widget";
 
 const MAX_HOSTED_STRUCTURE_BYTES = 3 * 1024 * 1024;
 const MAX_HOSTED_LABEL_LENGTH = 255;
-const MAX_HOSTED_SELECTION_RESIDUES = 96;
 const HOSTED_STRUCTURE_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
-let hostedSelectionRequestId = 0;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -13,12 +11,8 @@ export type HostedMcpStructure = {
   data: string;
   format: string;
   label: string;
-};
-
-type HostedMcpSelectionResidue = {
-  chain: string;
-  compId: string;
-  sequence: number | string | null;
+  source: UnknownRecord | null;
+  actions: UnknownRecord[];
 };
 
 function record(value: unknown): UnknownRecord | null {
@@ -52,60 +46,9 @@ function boundedLabel(value: unknown, fallback: string) {
   return (label || fallback).slice(0, MAX_HOSTED_LABEL_LENGTH);
 }
 
-function selectionResidue(value: unknown): HostedMcpSelectionResidue | null {
-  const residue = record(value);
-  if (!residue) return null;
-  const sequence = typeof residue.sequence === "number" || typeof residue.sequence === "string"
-    ? residue.sequence
-    : null;
-  return {
-    chain: boundedLabel(residue.chain, ""),
-    compId: boundedLabel(residue.compId, ""),
-    sequence,
-  };
-}
-
-export function createHostedMcpSelectionContext(value: unknown, documentId: string) {
-  const selection = record(value);
-  if (!selection || selection.source !== "lasso") return null;
-  const residues = Array.isArray(selection.residues)
-    ? selection.residues
-      .slice(0, MAX_HOSTED_SELECTION_RESIDUES)
-      .map(selectionResidue)
-      .filter((residue): residue is HostedMcpSelectionResidue => residue !== null)
-    : [];
-  const atoms = Math.max(0, Math.trunc(Number(selection.atoms) || 0));
-  const label = boundedLabel(
-    selection.label,
-    `Lasso selection with ${atoms} visible atoms across ${residues.length} residues`,
-  );
-  const activeSelection = {
-    source: "lasso",
-    documentId: boundedLabel(documentId, "active-structure"),
-    label,
-    atoms,
-    residues,
-  };
-  return {
-    content: [{
-      type: "text" as const,
-      text: `Current Burrete selection: ${label}. Treat this as the user's active molecular selection for their next request.`,
-    }],
-    structuredContent: { burrete: { activeSelection } },
-  };
-}
-
 export function updateHostedMcpSelectionContext(value: unknown, documentId: string) {
-  if (!isHostedMcpWidget() || !window.parent) return false;
-  const params = createHostedMcpSelectionContext(value, documentId);
-  if (!params) return false;
-  hostedSelectionRequestId += 1;
-  window.parent.postMessage({
-    jsonrpc: "2.0",
-    id: `burrete-selection-context-${hostedSelectionRequestId}`,
-    method: "ui/update-model-context",
-    params,
-  }, "*");
+  if (!isHostedMcpWidget() || !window.BurreteHostedAppBridge) return false;
+  void window.BurreteHostedAppBridge.updateSelection(value, documentId);
   return true;
 }
 
@@ -125,6 +68,7 @@ export function parseHostedMcpStructureResult(value: unknown): HostedMcpStructur
   if (!result) return null;
   const metadata = metadataFromResult(result);
   const structure = record(metadata?.structure);
+  const scene = record(metadata?.scene);
   const data = typeof structure?.data === "string" ? structure.data : "";
   const byteCount = new TextEncoder().encode(data).length;
   const format = normalizedFormat(structure?.format);
@@ -139,6 +83,10 @@ export function parseHostedMcpStructureResult(value: unknown): HostedMcpStructur
     data,
     format,
     label,
+    source: record(scene?.source),
+    actions: Array.isArray(scene?.actions)
+      ? scene.actions.slice(0, 8).map(record).filter((action): action is UnknownRecord => action !== null)
+      : [],
   };
 }
 

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -20,6 +20,15 @@ interface Window {
   __BURRETE_HOSTED_MCP_BRIDGE_READY__?: boolean;
   __BURRETE_HOSTED_MCP_RESULTS__?: unknown[];
   __BURRETE_HOSTED_MCP_WIDGET__?: boolean;
+  BurreteHostedAppBridge?: {
+    ready: Promise<boolean>;
+    setSource: (source: unknown) => void;
+    updateSelection: (selection: unknown, documentId: string) => Promise<boolean>;
+    updateScene: (report: unknown) => Promise<boolean>;
+    sanitizeViewerActions: (actions: unknown) => Record<string, unknown>[];
+  };
+  __BURRETE_HOSTED_APP_QUEUE__?: Array<{ method: string; args: unknown[] }>;
+  __BURRETE_HOSTED_APP_READY__?: (ready: boolean) => void;
   __BURRETE_WEB_ASSETS_BASE__?: string;
   __BURRETE_BOOT_OVERLAY__?: {
     report: (message: string, details?: string) => void;

--- a/tests/test-hosted-mcp-widget.mjs
+++ b/tests/test-hosted-mcp-widget.mjs
@@ -3,13 +3,13 @@ import assert from "node:assert/strict";
 
 import {
   HOSTED_MCP_WIDGET_MESSAGE_SOURCE,
-  createHostedMcpSelectionContext,
   isHostedMcpWidgetLocation,
   isHostedMcpToolResultMessage,
   parseHostedMcpStructureMessage,
   parseHostedMcpStructureResult,
   selectHostedMcpInitialStructure,
 } from "../apps/desktop/src/lib/hosted-mcp-widget.ts";
+import { createSelectionContext } from "../apps/burrete-public-plugin/lib/hosted-context.ts";
 import {
   deleteBrowserDevVirtualTextDocument,
   openBrowserDevMolstarContextDocument,
@@ -161,10 +161,13 @@ const initialStructure = selectHostedMcpInitialStructure([
 assert.equal(initialStructure?.label, "latest.pdb");
 assert.equal(initialStructure?.data, "LATEST");
 
-const selectionContext = createHostedMcpSelectionContext({
+const selectionContext = createSelectionContext({
   source: "lasso",
   label: "Lasso selection: 4 visible atoms across 2 residues",
   atoms: 4,
+  atomIdentities: [
+    { chain: "A", sequence: 12, compId: "CYS", atomName: "CA" },
+  ],
   residues: [
     { chain: "A", sequence: 12, compId: "CYS" },
     { chain: "A", sequence: 13, compId: "ARG" },
@@ -176,6 +179,9 @@ assert.deepEqual(selectionContext?.structuredContent.burrete.activeSelection.res
   { chain: "A", sequence: 13, compId: "ARG" },
 ]);
 assert.match(selectionContext?.content[0].text ?? "", /active molecular selection/);
-assert.equal(createHostedMcpSelectionContext({ source: "click" }, "document-1"), null);
+assert.deepEqual(selectionContext?.structuredContent.burrete.activeSelection.atomIdentities, [
+  { chain: "A", sequence: 12, compId: "CYS", atomName: "CA" },
+]);
+assert.equal(createSelectionContext(null, "document-1").structuredContent.burrete.activeSelection, null);
 
 console.log("Hosted MCP widget contract tests passed");


### PR DESCRIPTION
## Why

The hosted Burrete widget could render a structure, but its lasso selection was sent without the MCP Apps initialization handshake, so later model turns could not reliably see what the user selected. The public tool surface also had no bounded way to request selection, focus, visibility, or camera actions.

## What Changed

- add a versioned Apps SDK bridge that initializes before publishing bounded selection and scene context
- report full lasso counts plus up to 96 atom identities and residues, including explicit selection clearing
- queue early widget state until the bridge is ready and revalidate every client-side action against the public allowlist
- add `render_molecular_scene` for PDB entries or authorized attachments with select, focus, clear, reset-camera, and polymer/ligand/ion/water visibility actions
- execute actions through the existing Burrete viewer dispatcher and report actual client-side results back to model context
- update the public skill, submission metadata, review case, documentation, and widget URI to `molecular-viewer-v16.html`

The public MCP remains stateless: a model action produces a new isolated widget result for the supplied PDB or attachment; it does not address or persist an old iframe on the server.

## Verification

- `bun run build` in `apps/burrete-public-plugin`
- `bun test tests` in `apps/burrete-public-plugin` (31 passed)
- `bun run typecheck` in `apps/burrete-public-plugin`
- `bun tests/test-hosted-mcp-widget.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-burette-agent.mjs`
- `bun tests/test-agent-preview-server.mjs`
- pre-push `bash scripts/ci-fast.sh`

## Notes

Arbitrary selector isolation and persistent representation overpaint are intentionally outside this allowlist. Model-driven selection uses replace semantics; manual additive lasso remains supported and reports the accumulated selection.