### PR TITLE
Publish grid assets for the hosted demo

### DIFF
--- a/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
+++ b/apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs
@@ -16,6 +16,8 @@ const HOSTED_APP_SOURCE = path.join(APP_ROOT, "assets/burrete-hosted-app.ts");
 const HOSTED_APP_OUTPUT = path.join(APP_ROOT, "public/burrete-hosted-app.js");
 const VIEWER_FILES = [
   "burette-agent.js",
+  "grid-ui.js",
+  "grid-viewer.js",
   "viewer-runtime.css",
   "viewer-bootstrap.js",
   "viewer-shell.js",

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -201,6 +201,7 @@ const [
   buildDevScript,
   remoteCheckScript,
   patchWebAssetsScript,
+  hostedViewerBuildScript,
   desmondPreviewExtract,
   fepGraphmlSample,
   rdkitConformer,
@@ -398,6 +399,7 @@ const [
   source('scripts/build-dev.sh'),
   source('scripts/check-remote.sh'),
   source('scripts/patch-web-assets.sh'),
+  source('apps/burrete-public-plugin/scripts/build-hosted-viewer.mjs'),
   source('scripts/desmond_preview_extract.py'),
   source('samples/fep/ligand_network.graphml'),
   source('scripts/rdkit_conformer.py'),
@@ -672,6 +674,8 @@ assert.match(patchWebAssetsScript, /WEB ASSET PATCH SUCCEEDED/);
 assert.doesNotMatch(patchWebAssetsScript, /xcodebuild/);
 assert.doesNotMatch(patchWebAssetsScript, /cargo build/);
 assert.doesNotMatch(patchWebAssetsScript, /build:tauri/);
+assert.match(hostedViewerBuildScript, /"grid-ui\.js"/);
+assert.match(hostedViewerBuildScript, /"grid-viewer\.js"/);
 assert.equal(JSON.parse(tauriConfig).bundle.resources['../public/xyzrender-gallery'], 'xyzrender-gallery');
 assert.equal(JSON.parse(tauriConfig).bundle.resources['../../../PreviewExtension/Web'], 'ViewerWeb');
 assert.match(previewRuntimeViewer, /resolve\("ViewerWeb", tauri::path::BaseDirectory::Resource\)/);


### PR DESCRIPTION
## Why

The public web demo can open the requested MOSES CSV, but its molecule grid remains on `Loading molecule grid...` because `/burrete-viewer/grid-ui.js` and `/burrete-viewer/grid-viewer.js` are missing from the hosted deployment. The desktop app is unaffected because it loads those assets from the bundled viewer runtime.

## What changed

- publish `grid-ui.js` and `grid-viewer.js` with the hosted viewer assets
- add a UI shell contract assertion covering both required grid runtime files

## Affected surfaces

- Public hosted browser demo and hosted viewer grid rendering
- No desktop, Quick Look, format, or native application contract changes

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun run assets:viewer` from `apps/burrete-public-plugin`
- generated grid assets compared byte-for-byte with `PreviewExtension/Web` sources
- repository pre-push `ci-fast` passed