### PR TITLE
Resolve hosted RDKit from the iframe base

### DIFF
--- a/apps/desktop/src/lib/browser-dev-documents.ts
+++ b/apps/desktop/src/lib/browser-dev-documents.ts
@@ -117,9 +117,6 @@ const WEB_ASSETS_BASE = String(
   || "",
 )
   || fsUrl(`${REPO_ROOT}/PreviewExtension/Web/`);
-const RDKIT_WASM_PATH = WEB_ASSETS_BASE.startsWith("/@fs/")
-  ? "/__burette/rdkit-wasm"
-  : `${WEB_ASSETS_BASE.replace(/\/$/u, "")}/rdkit/RDKit_minimal.wasm`;
 const AMBER_NETCDF_EXTENSIONS = new Set(["nc", "ncdf", "netcdf", "ncrst"]);
 const TRAJECTORY_PAIR_EXTENSIONS = new Set([
   "xtc", "trr", "dcd", "nctraj", "nc", "ncdf", "netcdf", "ncrst", "lammpstrj",
@@ -1212,7 +1209,7 @@ function viewerHtml(
     trajectoryControls: renderer === "molstar" && trajectoryFrameCount > 1,
     trajectoryFrameCount,
     ...(reloadOptions?.activeModel != null ? { activeModel: reloadOptions.activeModel } : {}),
-    rdkitWasmPath: RDKIT_WASM_PATH,
+    rdkitWasmPath: "/__burette/rdkit-wasm",
     ...(reloadOptions?.sdfPoseControlLabel ? { sdfPoseControlLabel: reloadOptions.sdfPoseControlLabel } : {}),
     ...(stagedEntries?.some((entry) => entry?.representation === "structure-scene-entry") ? { structureSceneMode: "structurePoses" } : {}),
     appViewer: true,
@@ -1255,7 +1252,10 @@ function viewerHtml(
   <script id="burrete-runtime-data" type="application/json">${serializeInlineJson(bytesToBase64(embeddedBytes))}</script>
   <script src="${viewerAsset("viewer-bootstrap.js")}?v=${runtimeAssetVersion}"></script>`
     : `<script>${viewerBridgeJs()}</script>
-  <script>window.BurreteConfig = ${serializeInlineJson(config)};</script>
+  <script>
+    window.BurreteConfig = ${serializeInlineJson(config)};
+    if (!document.baseURI.includes('/@fs/')) window.BurreteConfig.rdkitWasmPath = new URL('rdkit/RDKit_minimal.wasm', document.baseURI).href;
+  </script>
   <script>window.BurreteDataBase64 = "${bytesToBase64(embeddedBytes)}";</script>`;
   return `<!doctype html>
 <html lang="en">
@@ -1427,7 +1427,7 @@ async function gridHtml(
     recordsIncluded: records.length,
     recordsTruncated: false,
     pageSize: 720,
-    rdkitWasmPath: RDKIT_WASM_PATH,
+    rdkitWasmPath: "/__burette/rdkit-wasm",
     xyzrenderPreset: "default",
     xyzrenderPresetOptions: [
       { value: "default", label: "Default" },
@@ -1491,7 +1491,10 @@ async function gridHtml(
 <body class="${visuals.transparentBackground ? "burette-transparent-background" : "burette-opaque-background"}">
   <div id="app"></div>
   <div id="status">Loading molecule grid...</div>
-  <script>window.BurreteConfig = ${serializeInlineJson(config)};</script>
+  <script>
+    window.BurreteConfig = ${serializeInlineJson(config)};
+    if (!document.baseURI.includes('/@fs/')) window.BurreteConfig.rdkitWasmPath = new URL('rdkit/RDKit_minimal.wasm', document.baseURI).href;
+  </script>
   <script>window.BurreteGridRecords = ${serializeInlineJson(records)};</script>
   ${format === "dwar" ? `<script src="openchemlib/openchemlib.js?v=${GRID_ASSET_VERSION}"></script>` : ""}
   <script src="rdkit/RDKit_minimal.js?v=${GRID_ASSET_VERSION}"></script>

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -597,7 +597,7 @@ assert.match(browserDevDocuments, /if \(normalized === "xyzrender-external"\) re
 assert.match(browserDevDocuments, /requestedRenderer: normalizeRendererMode\(preferences\.rendererMode\)/);
 assert.match(browserDevDocuments, /sourcePath: path/);
 assert.match(browserDevDocuments, /xyzrenderEndpoint: "\/__burette\/xyzrender"/);
-assert.match(browserDevDocuments, /WEB_ASSETS_BASE\.startsWith\("\/@fs\/"\)[\s\S]*"\/__burette\/rdkit-wasm"[\s\S]*\/rdkit\/RDKit_minimal\.wasm/);
+assert.equal(browserDevDocuments.match(/if \(!document\.baseURI\.includes\('\/@fs\/'\)\) window\.BurreteConfig\.rdkitWasmPath = new URL\('rdkit\/RDKit_minimal\.wasm', document\.baseURI\)\.href;/g)?.length, 2);
 assert.match(browserDevDocuments, /vdwAtoms: null/);
 assert.match(browserDevDocuments, /hullMode: null/);
 assert.match(browserDevDocuments, /hullAtoms: null/);
@@ -5900,7 +5900,7 @@ assert.match(browserDevDocuments, /documentId,\s*sourcePath: path,/);
 assert.match(browserDevDocuments, /body\.documentId = String\(window\.BurreteConfig\.documentId\)/);
 assert.match(browserDevDocuments, /window\.BurreteGridRecords =/);
 assert.match(browserDevDocuments, /openchemlib\/openchemlib\.js\?v=\$\{GRID_ASSET_VERSION\}/);
-assert.equal(browserDevDocuments.match(/rdkitWasmPath: RDKIT_WASM_PATH/g)?.length, 2);
+assert.equal(browserDevDocuments.match(/rdkitWasmPath: "\/__burette\/rdkit-wasm"/g)?.length, 2);
 assert.doesNotMatch(browserDevDocuments, /BurreteRDKitWasmBase64/);
 assert.match(gridViewer, /cfg\.appViewer === true && cfg\.gridDataMode === 'bridge'/);
 assert.match(gridViewer, /\(cfg\.appViewer === true \|\| cfg\.quickLookViewer === true\) && !!caps\.rendererSwitch/);


### PR DESCRIPTION
## Why

The hosted MOSES grid now loads its scripts and stylesheet, but production still selects `/__burette/rdkit-wasm` before the generated iframe base is rewritten to `/burrete-viewer/`. Its fallback therefore ends at a 404 and molecule cards remain unrendered.

## What changed

- keep the browser-dev RDKit endpoint in generated viewer configs
- after the iframe `<base>` is established, resolve hosted RDKit wasm from the actual `document.baseURI`
- apply the same runtime resolution to grid and structure viewer documents
- update the UI shell contract to require both runtime overrides

## Affected surfaces

- Hosted public viewer and molecule grid RDKit rendering
- Local Vite `/@fs/` sessions keep `/__burette/rdkit-wasm` unchanged
- No native desktop, Quick Look, or file-format contract changes

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-collection-documents.mjs`
- `bun run assets:viewer` from `apps/burrete-public-plugin`
- repository pre-push `ci-fast` passed
- production failure reproduced with config `/__burette/rdkit-wasm`; the new contract resolves against the iframe base before RDKit scripts execute