### PR TITLE
Document plugin demo evidence

### DIFF
--- a/apps/burrete-public-plugin/submission/portal-copy.md
+++ b/apps/burrete-public-plugin/submission/portal-copy.md
@@ -15,6 +15,8 @@
   captured from the production v21 widget in a real ChatGPT conversation after
   refreshing the developer connector.
 - **Live ChatGPT proof:** https://chatgpt.com/c/6a57781a-b1b0-83ea-bb65-4c5b13bcc3a8
+- **Desktop demo video:** https://burrete-landing.vercel.app/assets/burrete-chatgpt-plugin-demo.mp4
+- **Physical iPhone demo video:** https://burrete-landing.vercel.app/assets/burrete-chatgpt-plugin-demo-iphone.mp4
 - **Mobile verification:** the same production v21 plugin was confirmed working
   on a physical iPhone on July 15, 2026.
 


### PR DESCRIPTION
## Why

The OpenAI submission manifest should point to the now-published desktop and physical-iPhone demo recordings instead of leaving the evidence URLs implicit.

## What Changed

- add the stable desktop plugin demo URL
- add the stable physical iPhone demo URL

Affected surfaces: plugin/MCP submission documentation.

## Verification

- confirmed both production URLs return `200 video/mp4`
- played both production videos in the hosted documentation page
- `bun test tests/submission.test.ts`
- repository pre-push `ci-fast` hook