### PR TITLE
Speed up mobile MCP viewer startup

### DIFF
--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -92,6 +92,14 @@
     document.body.appendChild(script);
     return loaded;
   };
+  const preloadScript = (name) => {
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.as = "script";
+    link.crossOrigin = "anonymous";
+    link.href = `${assetsBase}/${name}`;
+    document.head.appendChild(link);
+  };
   const jsonElement = (id, value) => {
     const element = document.createElement("script");
     element.id = id;
@@ -147,6 +155,16 @@
     document.body.className = "burette-opaque-background burette-mobile-host";
     document.documentElement.classList.add("buret-hosted-mobile-direct");
 
+    const runtimeScripts = [
+      "viewer-shell.js",
+      "viewer-bootstrap.js",
+      "molstar.js",
+      "burette-agent.js",
+      "trajectory-smoothing.js",
+      "viewer.js",
+    ];
+    for (const name of runtimeScripts) preloadScript(name);
+
     await Promise.all([
       addStylesheet("viewer-runtime.css"),
       addStylesheet("molstar.css"),
@@ -193,17 +211,14 @@
     });
     jsonElement("burrete-runtime-data", base64Utf8(structure.data));
 
-    await loadScript("viewer-shell.js");
-    await loadScript("viewer-bootstrap.js");
+    await loadScript(runtimeScripts[0]);
+    await loadScript(runtimeScripts[1]);
     window.BurreteHostedAppBridge?.setSource(structure.source);
     void window.BurreteHostedAppBridge?.updateSelection(null, documentId);
     window.__mqlPost = (type, message, payload = {}) => {
       updateHostedContext({ type, message, ...payload, documentId });
     };
-    await loadScript("molstar.js");
-    await loadScript("burette-agent.js");
-    await loadScript("trajectory-smoothing.js");
-    await loadScript("viewer.js");
+    for (const name of runtimeScripts.slice(2)) await loadScript(name);
   }
 
   function acceptResult(value) {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -165,6 +165,9 @@ describe("viewer resource contract", () => {
     expect(source).toContain('layoutShowLog: false');
     expect(source).toContain('layoutShowLeftPanel: false');
     expect(source).toContain('await Promise.all([\n      addStylesheet("viewer-runtime.css"),\n      addStylesheet("molstar.css"),\n    ])');
+    expect(source).toContain('link.rel = "preload"');
+    expect(source).toContain('link.as = "script"');
+    expect(source).toContain('for (const name of runtimeScripts) preloadScript(name)');
     expect(source).toContain('canvasBackground: "black"');
     expect(source).toContain("BurreteHostedAppBridge");
     expect(source).not.toContain("<iframe");


### PR DESCRIPTION
## Why

The hosted Burrete MCP viewer could look indefinitely blank in ChatGPT on iPhone while its large runtime scripts downloaded one at a time.

## What Changed

- Preload the mobile viewer runtime scripts in parallel while preserving their dependency execution order.
- Keep the existing single direct mobile Mol*/WebGL viewer and stable MCP resource contract.
- Add contract coverage for the preload behavior.

Affected surface: public plugin/MCP mobile widget only.

## Verification

- `bun run typecheck`
- `bun test tests` (35 passed)
- `bun run build`
- Repository `ci-fast` pre-push check
- iPhone Simulator WebKit smoke with production MCP payload and PDB 1CRN: WebGL canvas created and structure rendered