### PR TITLE
Fix Ketcher multi-SMILES import and browser drops

### DIFF
--- a/apps/desktop/src/components/ketcher-page.tsx
+++ b/apps/desktop/src/components/ketcher-page.tsx
@@ -17,7 +17,7 @@ import { createPortal } from "react-dom";
 
 import ligandProLogo from "../assets/short-logo-ligandpro.svg";
 import { collectionExtension, collectionFamily as collectionFamilyForExtension, type CollectionFamily } from "../lib/collection-documents";
-import { detectKetcherImportFormat } from "../lib/ketcher-import-format";
+import { detectKetcherImportFormat, normalizeKetcherSmilesImport } from "../lib/ketcher-import-format";
 import { readStructureText } from "../lib/structure-text";
 import { hasStructureDrag, readStructureDragPayload, structureDragRecordsToFragments, writeStructureDragRecords } from "../lib/structure-drag";
 import { resolveThemeMode, useSystemThemeMode } from "../lib/theme";
@@ -1015,13 +1015,13 @@ export function KetcherPage({
 
   const handleDrop = useCallback((event: DragEvent<HTMLElement>) => {
     if (!hasStructureDrag(event.dataTransfer)) return;
+    const payload = readStructureDragPayload(event.dataTransfer);
+    const choices = shellDropActionChoices(payload, { kind: "ketcher" }, { kind: "ketcher" });
+    if (choices.length === 0) return;
     event.preventDefault();
     event.stopPropagation();
     actions.setStructureDragActive(false);
     setDropActive(false);
-    const payload = readStructureDragPayload(event.dataTransfer);
-    const choices = shellDropActionChoices(payload, { kind: "ketcher" }, { kind: "ketcher" });
-    if (choices.length === 0) return;
     runShellDropActionChoices(actions, payload, choices.slice(0, 1), { x: event.clientX, y: event.clientY }, {
       importKetcherStructures: (actionPayload) => {
         if (!ketcher) return false;
@@ -1498,7 +1498,7 @@ function peekQueuedKetcherImportRequest() {
 
 function ketcherImportCandidates(text: string) {
   return Array.from(new Set([
-    normalizeKetcherImportText(text),
+    normalizeKetcherImportText(text, detectKetcherImportFormat(text)),
     text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd(),
   ].map((candidate) => candidate.trimEnd()).filter(Boolean)));
 }
@@ -1595,6 +1595,7 @@ function waitForMs(ms: number) {
 
 function normalizeKetcherImportText(text: string, format?: KetcherTextFormat) {
   const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd();
+  if (format === "smiles") return normalizeKetcherSmilesImport(normalized);
   if (
     looksLikeMolBlock(normalized) ||
     looksLikeSdfRecord(normalized) ||

--- a/apps/desktop/src/lib/ketcher-import-format.ts
+++ b/apps/desktop/src/lib/ketcher-import-format.ts
@@ -37,3 +37,20 @@ export function detectKetcherImportFormat(text: string): KetcherDetectedImportFo
   if (/\$\(|\[[^\]]*(?:!|;|&|,|#\d)[^\]]*\]|[~?]/u.test(value)) return "smarts";
   return "smiles";
 }
+
+export function normalizeKetcherSmilesImport(text: string) {
+  const value = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+  const lines = value.split("\n").map((line) => line.trim()).filter(Boolean);
+  const candidates = lines.length > 1
+    ? lines.map((line) => line.split(/\s+/u)[0] ?? "")
+    : value.split(/\s+/u);
+  if (candidates.length < 2 || !candidates.every(looksLikeSmilesToken)) return value;
+  return candidates.join(".");
+}
+
+function looksLikeSmilesToken(value: string) {
+  if (!value || /\s/u.test(value)) return false;
+  const withoutAtoms = value.replace(/Br|Cl|\[[^\]]+\]|[BCNOFPSIbcnops*]/gu, "");
+  return withoutAtoms.length < value.length
+    && Array.from(withoutAtoms).every((character) => "0123456789@+-()\\/%=#$:.".includes(character));
+}

--- a/tests/test-ketcher-import-format.mjs
+++ b/tests/test-ketcher-import-format.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { detectKetcherImportFormat } from "../apps/desktop/src/lib/ketcher-import-format.ts";
+import { detectKetcherImportFormat, normalizeKetcherSmilesImport } from "../apps/desktop/src/lib/ketcher-import-format.ts";
 
 const molV2000 = [
   "example",
@@ -22,5 +22,8 @@ assert.equal(detectKetcherImportFormat("InChI=1S/CH4/h1H4"), "inchi");
 assert.equal(detectKetcherImportFormat("InChI=1S/CH4/h1H4\nAuxInfo=1/0/N:1/rA:1C/rB:/rC:;"), "inchi-aux");
 assert.equal(detectKetcherImportFormat('{"root":{"nodes":[]}}'), "ket");
 assert.equal(detectKetcherImportFormat("<cml><molecule /></cml>"), "cml");
+assert.equal(normalizeKetcherSmilesImport("CCO ethanol\nCC propane"), "CCO.CC");
+assert.equal(normalizeKetcherSmilesImport("CCO CC"), "CCO.CC");
+assert.equal(normalizeKetcherSmilesImport("CCO ethanol"), "CCO ethanol");
 
 console.log("Ketcher import format tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3130,6 +3130,7 @@ assert.match(ketcherPage, /panelMode\.format === "auto" \? detectedImportFormat 
 assert.match(ketcherPage, /liveImportSerialRef\.current = serial;/);
 assert.match(ketcherPage, /IS_KETCHER_WEB_DEMO && importText && ketcherImportUsesStructService\(format\)/);
 assert.match(ketcherPage, /await withKetcherTimeout\(loadInteractiveKetcherImport\(ketcher, importText, format\), `\$\{label\} import`\)/);
+assert.match(ketcherPage, /const handleDrop = useCallback[\s\S]*?const payload = readStructureDragPayload\(event\.dataTransfer\);\s*const choices = shellDropActionChoices[\s\S]*?if \(choices\.length === 0\) return;\s*event\.preventDefault\(\);\s*event\.stopPropagation\(\);/);
 assert.match(ketcherPage, /ketcherImportUsesStructService\(format\)\s*\?\s*instance\.setMolecule\(text, \{ needZoom: true \}\)\s*:\s*instance\.setMolfile\(firstMolBlock\(text\)\)/);
 assert.match(ketcherPage, /if \(ketcherStructServiceReady\) return Promise\.resolve\(\)/);
 assert.match(ketcherPage, /if \(!IS_KETCHER_WEB_DEMO\) fallbackId = window\.setTimeout\(finish, 750\)/);


### PR DESCRIPTION
## Why

Ketcher's Auto import field should accept pasted SMILES lists, including one molecule per line with optional names, and browser file drops should reach the shell fallback when the browser does not expose a local path.

## What Changed

- normalize multi-line and whitespace-separated SMILES lists into separate Ketcher molecules
- preserve a single `SMILES name` entry as-is
- apply the same normalization to detected SMILES file imports
- let browser `File` drops without a local path continue to the shell-level drag-and-drop handler
- add focused regression coverage for both import and drop routing

Affected surfaces: desktop app, browser-dev, and the hosted web demo built from the desktop frontend.

## Verification

- `bun tests/test-ketcher-import-format.mjs`
- `bun tests/test-structure-drag.mjs`
- `bun tests/test-drop-actions.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `bun run --cwd apps/burrete-public-plugin build`
- pre-push `ci-fast` hook, including JS/vendor/format checks, Rust fmt + clippy, UI/agent/update/structure contract suites
- live browser-dev import of named multi-line SMILES and browser drag-and-drop of an SDF file
