### PR TITLE
Restore one stable hosted viewer resource

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -29,7 +29,7 @@ The production Streamable HTTP endpoint is
 
 All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v17.html` with MIME type
+`ui://burrete/molecular-viewer-v16.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The widget uses the MCP Apps handshake before publishing bounded selection or

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -29,7 +29,7 @@ The production Streamable HTTP endpoint is
 
 All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v16.html` with MIME type
+`ui://burrete/molecular-viewer-v17.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The widget uses the MCP Apps handshake before publishing bounded selection or

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -3,9 +3,12 @@
 
   const MAX_STRUCTURE_BYTES = 3 * 1024 * 1024;
   const ASSET_LOAD_TIMEOUT_MS = 30_000;
+  const BOOTSTRAP_TIMEOUT_MS = 15_000;
   const SUPPORTED_FORMATS = new Set(["pdb", "mmcif", "sdf", "xyz"]);
   const assetsBase = String(window.__BURRETE_WEB_ASSETS_BASE__ || "/burrete-viewer/").replace(/\/$/u, "");
   let started = false;
+  let latestToolOutput;
+  let latestToolResponseMetadata;
 
   const record = (value) => value && typeof value === "object" ? value : null;
   const bounded = (value, fallback = "") => {
@@ -108,13 +111,39 @@
     }
   }
 
+  function showBootstrapError(message) {
+    let status = document.getElementById("status");
+    if (!status) {
+      const root = document.getElementById("root") || document.getElementById("app");
+      root?.insertAdjacentHTML("afterend", '<div id="status"></div>');
+      status = document.getElementById("status");
+    }
+    if (!status) return;
+    status.className = "error";
+    status.style.setProperty("display", "block", "important");
+    status.textContent = `[web] Burrete mobile renderer failed to start.\n\n${message}`;
+  }
+
+  const bootstrapTimeout = window.setTimeout(() => {
+    if (!started) {
+      showBootstrapError("Timed out waiting for molecular structure metadata from ChatGPT.");
+    }
+  }, BOOTSTRAP_TIMEOUT_MS);
+
   async function start(structure) {
     if (started) return;
-    started = true;
     const root = document.getElementById("root");
     if (!root) throw new Error("Hosted viewer root is unavailable");
+    started = true;
+    window.clearTimeout(bootstrapTimeout);
     root.id = "app";
-    root.insertAdjacentHTML("afterend", '<div id="status" class="loading">Loading structure...</div>');
+    let status = document.getElementById("status");
+    if (!status) {
+      root.insertAdjacentHTML("afterend", '<div id="status" class="loading">Loading structure...</div>');
+    } else {
+      status.className = "loading";
+      status.textContent = "Loading structure...";
+    }
     document.body.className = "burette-opaque-background burette-mobile-host";
     document.documentElement.classList.add("buret-hosted-mobile-direct");
 
@@ -182,12 +211,21 @@
     const structure = structureFromResult(value);
     if (!structure) return;
     start(structure).catch((error) => {
-      const status = document.getElementById("status");
-      if (status) {
-        status.className = "error";
-        status.style.setProperty("display", "block", "important");
-        status.textContent = `[web] Burrete mobile renderer failed to start.\n\n${error?.message || String(error)}`;
-      }
+      showBootstrapError(error?.message || String(error));
+    });
+  }
+
+  function acceptOpenAIGlobals(globals) {
+    const next = record(globals);
+    if (!next) return;
+    if (next.toolOutput !== undefined) latestToolOutput = next.toolOutput;
+    if (next.toolResponseMetadata !== undefined) {
+      latestToolResponseMetadata = next.toolResponseMetadata;
+    }
+    if (latestToolOutput === undefined && latestToolResponseMetadata === undefined) return;
+    acceptResult({
+      structuredContent: latestToolOutput,
+      _meta: latestToolResponseMetadata,
     });
   }
 
@@ -199,19 +237,31 @@
     }
   }, { passive: true });
   window.addEventListener("openai:set_globals", (event) => {
-    const globals = event.detail?.globals;
-    if (globals?.toolOutput === undefined) return;
-    acceptResult({ structuredContent: globals.toolOutput, _meta: globals.toolResponseMetadata });
+    acceptOpenAIGlobals(event.detail?.globals);
   }, { passive: true });
 
   const queued = Array.isArray(window.__BURRETE_HOSTED_MCP_RESULTS__)
     ? window.__BURRETE_HOSTED_MCP_RESULTS__
     : [];
-  if (queued.length > 0) acceptResult(queued[queued.length - 1]);
-  if (!started && window.openai?.toolOutput !== undefined) {
-    acceptResult({
-      structuredContent: window.openai.toolOutput,
-      _meta: window.openai.toolResponseMetadata,
-    });
+  for (const result of queued) {
+    const queuedResult = record(result);
+    if (queuedResult && (
+      Object.hasOwn(queuedResult, "structuredContent")
+      || Object.hasOwn(queuedResult, "_meta")
+    )) {
+      const globals = {};
+      if (Object.hasOwn(queuedResult, "structuredContent")) {
+        globals.toolOutput = queuedResult.structuredContent;
+      }
+      if (Object.hasOwn(queuedResult, "_meta")) {
+        globals.toolResponseMetadata = queuedResult._meta;
+      }
+      acceptOpenAIGlobals(globals);
+    } else {
+      acceptResult(result);
+    }
+    if (started) break;
   }
+  acceptOpenAIGlobals(window.__BURRETE_HOSTED_OPENAI_GLOBALS__);
+  if (!started) acceptOpenAIGlobals(window.openai);
 })();

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,4 +1,4 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v17.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v16.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,4 +1,4 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v16.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v17.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
@@ -6,7 +6,7 @@ export const VIEWER_SHELL_STYLES_PATH =
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
 export const VIEWER_APP_BRIDGE_SCRIPT_PATH = "/burrete-hosted-app.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-hosted-state-v1";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-mobile-bootstrap-v2";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -75,6 +75,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         window.__BURRETE_HOSTED_MCP_WIDGET__ = true;
         window.__BURRETE_WEB_ASSETS_BASE__ = config.viewerAssets;
         window.__BURRETE_HOSTED_MCP_RESULTS__ = [];
+        window.__BURRETE_HOSTED_OPENAI_GLOBALS__ = {};
         const appQueue = [];
         const appReady = new Promise((resolve) => { window.__BURRETE_HOSTED_APP_READY__ = resolve; });
         window.__BURRETE_HOSTED_APP_QUEUE__ = appQueue;
@@ -104,13 +105,16 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         }, { passive: true });
         window.addEventListener("openai:set_globals", (event) => {
           const globals = event.detail?.globals;
-          if (
-            !globals?.toolOutput
-            || window.__BURRETE_HOSTED_MCP_BRIDGE_READY__
-          ) return;
+          if (!globals || window.__BURRETE_HOSTED_MCP_BRIDGE_READY__) return;
+          if (Object.hasOwn(globals, "toolOutput")) {
+            window.__BURRETE_HOSTED_OPENAI_GLOBALS__.toolOutput = globals.toolOutput;
+          }
+          if (Object.hasOwn(globals, "toolResponseMetadata")) {
+            window.__BURRETE_HOSTED_OPENAI_GLOBALS__.toolResponseMetadata = globals.toolResponseMetadata;
+          }
           window.__BURRETE_HOSTED_MCP_RESULTS__.push({
-            structuredContent: globals.toolOutput,
-            _meta: globals.toolResponseMetadata,
+            structuredContent: window.__BURRETE_HOSTED_OPENAI_GLOBALS__.toolOutput,
+            _meta: window.__BURRETE_HOSTED_OPENAI_GLOBALS__.toolResponseMetadata,
           });
         }, { passive: true });
       })();
@@ -127,6 +131,16 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         script.src = mobile ? ${serializeForInlineScript(mobileScript)} : ${serializeForInlineScript(shellScript)};
         if (!mobile) script.type = "module";
         script.crossOrigin = "anonymous";
+        const timeout = window.setTimeout(() => {
+          const root = document.getElementById("root");
+          if (root) root.textContent = "Burrete viewer failed to load.";
+        }, 15000);
+        script.addEventListener("load", () => window.clearTimeout(timeout), { once: true });
+        script.addEventListener("error", () => {
+          window.clearTimeout(timeout);
+          const root = document.getElementById("root");
+          if (root) root.textContent = "Burrete viewer failed to load.";
+        }, { once: true });
         document.body.appendChild(script);
       })();
     </script>

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -118,7 +118,7 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v17.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
     expect(html).toContain("?v=viewer-mobile-bootstrap-v2");

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import vm from "node:vm";
 import { z } from "zod/v4";
 import {
   publicStructureOutputSchema,
@@ -117,10 +118,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v17.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-hosted-state-v1");
+    expect(html).toContain("?v=viewer-mobile-bootstrap-v2");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_APP_BRIDGE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
@@ -129,6 +130,8 @@ describe("viewer resource contract", () => {
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");
+    expect(html).toContain("__BURRETE_HOSTED_OPENAI_GLOBALS__");
+    expect(html).toContain("Burrete viewer failed to load.");
     expect(html).toContain('<div id="root"></div>');
     expect(html).toContain("body .app-shell { width: 100%; height: 100%; }");
     expect(html).not.toContain("<iframe");
@@ -162,6 +165,76 @@ describe("viewer resource contract", () => {
     expect(source).toContain("BurreteHostedAppBridge");
     expect(source).not.toContain("<iframe");
     expect(source).not.toContain("srcdoc");
+  });
+
+  test("starts the mobile viewer when tool output and metadata arrive separately", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../assets/burrete-hosted-mobile.js",
+    ), "utf8");
+    const listeners = new Map<string, Array<(event: unknown) => void>>();
+    const root = {
+      id: "root",
+      insertedHtml: "",
+      insertAdjacentHTML(_position: string, html: string) {
+        this.insertedHtml = html;
+      },
+    };
+    const createElement = () => {
+      const elementListeners = new Map<string, Array<() => void>>();
+      return {
+        addEventListener(type: string, listener: () => void) {
+          const handlers = elementListeners.get(type) || [];
+          handlers.push(listener);
+          elementListeners.set(type, handlers);
+        },
+        style: { setProperty() {} },
+        textContent: "",
+      };
+    };
+    const parent = {};
+    const window = {
+      parent,
+      setTimeout: () => 1,
+      clearTimeout() {},
+      addEventListener(type: string, listener: (event: unknown) => void) {
+        const handlers = listeners.get(type) || [];
+        handlers.push(listener);
+        listeners.set(type, handlers);
+      },
+      dispatchOpenAI(globals: Record<string, unknown>) {
+        for (const listener of listeners.get("openai:set_globals") || []) {
+          listener({ detail: { globals } });
+        }
+      },
+    };
+    const document = {
+      body: { className: "", appendChild() {} },
+      head: { appendChild() {} },
+      documentElement: { classList: { add() {} } },
+      getElementById(id: string) {
+        return id === root.id ? root : null;
+      },
+      createElement,
+    };
+
+    vm.runInNewContext(source, {
+      TextEncoder,
+      btoa,
+      document,
+      navigator: { userAgent: "iPhone" },
+      window,
+    });
+
+    window.dispatchOpenAI({ toolOutput: { fileName: "1CRN.pdb" } });
+    expect(root.id).toBe("root");
+    window.dispatchOpenAI({
+      toolResponseMetadata: {
+        structure: { data: "ATOM\nEND\n", format: "pdb", label: "1CRN.pdb" },
+      },
+    });
+    expect(root.id).toBe("app");
+    expect(root.insertedHtml).toContain("Loading structure");
   });
 
   test("initializes the Apps bridge before publishing bounded viewer state", () => {


### PR DESCRIPTION
## Why

The ChatGPT mobile client can retain the viewer resource URI from its existing Burrete tool descriptor. Production no longer served that URI, so successful tool calls rendered as a blank widget.

## What Changed

- Make `ui://burrete/molecular-viewer-v16.html` the single canonical MCP widget resource.
- Keep the current mobile bootstrap and remove the v17 contract instead of adding compatibility aliases.
- Align the plugin documentation and contract test with the single resource URI.

Affected surfaces: hosted plugin/MCP widget on ChatGPT web and iPhone.

## Verification

- `bun run test` in `apps/burrete-public-plugin` (32 tests, 140 assertions)
- `bun run typecheck` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook