### PR TITLE
Use one stable hosted viewer resource

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -29,7 +29,7 @@ The production Streamable HTTP endpoint is
 
 All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v17.html` with MIME type
+`ui://burrete/molecular-viewer-v16.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The widget uses the MCP Apps handshake before publishing bounded selection or

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,4 +1,4 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v17.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v16.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -118,7 +118,7 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v17.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
     expect(html).toContain("?v=viewer-mobile-bootstrap-v2");


### PR DESCRIPTION
## Why

ChatGPT mobile can retain the Burrete `v16` resource URI from its tool descriptor. Production served only `v17`, so a successful tool call could render as a blank widget.

## What Changed

- Make `ui://burrete/molecular-viewer-v16.html` the single canonical MCP widget resource.
- Keep the current mobile bootstrap without compatibility aliases or additional resource routes.
- Align the plugin documentation and contract test with the one resource URI.

Affected surfaces: hosted plugin/MCP widget on ChatGPT web and iPhone.

## Verification

- `bun run test` in `apps/burrete-public-plugin` (32 tests, 140 assertions)
- `bun run typecheck` in `apps/burrete-public-plugin`
- repository `ci-fast` pre-push hook