### PR TITLE
Fix SMILES Quick Look type collision

### DIFF
--- a/PreviewExtension/Info.plist
+++ b/PreviewExtension/Info.plist
@@ -35,6 +35,7 @@
 				<string>com.local.burrete10.mmtf</string>
 				<string>com.local.burrete10.sdf</string>
 				<string>com.local.burrete10.smiles</string>
+				<string>gg.flew.unfold.subtitle-smi</string>
 				<string>com.local.burrete10.csv</string>
 				<string>com.local.burrete10.datawarrior</string>
 				<string>com.local.burrete10.tsv</string>

--- a/PreviewExtension/ThumbnailInfo.plist
+++ b/PreviewExtension/ThumbnailInfo.plist
@@ -35,6 +35,7 @@
 				<string>com.local.burrete10.mmtf</string>
 				<string>com.local.burrete10.sdf</string>
 				<string>com.local.burrete10.smiles</string>
+				<string>gg.flew.unfold.subtitle-smi</string>
 				<string>com.local.burrete10.csv</string>
 				<string>com.local.burrete10.datawarrior</string>
 				<string>com.local.burrete10.tsv</string>

--- a/config/preview-formats.json
+++ b/config/preview-formats.json
@@ -117,6 +117,7 @@
     {
       "id": "smiles",
       "contentType": "com.local.burrete10.smiles",
+      "quickLookContentTypeAliases": ["gg.flew.unfold.subtitle-smi"],
       "extensions": ["smi", "smiles"],
       "mimeTypes": ["chemical/x-daylight-smiles", "chemical/x-smiles"],
       "conformsTo": ["public.plain-text", "public.data"],
@@ -494,6 +495,7 @@
       "com.local.burrete10.mmtf",
       "com.local.burrete10.sdf",
       "com.local.burrete10.smiles",
+      "gg.flew.unfold.subtitle-smi",
       "com.local.burrete10.csv",
       "com.local.burrete10.tsv",
       "com.local.burrete10.datawarrior",

--- a/scripts/check-preview-format-registry.mjs
+++ b/scripts/check-preview-format-registry.mjs
@@ -86,6 +86,7 @@ const allowedSystemQuickLookContentTypes = new Set([
   'com.schrodinger.pdb',
   'com.schrodinger.sdf',
   'gg.flew.unfold.gromacs-structure',
+  'gg.flew.unfold.subtitle-smi',
   'net.sourceforge.openbabel.mdl',
   'net.sourceforge.openbabel.xyz',
   'public.cif',

--- a/tests/fixtures/quicklook-compatibility/manifest.json
+++ b/tests/fixtures/quicklook-compatibility/manifest.json
@@ -32,6 +32,11 @@
       "observedContentType": "com.revvity.external.cif"
     },
     {
+      "path": "tests/fixtures/quicklook-compatibility/single.smi",
+      "formatId": "smiles",
+      "observedContentType": "gg.flew.unfold.subtitle-smi"
+    },
+    {
       "path": "tests/fixtures/quicklook-compatibility/junk2.sdf",
       "formatId": "sdf",
       "observedContentType": "com.schrodinger.sdf"

--- a/tests/fixtures/quicklook-compatibility/single.smi
+++ b/tests/fixtures/quicklook-compatibility/single.smi
@@ -1,0 +1,1 @@
+CCO ethanol


### PR DESCRIPTION
## Why

macOS can classify `.smi` files as Unfold's `gg.flew.unfold.subtitle-smi`, causing Finder Quick Look to bypass Burrete even when the file contains valid SMILES.

## What Changed

- register the observed Unfold `.smi` UTI as a Quick Look-only alias for SMILES
- keep preview and thumbnail extension metadata synchronized
- add a compatibility fixture covering a single-record SMILES file

## Verification

- `bun run test:update`
- pre-push `ci-fast`
- native Quick Look smoke on `single.smi`: grid renderer ready with 1 molecule and 1 RDKit image
