### PR TITLE
Add Vercel Analytics to hosted MCP widget

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -40,6 +40,11 @@ process network and request metadata such as IP address, request time, route,
 client type, approximate region, performance, and security events under its
 policies. RCSB processes public PDB lookup requests.
 
+When the hosted molecular viewer loads, it sends one anonymized Vercel Web
+Analytics pageview for the fixed path `/mcp/widget`. Automatic URL tracking is
+disabled. Burrete does not include a PDB ID, filename, molecular content,
+viewer selection, or chat/session identifier in that analytics event.
+
 Burrete does not intentionally configure application logs to record raw
 molecular content or temporary signed download URLs. Technical logs and
 security metadata are retained according to the applicable OpenAI and Vercel

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -68,6 +68,10 @@ from the model and conversation transcript.
   widget-only `_meta`.
 
 Hosting infrastructure may retain ordinary request metadata in platform logs.
+The hosted widget also sends one anonymized Vercel Web Analytics pageview for
+the fixed path `/mcp/widget` when it loads. Automatic URL tracking is disabled,
+and the event does not contain PDB IDs, filenames, molecular content, viewer
+selection, or chat/session identifiers.
 The public [privacy policy](https://burrete-landing.vercel.app/privacy)
 describes that hosting boundary, recipients, retention, user controls, and RCSB
 lookup behavior.

--- a/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
@@ -1,4 +1,5 @@
 import { App, type McpUiUpdateModelContextRequest } from "@modelcontextprotocol/ext-apps";
+import { inject, pageview } from "@vercel/analytics";
 import {
   createSceneContext,
   createSelectionContext,
@@ -16,7 +17,19 @@ declare global {
     };
     __BURRETE_HOSTED_APP_QUEUE__?: Array<{ method: string; args: unknown[] }>;
     __BURRETE_HOSTED_APP_READY__?: (ready: boolean) => void;
+    __BURRETE_HOSTED_ANALYTICS_ORIGIN__?: string;
   }
+}
+
+const analyticsOrigin = window.__BURRETE_HOSTED_ANALYTICS_ORIGIN__;
+if (analyticsOrigin?.startsWith("https://")) {
+  inject({
+    mode: "production",
+    disableAutoTrack: true,
+    scriptSrc: `${analyticsOrigin}/_vercel/insights/script.js`,
+    endpoint: `${analyticsOrigin}/_vercel/insights`,
+  });
+  pageview({ route: "/mcp/widget", path: "/mcp/widget" });
 }
 
 const app = new App(

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -51,6 +51,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
   const appBridgeScript = `${assetUrl(assetOrigin, VIEWER_APP_BRIDGE_SCRIPT_PATH)}?v=${VIEWER_SHELL_ASSET_VERSION}`;
   const bootstrap = serializeForInlineScript({
     viewerAssets,
+    analyticsOrigin: assetOrigin.replace(/\/$/u, ""),
   });
 
   return `<!doctype html>
@@ -74,6 +75,7 @@ export function createViewerWidgetHtml(assetOrigin = ""): string {
         const config = ${bootstrap};
         window.__BURRETE_HOSTED_MCP_WIDGET__ = true;
         window.__BURRETE_WEB_ASSETS_BASE__ = config.viewerAssets;
+        window.__BURRETE_HOSTED_ANALYTICS_ORIGIN__ = config.analyticsOrigin;
         window.__BURRETE_HOSTED_MCP_RESULTS__ = [];
         window.__BURRETE_HOSTED_OPENAI_GLOBALS__ = {};
         const appQueue = [];

--- a/apps/burrete-public-plugin/package.json
+++ b/apps/burrete-public-plugin/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "1.7.4",
     "@modelcontextprotocol/sdk": "1.29.0",
+    "@vercel/analytics": "2.0.1",
     "molstar": "5.7.0",
     "next": "16.2.10",
     "react": "19.2.7",

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -129,6 +129,10 @@ describe("viewer resource contract", () => {
     expect(html).toContain("iPhone|iPad|iPod");
     expect(html).toContain("ui/notifications/tool-result");
     expect(html).toContain("__BURRETE_HOSTED_MCP_WIDGET__");
+    expect(html).toContain(
+      '"analyticsOrigin":"https://burrete.example"',
+    );
+    expect(html).toContain("__BURRETE_HOSTED_ANALYTICS_ORIGIN__");
     expect(html).toContain("__BURRETE_HOSTED_MCP_BRIDGE_READY__");
     expect(html).toContain("__BURRETE_HOSTED_OPENAI_GLOBALS__");
     expect(html).toContain("Burrete viewer failed to load.");
@@ -246,6 +250,11 @@ describe("viewer resource contract", () => {
     expect(source).toContain("app.connect()");
     expect(source).toContain("getHostCapabilities()?.updateModelContext");
     expect(source).toContain("await app.updateModelContext(params)");
+    expect(source).toContain('from "@vercel/analytics"');
+    expect(source).toContain("disableAutoTrack: true");
+    expect(source).toContain('route: "/mcp/widget", path: "/mcp/widget"');
+    expect(source).not.toContain("pdbId");
+    expect(source).not.toContain("fileName");
 
     const selection = createSelectionContext({
       source: "lasso",

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "1.7.4",
         "@modelcontextprotocol/sdk": "1.29.0",
+        "@vercel/analytics": "2.0.1",
         "molstar": "5.7.0",
         "next": "16.2.10",
         "react": "19.2.7",
@@ -732,6 +733,8 @@
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 


### PR DESCRIPTION
## Why

The hosted Burrete plugin has no standalone page to measure: its root redirects to documentation and users interact with the molecular viewer inside the MCP Apps iframe. Standard page analytics would therefore miss real plugin usage.

## What Changed

- add Vercel Web Analytics to the hosted MCP Apps bridge
- record one canonical /mcp/widget pageview when the viewer loads
- disable automatic URL tracking so analytics never includes PDB IDs, filenames, molecular content, viewer selections, or chat/session identifiers
- document the analytics boundary in the hosted plugin README and privacy policy
- add a contract check for the fixed analytics origin and event path

Affected surfaces: hosted plugin/MCP widget and privacy documentation. Desktop, Quick Look, browser-dev, and the iPhone source app are unchanged.

## Verification

- bun run typecheck in apps/burrete-public-plugin
- bun run test in apps/burrete-public-plugin - 32 passed, 0 failed
- inspected the compiled hosted bridge for the Insights endpoint, disabled auto tracking, and fixed /mcp/widget route
- confirmed Vercel Web Analytics is enabled for the burrete-plugin project
