### PR TITLE
Bind Cmd+P to the command palette and surface commands in sidebar search

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -227,7 +227,7 @@
       const key = event.key?.toLowerCase();
       const commandKey = event.metaKey || event.ctrlKey;
       const togglesSidebar = commandKey && !event.altKey && !event.shiftKey && key === 'b';
-      const opensCommandPalette = (commandKey && event.shiftKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
+      const opensCommandPalette = (commandKey && !event.altKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
       if (!opensCommandPalette && !togglesSidebar) return;
       event.preventDefault();
       post(togglesSidebar ? 'toggleSidebar' : 'openCommandPalette');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -195,7 +195,7 @@
       const key = event.key?.toLowerCase();
       const commandKey = event.metaKey || event.ctrlKey;
       const togglesSidebar = commandKey && !event.altKey && !event.shiftKey && key === 'b';
-      const opensCommandPalette = (commandKey && event.shiftKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
+      const opensCommandPalette = (commandKey && !event.altKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
       if (!opensCommandPalette && !togglesSidebar) return;
       event.preventDefault();
       postHostMessage({ type: togglesSidebar ? 'toggleSidebar' : 'openCommandPalette' });

--- a/apps/desktop/src-tauri/src/menu/build.rs
+++ b/apps/desktop/src-tauri/src/menu/build.rs
@@ -205,7 +205,7 @@ pub(crate) fn configure_menu<R: Runtime>(app: &tauri::App<R>) -> tauri::Result<(
         .items(&[&rdkit, &xyzrender])
         .build()?;
     let command_palette = MenuItemBuilder::with_id("view.command-palette", "Command Palette…")
-        .accelerator("CmdOrCtrl+Shift+P")
+        .accelerator("CmdOrCtrl+P")
         .build(app)?;
     let view_menu = SubmenuBuilder::new(app, "View")
         .items(&[

--- a/apps/desktop/src/components/command-palette/index.tsx
+++ b/apps/desktop/src/components/command-palette/index.tsx
@@ -18,8 +18,7 @@ import {
 import { formatBytes, rendererLabel } from "../format";
 import type { ShellActions, ShellViewState } from "../types";
 import { isRemoteStructureUrl } from "../../lib/remote-structure";
-import { parsePdbFetchCommand, parseSmilesCommand } from "../../lib/structure-fetch";
-import type { ViewerPreferences } from "../../types";
+import { buildShellCommands, filterShellCommands, type ShellCommand } from "../../lib/shell-commands";
 
 type CommandPaletteProps = {
   state: ShellViewState;
@@ -31,29 +30,7 @@ type CommandPaletteProps = {
   onRunError: (error: unknown, prefix?: string) => void;
 };
 
-type PaletteItem = {
-  id: string;
-  group: string;
-  label: string;
-  description: string;
-  run: () => void | Promise<void>;
-};
-
-const rendererCommands: Array<{
-  id: string;
-  label: string;
-  value: ViewerPreferences["rendererMode"];
-}> = [
-  { id: "renderer-auto", label: "Renderer: Auto", value: "auto" },
-  { id: "renderer-molstar", label: "Renderer: Mol*", value: "molstar" },
-  { id: "renderer-xyzrender", label: "Renderer: xyzrender external", value: "xyzrender-external" },
-];
-
-function promptRemoteStructureUrl(actions: ShellActions) {
-  const url = window.prompt("Structure URL");
-  if (!url?.trim()) return;
-  return actions.openStructureUrlInMolstar(url);
-}
+type PaletteItem = ShellCommand;
 
 export function CommandPalette({
   state,
@@ -72,7 +49,6 @@ export function CommandPalette({
   }, [isOpen]);
 
   const items = useMemo<PaletteItem[]>(() => {
-    const queryItems = commandItemsForQuery(query, actions);
     const projectItems = state.sidebarProjects.flatMap((project) => project.items.map((item) => ({
       id: `${item.source}-${item.path}`,
       group: "Projects",
@@ -95,196 +71,13 @@ export function CommandPalette({
     })));
 
     const commands: PaletteItem[] = [
-      {
-        id: "open-structure",
-        group: "Suggested",
-        label: "Open Structure",
-        description: "Choose molecular structure files",
-        run: actions.chooseFiles,
-      },
-      ...queryItems,
-      {
-        id: "open-clipboard",
-        group: "Suggested",
-        label: "Open from Clipboard",
-        description: "Open molecular text or copied structure paths",
-        run: actions.openClipboard,
-      },
-      {
-        id: "fetch-structure-url",
-        group: "Suggested",
-        label: "Fetch Structure URL in Mol*",
-        description: "Download a remote structure URL into Mol*",
-        run: () => promptRemoteStructureUrl(actions),
-      },
-      {
-        id: "new-window",
-        group: "Suggested",
-        label: "New Window",
-        description: "Open another Burrete workspace window",
-        run: actions.openNewWindow,
-      },
-      {
-        id: "open-recent",
-        group: "Suggested",
-        label: "Open Recent",
-        description: "Open the most recent structure",
-        run: actions.openMostRecentStructure,
-      },
-      {
-        id: "search-projects",
-        group: "Suggested",
-        label: "Search Projects and Structures",
-        description: "Focus project and structure search",
-        run: actions.focusSidebarSearch,
-      },
-      {
-        id: "open-settings",
-        group: "Suggested",
-        label: "Settings",
-        description: "Open Burette settings",
-        run: actions.openSettings,
-      },
-      {
-        id: "open-ketcher",
-        group: "Suggested",
-        label: "Ketcher",
-        description: "Open molecule sketch tab",
-        run: actions.openKetcher,
-      },
-      {
-        id: "open-fep-network",
-        group: "Suggested",
-        label: "FEP Network Preview",
-        description: "Open the ligand network graph workspace",
-        run: actions.openFepNetworkPreview,
-      },
-      {
-        id: "open-agent-integration",
-        group: "Suggested",
-        label: "Codex Agent",
-        description: "Open MCP plugin status",
-        run: () => actions.openSettingsSection("agent"),
-      },
-      {
-        id: "toggle-sidebar",
-        group: "Suggested",
-        label: state.sidebarOpen ? "Hide Sidebar" : "Show Sidebar",
-        description: "Toggle the molecule browser",
-        run: actions.toggleSidebar,
-      },
-      {
-        id: "close-active",
-        group: "Suggested",
-        label: "Close Active Tab",
-        description: "Close the selected tab",
-        run: actions.closeActiveDocument,
-      },
-      {
-        id: "close-all",
-        group: "Suggested",
-        label: "Close All Tabs",
-        description: "Close every open workspace tab",
-        run: actions.clearAllDocuments,
-      },
-      {
-        id: "clear-recent",
-        group: "Suggested",
-        label: "Clear Recent Structures",
-        description: "Forget the recent structure list",
-        run: actions.clearRecentStructures,
-      },
-      {
-        id: "clear-cache",
-        group: "Suggested",
-        label: "Clear Preview Cache",
-        description: "Remove generated preview runtimes",
-        run: actions.clearCache,
-      },
-      {
-        id: "reveal-active",
-        group: "Active Structure",
-        label: "Reveal in Finder",
-        description: "Show the active structure in Finder",
-        run: actions.revealActiveDocument,
-      },
-      {
-        id: "copy-active-path",
-        group: "Active Structure",
-        label: "Copy Path",
-        description: "Copy the active structure path",
-        run: actions.copyActiveDocumentPath,
-      },
-      {
-        id: "show-active-metadata",
-        group: "Active Structure",
-        label: "Get Info",
-        description: "Show active structure path, renderer, format, and size",
-        run: actions.showActiveDocumentMetadata,
-      },
-      {
-        id: "export-preview-png",
-        group: "Active Structure",
-        label: "Export Preview as PNG",
-        description: "Save the active external SVG preview as PNG",
-        run: actions.exportActivePreviewAsPng,
-      },
-      {
-        id: "export-preview-svg",
-        group: "Active Structure",
-        label: "Export Preview as SVG",
-        description: "Save the active external SVG preview",
-        run: actions.exportActivePreviewAsSvg,
-      },
-      {
-        id: "reset-quicklook",
-        group: "Suggested",
-        label: "Reset Quick Look",
-        description: "Refresh Finder preview registration",
-        run: actions.resetQuickLook,
-      },
-      {
-        id: "open-logs",
-        group: "Suggested",
-        label: "Open Logs Folder",
-        description: "Show Burette runtime logs",
-        run: actions.openLogs,
-      },
-      {
-        id: "export-diagnostics",
-        group: "Suggested",
-        label: "Export Diagnostics",
-        description: "Save logs, environment, size report, and performance marks",
-        run: actions.exportDiagnostics,
-      },
-      {
-        id: "runtime-doctor",
-        group: "Suggested",
-        label: "Runtime Doctor",
-        description: "Check external molecular runtime availability",
-        run: actions.runExternalRuntimeDoctor,
-      },
-      {
-        id: "check-updates",
-        group: "Suggested",
-        label: "Check for Updates",
-        description: "Check Burette releases",
-        run: actions.checkForUpdates,
-      },
-      ...rendererCommands.map((command) => ({
-        id: command.id,
-        group: "Renderer",
-        label: command.label,
-        description: state.preferences.rendererMode === command.value ? "Current renderer mode" : "Switch renderer mode",
-        run: () => actions.setPreference("rendererMode", command.value),
-      })),
+      ...buildShellCommands(state, actions, query),
       ...projectItems,
     ];
     return commands;
-  }, [actions, query, state.preferences.rendererMode, state.sidebarOpen, state.sidebarProjects]);
+  }, [actions, query, state]);
 
   const visibleItems = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
     const queryUrl = query.trim();
     const allItems = isRemoteStructureUrl(queryUrl)
       ? [{
@@ -295,11 +88,7 @@ export function CommandPalette({
           run: () => actions.openStructureUrlInMolstar(queryUrl),
         }, ...items]
       : items;
-    if (!normalized) return allItems;
-    return allItems.filter((item) => (
-      item.label.toLowerCase().includes(normalized)
-      || item.description.toLowerCase().includes(normalized)
-    ));
+    return filterShellCommands(allItems, query);
   }, [actions, items, query]);
 
   const visibleGroups = useMemo(() => {
@@ -380,42 +169,4 @@ export function CommandPalette({
       </DialogPortal>
     </DialogRoot>
   );
-}
-
-function commandItemsForQuery(query: string, actions: ShellActions): PaletteItem[] {
-  const fetchCommand = parsePdbFetchCommand(query);
-  const smilesCommand = parseSmilesCommand(query);
-  const items: PaletteItem[] = [];
-  if (fetchCommand) {
-    items.push({
-      id: `fetch-pdb-${fetchCommand.pdbId}`,
-      group: "Commands",
-      label: `Fetch ${fetchCommand.pdbId} from RCSB PDB`,
-      description: `Command: ${fetchCommand.command} · Download and open in Molstar`,
-      run: () => actions.fetchPdbStructure(fetchCommand.pdbId),
-    });
-  }
-  if (smilesCommand) {
-    const title = smilesTitle(smilesCommand.smiles);
-    items.push({
-      id: `draw-smiles-${smilesCommand.smiles}`,
-      group: "Commands",
-      label: `Draw SMILES in Ketcher: ${shortCommandValue(smilesCommand.smiles)}`,
-      description: `Command: ${smilesCommand.command} · Import SMILES into the molecule sketcher`,
-      run: () => actions.openKetcherWithStructures([], [{
-        title,
-        text: `${smilesCommand.smiles}\n`,
-      }]),
-    });
-  }
-  return items;
-}
-
-function smilesTitle(smiles: string) {
-  return `${shortCommandValue(smiles).replace(/[^a-z0-9_.-]+/giu, "-") || "smiles"}.smi`;
-}
-
-function shortCommandValue(value: string) {
-  const trimmed = value.trim();
-  return trimmed.length > 48 ? `${trimmed.slice(0, 45)}...` : trimmed;
 }

--- a/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
+++ b/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
@@ -11,7 +11,7 @@ const keyboardShortcutRows: ShortcutRow[] = [
   {
     command: "Open command palette",
     description: "Search commands, settings, projects, and structures.",
-    keybindings: ["⇧⌘P", "/"],
+    keybindings: ["⌘P", "/"],
   },
   {
     command: "New window",

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -4,6 +4,7 @@ import { AnimatedOrbitIcon } from "../ui/animated-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { isRemoteStructureUrl } from "../../lib/remote-structure";
 import { filterSidebarProjects } from "../../lib/sidebar-projects";
+import { buildShellCommands, filterShellCommands } from "../../lib/shell-commands";
 import { hasStructureDrag, readStructureDragPayload } from "../../lib/structure-drag";
 import { runShellDropActionChoices, shellDropActionChoices } from "../drop-action-executor";
 import { RadixDropdownMenu } from "../radix-menu";
@@ -13,6 +14,7 @@ import { ProjectGroup, ProjectItem } from "./file-tree-node";
 import { useSidebarStructureDrag } from "./use-sidebar-structure-drag";
 
 const SIDEBAR_TREE_ROW_SELECTOR = ".project-group-row, .project-folder-row, [data-sidebar-structure-path]";
+const SIDEBAR_COMMAND_LIMIT = 6;
 
 // DOM-based tree keyboard navigation: move focus across visible rows with the
 // arrow keys, expand/collapse the focused folder with Right/Left, and jump with
@@ -80,6 +82,9 @@ export function FileBrowser({
   const sidebarQuery = state.sidebarQuery.trim();
   const hasSidebarQuery = sidebarQuery.length > 0;
   const canFetchRemoteStructure = isRemoteStructureUrl(sidebarQuery);
+  const matchingCommands = hasSidebarQuery
+    ? filterShellCommands(buildShellCommands(state, actions, sidebarQuery), sidebarQuery).slice(0, SIDEBAR_COMMAND_LIMIT)
+    : [];
   const visibleProjects = hideProjectPreviews ? [] : filterSidebarProjects(state.sidebarProjects, state.sidebarQuery);
   const pinnedItems = visibleProjects.flatMap((project) => project.items.filter((item) => item.isPinned));
   const pinnedExpanded = pinnedOpen || hasSidebarQuery;
@@ -201,6 +206,28 @@ export function FileBrowser({
           <kbd>⌘<span>P</span></kbd>
         </label>
       ) : null}
+      {matchingCommands.length > 0 && (
+        <section className="sidebar-section sidebar-command-section" aria-label="Matching commands">
+          <div className="sidebar-section-header">
+            <span className="sidebar-section-title">Commands</span>
+          </div>
+          {matchingCommands.map((command) => (
+            <button
+              key={command.id}
+              type="button"
+              className="sidebar-command-row"
+              title={command.description}
+              onClick={() => {
+                actions.setSidebarQuery("");
+                void command.run();
+              }}
+            >
+              <span className="sidebar-command-label">{command.label}</span>
+              <span className="sidebar-command-description">{command.description}</span>
+            </button>
+          ))}
+        </section>
+      )}
       {canFetchRemoteStructure && (
         <button
           type="button"

--- a/apps/desktop/src/components/welcome/index.tsx
+++ b/apps/desktop/src/components/welcome/index.tsx
@@ -35,8 +35,8 @@ export function WelcomeScreen({ actions, buildInfo }: { actions: ShellActions; b
           <ShortcutTooltip label="Open Structure" shortcut="⌘O" />
         </button>
         <button type="button" data-analytics-control="open_command_palette" onClick={actions.openCommandPalette}>
-          Command Palette <kbd>⇧⌘P</kbd> <kbd>/</kbd>
-          <ShortcutTooltip label="Command Palette" shortcut="⇧⌘P /" />
+          Command Palette <kbd>⌘P</kbd> <kbd>/</kbd>
+          <ShortcutTooltip label="Command Palette" shortcut="⌘P /" />
         </button>
         <button type="button" data-analytics-control="open_settings" onClick={actions.openSettings}>
           Settings <kbd>⌘,</kbd>

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -98,7 +98,7 @@ export function useKeyboardShortcuts(state: ShellViewState, actions: ShellAction
         }
         return;
       }
-      if (commandKey && !event.altKey && event.shiftKey && key === "p") {
+      if (commandKey && !event.altKey && key === "p") {
         event.preventDefault();
         actions.openCommandPalette();
         return;

--- a/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcuts.ts
@@ -31,6 +31,14 @@ export function useKeyboardShortcuts(state: ShellViewState, actions: ShellAction
         actions.openCommandPalette();
         return;
       }
+      // Kept above the Tauri gate so the webview default (macOS print) is
+      // suppressed even when the native menu accelerator owns the shortcut;
+      // otherwise the print sheet steals focus and dismisses the palette.
+      if (commandKey && !event.altKey && key === "p") {
+        event.preventDefault();
+        actions.openCommandPalette();
+        return;
+      }
       if (commandKey && !event.altKey && !event.shiftKey && /^[1-9]$/.test(event.key)) {
         const tab = state.tabs[Number(event.key) - 1];
         if (tab) {
@@ -96,11 +104,6 @@ export function useKeyboardShortcuts(state: ShellViewState, actions: ShellAction
         } else {
           void actions.exportActivePreviewAsPng();
         }
-        return;
-      }
-      if (commandKey && !event.altKey && key === "p") {
-        event.preventDefault();
-        actions.openCommandPalette();
         return;
       }
       if (commandKey && !event.altKey && !event.shiftKey && key === "j") {

--- a/apps/desktop/src/lib/shell-commands.ts
+++ b/apps/desktop/src/lib/shell-commands.ts
@@ -1,0 +1,266 @@
+import type { ShellActions, ShellViewState } from "../components/types";
+import { parsePdbFetchCommand, parseSmilesCommand } from "./structure-fetch";
+import type { ViewerPreferences } from "../types";
+
+export type ShellCommand = {
+  id: string;
+  group: string;
+  label: string;
+  description: string;
+  run: () => void | Promise<void>;
+};
+
+const rendererCommands: Array<{
+  id: string;
+  label: string;
+  value: ViewerPreferences["rendererMode"];
+}> = [
+  { id: "renderer-auto", label: "Renderer: Auto", value: "auto" },
+  { id: "renderer-molstar", label: "Renderer: Mol*", value: "molstar" },
+  { id: "renderer-xyzrender", label: "Renderer: xyzrender external", value: "xyzrender-external" },
+];
+
+function promptRemoteStructureUrl(actions: ShellActions) {
+  const url = window.prompt("Structure URL");
+  if (!url?.trim()) return;
+  return actions.openStructureUrlInMolstar(url);
+}
+
+export function buildShellCommands(
+  state: ShellViewState,
+  actions: ShellActions,
+  query: string,
+): ShellCommand[] {
+  return [
+    {
+      id: "open-structure",
+      group: "Suggested",
+      label: "Open Structure",
+      description: "Choose molecular structure files",
+      run: actions.chooseFiles,
+    },
+    ...shellCommandsForQuery(query, actions),
+    {
+      id: "open-clipboard",
+      group: "Suggested",
+      label: "Open from Clipboard",
+      description: "Open molecular text or copied structure paths",
+      run: actions.openClipboard,
+    },
+    {
+      id: "fetch-structure-url",
+      group: "Suggested",
+      label: "Fetch Structure URL in Mol*",
+      description: "Download a remote structure URL into Mol*",
+      run: () => promptRemoteStructureUrl(actions),
+    },
+    {
+      id: "new-window",
+      group: "Suggested",
+      label: "New Window",
+      description: "Open another Burrete workspace window",
+      run: actions.openNewWindow,
+    },
+    {
+      id: "open-recent",
+      group: "Suggested",
+      label: "Open Recent",
+      description: "Open the most recent structure",
+      run: actions.openMostRecentStructure,
+    },
+    {
+      id: "search-projects",
+      group: "Suggested",
+      label: "Search Projects and Structures",
+      description: "Focus project and structure search",
+      run: actions.focusSidebarSearch,
+    },
+    {
+      id: "open-settings",
+      group: "Suggested",
+      label: "Settings",
+      description: "Open Burette settings",
+      run: actions.openSettings,
+    },
+    {
+      id: "open-ketcher",
+      group: "Suggested",
+      label: "Ketcher",
+      description: "Open molecule sketch tab",
+      run: actions.openKetcher,
+    },
+    {
+      id: "open-fep-network",
+      group: "Suggested",
+      label: "FEP Network Preview",
+      description: "Open the ligand network graph workspace",
+      run: actions.openFepNetworkPreview,
+    },
+    {
+      id: "open-agent-integration",
+      group: "Suggested",
+      label: "Codex Agent",
+      description: "Open MCP plugin status",
+      run: () => actions.openSettingsSection("agent"),
+    },
+    {
+      id: "toggle-sidebar",
+      group: "Suggested",
+      label: state.sidebarOpen ? "Hide Sidebar" : "Show Sidebar",
+      description: "Toggle the molecule browser",
+      run: actions.toggleSidebar,
+    },
+    {
+      id: "close-active",
+      group: "Suggested",
+      label: "Close Active Tab",
+      description: "Close the selected tab",
+      run: actions.closeActiveDocument,
+    },
+    {
+      id: "close-all",
+      group: "Suggested",
+      label: "Close All Tabs",
+      description: "Close every open workspace tab",
+      run: actions.clearAllDocuments,
+    },
+    {
+      id: "clear-recent",
+      group: "Suggested",
+      label: "Clear Recent Structures",
+      description: "Forget the recent structure list",
+      run: actions.clearRecentStructures,
+    },
+    {
+      id: "clear-cache",
+      group: "Suggested",
+      label: "Clear Preview Cache",
+      description: "Remove generated preview runtimes",
+      run: actions.clearCache,
+    },
+    {
+      id: "reveal-active",
+      group: "Active Structure",
+      label: "Reveal in Finder",
+      description: "Show the active structure in Finder",
+      run: actions.revealActiveDocument,
+    },
+    {
+      id: "copy-active-path",
+      group: "Active Structure",
+      label: "Copy Path",
+      description: "Copy the active structure path",
+      run: actions.copyActiveDocumentPath,
+    },
+    {
+      id: "show-active-metadata",
+      group: "Active Structure",
+      label: "Get Info",
+      description: "Show active structure path, renderer, format, and size",
+      run: actions.showActiveDocumentMetadata,
+    },
+    {
+      id: "export-preview-png",
+      group: "Active Structure",
+      label: "Export Preview as PNG",
+      description: "Save the active external SVG preview as PNG",
+      run: actions.exportActivePreviewAsPng,
+    },
+    {
+      id: "export-preview-svg",
+      group: "Active Structure",
+      label: "Export Preview as SVG",
+      description: "Save the active external SVG preview",
+      run: actions.exportActivePreviewAsSvg,
+    },
+    {
+      id: "reset-quicklook",
+      group: "Suggested",
+      label: "Reset Quick Look",
+      description: "Refresh Finder preview registration",
+      run: actions.resetQuickLook,
+    },
+    {
+      id: "open-logs",
+      group: "Suggested",
+      label: "Open Logs Folder",
+      description: "Show Burette runtime logs",
+      run: actions.openLogs,
+    },
+    {
+      id: "export-diagnostics",
+      group: "Suggested",
+      label: "Export Diagnostics",
+      description: "Save logs, environment, size report, and performance marks",
+      run: actions.exportDiagnostics,
+    },
+    {
+      id: "runtime-doctor",
+      group: "Suggested",
+      label: "Runtime Doctor",
+      description: "Check external molecular runtime availability",
+      run: actions.runExternalRuntimeDoctor,
+    },
+    {
+      id: "check-updates",
+      group: "Suggested",
+      label: "Check for Updates",
+      description: "Check Burette releases",
+      run: actions.checkForUpdates,
+    },
+    ...rendererCommands.map((command) => ({
+      id: command.id,
+      group: "Renderer",
+      label: command.label,
+      description: state.preferences.rendererMode === command.value ? "Current renderer mode" : "Switch renderer mode",
+      run: () => actions.setPreference("rendererMode", command.value),
+    })),
+  ];
+}
+
+export function shellCommandsForQuery(query: string, actions: ShellActions): ShellCommand[] {
+  const fetchCommand = parsePdbFetchCommand(query);
+  const smilesCommand = parseSmilesCommand(query);
+  const items: ShellCommand[] = [];
+  if (fetchCommand) {
+    items.push({
+      id: `fetch-pdb-${fetchCommand.pdbId}`,
+      group: "Commands",
+      label: `Fetch ${fetchCommand.pdbId} from RCSB PDB`,
+      description: `Command: ${fetchCommand.command} · Download and open in Molstar`,
+      run: () => actions.fetchPdbStructure(fetchCommand.pdbId),
+    });
+  }
+  if (smilesCommand) {
+    const title = smilesTitle(smilesCommand.smiles);
+    items.push({
+      id: `draw-smiles-${smilesCommand.smiles}`,
+      group: "Commands",
+      label: `Draw SMILES in Ketcher: ${shortCommandValue(smilesCommand.smiles)}`,
+      description: `Command: ${smilesCommand.command} · Import SMILES into the molecule sketcher`,
+      run: () => actions.openKetcherWithStructures([], [{
+        title,
+        text: `${smilesCommand.smiles}\n`,
+      }]),
+    });
+  }
+  return items;
+}
+
+export function filterShellCommands<T extends ShellCommand>(commands: T[], query: string): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return commands;
+  return commands.filter((command) => (
+    command.label.toLowerCase().includes(normalized)
+    || command.description.toLowerCase().includes(normalized)
+  ));
+}
+
+function smilesTitle(smiles: string) {
+  return `${shortCommandValue(smiles).replace(/[^a-z0-9_.-]+/giu, "-") || "smiles"}.smi`;
+}
+
+function shortCommandValue(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 48 ? `${trimmed.slice(0, 45)}...` : trimmed;
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -933,6 +933,31 @@ button:focus-visible > .shortcut-tooltip {
   box-shadow: inset 0 0 0 1px var(--line-subtle);
 }
 .sidebar-tool-row:active { transform: scale(0.99); }
+.sidebar-command-section { margin-bottom: 10px; }
+.sidebar-command-row {
+  width: 100%;
+  border-radius: var(--control-radius);
+  border: 0;
+  background: transparent;
+  display: grid;
+  gap: 1px;
+  padding: 4px 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: left;
+  transition: background 140ms ease-out, color 140ms ease-out, transform 140ms ease-out;
+}
+.sidebar-command-label,
+.sidebar-command-description {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sidebar-command-description { color: var(--text-faint); font-size: 11px; }
+.sidebar-command-row:hover,
+.sidebar-command-row:focus-visible { background: var(--surface-subtle); color: var(--text-secondary); outline: none; }
+.sidebar-command-row:active { transform: scale(0.99); }
 kbd { color: var(--text-faint); font-size: 11px; font-family: inherit; font-weight: 400; }
 kbd span { margin-left: 2px; }
 .sidebar-section { display: grid; gap: 0; margin-top: 0; }

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -9,7 +9,7 @@ open.
 
 | Shortcut | Action |
 | --- | --- |
-| Cmd+Shift+P or / | Open command palette |
+| Cmd+P or / | Open command palette |
 | Cmd+N | Open a new Burrete window |
 | Cmd+T | Open a new launcher tab |
 | Cmd+O | Open molecular structure files |

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/nikolenko/Documents/Projects/Burette/.claude/worktrees/cleanup-stale-branches-0c3de5/node_modules

--- a/plugins/burette-agent/preview-web/grid-viewer.js
+++ b/plugins/burette-agent/preview-web/grid-viewer.js
@@ -227,7 +227,7 @@
       const key = event.key?.toLowerCase();
       const commandKey = event.metaKey || event.ctrlKey;
       const togglesSidebar = commandKey && !event.altKey && !event.shiftKey && key === 'b';
-      const opensCommandPalette = (commandKey && event.shiftKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
+      const opensCommandPalette = (commandKey && !event.altKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
       if (!opensCommandPalette && !togglesSidebar) return;
       event.preventDefault();
       post(togglesSidebar ? 'toggleSidebar' : 'openCommandPalette');

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -195,7 +195,7 @@
       const key = event.key?.toLowerCase();
       const commandKey = event.metaKey || event.ctrlKey;
       const togglesSidebar = commandKey && !event.altKey && !event.shiftKey && key === 'b';
-      const opensCommandPalette = (commandKey && event.shiftKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
+      const opensCommandPalette = (commandKey && !event.altKey && key === 'p') || (!commandKey && !event.altKey && key === '/');
       if (!opensCommandPalette && !togglesSidebar) return;
       event.preventDefault();
       postHostMessage({ type: togglesSidebar ? 'toggleSidebar' : 'openCommandPalette' });

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -54,7 +54,7 @@ const [
   performanceSource,
   shellActionsSource,
   settingsPanelSource,
-  commandPaletteSource,
+  shellCommandsSource,
   quickLookCommand,
   updaterCommand,
   tray,
@@ -139,7 +139,7 @@ const [
   source('apps/desktop/src/lib/performance.ts'),
   source('apps/desktop/src/components/types.ts'),
   source('apps/desktop/src/components/settings-panel/index.tsx'),
-  source('apps/desktop/src/components/command-palette/index.tsx'),
+  source('apps/desktop/src/lib/shell-commands.ts'),
   source('apps/desktop/src-tauri/src/commands/quicklook.rs'),
   source('apps/desktop/src-tauri/src/commands/updater.rs'),
   source('apps/desktop/src-tauri/src/tray.rs'),
@@ -582,7 +582,7 @@ assert.match(performanceSource, /export function collectPerformanceMarks/);
 assert.match(performanceSource, /export async function measureAsync/);
 assert.match(shellActionsSource, /exportDiagnostics: \(\) => void \| Promise<void>;/);
 assert.match(settingsPanelSource, /actionRow\("Diagnostics"/);
-assert.match(commandPaletteSource, /id: "export-diagnostics"/);
+assert.match(shellCommandsSource, /id: "export-diagnostics"/);
 assert.match(shellCommand, /#\[tauri::command\]\s+pub\(crate\) fn open_logs_folder/);
 assert.match(shellCommand, /#\[tauri::command\]\s+pub\(crate\) fn open_external_url/);
 assert.match(shellCommand, /#\[tauri::command\]\s+pub\(crate\) fn read_external_preview_svg/);
@@ -1161,7 +1161,7 @@ for (const [id, accelerator] of [
   assertMenuItemAccelerator(nativeMenuSource, id, accelerator);
 }
 assert.doesNotMatch(nativeMenuSource, /accelerator\("CmdOrCtrl\+Shift\+N"\)/);
-assert.match(nativeMenuSource, /accelerator\("CmdOrCtrl\+Shift\+P"\)/);
+assert.match(nativeMenuSource, /accelerator\("CmdOrCtrl\+P"\)/);
 assert.doesNotMatch(nativeMenuSource, /accelerator\("CmdOrCtrl\+U"\)/);
 assert.match(nativeMenuSource, /const MENU_COMMAND_EVENT/);
 assert.match(nativeMenuSource, /pub\(crate\) fn emit_command_to_focused_window/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -121,6 +121,7 @@ const [
   dropActionExecutor,
   componentsTypes,
   commandPalette,
+  shellCommands,
   editorArea,
   editorTabs,
   editorScrollContainer,
@@ -323,6 +324,7 @@ const [
   source('apps/desktop/src/components/drop-action-executor.ts'),
   source('apps/desktop/src/components/types.ts'),
   source('apps/desktop/src/components/command-palette/index.tsx'),
+  source('apps/desktop/src/lib/shell-commands.ts'),
   source('apps/desktop/src/components/editor-area/index.tsx'),
   source('apps/desktop/src/components/editor-area/editor-tabs.tsx'),
   source('apps/desktop/src/components/editor-area/editor-scroll-container.tsx'),
@@ -1181,7 +1183,7 @@ assert.match(appShellActionsHook, /runExternalRuntimeDoctor: ShellActions\["runE
 assert.match(appShellActionsHook, /runExternalRuntimeDoctor,/);
 assert.match(componentsTypes, /runExternalRuntimeDoctor: \(\) => void \| Promise<void>;/);
 assert.match(settingsPanel, /actionRow\("Runtime doctor"/);
-assert.match(commandPalette, /id: "runtime-doctor"/);
+assert.match(shellCommands, /id: "runtime-doctor"/);
 assert.match(app, /useAppDiagnostics\(\{\s*pushErrorStatus,\s*pushStatus,\s*recentErrorsRef,\s*\}\)/s);
 assert.doesNotMatch(app, /collectPerformanceMarks/);
 assert.doesNotMatch(app, /measureAsync\("ipc:export-diagnostics"/);
@@ -3361,7 +3363,7 @@ assert.match(welcome, /Command Palette/);
 assert.match(welcome, /Settings/);
 assert.match(welcome, /from "\.\.\/shortcut-tooltip"/);
 assert.match(welcome, /<ShortcutTooltip label="Open Structure" shortcut="⌘O" \/>/);
-assert.match(welcome, /<ShortcutTooltip label="Command Palette" shortcut="⇧⌘P \/" \/>/);
+assert.match(welcome, /<ShortcutTooltip label="Command Palette" shortcut="⌘P \/" \/>/);
 assert.match(welcome, /<ShortcutTooltip label="Settings" shortcut="⌘," \/>/);
 assert.doesNotMatch(welcome, /Open molecular structures/);
 assert.match(errorBoundary, /export class ErrorBoundary/);
@@ -3649,22 +3651,22 @@ assert.match(styles, /\.page-surface:not\(\[data-active\]\) \{[^}]*display: none
 assert.doesNotMatch(editorScrollContainer, /ProgressiveBlur|editor-progressive-blur/);
 assert.doesNotMatch(styles, /\.editor-progressive-blur/);
 assert.match(commandPalette, /group: "Projects"/);
-assert.match(commandPalette, /id: "open-clipboard"/);
-assert.match(commandPalette, /parsePdbFetchCommand/);
-assert.match(commandPalette, /parseSmilesCommand/);
-assert.match(commandPalette, /actions\.fetchPdbStructure\(fetchCommand\.pdbId\)/);
-assert.match(commandPalette, /actions\.openKetcherWithStructures\(\[\], \[\{/);
-assert.match(commandPalette, /Fetch \$\{fetchCommand\.pdbId\} from RCSB PDB/);
-assert.match(commandPalette, /Draw SMILES in Ketcher/);
-assert.match(commandPalette, /id: "open-agent-integration"/);
-assert.match(commandPalette, /label: "Codex Agent"/);
-assert.match(commandPalette, /run: \(\) => actions\.openSettingsSection\("agent"\)/);
-assert.match(commandPalette, /Open from Clipboard/);
-assert.match(commandPalette, /run: actions\.openClipboard/);
-assert.match(commandPalette, /Clear Recent Structures/);
-assert.match(commandPalette, /group: "Suggested"/);
-assert.doesNotMatch(commandPalette, /renderer-xyz-fast/);
-assert.match(commandPalette, /group: "Renderer"/);
+assert.match(shellCommands, /id: "open-clipboard"/);
+assert.match(shellCommands, /parsePdbFetchCommand/);
+assert.match(shellCommands, /parseSmilesCommand/);
+assert.match(shellCommands, /actions\.fetchPdbStructure\(fetchCommand\.pdbId\)/);
+assert.match(shellCommands, /actions\.openKetcherWithStructures\(\[\], \[\{/);
+assert.match(shellCommands, /Fetch \$\{fetchCommand\.pdbId\} from RCSB PDB/);
+assert.match(shellCommands, /Draw SMILES in Ketcher/);
+assert.match(shellCommands, /id: "open-agent-integration"/);
+assert.match(shellCommands, /label: "Codex Agent"/);
+assert.match(shellCommands, /run: \(\) => actions\.openSettingsSection\("agent"\)/);
+assert.match(shellCommands, /Open from Clipboard/);
+assert.match(shellCommands, /run: actions\.openClipboard/);
+assert.match(shellCommands, /Clear Recent Structures/);
+assert.match(shellCommands, /group: "Suggested"/);
+assert.doesNotMatch(shellCommands, /renderer-xyz-fast/);
+assert.match(shellCommands, /group: "Renderer"/);
 assert.match(commandPalette, /from "cmdk"/);
 assert.match(commandPalette, /from "@radix-ui\/react-dialog"/);
 assert.doesNotMatch(commandPalette, /CommandDialog/);
@@ -5854,7 +5856,7 @@ assert.match(keyboardShortcutsSection, /command: "Undo"[\s\S]*?keybindings: \["�
 assert.match(keyboardShortcutsSection, /command: "Redo"[\s\S]*?keybindings: \["⇧⌘Z"\]/);
 assert.match(shortcutDocs, /\| Cmd\+Z \| Undo the latest workspace or focused preview edit \|/);
 assert.match(shortcutDocs, /\| Cmd\+Shift\+Z \| Redo the latest workspace or focused preview edit when available \|/);
-assert.match(shortcuts, /commandKey && !event\.altKey && event\.shiftKey && key === "p"/);
+assert.match(shortcuts, /commandKey && !event\.altKey && key === "p"/);
 assert.match(shortcuts, /if \(isTauriRuntime\(\)\) return/);
 assert.match(shortcuts, /commandKey && !event\.altKey && !event\.shiftKey && key === "n"/);
 assert.match(shortcuts, /commandKey && !event\.altKey && !event\.shiftKey && key === "t"/);
@@ -6094,13 +6096,13 @@ const gridSelectionKeydown = gridViewer.match(/function handleGridSelectionKeydo
 assert.match(gridSelectionKeydown, /isEditableShortcutTarget\(target\)/);
 assert.match(gridSelectionKeydown, /event\.shiftKey\) redoLastGridEdit\(cfg\)/);
 assert.match(gridSelectionKeydown, /else undoLastGridEdit\(cfg\)/);
-assert.match(commandPalette, /id: "open-recent"/);
-assert.match(commandPalette, /id: "search-projects"/);
-assert.match(commandPalette, /id: "reveal-active"/);
-assert.match(commandPalette, /id: "copy-active-path"/);
-assert.match(commandPalette, /id: "show-active-metadata"/);
-assert.match(commandPalette, /id: "export-preview-png"/);
-assert.match(commandPalette, /id: "export-preview-svg"/);
+assert.match(shellCommands, /id: "open-recent"/);
+assert.match(shellCommands, /id: "search-projects"/);
+assert.match(shellCommands, /id: "reveal-active"/);
+assert.match(shellCommands, /id: "copy-active-path"/);
+assert.match(shellCommands, /id: "show-active-metadata"/);
+assert.match(shellCommands, /id: "export-preview-png"/);
+assert.match(shellCommands, /id: "export-preview-svg"/);
 assert.match(editorTabs, /id: "reveal-tab-document"/);
 assert.match(editorTabs, /id: "copy-tab-document-path"/);
 assert.match(editorTabs, /id: "show-tab-document-metadata"/);
@@ -6348,7 +6350,7 @@ assert.match(appMaintenanceHook, /Quick Look reset completed/);
 assert.match(appMaintenanceHook, /Quick Look reset reported issues/);
 assert.doesNotMatch(app, /Quick Look reset requested/);
 
-assert.match(shortcutDocs, /\| Cmd\+Shift\+P or \/ \| Open command palette \|/);
+assert.match(shortcutDocs, /\| Cmd\+P or \/ \| Open command palette \|/);
 assert.match(shortcutDocs, /\| Cmd\+N \| Open a new Burrete window \|/);
 assert.match(shortcutDocs, /\| Cmd\+T \| Open a new launcher tab \|/);
 assert.match(shortcutDocs, /\| Cmd\+B \| Toggle sidebar \|/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5866,7 +5866,7 @@ const closeTabShortcutIndex = shortcuts.indexOf('if (commandKey && !event.altKey
 assert.ok(nativeShortcutGuardIndex >= 0 && nativeShortcutGuardIndex < closeTabShortcutIndex);
 assert.doesNotMatch(shortcuts, /commandKey && key === "w"/);
 for (const embeddedViewer of [previewViewer, gridViewer, agentPreviewViewer, agentGridViewer]) {
-  assert.match(embeddedViewer, /commandKey && event\.shiftKey && key === 'p'/);
+  assert.match(embeddedViewer, /commandKey && !event\.altKey && key === 'p'/);
   assert.match(embeddedViewer, /!commandKey && !event\.altKey && key === '\/'/);
 }
 for (const embeddedGridViewer of [gridViewer, agentGridViewer]) {


### PR DESCRIPTION
## Problem

Two separate defects around the command palette:

1. **`Cmd+P` was never bound.** The palette only answered `Cmd+Shift+P` and `/`, while the sidebar search field rendered a `⌘P` hint and the README documented `Cmd+P`. On top of that, `Cmd+P` is the macOS print shortcut — with the native menu accelerator alone, the palette opened and was then immediately dismissed when the webview print sheet took focus.
2. **Commands only existed inside the palette.** The ~30 command definitions were inlined in a `useMemo` inside `CommandPalette`, so sidebar search could filter projects and structures but never commands.

## Changes

- New `apps/desktop/src/lib/shell-commands.ts` (`buildShellCommands`, `shellCommandsForQuery`, `filterShellCommands`) as the single source of palette commands; `CommandPalette` now consumes it and drops ~260 lines of inlined definitions.
- Sidebar search renders a **Commands** section (max 6 matches) above the project results; selecting one runs it and clears the query.
- `Cmd+P` opens the palette, from the native macOS menu accelerator and from the web keydown handler. The handler branch sits above the Tauri guard so `preventDefault()` always suppresses the print default.
- The embedded Mol* and grid viewers bridged only `Cmd+Shift+P` to the host, so `Cmd+P` did nothing while focus was inside a preview iframe — updated in both `PreviewExtension/Web` and the agent plugin copies.
- Aligned the shortcut labels and docs that still advertised `⇧⌘P` (welcome screen, settings shortcuts section, `docs/keyboard-shortcuts.md`).

## Verification

Browser dev build:

- `⌘P` / `⌃P` / `⇧⌘P` / `/` all open the palette; the keydown reports `defaultPrevented: true`.
- Sidebar search for `settings` shows the Settings command; `close` shows both tab-closing commands; clicking runs the command and clears the query.
- `fetch 1HTB` from the palette renders the structure; console clean.

Contract tests repointed at the extracted module and updated for the new accelerator: `test-ui-shell-contract`, `test-tauri-structure`, `test-native-menu-paths`, `test-sidebar-projects`, `test-sidebar-tree-render`, `test-shadcn-foundation` — all passing, plus the pre-push `ci-fast` suite.