### PR TITLE
Deduplicate Dependabot Cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,17 +20,3 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-
-  - package-ecosystem: cargo
-    directory: /apps/desktop/src-tauri
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: cargo
-    directory: /crates/burrete-core
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
## Why

Dependabot was configured to scan the root Cargo workspace and both workspace member directories independently. This produced duplicate Rust dependency pull requests for the same update.

## What Changed

- Keep the root Cargo workspace update entry.
- Remove the overlapping `apps/desktop/src-tauri` and `crates/burrete-core` Cargo entries.
- Leave the GitHub Actions and Bun update configuration unchanged.

This only changes dependency-update automation; desktop, Quick Look, browser-dev, iPhone, plugin/MCP, and release runtime behavior are unaffected.

## Verification

- Parsed `.github/dependabot.yml` and asserted exactly one root Cargo update entry.
- Confirmed Cargo resolves `apps/desktop/src-tauri/Cargo.toml` through the repository root workspace.
- Ran the full local `ci:fast` pre-push gate successfully.
