### PR TITLE
Fix hosted widget analytics delivery

### DIFF
--- a/apps/burrete-public-plugin/app/api/analytics/view/route.ts
+++ b/apps/burrete-public-plugin/app/api/analytics/view/route.ts
@@ -1,0 +1,48 @@
+import { getAppOrigin } from "@/lib/origin";
+
+export const dynamic = "force-dynamic";
+
+const WIDGET_ANALYTICS_PATH = "/mcp/widget";
+const ANALYTICS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Cache-Control": "no-store",
+} as const;
+
+export function OPTIONS(): Response {
+  return new Response(null, { status: 204, headers: ANALYTICS_HEADERS });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const appOrigin = getAppOrigin();
+  const upstreamUrl = new URL("/_vercel/insights/view", appOrigin);
+  const userAgent = request.headers.get("user-agent")?.slice(0, 512);
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(userAgent ? { "User-Agent": userAgent } : {}),
+      },
+      body: JSON.stringify({
+        o: `${appOrigin}${WIDGET_ANALYTICS_PATH}`,
+        sv: "0.1.3",
+        sdkn: "@vercel/analytics",
+        sdkv: "2.0.1",
+        ts: Date.now(),
+        dp: WIDGET_ANALYTICS_PATH,
+      }),
+    });
+    return new Response(upstream.ok ? "OK" : "Analytics unavailable", {
+      status: upstream.ok ? 200 : 502,
+      headers: ANALYTICS_HEADERS,
+    });
+  } catch {
+    return new Response("Analytics unavailable", {
+      status: 502,
+      headers: ANALYTICS_HEADERS,
+    });
+  }
+}

--- a/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-app.ts
@@ -27,7 +27,7 @@ if (analyticsOrigin?.startsWith("https://")) {
     mode: "production",
     disableAutoTrack: true,
     scriptSrc: `${analyticsOrigin}/_vercel/insights/script.js`,
-    endpoint: `${analyticsOrigin}/_vercel/insights`,
+    viewEndpoint: `${analyticsOrigin}/api/analytics/view`,
   });
   pageview({ route: "/mcp/widget", path: "/mcp/widget" });
 }

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -6,7 +6,7 @@ export const VIEWER_SHELL_STYLES_PATH =
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
 export const VIEWER_APP_BRIDGE_SCRIPT_PATH = "/burrete-hosted-app.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-mobile-bootstrap-v2";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-analytics-v1";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;

--- a/apps/burrete-public-plugin/tests/analytics.test.ts
+++ b/apps/burrete-public-plugin/tests/analytics.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { OPTIONS, POST } from "../app/api/analytics/view/route";
+
+const originalFetch = globalThis.fetch;
+type FetchImplementation = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => ReturnType<typeof fetch>;
+
+function stubFetch(implementation: FetchImplementation): void {
+  globalThis.fetch = Object.assign(implementation, { preconnect: originalFetch.preconnect });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("hosted widget analytics", () => {
+  test("allows the sandbox to post a pageview without credentials", () => {
+    const response = OPTIONS();
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe("POST, OPTIONS");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+  });
+
+  test("forwards only a canonical widget pageview", async () => {
+    let forwardedUrl = "";
+    let forwardedBody = "";
+    stubFetch(async (input, init) => {
+      forwardedUrl = String(input);
+      forwardedBody = String(init?.body ?? "");
+      return new Response("OK", { status: 200 });
+    });
+
+    const response = await POST(new Request("https://burrete.example/api/analytics/view", {
+      method: "POST",
+      headers: { "User-Agent": "Burrete analytics contract test" },
+      body: JSON.stringify({
+        pdbId: "1CRN",
+        fileName: "private.pdb",
+        chatSessionId: "private-session",
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(forwardedUrl).toBe("http://localhost:3000/_vercel/insights/view");
+    expect(JSON.parse(forwardedBody)).toMatchObject({
+      o: "http://localhost:3000/mcp/widget",
+      sdkn: "@vercel/analytics",
+      sdkv: "2.0.1",
+      dp: "/mcp/widget",
+    });
+    expect(forwardedBody).not.toContain("1CRN");
+    expect(forwardedBody).not.toContain("private.pdb");
+    expect(forwardedBody).not.toContain("private-session");
+  });
+
+  test("reports an unavailable analytics upstream without throwing", async () => {
+    stubFetch(async () => new Response("Unavailable", { status: 503 }));
+    const response = await POST(new Request("https://burrete.example/api/analytics/view", {
+      method: "POST",
+    }));
+    expect(response.status).toBe(502);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -121,7 +121,7 @@ describe("viewer resource contract", () => {
     expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-mobile-bootstrap-v2");
+    expect(html).toContain("?v=viewer-analytics-v1");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_APP_BRIDGE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
@@ -252,6 +252,7 @@ describe("viewer resource contract", () => {
     expect(source).toContain("await app.updateModelContext(params)");
     expect(source).toContain('from "@vercel/analytics"');
     expect(source).toContain("disableAutoTrack: true");
+    expect(source).toContain('viewEndpoint: `${analyticsOrigin}/api/analytics/view`');
     expect(source).toContain('route: "/mcp/widget", path: "/mcp/widget"');
     expect(source).not.toContain("pdbId");
     expect(source).not.toContain("fileName");


### PR DESCRIPTION
## Why

ChatGPT renders MCP widgets from an isolated OpenAI sandbox origin. Vercel's system Web Analytics ingestion endpoint does not expose the CORS headers required for that cross-origin request, so the script could load while the pageview itself was blocked.

## What changed

- route widget pageviews through a same-project CORS-safe API endpoint;
- ignore the incoming request body and forward only the canonical `/mcp/widget` pageview;
- preserve the stable v16 MCP resource URI while bumping the hosted asset cache key;
- add contracts for sandbox CORS, canonical analytics payloads, and upstream failure handling.

## Verification

- `bun run typecheck`
- `bun run test` (35 passed, 0 failed)
- `git diff --check`
