### PR TITLE
Release Burrete 1.0.27

### DIFF
--- a/Burrete.xcodeproj/project.pbxproj
+++ b/Burrete.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -474,7 +474,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -524,7 +524,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -545,7 +545,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -568,7 +568,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BurreteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0.26;
+				MARKETING_VERSION = 1.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BurreteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burrete"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "base64 0.22.1",
  "burrete-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burrete"
-version = "1.0.26"
+version = "1.0.27"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burrete"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burrete",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "identifier": "com.local.BurreteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "packages/burrete": {
       "name": "burrete",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "bin": "bin/burrete.mjs",
     },
     "packages/ketcher-agent-contract": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burrete/package.json
+++ b/packages/burrete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burrete",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "CLI installer for the Burrete macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why

Publish the live molecular source editor together with the accumulated browser, hosted widget, Ketcher, Quick Look, and plugin submission improvements since 1.0.26.

## What Changed

- bump Burrete desktop, CLI installer, Rust, Tauri, lockfile, and Xcode versions to 1.0.27
- package live text editing for supported molecular structures with synchronized viewer updates
- include default-hidden workspace docks and xyzrender controls scoped to the xyzrender mode
- include Ketcher desktop/hosted agent integration and recent browser, hosted renderer, Quick Look, mobile widget, and plugin evidence fixes

Affected surfaces: macOS desktop app, browser-dev, hosted widget, Quick Look preview and thumbnail extensions, iPhone source app version metadata, CLI installer, release artifacts, and Homebrew cask.

## Verification

- `bun run check:release`
- `./scripts/release.sh --dry-run`
- `bun run ci:fast`
- pre-push `ci-fast` hook

## Notes / Follow-Up

After publication, verify the GitHub ZIP/DMG checksums and the external Homebrew cask. npm publication remains a separate distribution lane.