### PR TITLE
Restore sidebar animations, tab-strip tracking, and dock pixel stability

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -73,6 +73,85 @@ function useInitialSize(sizePx: number) {
   return useRef(sizePx).current;
 }
 
+// Marks a group as animating for the duration of an open/close toggle. The CSS
+// flex transition on `[data-panels-animating] > [data-panel]` must apply only
+// then: react-resizable-panels rewrites flex-grow every frame during drags and
+// window resizes, and a standing transition would rubber-band both.
+function usePanelToggleAnimation(open: boolean) {
+  const [animating, setAnimating] = useState(false);
+  const animatingRef = useRef(false);
+  const mounted = useRef(false);
+  useLayoutEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+    animatingRef.current = true;
+    setAnimating(true);
+    const timer = window.setTimeout(() => {
+      animatingRef.current = false;
+      setAnimating(false);
+    }, 220);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+  return { animating, animatingRef };
+}
+
+// True while one of the group's own separators is being dragged. Nested groups
+// carry their own separators, so only direct children count.
+function groupHasActiveSeparator(element: HTMLElement | null) {
+  return Boolean(element?.querySelector(':scope > [data-separator="active"]'));
+}
+
+type PixelGuardEntry = {
+  panelRef: React.RefObject<PanelImperativeHandle | null>;
+  openRef: React.RefObject<boolean>;
+  sizePxRef: React.RefObject<number>;
+};
+
+// groupResizeBehavior="preserve-pixel-size" is inert in react-resizable-panels
+// 4.12.2: any container resize (window resize, or the sidebar moving the
+// workbench) redistributes panel sizes proportionally, so the right dock used
+// to drift through the 360px tab-label container-query threshold and flicker.
+// Re-assert the stored pixel size of fixed panels whenever the group's element
+// resizes. The observer fires between layout and paint, so the proportional
+// intermediate state is corrected before it becomes visible, and correcting the
+// group's inner layout does not resize the group element again (no loop).
+function useGroupPixelGuard(entries: PixelGuardEntry[]) {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+    let frame = 0;
+    const correct = () => {
+      frame = 0;
+      for (const { panelRef, openRef, sizePxRef } of entriesRef.current) {
+        const panel = panelRef.current;
+        if (!panel || !openRef.current || panel.isCollapsed()) continue;
+        const want = sizePxRef.current;
+        if (want <= 1) continue;
+        if (Math.abs(panel.getSize().inPixels - want) > 0.75) panel.resize(`${want}px`);
+      }
+    };
+    // Correct on the next frame, not inside the observer callback: the library
+    // processes the same container resize in its own observer and converts
+    // px→% through a cached group size, so a same-frame resize() races it and
+    // lands on a stale conversion. By the rAF the library has settled; if the
+    // container moves again the observer refires and schedules another pass.
+    const observer = new ResizeObserver(() => {
+      if (!frame) frame = requestAnimationFrame(correct);
+    });
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, []);
+  return elementRef;
+}
+
 export function AppLayout({
   state,
   actions,
@@ -138,12 +217,31 @@ export function AppLayout({
       : compactLeadingChrome ? 112 : 192;
   const rightDockOpen = !settingsMode && !hostedMcpWidget && state.rightDockOpen;
   const bottomDockOpen = !settingsMode && !hostedMcpWidget && state.bottomDockOpen;
+  // Toggle-animation hooks must come before the collapse/expand sync hooks:
+  // layout effects run in hook order, and collapse() reports a synchronous
+  // onResize that the handlers below gate on animatingRef — registered after
+  // the collapse, the flag would still be false and the closing panel would
+  // immediately flip its open flag (and itself) back.
+  const sidebarToggle = usePanelToggleAnimation(sidebarVisible);
+  const rightDockToggle = usePanelToggleAnimation(rightDockOpen);
+  const bottomDockToggle = usePanelToggleAnimation(bottomDockOpen);
   const sidebarPanelRef = useCollapsiblePanelSync(sidebarVisible, sidebarWidth);
   const rightDockPanelRef = useCollapsiblePanelSync(rightDockOpen, rightDockWidth);
   const bottomDockPanelRef = useCollapsiblePanelSync(bottomDockOpen, state.bottomDockHeight);
   const initialSidebarSize = useInitialSize(sidebarWidth);
   const initialRightDockSize = useInitialSize(rightDockWidth);
   const initialBottomDockSize = useInitialSize(state.bottomDockHeight);
+  // Latest open flags / stored pixel sizes, readable from observer callbacks.
+  const rightDockOpenRef = useRef(rightDockOpen);
+  rightDockOpenRef.current = rightDockOpen;
+  const bottomDockOpenRef = useRef(bottomDockOpen);
+  bottomDockOpenRef.current = bottomDockOpen;
+  const sidebarWidthRef = useRef(sidebarWidth);
+  sidebarWidthRef.current = sidebarWidth;
+  const rightDockWidthRef = useRef(rightDockWidth);
+  rightDockWidthRef.current = rightDockWidth;
+  const bottomDockHeightRef = useRef(state.bottomDockHeight);
+  bottomDockHeightRef.current = state.bottomDockHeight;
   // The sidebar store only exposes a toggle; wrap it as an idempotent setter so
   // drag-to-collapse can sync the flag without double-toggling.
   const sidebarOpenRef = useRef(sidebarVisible);
@@ -156,6 +254,15 @@ export function AppLayout({
     },
     [onToggleSidebar],
   );
+  const workspaceGroupRef = useGroupPixelGuard([
+    { panelRef: sidebarPanelRef, openRef: sidebarOpenRef, sizePxRef: sidebarWidthRef },
+  ]);
+  const workbenchGroupRef = useGroupPixelGuard([
+    { panelRef: rightDockPanelRef, openRef: rightDockOpenRef, sizePxRef: rightDockWidthRef },
+  ]);
+  const workbenchMainGroupRef = useGroupPixelGuard([
+    { panelRef: bottomDockPanelRef, openRef: bottomDockOpenRef, sizePxRef: bottomDockHeightRef },
+  ]);
   const systemThemeMode = useSystemThemeMode();
   const shellStyle = {
     ...buildThemeStyle(state.preferences, systemThemeMode),
@@ -297,6 +404,8 @@ export function AppLayout({
         <ResizablePanelGroup
           orientation="horizontal"
           className="workspace-panels"
+          elementRef={workspaceGroupRef}
+          data-panels-animating={sidebarToggle.animating || undefined}
           onLayoutChanged={(_layout, meta) => {
             if (!meta.isUserInteraction) return;
             const px = Math.round(sidebarPanelRef.current?.getSize().inPixels ?? 0);
@@ -315,7 +424,12 @@ export function AppLayout({
             maxSize={`${maxSidebarWidth}px`}
             groupResizeBehavior="preserve-pixel-size"
             onResize={(size) => {
-              if (!settingsMode) setSidebarOpen(Math.round(size.inPixels) > 1);
+              if (settingsMode) return;
+              // While the toggle transition animates through intermediate
+              // sizes, only a real drag on this group's separator may flip the
+              // open flag — otherwise closing would re-open itself mid-animation.
+              if (sidebarToggle.animatingRef.current && !groupHasActiveSeparator(workspaceGroupRef.current)) return;
+              setSidebarOpen(Math.round(size.inPixels) > 1);
             }}
           >
             <div className="sidebar-shell-inner">
@@ -323,13 +437,15 @@ export function AppLayout({
             </div>
           </ResizablePanel>
           {chromeVisible ? (
-            <ResizableHandle withHandle aria-label="Resize sidebar" data-collapsed={!state.sidebarOpen || undefined} />
+            <ResizableHandle withHandle className="workspace-sidebar-handle" aria-label="Resize sidebar" data-collapsed={!state.sidebarOpen || undefined} />
           ) : null}
           <ResizablePanel id="center" className="workspace-center-panel" style={CLIPPED_PANEL_STYLE}>
             <section className="workbench">
               <ResizablePanelGroup
                 orientation="horizontal"
                 className="workbench-panels"
+                elementRef={workbenchGroupRef}
+                data-panels-animating={rightDockToggle.animating || undefined}
                 onLayoutChanged={(_layout, meta) => {
                   if (!meta.isUserInteraction) return;
                   const px = Math.round(rightDockPanelRef.current?.getSize().inPixels ?? 0);
@@ -340,6 +456,8 @@ export function AppLayout({
                   <ResizablePanelGroup
                     orientation="vertical"
                     className="workbench-main-panels"
+                    elementRef={workbenchMainGroupRef}
+                    data-panels-animating={bottomDockToggle.animating || undefined}
                     onLayoutChanged={(_layout, meta) => {
                       if (!meta.isUserInteraction) return;
                       const px = Math.round(bottomDockPanelRef.current?.getSize().inPixels ?? 0);
@@ -366,8 +484,9 @@ export function AppLayout({
                       maxSize="70%"
                       groupResizeBehavior="preserve-pixel-size"
                       onResize={(size) => {
+                        if (bottomDockToggle.animatingRef.current && !groupHasActiveSeparator(workbenchMainGroupRef.current)) return;
                         const open = Math.round(size.inPixels) > 1;
-                        if (open !== bottomDockOpen) actions.setDockOpen("bottom", open);
+                        if (open !== bottomDockOpenRef.current) actions.setDockOpen("bottom", open);
                       }}
                     >
                       {/* Always mounted: DockPanel renders its own closed state
@@ -393,8 +512,9 @@ export function AppLayout({
                   maxSize="70%"
                   groupResizeBehavior="preserve-pixel-size"
                   onResize={(size) => {
+                    if (rightDockToggle.animatingRef.current && !groupHasActiveSeparator(workbenchGroupRef.current)) return;
                     const open = Math.round(size.inPixels) > 1;
-                    if (open !== rightDockOpen) actions.setDockOpen("right", open);
+                    if (open !== rightDockOpenRef.current) actions.setDockOpen("right", open);
                   }}
                 >
                   <DockPanel area="right" state={layoutState} actions={actions} readOnly={hostedMcpWidget} />

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -324,6 +324,9 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
   pointer-events: none;
   gap: 12px;
   padding: var(--chrome-control-padding) 0;
+  /* `left` is set inline from the sidebar width; ease it so the tab strip
+     travels with the sidebar edge instead of teleporting on toggle. */
+  transition: left 140ms ease-out;
   container-type: inline-size;
 }
 .chrome-button,
@@ -606,6 +609,20 @@ button:focus-visible > .shortcut-tooltip {
 .utility-tab { min-width: auto; }
 .workspace { position: relative; min-height: 0; flex: 1; display: flex; }
 .workspace-panels { flex: 1; min-width: 0; min-height: 0; height: 100%; }
+/* Open/close animation for the sidebar and the docks. Panels are sized through
+   flex-grow on the library's `[data-panel]` wrappers, and collapse()/expand()
+   swap that value instantly; easing it recreates the pre-refactor slide. The
+   transition only exists while the app marks the group as animating a toggle —
+   a standing one would rubber-band pointer drags and window resizes, where the
+   library rewrites flex-grow every frame. Timings match the old .sidebar-shell
+   (140ms ease-out) and .dock-panel (180ms) rules. */
+.workspace-panels[data-panels-animating] > [data-panel] {
+  transition: flex-grow 140ms ease-out;
+}
+.workbench-panels[data-panels-animating] > [data-panel],
+.workbench-main-panels[data-panels-animating] > [data-panel] {
+  transition: flex-grow 180ms cubic-bezier(0.2, 0, 0, 1);
+}
 .workspace-sidebar-panel { position: relative; height: 100%; min-height: 0; overflow: hidden; }
 .workspace-center-panel { position: relative; min-width: 0; min-height: 0; overflow: hidden; display: flex; }
 .workbench-panels { flex: 1; min-width: 0; min-height: 0; }
@@ -632,6 +649,21 @@ button:focus-visible > .shortcut-tooltip {
   height: 14px;
   margin: -7px 0;
   cursor: row-resize;
+}
+/* The workbench card's soft shadow over the glass sidebar. It sits on this
+   handle (centered on the sidebar/workbench boundary) because the handle rides
+   the animated edge and is never clipped, unlike the center panel's children.
+   With the sidebar collapsed the boundary is at the window edge and the
+   leftward shadow lands off-screen, matching the old .workbench behavior. */
+.workspace-sidebar-handle::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  box-shadow: -12px 0 28px var(--workspace-edge-shadow);
+  pointer-events: none;
 }
 .resizable-handle::after {
   content: "";
@@ -697,7 +729,9 @@ button:focus-visible > .shortcut-tooltip {
   overflow: hidden;
   border-left: 1px solid var(--workspace-edge-border);
   border-radius: 20px 0 0 20px;
-  box-shadow: -12px 0 28px var(--workspace-edge-shadow);
+  /* The soft edge shadow this card used to cast over the glass sidebar lives on
+     .workspace-sidebar-handle::before now: the center ResizablePanel clips its
+     children (overflow: hidden), so a box-shadow here can never reach out. */
 }
 .app-shell[data-settings-mode="true"] .workbench {
   border-radius: 0;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2054,7 +2054,13 @@ assert.match(styles, /--sidebar-divider-right: transparent/);
 assert.match(styles, /--workspace-edge-border: color-mix\(in srgb, var\(--fg-base\) calc\(var\(--contrast\) \* 22%\), transparent\)/);
 assert.match(styles, /\.sidebar::after \{[^}]*background: var\(--sidebar-divider-right\);/s);
 assert.doesNotMatch(styles, /\.splitter::after \{ background: var\(--sidebar-divider-right\); \}/);
-assert.match(styles, /\.workbench \{[^}]*background: var\(--bg-base\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;[^}]*box-shadow: -12px 0 28px var\(--workspace-edge-shadow\);/s);
+// The workbench card's edge shadow lives on the sidebar handle now: the center
+// ResizablePanel clips its children (overflow: hidden), so a box-shadow on
+// .workbench itself can never reach over the sidebar.
+assert.match(styles, /\.workbench \{[^}]*background: var\(--bg-base\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;/s);
+assert.doesNotMatch(styles, /\.workbench \{[^}]*box-shadow: -12px 0 28px/s);
+assert.match(styles, /\.workspace-sidebar-handle::before \{[^}]*box-shadow: -12px 0 28px var\(--workspace-edge-shadow\);[^}]*pointer-events: none;/s);
+assert.match(appLayout, /className="workspace-sidebar-handle"/);
 assert.match(styles, /\.app-shell\[data-settings-mode="true"\] \.workbench \{[^}]*border-radius: 0;[^}]*box-shadow: none;[^}]*\}/s);
 assert.match(styles, /\.app-shell\[data-hosted-mcp-widget="true"\] \.workbench \{[^}]*border-radius: 0;[^}]*box-shadow: none;[^}]*\}/s);
 assert.doesNotMatch(styles, /\.main-stage \{[^}]*border-radius: 20px 0 0 20px;/s);
@@ -2121,6 +2127,28 @@ assert.match(appLayout, /\}, \[open\]\);/);
 assert.match(appLayout, /function useInitialSize/);
 assert.match(appLayout, /onLayoutChanged=\{\(_layout, meta\) => \{/);
 assert.match(appLayout, /if \(!meta\.isUserInteraction\) return;/);
+// Open/close toggles animate through a transient flex-grow transition on the
+// library's [data-panel] wrappers. The transition must exist only while a
+// toggle is animating (drags and window resizes rewrite flex-grow every frame
+// and would rubber-band), and the animation hooks must register their layout
+// effects before the collapse/expand sync hooks: collapse() reports a
+// synchronous onResize that the handlers gate on animatingRef.
+assert.match(appLayout, /function usePanelToggleAnimation/);
+assert.ok(appLayout.indexOf("usePanelToggleAnimation(sidebarVisible)") < appLayout.indexOf("useCollapsiblePanelSync(sidebarVisible"), "toggle-animation hooks must be called before the collapse/expand sync hooks");
+assert.match(appLayout, /data-panels-animating=\{sidebarToggle\.animating \|\| undefined\}/);
+assert.match(appLayout, /sidebarToggle\.animatingRef\.current && !groupHasActiveSeparator\(workspaceGroupRef\.current\)/);
+assert.match(styles, /\.workspace-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 140ms ease-out;/);
+assert.match(styles, /\.workbench-main-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 180ms cubic-bezier\(0\.2, 0, 0, 1\);/);
+// The tab strip follows the sidebar edge through the same easing.
+assert.match(styles, /\.topbar \{[^}]*transition: left 140ms ease-out;/s);
+// groupResizeBehavior="preserve-pixel-size" is inert in react-resizable-panels
+// 4.12.2, so fixed panels re-assert their stored pixel size when the group's
+// container resizes — deferred to the next frame because a resize() inside the
+// ResizeObserver callback races the library's own observer and converts px→%
+// through a stale cached group size.
+assert.match(appLayout, /function useGroupPixelGuard/);
+assert.match(appLayout, /frame = requestAnimationFrame\(correct\)/);
+assert.match(appLayout, /panel\.resize\(`\$\{want\}px`\)/);
 assert.doesNotMatch(appLayout, /\{rightDockOpen \? <DockPanel/);
 assert.doesNotMatch(appLayout, /\{bottomDockOpen \? <DockPanel/);
 assert.match(dockPanel, /data-open=\{open \? "true" : "false"\}/);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,14 +11,27 @@ const extraFsAllow = (process.env.BURRETE_DEV_FS_ALLOW ?? "").split(delimiter).f
 export default defineConfig({
   root: desktopRoot,
   plugins: lazyPlugins(async () => {
-    const [{ default: react }, { browserDevXyzrenderPlugin }] = await Promise.all([
+    // tailwindcss must load here too: the desktop config carries it for native
+    // builds, but browser dev runs through this root config, and without the
+    // plugin every shadcn control (settings sliders, switches, selects) renders
+    // unstyled — collapsed tracks, stray chevrons.
+    const [{ default: react }, { browserDevXyzrenderPlugin }, { default: tailwindcss }] = await Promise.all([
       import("@vitejs/plugin-react"),
       import("./apps/desktop/vite.config"),
+      import("@tailwindcss/vite"),
     ]);
-    return [react(), browserDevXyzrenderPlugin()];
+    return [tailwindcss(), react(), browserDevXyzrenderPlugin()];
   }),
   define: {
     "import.meta.env.BURRETE_REPO_ROOT": JSON.stringify(repoRoot),
+  },
+  // Plain `vite` does not read tsconfig `paths`, so the shadcn-style `@/` imports
+  // only resolved under the desktop config's alias. Mirror it here for the
+  // browser-dev flow that runs this root config directly.
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("apps/desktop/src", import.meta.url)),
+    },
   },
   server: {
     port: 1420,


### PR DESCRIPTION
## Summary

The react-resizable-panels rebuild (#480) regressed several shell behaviors. This PR restores them:

- **Smooth open/close for the sidebar and both docks.** collapse()/expand() swap flex-grow instantly; ease it on the library's `[data-panel]` wrappers only while a toggle is animating (`data-panels-animating`, 140ms sidebar / 180ms docks — the pre-refactor timings). The onResize open-flag sync is gated during the animation (collapse() reports a synchronous onResize with the pre-collapse size that would otherwise flip the panel right back open), with an active-separator escape hatch so drag-to-collapse still syncs live.
- **The tab strip travels with the sidebar edge again** (restored `transition: left 140ms ease-out` on `.topbar`).
- **Right dock no longer flickers its Info/Text tab labels while the sidebar moves.** `groupResizeBehavior="preserve-pixel-size"` is inert in react-resizable-panels 4.12.2 — container resizes redistribute proportionally, sailing the dock through the 360px label container-query threshold. `useGroupPixelGuard` re-asserts stored pixel sizes on group container resizes, deferred to the next frame (a resize() inside the ResizeObserver callback races the library's own observer through a stale cached group size).
- **Workbench edge shadow over the glass sidebar** is back — it was clipped by the center panel's `overflow: hidden`; it lives on the sidebar handle now.
- **Browser dev works again through .claude/launch.json**: the root Vite config now mirrors the `@` alias and the tailwindcss plugin from the desktop config. Without them browser dev failed to resolve every `@/` import, and with the alias alone all shadcn controls rendered unstyled (the settings Translucent slider collapsed to a 0px track — 'transparency mode is broken').

## Testing

- `bun run test:ui` (38 suites, includes the updated ui-shell contract test pinning the new invariants)
- `tsc --noEmit`
- Manual browser-dev verification: toggle animation targets, 1:1 handle drag, drag-to-collapse + flag sync, right dock steady at its stored width through sidebar drags/toggles/window resizes, settings sliders styled
- flex-grow animatability proven via the Web Animations API on the live panel wrapper (CSSTransition interpolates value and width)