### PR TITLE
Add an illustrative surface preset, restore water rendering, and keep theme changes from rebuilding the viewer

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,7 +7,7 @@
       "runtimeArgs": [
         "node_modules/.bin/vite",
         "--config",
-        "vite.config.ts",
+        "apps/desktop/vite.config.ts",
         "--host",
         "127.0.0.1"
       ],

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -37,6 +37,7 @@
   const MOLSTAR_STYLE_OPTIONS = [
     { value: 'default', label: 'Default' },
     { value: 'illustrative', label: 'Illustrative' },
+    { value: 'illustrative-surface', label: 'Illustrative+Surface' },
     { value: 'polymer-ligand', label: 'Polymer+Ligand' },
     { value: 'cartoon', label: 'Cartoon' },
     { value: 'ball-and-stick', label: 'Ball+Stick' },
@@ -8500,6 +8501,26 @@
     );
   }
 
+  // Adds a translucent grey envelope on top of the representations the default
+  // preset already built, so the illustrative cartoon stays visible through it.
+  // Style switches clear and reload the plugin, so this never stacks surfaces.
+  async function addMolstarGhostSurfaceRepresentation(viewer) {
+    const plugin = viewer?.plugin;
+    if (!plugin) return;
+    const representation = {
+      type: 'molecular-surface',
+      typeParams: { alpha: 0.24, transparentBackfaces: 'on' },
+      color: 'uniform',
+      colorParams: { value: 0x9aa3ad }
+    };
+    for (const structure of molstarCurrentStructures(viewer)) {
+      const polymer = await tryCreateMolstarComponent(plugin, structure, 'polymer');
+      if (await addMolstarRepresentation(plugin, polymer, representation)) continue;
+      const all = await tryCreateMolstarComponent(plugin, structure, 'all');
+      await addMolstarRepresentation(plugin, all, representation);
+    }
+  }
+
   function resetMolstarPostprocessing(viewer) {
     const canvas = viewer?.plugin?.canvas3d;
     if (!canvas) return;
@@ -8570,7 +8591,7 @@
     if (!plugin) return;
     const normalized = normalizeMolstarStyle(style);
 
-    if (normalized !== 'illustrative') {
+    if (normalized !== 'illustrative' && normalized !== 'illustrative-surface') {
       await applyMolstarNonIllustrativePostprocessing(viewer);
     }
 
@@ -8608,6 +8629,11 @@
     }
     if (normalized === 'illustrative') {
       await applyMolstarIllustrativePostprocessing(viewer);
+      return;
+    }
+    if (normalized === 'illustrative-surface') {
+      await applyMolstarIllustrativePostprocessing(viewer);
+      await addMolstarGhostSurfaceRepresentation(viewer);
       return;
     }
     if (normalized === 'cartoon' || normalized === 'polymer-ligand') {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -8516,16 +8516,17 @@
   async function addMolstarGhostSurfaceRepresentation(viewer) {
     const plugin = viewer?.plugin;
     if (!plugin) return;
-    // Glass look: the envelope stays lit while the illustrative cartoon under it
-    // keeps its flat shading, so the specular highlight reads as a surface rather
-    // than as a grey wash.
+    // Cel shading banks the envelope into flat tones, and the caller switches the
+    // outline pass onto transparent geometry, so it reads as a drawn shell with
+    // edges rather than as a featureless grey wash.
     const representation = {
       type: 'molecular-surface',
       typeParams: {
-        alpha: 0.11,
+        alpha: 0.12,
         transparentBackfaces: 'on',
         ignoreLight: false,
-        material: { roughness: 0.08, metalness: 0 }
+        celShaded: true,
+        material: { roughness: 0.2, metalness: 0 }
       },
       color: 'uniform',
       colorParams: { value: 0xc8d0d8 }
@@ -8560,7 +8561,10 @@
     resetMolstarPostprocessing(viewer);
   }
 
-  async function applyMolstarIllustrativePostprocessing(viewer) {
+  // `includeTransparent` is always written out: the outline otherwise skips
+  // translucent geometry, and leaving the previous value in place would leak the
+  // surface preset's outlining into the plain illustrative style.
+  async function applyMolstarIllustrativePostprocessing(viewer, options = {}) {
     const plugin = viewer?.plugin;
     if (!plugin) return;
     await plugin.managers.structure.component.setOptions({
@@ -8573,14 +8577,16 @@
       postprocessing: {
         outline: {
           name: 'on',
-          params: postprocessing.outline.name === 'on'
-            ? postprocessing.outline.params
-            : {
-                scale: 1,
-                color: 0x000000,
-                threshold: 0.33,
-                includeTransparent: false
-              }
+          params: {
+            ...(postprocessing.outline.name === 'on'
+              ? postprocessing.outline.params
+              : {
+                  scale: 1,
+                  color: 0x000000,
+                  threshold: 0.33
+                }),
+            includeTransparent: options.includeTransparent === true
+          }
         },
         occlusion: {
           name: 'on',
@@ -8649,7 +8655,7 @@
       return;
     }
     if (normalized === 'illustrative-surface') {
-      await applyMolstarIllustrativePostprocessing(viewer);
+      await applyMolstarIllustrativePostprocessing(viewer, { includeTransparent: true });
       await addMolstarGhostSurfaceRepresentation(viewer);
       return;
     }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2056,6 +2056,15 @@
       void handleWorkspaceHistoryCommand(body, event.source);
       return;
     }
+    // Applied in place so a theme change never costs a viewer rebuild: the runtime
+    // already carries the token sets for both themes.
+    if (body.type === 'setViewerTheme') {
+      const nextTheme = normalizeViewerTheme(body.value);
+      if (activeConfig) activeConfig.theme = nextTheme;
+      if (window.BurreteConfig) window.BurreteConfig.theme = nextTheme;
+      setViewerTheme(nextTheme, activeViewer);
+      return;
+    }
     if (body.type === 'setXyzrenderControls') {
       const config = activeConfig || window.BurreteConfig || {};
       const documentId = String(config.documentId || '');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -8516,7 +8516,7 @@
         alpha: 0.11,
         transparentBackfaces: 'on',
         ignoreLight: false,
-        material: { roughness: 0.08, metalness: 0, reflectivity: 1 }
+        material: { roughness: 0.08, metalness: 0 }
       },
       color: 'uniform',
       colorParams: { value: 0xc8d0d8 }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -8507,11 +8507,19 @@
   async function addMolstarGhostSurfaceRepresentation(viewer) {
     const plugin = viewer?.plugin;
     if (!plugin) return;
+    // Glass look: the envelope stays lit while the illustrative cartoon under it
+    // keeps its flat shading, so the specular highlight reads as a surface rather
+    // than as a grey wash.
     const representation = {
       type: 'molecular-surface',
-      typeParams: { alpha: 0.24, transparentBackfaces: 'on' },
+      typeParams: {
+        alpha: 0.11,
+        transparentBackfaces: 'on',
+        ignoreLight: false,
+        material: { roughness: 0.08, metalness: 0, reflectivity: 1 }
+      },
       color: 'uniform',
-      colorParams: { value: 0x9aa3ad }
+      colorParams: { value: 0xc8d0d8 }
     };
     for (const structure of molstarCurrentStructures(viewer)) {
       const polymer = await tryCreateMolstarComponent(plugin, structure, 'polymer');
@@ -8699,6 +8707,33 @@
     };
   }
 
+  // Crystallographic waters are lone oxygens, so the bond-only line visual has
+  // nothing to draw for them. Dots keep those waters visible without changing how
+  // bonded MD solvent (GRO/Desmond) renders.
+  function molstarWaterPointRepresentation() {
+    return {
+      type: 'point',
+      typeParams: {
+        alpha: 0.5,
+        sizeFactor: 1,
+        pointSizeAttenuation: true,
+        pointStyle: 'circle'
+      },
+      color: 'uniform',
+      colorParams: { value: 0x4db6ff },
+      size: 'uniform',
+      sizeParams: { value: 0.22 }
+    };
+  }
+
+  function molstarWaterRepresentationFor(component) {
+    const structure = component?.cell?.obj?.data || component?.obj?.data || null;
+    for (const unit of structure?.units || []) {
+      if (unit.bonds?.edgeCount > 0) return molstarWaterLineRepresentation();
+    }
+    return molstarWaterPointRepresentation();
+  }
+
   async function applyMolstarWaterLineRepresentation(viewer) {
     if (!shouldUseMolstarWaterLines(activeConfig)) return;
     const plugin = viewer?.plugin;
@@ -8723,10 +8758,10 @@
       await plugin.managers.structure.component.removeRepresentations(waterComponents);
     }
     for (const component of waterComponents) {
-      await plugin.builders.structure.representation.addRepresentation(component.cell, molstarWaterLineRepresentation(), { tag: 'water' });
+      await plugin.builders.structure.representation.addRepresentation(component.cell, molstarWaterRepresentationFor(component), { tag: 'water' });
     }
     for (const component of createdWaterComponents) {
-      await plugin.builders.structure.representation.addRepresentation(component.cell || component, molstarWaterLineRepresentation(), { tag: 'water' });
+      await plugin.builders.structure.representation.addRepresentation(component.cell || component, molstarWaterRepresentationFor(component), { tag: 'water' });
     }
     return waterComponents.length;
   }

--- a/apps/desktop/src/hooks/use-app-preference-effects.ts
+++ b/apps/desktop/src/hooks/use-app-preference-effects.ts
@@ -1,4 +1,4 @@
-import { useEffect, type MutableRefObject } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { isTauriRuntime } from "../lib/tauri";
 import { isTemporaryDocumentPath } from "../lib/temporary-documents";
@@ -7,6 +7,33 @@ import type { OpenDocumentsResult, ViewerPreferences } from "../types";
 
 type PushErrorStatus = (error: unknown, prefix?: string, details?: string[]) => void;
 type OpenDocuments = (paths: string[]) => Promise<OpenDocumentsResult | null | undefined>;
+
+// Preferences the mounted viewers can apply without being rebuilt. Everything
+// else is baked into the viewer runtime HTML, so changing it still reopens the
+// document. `theme` qualifies because the runtime already carries the token sets
+// for both themes and switches between them at runtime.
+const LIVE_APPLIED_PREFERENCE_KEYS = ["theme"] as const satisfies readonly (keyof ViewerPreferences)[];
+
+function onlyLiveAppliedPreferencesChanged(previous: ViewerPreferences, next: ViewerPreferences) {
+  const live = new Set<string>(LIVE_APPLIED_PREFERENCE_KEYS);
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  let liveChanged = false;
+  for (const key of keys) {
+    if (previous[key as keyof ViewerPreferences] === next[key as keyof ViewerPreferences]) continue;
+    if (!live.has(key)) return false;
+    liveChanged = true;
+  }
+  return liveChanged;
+}
+
+function broadcastViewerTheme(theme: ViewerPreferences["theme"]) {
+  for (const frame of document.querySelectorAll<HTMLIFrameElement>("iframe[data-document-id]")) {
+    frame.contentWindow?.postMessage({
+      source: "burrete-host",
+      body: { type: "setViewerTheme", value: theme },
+    }, "*");
+  }
+}
 
 type UseAppPreferenceEffectsOptions = {
   activeTab: MoleculeTab | null | undefined;
@@ -27,6 +54,8 @@ export function useAppPreferenceEffects({
   setActiveTab,
   skipNextPreferenceRefreshRef,
 }: UseAppPreferenceEffectsOptions) {
+  const previousPreferencesRef = useRef(preferences);
+
   useEffect(() => {
     if (!isTauriRuntime()) return;
     void invoke("sync_viewer_preferences", { preferences }).catch((error) => {
@@ -35,8 +64,16 @@ export function useAppPreferenceEffects({
   }, [preferences, pushErrorStatus]);
 
   useEffect(() => {
+    const previousPreferences = previousPreferencesRef.current;
+    previousPreferencesRef.current = preferences;
     if (skipNextPreferenceRefreshRef.current) {
       skipNextPreferenceRefreshRef.current = false;
+      return;
+    }
+    // Reopening would drop the live Mol* scene (camera, components, selections),
+    // so preferences the mounted viewers can apply themselves are pushed instead.
+    if (onlyLiveAppliedPreferencesChanged(previousPreferences, preferences)) {
+      broadcastViewerTheme(preferences.theme);
       return;
     }
     const path = activeTab?.location.kind === "file" && !isTemporaryDocumentPath(activeTab.location.path)

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -6346,6 +6346,15 @@ assert.doesNotMatch(app, /void openDocuments\(\[path\]\)\.then/);
 assert.match(appPreferenceEffectsHook, /Preferences refresh only the mounted file runtime\. Inactive file tabs are unloaded\./);
 assert.match(appPreferenceEffectsHook, /if \(skipNextPreferenceRefreshRef\.current\) \{\s*skipNextPreferenceRefreshRef\.current = false;\s*return;\s*\}/s);
 assert.match(appPreferenceEffectsHook, /void openDocuments\(\[path\]\)\.then/);
+// A theme change must reach mounted viewers as a message instead of reopening the
+// document, otherwise the live Mol* scene (camera, components, selections) is lost.
+assert.match(appPreferenceEffectsHook, /const LIVE_APPLIED_PREFERENCE_KEYS = \["theme"\] as const/);
+assert.match(appPreferenceEffectsHook, /function onlyLiveAppliedPreferencesChanged\(previous: ViewerPreferences, next: ViewerPreferences\)/);
+assert.match(appPreferenceEffectsHook, /querySelectorAll<HTMLIFrameElement>\("iframe\[data-document-id\]"\)/);
+assert.match(appPreferenceEffectsHook, /body: \{ type: "setViewerTheme", value: theme \}/);
+assert.match(appPreferenceEffectsHook, /if \(onlyLiveAppliedPreferencesChanged\(previousPreferences, preferences\)\) \{\s*broadcastViewerTheme\(preferences\.theme\);\s*return;\s*\}/s);
+assert.match(previewViewer, /if \(body\.type === 'setViewerTheme'\) \{\s*const nextTheme = normalizeViewerTheme\(body\.value\);/s);
+assert.match(previewViewer, /setViewerTheme\(nextTheme, activeViewer\);/);
 assert.match(appMaintenanceHook, /Quick Look reset completed/);
 assert.match(appMaintenanceHook, /Quick Look reset reported issues/);
 assert.doesNotMatch(app, /Quick Look reset requested/);


### PR DESCRIPTION
## Summary

Adds an `Illustrative+Surface` Mol* preset, makes crystallographic waters visible again, and stops a theme toggle from destroying the live viewer scene.

## Changes

**New `Illustrative+Surface` preset** (`PreviewExtension/Web/viewer.js`)

Sits right after `Illustrative` in the viewer toolbar. Keeps the illustrative cartoon and adds a translucent grey `molecular-surface` envelope on the existing polymer component, so nothing the default preset built is removed. The envelope is cel shaded, and the preset switches the illustrative outline pass onto transparent geometry so the shell gets drawn edges instead of reading as a featureless grey wash.

`applyMolstarIllustrativePostprocessing` now takes an `includeTransparent` option and always writes that field out. Previously it preserved the whole existing outline parameter object when the outline was already on, which would have leaked the surface preset's outlining into the plain illustrative style.

**Waters render again for crystallographic PDBs** (`PreviewExtension/Web/viewer.js`)

The water component was drawn with a `line` representation restricted to `visuals: ['intra-bond']`, so it only ever drew bonds. Crystallographic waters are lone oxygens — on 3HTB, 220 water atoms with 0 bonds — so nothing was drawn in any style. This was a regression from 9636a46f, which tuned water for GRO/Desmond solvent.

Water representation is now chosen per component: bonded solvent (GRO/Desmond, TIP3P with hydrogens) keeps the existing lines, bondless water renders as points. MD trajectory rendering is unchanged. Note that `line` has no `element-point` visual in Mol* 5, which is likely why the earlier attempt at this was reverted; `point` is a separate representation type.

**Theme changes no longer rebuild the viewer** (`apps/desktop/src/hooks/use-app-preference-effects.ts`)

Any preference change reopened the active document. The viewer iframe is keyed on its whole srcdoc, which embeds the config, so changing one word of theme remounted the iframe and destroyed the Mol* scene — camera, user-added components and representations, selections.

Preferences are now split: those a mounted viewer can apply itself are pushed to every mounted viewer as a `setViewerTheme` message, everything else keeps the existing reopen path. Only `theme` qualifies today, because the runtime already carries the token sets for both themes; the accent/font/contrast tokens are baked into the runtime HTML and still need a reload.

**Preview launch config** (`.claude/launch.json`)

Pointed at `apps/desktop/vite.config.ts`. The root config is the vite-plus one used for `vp check/test/build` and has neither the `@` alias nor the browser-dev routes, so the dev server started but the app failed to resolve its imports.

## Verification

- `bun run check:js`, `bun run test:ui` (full suite), `tsc --noEmit` on `apps/desktop` — all green, re-run after rebasing onto current `main`.
- Five new assertions in `tests/test-ui-shell-contract.mjs` pin the live-theme path on both sides.
- Theme fix checked in the browser by marking each iframe in the DOM and in its `window`: before the fix the active viewer came back as a new node with its scene gone; after it, both viewers keep identity, both switch light → dark, and added representations survive. Background viewers now follow the theme too, where before they stayed stale until reloaded.
- The reopen path was confirmed still intact: changing `rendererMode` still replaces the active viewer's iframe.
- Preset and water changes verified visually on 1HTB and 3HTB, and by reading back the applied Mol* parameters rather than trusting the request.

## Known gaps

- Switching style right after opening a document can leave the camera off-target until a camera reset. Reproduces on the stock `cartoon` style too, so it is a pre-existing bug in `reloadMolstarStyle`'s camera restore, not from this branch.
- Settings still offers only `default` / `illustrative` for the default Mol* style; the new preset is toolbar-only.
- `readStoredViewerTheme()` in `viewer.js` remains dead code — the viewer persists the theme but reads it from config on boot. Left alone as unrelated cleanup.
