### PR TITLE
Remove the stray node_modules symlink from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 build/
 build-dev/
 DerivedData/
-node_modules/
+node_modules
 npm-cache/
 xcuserdata/
 *.xcuserstate

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/nikolenko/Documents/Projects/Burette/.claude/worktrees/cleanup-stale-branches-0c3de5/node_modules


### PR DESCRIPTION
Follow-up to #483, which accidentally committed a `node_modules` symlink.

The symlink was created locally to run the dev server from a worktree that has no installed dependencies. `git add -A` picked it up because the `.gitignore` entry was `node_modules/` — a trailing slash only matches directories, not a symlink of the same name.

- Drop the tracked `node_modules` entry.
- Widen the ignore rule to `node_modules` so a symlink cannot be staged again.