### PR TITLE
Fix hosted viewer startup on iPhone

### DIFF
--- a/PreviewExtension/Web/viewer-bootstrap.js
+++ b/PreviewExtension/Web/viewer-bootstrap.js
@@ -14,15 +14,12 @@
       try { window.parent.postMessage({ source: 'burrete-viewer', body }, '*'); } catch (_) {}
     }
   };
-  const webkit = window.webkit || {};
-  const messageHandlers = webkit.messageHandlers || {};
-  if (!messageHandlers.burrete) {
-    messageHandlers.burrete = { postMessage: postToParent };
-  }
-  webkit.messageHandlers = messageHandlers;
-  window.webkit = webkit;
+  const nativeHandler = window.webkit?.messageHandlers?.burrete;
+  const burreteHandler = nativeHandler && typeof nativeHandler.postMessage === 'function'
+    ? nativeHandler
+    : { postMessage: postToParent };
   window.__mqlPost = (type, message, payload) => postToParent({ type, message: message || '', ...(payload || {}) });
-  window.__mqlAction = (name) => messageHandlers.burrete.postMessage({ type: 'action', message: name });
+  window.__mqlAction = (name) => burreteHandler.postMessage({ type: 'action', message: name });
   window.__mqlDebug = () => {};
   window.BurreteInlineMode = true;
   window.BurreteDebug = false;

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -14623,7 +14623,10 @@ ${config.label || 'structure'} (${formatLabel}${size ? `, ${size}` : ''})`);
 
   function showError(error) {
     const message = error && (error.stack || error.message) ? (error.stack || error.message) : String(error);
-    setStatus(`[web] Burrete web renderer failed to load this file.\n\n${message}\n\nCheck: ./scripts/tail-log.sh`, 'error');
+    const diagnostics = window.__BURRETE_HOSTED_MCP_WIDGET__ === true
+      ? ''
+      : '\n\nCheck: ./scripts/tail-log.sh';
+    setStatus(`[web] Burrete web renderer failed to load this file.\n\n${message}${diagnostics}`, 'error');
     // eslint-disable-next-line no-console
     console.error(error);
   }

--- a/apps/burrete-public-plugin/README.md
+++ b/apps/burrete-public-plugin/README.md
@@ -29,7 +29,7 @@ The production Streamable HTTP endpoint is
 
 All tools are read-only, idempotent, non-destructive, and cannot write to the
 public internet. Each declares an exact output schema and renders
-`ui://burrete/molecular-viewer-v18.html` with MIME type
+`ui://burrete/molecular-viewer-v19.html` with MIME type
 `text/html;profile=mcp-app`.
 
 The widget uses the MCP Apps handshake before publishing bounded selection or

--- a/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
+++ b/apps/burrete-public-plugin/assets/burrete-hosted-mobile.js
@@ -92,14 +92,6 @@
     document.body.appendChild(script);
     return loaded;
   };
-  const preloadScript = (name) => {
-    const link = document.createElement("link");
-    link.rel = "preload";
-    link.as = "script";
-    link.crossOrigin = "anonymous";
-    link.href = `${assetsBase}/${name}`;
-    document.head.appendChild(link);
-  };
   const jsonElement = (id, value) => {
     const element = document.createElement("script");
     element.id = id;
@@ -158,12 +150,10 @@
     const runtimeScripts = [
       "viewer-shell.js",
       "viewer-bootstrap.js",
-      "molstar.js",
       "burette-agent.js",
       "trajectory-smoothing.js",
       "viewer.js",
     ];
-    for (const name of runtimeScripts) preloadScript(name);
 
     await Promise.all([
       addStylesheet("viewer-runtime.css"),
@@ -213,6 +203,7 @@
 
     await loadScript(runtimeScripts[0]);
     await loadScript(runtimeScripts[1]);
+    window.BurreteMolstarURL = `${assetsBase}/molstar.js`;
     window.BurreteHostedAppBridge?.setSource(structure.source);
     void window.BurreteHostedAppBridge?.updateSelection(null, documentId);
     window.__mqlPost = (type, message, payload = {}) => {

--- a/apps/burrete-public-plugin/lib/widget.ts
+++ b/apps/burrete-public-plugin/lib/widget.ts
@@ -1,4 +1,4 @@
-export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v18.html";
+export const VIEWER_RESOURCE_URI = "ui://burrete/molecular-viewer-v19.html";
 export const VIEWER_SHELL_SCRIPT_PATH =
   "/viewer-shell/assets/burrete-hosted-shell.js";
 export const VIEWER_SHELL_STYLES_PATH =
@@ -6,7 +6,7 @@ export const VIEWER_SHELL_STYLES_PATH =
 export const VIEWER_RUNTIME_ASSETS_PATH = "/burrete-viewer/";
 export const VIEWER_MOBILE_SCRIPT_PATH = "/burrete-hosted-mobile.js";
 export const VIEWER_APP_BRIDGE_SCRIPT_PATH = "/burrete-hosted-app.js";
-const VIEWER_SHELL_ASSET_VERSION = "viewer-v18";
+const VIEWER_SHELL_ASSET_VERSION = "viewer-v19";
 
 function assetUrl(origin: string, assetPath: string): string {
   if (!origin) return assetPath;

--- a/apps/burrete-public-plugin/tests/contracts.test.ts
+++ b/apps/burrete-public-plugin/tests/contracts.test.ts
@@ -127,10 +127,10 @@ describe("viewer resource contract", () => {
 
   test("mounts the real Burrete shell directly and listens for MCP tool results", () => {
     const html = createViewerWidgetHtml("https://burrete.example");
-    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v18.html");
+    expect(VIEWER_RESOURCE_URI).toBe("ui://burrete/molecular-viewer-v19.html");
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_SHELL_STYLES_PATH}`);
-    expect(html).toContain("?v=viewer-v18");
+    expect(html).toContain("?v=viewer-v19");
     expect(html).toContain(`https://burrete.example${VIEWER_MOBILE_SCRIPT_PATH}`);
     expect(html).toContain(`https://burrete.example${VIEWER_APP_BRIDGE_SCRIPT_PATH}`);
     expect(html).toContain('window.matchMedia("(max-width: 600px)").matches');
@@ -164,6 +164,7 @@ describe("viewer resource contract", () => {
     expect(source).toContain('quickLookBuild: "burrete-hosted-mobile-direct"');
     expect(source).toContain('document.body.className = "burette-opaque-background burette-mobile-host"');
     expect(source).toContain('molstarPowerPreference: "default"');
+    expect(source).toContain('window.BurreteMolstarURL = `${assetsBase}/molstar.js`');
     expect(source).toContain('molstarPreferWebgl1: true');
     expect(source).toContain('molstarDisableAntialiasing: true');
     expect(source).toContain('molstarPixelScale: 0.75');
@@ -174,13 +175,94 @@ describe("viewer resource contract", () => {
     expect(source).toContain('layoutShowLog: false');
     expect(source).toContain('layoutShowLeftPanel: false');
     expect(source).toContain('await Promise.all([\n      addStylesheet("viewer-runtime.css"),\n      addStylesheet("molstar.css"),\n    ])');
-    expect(source).toContain('link.rel = "preload"');
-    expect(source).toContain('link.as = "script"');
-    expect(source).toContain('for (const name of runtimeScripts) preloadScript(name)');
+    expect(source).not.toContain('link.rel = "preload"');
+    expect(source).not.toContain('preloadScript');
     expect(source).toContain('canvasBackground: "black"');
     expect(source).toContain("BurreteHostedAppBridge");
     expect(source).not.toContain("<iframe");
     expect(source).not.toContain("srcdoc");
+  });
+
+  test("bootstraps inside a WKWebView with protected native WebKit globals", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../../../PreviewExtension/Web/viewer-bootstrap.js",
+    ), "utf8");
+    const posted: unknown[] = [];
+    const parent = {
+      postMessage(message: unknown) {
+        posted.push(message);
+      },
+    };
+    const window = { parent } as {
+      parent: typeof parent;
+      webkit?: unknown;
+      BurreteConfig?: Record<string, unknown>;
+      BurreteDataBase64?: string;
+      __mqlPost?: (type: string, message: string, payload?: Record<string, unknown>) => void;
+    };
+    Object.defineProperty(window, "webkit", {
+      configurable: false,
+      value: Object.freeze({ messageHandlers: Object.freeze({}) }),
+      writable: false,
+    });
+    const runtimeElements = new Map([
+      ["burrete-runtime-config", { textContent: JSON.stringify({ documentId: "document-1" }) }],
+      ["burrete-runtime-data", { textContent: JSON.stringify("QUJD") }],
+    ]);
+    const document = {
+      getElementById(id: string) {
+        return runtimeElements.get(id) || null;
+      },
+    };
+
+    vm.runInNewContext(source, { document, window });
+
+    expect(window.BurreteConfig).toEqual({ documentId: "document-1" });
+    expect(window.BurreteDataBase64).toBe("QUJD");
+    window.__mqlPost?.("ready", "Ready");
+    expect(posted).toEqual([{
+      source: "burrete-viewer",
+      body: { type: "ready", message: "Ready", documentId: "document-1" },
+    }]);
+  });
+
+  test("preserves the native Quick Look message handler", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../../../PreviewExtension/Web/viewer-bootstrap.js",
+    ), "utf8");
+    const posted: unknown[] = [];
+    const nativeHandler = Object.freeze({
+      postMessage(message: unknown) {
+        posted.push(message);
+      },
+    });
+    const window = {
+      parent: null,
+      webkit: Object.freeze({
+        messageHandlers: Object.freeze({ burrete: nativeHandler }),
+      }),
+    } as {
+      parent: null;
+      webkit: unknown;
+      __mqlAction?: (name: string) => void;
+    };
+    const document = { getElementById: () => null };
+
+    vm.runInNewContext(source, { document, window });
+    window.__mqlAction?.("resetCamera");
+
+    expect(posted).toEqual([{ type: "action", message: "resetCamera" }]);
+  });
+
+  test("does not expose local diagnostics inside the hosted widget", () => {
+    const source = readFileSync(path.resolve(
+      import.meta.dir,
+      "../../../PreviewExtension/Web/viewer.js",
+    ), "utf8");
+    expect(source).toContain("window.__BURRETE_HOSTED_MCP_WIDGET__ === true");
+    expect(source).toContain("? ''\n      : '\\n\\nCheck: ./scripts/tail-log.sh'");
   });
 
   test("starts the mobile viewer when tool output and metadata arrive separately", () => {


### PR DESCRIPTION
## Why

The hosted Burrete widget could open in ChatGPT on desktop but fail on a physical iPhone before Mol* rendered. The WKWebView runtime exposes protected WebKit bridge objects, and the Mol* recovery path resolved to a missing root-relative asset.

## What Changed

- stop mutating the native `window.webkit` bridge while preserving the Quick Look message handler
- let the viewer load Mol* once from the explicit same-origin `/burrete-viewer/molstar.js` URL
- remove the eager mobile script preloads that increased WKWebView startup pressure
- hide local `tail-log.sh` guidance inside the public hosted widget
- publish the updated widget contract as `molecular-viewer-v19.html`
- add WKWebView bridge, native handler, hosted diagnostics, and mobile asset URL contract coverage

Affected surfaces: plugin/MCP hosted widget, iPhone ChatGPT rendering, and the shared Quick Look bootstrap bridge.

## Verification

- `bun run test` in `apps/burrete-public-plugin` — 38 passed
- `bun run typecheck` in `apps/burrete-public-plugin`
- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-tauri-structure.mjs`
- `bun tests/test-viewer-bridge-message-contract.mjs`
- pre-push `scripts/ci-fast.sh`

## Notes / Follow-Up

Production deployment and a fresh physical-iPhone ChatGPT smoke will follow merge.
