### PR TITLE
Publish molecular scene input schema

### DIFF
--- a/apps/burrete-public-plugin/app/mcp/route.ts
+++ b/apps/burrete-public-plugin/app/mcp/route.ts
@@ -144,13 +144,13 @@ function createServer(): McpServer {
     async (input) => {
       try {
         const prepared = input.source === "pdb"
-          ? await preparePdbStructure(input.pdbId)
-          : await prepareAttachedStructure(input.structureFile);
+          ? await preparePdbStructure(input.pdbId!)
+          : await prepareAttachedStructure(input.structureFile!);
         const sourceDescriptor = input.source === "pdb"
-          ? { kind: "pdb", pdbId: input.pdbId.toUpperCase() }
+          ? { kind: "pdb", pdbId: input.pdbId!.toUpperCase() }
           : {
               kind: "attachment",
-              fileName: input.structureFile.file_name ?? prepared.summary.fileName,
+              fileName: input.structureFile!.file_name ?? prepared.summary.fileName,
             };
         return {
           content: [{

--- a/apps/burrete-public-plugin/lib/contracts.ts
+++ b/apps/burrete-public-plugin/lib/contracts.ts
@@ -142,18 +142,41 @@ export const viewerActionSchema = z.discriminatedUnion("type", [
 
 const sceneActionsSchema = z.array(viewerActionSchema).min(1).max(8);
 
-export const molecularSceneInputSchema = z.discriminatedUnion("source", [
-  z.object({
-    source: z.literal("pdb"),
-    pdbId: z.string().trim().regex(/^[0-9][A-Za-z0-9]{3}$/u),
-    actions: sceneActionsSchema,
-  }).strict(),
-  z.object({
-    source: z.literal("attachment"),
-    structureFile: fileReferenceSchema,
-    actions: sceneActionsSchema,
-  }).strict(),
-]);
+export const molecularSceneInputSchema = z.object({
+  source: z.enum(["pdb", "attachment"]),
+  pdbId: z.string().trim().regex(/^[0-9][A-Za-z0-9]{3}$/u).optional(),
+  structureFile: fileReferenceSchema.optional(),
+  actions: sceneActionsSchema,
+}).strict().superRefine((input, context) => {
+  if (input.source === "pdb" && !input.pdbId) {
+    context.addIssue({
+      code: "custom",
+      path: ["pdbId"],
+      message: "pdbId is required when source is pdb.",
+    });
+  }
+  if (input.source === "attachment" && !input.structureFile) {
+    context.addIssue({
+      code: "custom",
+      path: ["structureFile"],
+      message: "structureFile is required when source is attachment.",
+    });
+  }
+  if (input.source === "pdb" && input.structureFile) {
+    context.addIssue({
+      code: "custom",
+      path: ["structureFile"],
+      message: "structureFile is only valid when source is attachment.",
+    });
+  }
+  if (input.source === "attachment" && input.pdbId) {
+    context.addIssue({
+      code: "custom",
+      path: ["pdbId"],
+      message: "pdbId is only valid when source is pdb.",
+    });
+  }
+});
 
 export function viewerToolMeta(invoking: string, invoked: string) {
   return {

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -99,6 +99,17 @@ describe("submission tool contract", () => {
       pdbId: "1CRN",
       actions: [{ type: "select_residues", selector: { arbitrary: "javascript" } }],
     })).toThrow();
+    expect(() => schema.parse({
+      source: "attachment",
+      pdbId: "1CRN",
+      actions: [{ type: "reset_camera" }],
+    })).toThrow();
+
+    const jsonSchema = z.toJSONSchema(schema, { io: "input" }) as {
+      properties?: Record<string, unknown>;
+    };
+    expect(jsonSchema.properties).toHaveProperty("pdbId");
+    expect(jsonSchema.properties).toHaveProperty("structureFile");
   });
 });
 


### PR DESCRIPTION
## Summary
- publish `pdbId` and `structureFile` as top-level MCP input schema properties
- preserve source-specific validation for PDB and attachment requests
- assert the file parameter survives JSON Schema serialization

## Validation
- `bun run typecheck`
- `bun run test` (35 pass)
- `bun run build`
- pre-push `scripts/ci-fast.sh`