### PR TITLE
Fix macOS window close sheet lifecycle

### DIFF
--- a/apps/desktop/src/hooks/use-app-native-menu.ts
+++ b/apps/desktop/src/hooks/use-app-native-menu.ts
@@ -310,6 +310,10 @@ export function useAppNativeMenu({
             || finalDirtySnapshot.closeGuardRevision !== closeGuardRevision) {
             throw new Error("Window contents changed while closing.");
           }
+          if (windowInteractionPaused) {
+            await currentWindow.setEnabled(true);
+            windowInteractionPaused = false;
+          }
           await currentWindow.close();
         } catch (error) {
           if (closeTransitionStarted) {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5946,6 +5946,10 @@ assert.match(appNativeMenuHook, /await permit\.waitForPending\(\)/);
 assert.match(appNativeMenuHook, /sameWindowItemIds\(documentIds, windowDocumentIdsRef\.current\)/);
 assert.match(appNativeMenuHook, /sameWindowItemIds\(tabIds, windowTabIdsRef\.current\)/);
 assert.match(appNativeMenuHook, /finalDirtySnapshot\.closeGuardRevision !== closeGuardRevision/);
+assert.match(
+  appNativeMenuHook,
+  /if \(windowInteractionPaused\) \{\s*await currentWindow\.setEnabled\(true\);\s*windowInteractionPaused = false;\s*\}\s*await currentWindow\.close\(\)/,
+);
 assert.match(appNativeMenuHook, /if \(closingWindowRef\.current\) return;/);
 assert.match(appNativeMenuHook, /listen<ExitPreflightRequest>\(EXIT_PREFLIGHT_EVENT/);
 assert.match(appNativeMenuHook, /invoke<string>\("register_exit_preflight_listener"\)/);


### PR DESCRIPTION
## Why

Closing the Burrete window with the macOS red close button could leave an attached disabled-window sheet alive after the webview was destroyed, making the application appear hung instead of closing cleanly.

## What changed

- Re-enable the Tauri window before closing it when a native window interaction is paused.
- Clear the paused-interaction state after re-enabling the window.
- Add a UI shell contract regression test for the close lifecycle.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-window-mutation-barrier.mjs`
- `bun run typecheck` in `apps/desktop`
- `bun run ci:fast` (452 Rust tests passed; 0 failed)
- Packaged macOS dev-flavor build: red close button removes the window without a lingering gray sheet; activating Burrete reopens a full HTML window.

## Notes

The fix is intentionally scoped to the native close path and does not change quit semantics.