### PR TITLE
Refresh hosted widget registration

### DIFF
--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -29,7 +29,7 @@ The production Streamable HTTP endpoint is
 
 All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v16.html` with MIME type
+`ui://burrete/molecular-viewer-v18.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The widget uses the MCP Apps handshake before publishing bounded selection or
@@ -55,7 +55,7 @@ from the model and conversation transcript.
 - PDB lookups use the fixed `files.rcsb.org` download origin.
 - The MCP resource mounts the compiled Burrete React shell directly instead of
   wrapping a separate viewer page. Its CSP permits only the stable production
-  origin for runtime fetches, resources, and the shell's internal viewer frame.
+  origin for runtime fetches and resources; the widget does not embed subframes.
 - The hosted shell loads only the plugin's pinned, self-hosted Burrete, Mol*,
   and RDKit runtime assets.
 - The Mol* 5.7.0 build is transformed by

--- a/apps/burrete-public-plugin/lib/contracts.ts
+++ b/apps/burrete-public-plugin/lib/contracts.ts
@@ -158,7 +158,7 @@ export const molecularSceneInputSchema = z.discriminatedUnion("source", [
 export function viewerToolMeta(invoking: string, invoked: string) {
   return {
     securitySchemes: NOAUTH_SECURITY_SCHEMES,
-    ui: { resourceUri: VIEWER_RESOURCE_URI, visibility: ["model"] as const },
+    ui: { resourceUri: VIEWER_RESOURCE_URI },
     "openai/outputTemplate": VIEWER_RESOURCE_URI,
     "openai/toolInvocation/invoking": invoking,
     "openai/toolInvocation/invoked": invoked,

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,4 +1,4 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v16.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v18.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
@@ -6,7 +6,7 @@ export const VIEWER_SHELL_STYLES_PATH =
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
 export const VIEWER_APP_BRIDGE_SCRIPT_PATH = "/burrete-hosted-app.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-analytics-v1";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-v18";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;
@@ -28,7 +28,6 @@ export function createViewerResourceMeta(appOrigin: string) {
       csp: {
         connectDomains: [appOrigin],
         resourceDomains: [appOrigin],
-        frameDomains: [appOrigin],
       },
     },
     "openai/widgetDescription":
@@ -37,7 +36,6 @@ export function createViewerResourceMeta(appOrigin: string) {
     "openai/widgetCSP": {
       connect_domains: [appOrigin],
       resource_domains: [appOrigin],
-      frame_domains: [appOrigin],
     },
     "openai/widgetDomain": appOrigin,
   } as const;

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -73,7 +73,7 @@ describe("submission tool contract", () => {
   test("links render tools to the versioned viewer resource", () => {
     const meta = viewerToolMeta("Loading…", "Loaded");
     expect(meta.ui.resourceUri).toBe(VIEWER_RESOURCE_URI);
-    expect(meta.ui.visibility).toEqual(["model"]);
+    expect(meta.ui).toEqual({ resourceUri: VIEWER_RESOURCE_URI });
     expect(meta["openai/outputTemplate"]).toBe(VIEWER_RESOURCE_URI);
     expect(meta["openai/widgetAccessible"]).toBe(false);
   });
@@ -108,20 +108,18 @@ describe("viewer resource contract", () => {
     expect(meta.ui.domain).toBe("https://burrete.example");
     expect(meta.ui.csp.connectDomains).toEqual(["https://burrete.example"]);
     expect(meta.ui.csp.resourceDomains).toEqual(["https://burrete.example"]);
-    expect(meta.ui.csp.frameDomains).toEqual(["https://burrete.example"]);
+    expect(meta.ui.csp).not.toHaveProperty("frameDomains");
     expect(meta.ui.prefersBorder).toBe(false);
     expect(meta["openai/widgetPrefersBorder"]).toBe(false);
-    expect(meta["openai/widgetCSP"].frame_domains).toEqual([
-      "https://burrete.example",
-    ]);
+    expect(meta["openai/widgetCSP"]).not.toHaveProperty("frame_domains");
   });
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v16.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v18.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-analytics-v1");
+    expect(html).toContain("?v=viewer-v18");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_APP_BRIDGE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');


### PR DESCRIPTION
## Summary

- move the hosted MCP viewer to a never-used v18 resource URI
- refresh linked asset cache keys so ChatGPT mobile cannot reuse the stale loader
- align tool visibility and CSP metadata with the current MCP Apps contract

## Verification

- `bun run test`
- `bun run typecheck`
- `bun run build`
- local live MCP `tools/list`, `resources/list`, and `resources/read` agreement on v18

## Root cause

The hosted viewer HTML and mobile loader had changed while reusing previously published v16/v17 cache keys. ChatGPT treats the resource URI as the widget cache key, so iOS could receive the tool result without mounting the current component.