### PR TITLE
Hide workspace docks by default

### DIFF
--- a/apps/desktop/src/stores/shell-store.ts
+++ b/apps/desktop/src/stores/shell-store.ts
@@ -232,7 +232,7 @@ export const useShellStore = create<ShellState>()(
     (set) => ({
       sidebarOpen: true,
       sidebarWidth: 240,
-      rightDockOpen: true,
+      rightDockOpen: false,
       rightDockWidth: 360,
       rightDockTabs: normalizeDockTabs("right", undefined),
       rightDockActiveTab: firstDockTabKind("right"),

--- a/tests/test-shell-store-behavior.mjs
+++ b/tests/test-shell-store-behavior.mjs
@@ -23,7 +23,7 @@ globalThis.window = { localStorage: globalThis.localStorage };
 const { useShellStore } = await import("../apps/desktop/src/stores/shell-store.ts");
 
 const initial = useShellStore.getState();
-assert.equal(initial.rightDockOpen, true);
+assert.equal(initial.rightDockOpen, false);
 assert.deepEqual(initial.rightDockTabs.map((tab) => tab.kind), [
   "inspector",
   "text",

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -472,7 +472,7 @@ assert.match(sidebarHook, /export function useSidebar\(/);
 assert.match(sidebarHook, /from "\.\.\/stores\/shell-store"/);
 assert.match(sidebarHook, /sidebarWidth/);
 assert.match(shellStore, /sidebarWidth: 240/);
-assert.match(shellStore, /rightDockOpen: true/);
+assert.match(shellStore, /rightDockOpen: false/);
 assert.match(shellStore, /bottomDockOpen: false/);
 assert.match(viewerFrame, /"data-renderer": document\.renderer/);
 assert.match(appViewerReloadActionsHook, /activeViewerIframeForDocument\(document\.id\)/);


### PR DESCRIPTION
## Why

Burrete opened with the right inspector dock visible, while the intended default workspace is focused on the main content area with auxiliary docks hidden.

## What Changed

- Set the desktop shell's initial right dock state to closed.
- Kept the bottom dock closed by default.
- Updated shell behavior and UI contract tests.

## Verification

- `bun tests/test-shell-store-behavior.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `git diff --check`

The persisted `burrete.shell.ui` layout remains respected for existing users.