### PR TITLE
Make window and tab closing unblockable

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -465,7 +465,6 @@ export default function App() {
       dirty: gridSnapshot.dirty || sourceSnapshot.dirty,
       revision: combined.revision,
       closeTransitionActive: sourceSnapshot.closeTransitionActive,
-      closeGuardRevision: sourceSnapshot.revision,
     };
   }, [getGridWindowDocumentDirtySnapshot, sourceEditing]);
   const {

--- a/apps/desktop/src/hooks/use-app-native-menu.ts
+++ b/apps/desktop/src/hooks/use-app-native-menu.ts
@@ -24,10 +24,7 @@ import { isTauriRuntime, trackTauriListener } from "../lib/tauri";
 import { activeViewerIframeForDocument } from "../lib/viewer-bridge";
 import {
   resumeWindowMutations,
-  sameWindowItemIds,
   sealWindowMutations,
-  setGridDocumentCloseTransition,
-  setWindowShellCloseTransition,
   type WindowCloseMutationPermit,
 } from "../lib/window-mutation-barrier";
 import type { ViewerPreferences, ViewerReloadOptions } from "../types";
@@ -57,7 +54,6 @@ type UseAppNativeMenuOptions = {
     dirty: boolean;
     revision: number;
     closeTransitionActive: boolean;
-    closeGuardRevision: number;
   };
   windowDocumentDirty: boolean;
   sourceSaveEnabled: boolean;
@@ -234,13 +230,9 @@ export function useAppNativeMenu({
   const closeConfirmationPendingRef = useRef(false);
   const closingWindowRef = useRef(false);
   const getWindowDocumentDirtySnapshotRef = useRef(getWindowDocumentDirtySnapshot);
-  const windowDocumentIdsRef = useRef(state.documents.map((document) => document.id));
-  const windowTabIdsRef = useRef(state.tabs.map((tab) => tab.id));
   nativeStateRef.current = { ...nativeState, recentDocuments };
   confirmCloseWindowRef.current = confirmCloseWindow;
   getWindowDocumentDirtySnapshotRef.current = getWindowDocumentDirtySnapshot;
-  windowDocumentIdsRef.current = state.documents.map((document) => document.id);
-  windowTabIdsRef.current = state.tabs.map((tab) => tab.id);
 
   useEffect(() => {
     if (!isTauriRuntime()) return;
@@ -277,58 +269,19 @@ export function useAppNativeMenu({
       closeConfirmationPendingRef.current = true;
       void (async () => {
         let permit: WindowCloseMutationPermit | null = null;
-        let closeTransitionStarted = false;
-        let windowInteractionPaused = false;
-        let documentIds: string[] = [];
-        let tabIds: string[] = [];
-        let closeGuardRevision = 0;
-        const currentWindow = getCurrentWindow();
         try {
           permit = await confirmCloseWindowRef.current();
+          // Only an explicit "cancel" in the unsaved-changes prompt stops the
+          // close. Past this point nothing may gate it: the window shuts down
+          // immediately rather than waiting on in-flight work, because that
+          // wait was unbounded and left the shell frozen when it never settled.
           if (!permit) return;
-          const dirtySnapshot = getWindowDocumentDirtySnapshotRef.current();
-          if (dirtySnapshot.closeTransitionActive) {
-            permit.release();
-            return;
-          }
-          closeGuardRevision = dirtySnapshot.closeGuardRevision;
-          documentIds = [...windowDocumentIdsRef.current];
-          tabIds = [...windowTabIdsRef.current];
-          closeTransitionStarted = true;
+          permit.release();
           closingWindowRef.current = true;
-          setWindowShellCloseTransition(true);
-          setGridDocumentCloseTransition(documentIds, true);
-          if (await currentWindow.isEnabled()) {
-            await currentWindow.setEnabled(false);
-            windowInteractionPaused = true;
-          }
-          await permit.waitForPending();
-          const finalDirtySnapshot = getWindowDocumentDirtySnapshotRef.current();
-          if (!sameWindowItemIds(documentIds, windowDocumentIdsRef.current)
-            || !sameWindowItemIds(tabIds, windowTabIdsRef.current)
-            || finalDirtySnapshot.closeTransitionActive
-            || finalDirtySnapshot.closeGuardRevision !== closeGuardRevision) {
-            throw new Error("Window contents changed while closing.");
-          }
-          if (windowInteractionPaused) {
-            await currentWindow.setEnabled(true);
-            windowInteractionPaused = false;
-          }
-          await currentWindow.close();
+          await getCurrentWindow().close();
         } catch (error) {
-          if (closeTransitionStarted) {
-            closingWindowRef.current = false;
-            setGridDocumentCloseTransition(documentIds, false);
-            setWindowShellCloseTransition(false);
-            permit?.release();
-            if (windowInteractionPaused) {
-              await currentWindow.setEnabled(true).catch((restoreError) => {
-                console.warn("Native window interaction restore failed", restoreError);
-              });
-            }
-          } else {
-            permit?.release();
-          }
+          closingWindowRef.current = false;
+          permit?.release();
           console.warn("Native window close failed", error);
         } finally {
           closeConfirmationPendingRef.current = false;

--- a/apps/desktop/src/hooks/use-app-shell-actions.ts
+++ b/apps/desktop/src/hooks/use-app-shell-actions.ts
@@ -1,10 +1,7 @@
 import { useMemo } from "react";
 import type { ShellActions } from "../components/types";
 import type { DockDropInput } from "../lib/dock";
-import {
-  setGridDocumentCloseTransition,
-  type WindowCloseMutationPermit,
-} from "../lib/window-mutation-barrier";
+import type { WindowCloseMutationPermit } from "../lib/window-mutation-barrier";
 import {
   useWorkspaceHistoryStore,
   workspaceHistoryNone,
@@ -1078,17 +1075,14 @@ export function createDocumentCloseShellActions({
   pushStatus: PushStatus;
   tabs: MoleculeTab[];
 }): Pick<ShellActions, "closeDocument" | "closeTab" | "closeOtherTabs" | "closeActiveDocument" | "clearAllDocuments"> {
-  const completeClose = async (
-    permit: WindowCloseMutationPermit,
-    documentIds: string[],
-    close: () => void,
-  ) => {
-    setGridDocumentCloseTransition(documentIds, true);
+  // Closing runs to completion straight away. It used to freeze the document's
+  // grid and wait for in-flight mutations first, but that wait had no timeout,
+  // so one unfinished operation left the "Finishing current change…" overlay up
+  // for good and blocked every later close.
+  const completeClose = (permit: WindowCloseMutationPermit, close: () => void) => {
     try {
-      await permit.waitForPending(documentIds);
       close();
     } finally {
-      setGridDocumentCloseTransition(documentIds, false);
       permit.release();
     }
   };
@@ -1108,7 +1102,7 @@ export function createDocumentCloseShellActions({
       if (!confirmCloseSourceDocuments([id])) return;
       const permit = await confirmDiscardDirtyGridDocument(id);
       if (!permit) return;
-      await completeClose(permit, [id], () => {
+      completeClose(permit, () => {
         closeGridRuntime(id);
         forgetDirtyGridDocument(id);
         closeDocument(id);
@@ -1121,7 +1115,7 @@ export function createDocumentCloseShellActions({
       if (!confirmCloseSourceDocuments(documentIds)) return;
       const permit = await confirmDiscardDirtyGridDocuments(documentIds);
       if (!permit) return;
-      await completeClose(permit, documentIds, () => {
+      completeClose(permit, () => {
         closeGridRuntime(targetDocumentId);
         forgetDirtyGridDocument(targetDocumentId);
         closeTab(id);
@@ -1138,7 +1132,7 @@ export function createDocumentCloseShellActions({
       if (!confirmCloseSourceDocuments(documentIds)) return;
       const permit = await confirmDiscardDirtyGridDocuments(documentIds);
       if (!permit) return;
-      await completeClose(permit, documentIds, () => {
+      completeClose(permit, () => {
         for (const documentId of documentIds) closeGridRuntime(documentId);
         forgetDirtyGridDocuments(documentIds);
         for (const tab of otherTabs) closeTab(tab.id);
@@ -1150,7 +1144,7 @@ export function createDocumentCloseShellActions({
       if (activeDocument && !confirmCloseSourceDocuments([activeDocument.id])) return;
       const permit = await confirmDiscardDirtyGridDocument(documentId);
       if (!permit) return;
-      await completeClose(permit, documentId ? [documentId] : [], () => {
+      completeClose(permit, () => {
         closeGridRuntime(documentId);
         forgetDirtyGridDocument(documentId);
         closeActiveDocument();
@@ -1162,7 +1156,7 @@ export function createDocumentCloseShellActions({
       if (!confirmCloseSourceDocuments(documentIds)) return;
       const permit = await confirmDiscardDirtyGridDocuments(documentIds);
       if (!permit) return;
-      await completeClose(permit, documentIds, () => {
+      completeClose(permit, () => {
         for (const document of documents) closeGridRuntime(document.id);
         clearDirtyGridDocuments();
         closeAllDocuments();

--- a/apps/desktop/src/lib/window-mutation-barrier.ts
+++ b/apps/desktop/src/lib/window-mutation-barrier.ts
@@ -7,44 +7,27 @@ export class ExitTransitionActiveError extends Error {
 
 export type WindowCloseMutationPermit = {
   release: () => void;
-  waitForPending: (documentIds?: Iterable<string>) => Promise<void>;
 };
 
 export function createExitMutationBarrier() {
   let exitSealed = false;
-  let closeTransitionActive = false;
+  // Counted rather than a boolean: close transitions overlap (a tab's unsaved
+  // prompt can still be open when the window close button is pressed), and
+  // beginCloseTransition must never refuse the second one — refusing it used to
+  // make the window close button silently do nothing.
+  let closeTransitionDepth = 0;
   let nextLeaseId = 0;
   const leases = new Map<number, string>();
-  const pendingWaiters = new Set<{
-    documentIds: Set<string> | null;
-    resolve: () => void;
-  }>();
-
-  const hasPendingLease = (documentIds: Set<string> | null) => {
-    if (documentIds === null) return leases.size > 0;
-    for (const documentId of leases.values()) {
-      if (documentIds.has(documentId)) return true;
-    }
-    return false;
-  };
-
-  const resolveSettledWaiters = () => {
-    for (const waiter of pendingWaiters) {
-      if (hasPendingLease(waiter.documentIds)) continue;
-      pendingWaiters.delete(waiter);
-      waiter.resolve();
-    }
-  };
 
   const snapshot = () => ({
-    closeTransitionActive,
+    closeTransitionActive: closeTransitionDepth > 0,
     pendingCount: leases.size,
     pendingDocumentIds: [...new Set(leases.values())],
   });
 
   return {
     begin(documentId: string) {
-      if (exitSealed || closeTransitionActive) throw new ExitTransitionActiveError();
+      if (exitSealed || closeTransitionDepth > 0) throw new ExitTransitionActiveError();
       const leaseId = nextLeaseId;
       nextLeaseId += 1;
       leases.set(leaseId, documentId);
@@ -53,26 +36,18 @@ export function createExitMutationBarrier() {
         if (released) return;
         released = true;
         leases.delete(leaseId);
-        resolveSettledWaiters();
       };
     },
     beginCloseTransition(): WindowCloseMutationPermit & ReturnType<typeof snapshot> {
-      if (exitSealed || closeTransitionActive) throw new ExitTransitionActiveError();
-      closeTransitionActive = true;
+      if (exitSealed) throw new ExitTransitionActiveError();
+      closeTransitionDepth += 1;
       let released = false;
       return {
         ...snapshot(),
         release() {
           if (released) return;
           released = true;
-          closeTransitionActive = false;
-        },
-        waitForPending(documentIds?: Iterable<string>) {
-          const targetIds = documentIds === undefined ? null : new Set(documentIds);
-          if (!hasPendingLease(targetIds)) return Promise.resolve();
-          return new Promise<void>((resolve) => {
-            pendingWaiters.add({ documentIds: targetIds, resolve });
-          });
+          closeTransitionDepth -= 1;
         },
       };
     },
@@ -231,21 +206,6 @@ export async function waitForGridDocumentCloseTransition(documentIds: Iterable<s
     }));
   }
   await Promise.all(acknowledgements);
-}
-
-export function sameWindowItemIds(before: Iterable<string>, after: Iterable<string>) {
-  const beforeIds = [...before];
-  const afterIds = [...after];
-  return beforeIds.length === afterIds.length
-    && beforeIds.every((itemId, index) => itemId === afterIds[index]);
-}
-
-export function setWindowShellCloseTransition(active: boolean) {
-  if (typeof document === "undefined") return;
-  const shell = document.querySelector<HTMLElement>(".app-shell");
-  if (!shell) return;
-  shell.inert = active;
-  shell.toggleAttribute("aria-busy", active);
 }
 
 export function resumeWindowMutations() {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -720,12 +720,16 @@ button:focus-visible > .shortcut-tooltip {
 .resizable-handle:active .resizable-handle-grip { height: 56px; }
 .resizable-handle-horizontal:hover .resizable-handle-grip,
 .resizable-handle-horizontal:active .resizable-handle-grip { height: 4px; width: 56px; }
+/* The workbench card, the stage and the docks paint `--bg`, not `--bg-base`:
+   `--bg-base` is the raw theme color and ignores the Translucent preference, so
+   using it here covered the whole window with an opaque sheet and left the
+   slider affecting only the sidebar strip. */
 .workbench {
   min-width: 0;
   min-height: 0;
   flex: 1;
   display: flex;
-  background: var(--bg-base);
+  background: var(--bg);
   overflow: hidden;
   border-left: 1px solid var(--workspace-edge-border);
   border-radius: 20px 0 0 20px;
@@ -1821,7 +1825,7 @@ img.radix-menu-item-icon {
   min-height: 0;
   flex: 1;
   display: grid;
-  background: var(--bg-base);
+  background: var(--bg);
   overflow: hidden;
 }
 .dock-panel {
@@ -1833,7 +1837,7 @@ img.radix-menu-item-icon {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg-base);
+  background: var(--bg);
   color: var(--text-primary);
   overflow: hidden;
   opacity: 1;

--- a/tests/test-document-close-shell-actions.mjs
+++ b/tests/test-document-close-shell-actions.mjs
@@ -13,32 +13,12 @@ const tabs = [
   { id: "tab-launcher", location: { kind: "launcher" } },
 ];
 
-function closeActions(approveClose, waitForPending) {
+function closeActions(approveClose) {
   const calls = [];
-  globalThis.document = {
-    querySelectorAll: () => [{
-      dataset: { documentId: "doc-b" },
-      inert: false,
-      blur: () => calls.push(["blur-grid", "doc-b"]),
-      toggleAttribute: () => {},
-      contentWindow: {
-        postMessage: (message) => calls.push([
-          "grid-close-transition",
-          message.body.active,
-        ]),
-      },
-    }],
-  };
   const confirm = (ids) => {
     calls.push(["confirm", ids]);
     if (!approveClose) return null;
-    return {
-      waitForPending: async (pendingIds) => {
-        calls.push(["wait-pending", [...pendingIds]]);
-        await waitForPending?.();
-      },
-      release: () => calls.push(["release-permit"]),
-    };
+    return { release: () => calls.push(["release-permit"]) };
   };
   const actions = createDocumentCloseShellActions({
     activeDocument: documents[0],
@@ -66,37 +46,46 @@ function closeActions(approveClose, waitForPending) {
   assert.deepEqual(calls, [["confirm", ["doc-b"]]]);
 }
 
+// Closing never waits on in-flight work: once the prompt approves, the tabs go
+// away in the same turn and the permit is released.
 {
-  let finishPending;
-  const pending = new Promise((resolve) => {
-    finishPending = resolve;
-  });
-  const { actions, calls } = closeActions(true, () => pending);
-  const closing = actions.closeOtherTabs("tab-a");
-  await Promise.resolve();
+  const { actions, calls } = closeActions(true);
+  await actions.closeOtherTabs("tab-a");
   assert.deepEqual(calls, [
     ["confirm", ["doc-b"]],
-    ["blur-grid", "doc-b"],
-    ["grid-close-transition", true],
-    ["wait-pending", ["doc-b"]],
-  ]);
-  finishPending();
-  await closing;
-  assert.deepEqual(calls, [
-    ["confirm", ["doc-b"]],
-    ["blur-grid", "doc-b"],
-    ["grid-close-transition", true],
-    ["wait-pending", ["doc-b"]],
     ["close-runtime", "doc-b"],
     ["forget-dirty-many", ["doc-b"]],
     ["close-tab", "tab-b"],
     ["close-tab", "tab-launcher"],
     ["status", "Closed other tabs"],
-    ["grid-close-transition", false],
     ["release-permit"],
   ]);
 }
 
-delete globalThis.document;
+// A throwing close still releases the permit, so a later close is never refused.
+{
+  const calls = [];
+  const actions = createDocumentCloseShellActions({
+    activeDocument: documents[0],
+    clearDirtyGridDocuments: () => {},
+    closeActiveDocument: () => {},
+    closeAllDocuments: () => {},
+    closeDocument: () => {
+      throw new Error("close failed");
+    },
+    closeGridRuntime: () => {},
+    closeTab: () => {},
+    confirmCloseSourceDocuments: () => true,
+    confirmDiscardDirtyGridDocument: () => ({ release: () => calls.push("release-permit") }),
+    confirmDiscardDirtyGridDocuments: () => ({ release: () => calls.push("release-permit") }),
+    documents,
+    forgetDirtyGridDocument: () => {},
+    forgetDirtyGridDocuments: () => {},
+    pushStatus: () => {},
+    tabs,
+  });
+  await assert.rejects(actions.closeDocument("doc-a"), /close failed/);
+  assert.deepEqual(calls, ["release-permit"]);
+}
 
 console.log("document close shell action tests passed");

--- a/tests/test-source-editing-window-lifecycle.mjs
+++ b/tests/test-source-editing-window-lifecycle.mjs
@@ -25,13 +25,12 @@ assert.match(sourceEditingContext, /getWindowDirtySnapshot: \(\) => SourceEditin
 assert.match(app, /const confirmCloseWindow = useCallback[\s\S]*sourceEditing\.confirmCloseWindow\(\)[\s\S]*confirmDiscardAllDirtyGridDocuments\(\)[\s\S]*try \{[\s\S]*return permit;[\s\S]*catch \(error\) \{\s*permit\.release\(\);/u);
 assert.match(app, /dirty: gridSnapshot\.dirty \|\| sourceSnapshot\.dirty/u);
 assert.match(app, /closeTransitionActive: sourceSnapshot\.closeTransitionActive/u);
-assert.match(app, /closeGuardRevision: sourceSnapshot\.revision/u);
 assert.match(app, /windowDocumentDirty: hasDirtyGridDocuments \|\| sourceEditing\.hasUnsavedOrSavingSessions/u);
 
 assert.match(nativeMenuHook, /canSave: sourceSaveEnabled\s*\|\| Boolean\(isGrid/u);
 assert.match(nativeMenuHook, /case "file\.save":\s*if \(sourceSaveEnabled\) await saveActiveSource\(\);\s*else gridCommand\(\);/su);
 assert.match(nativeMenuHook, /closeTransitionActive: snapshot\.closeTransitionActive\s*\|\| barrier\.closeTransitionActive/su);
-assert.match(nativeMenuHook, /finalDirtySnapshot\.closeGuardRevision !== closeGuardRevision/u);
-assert.match(nativeMenuHook, /else \{\s*permit\?\.release\(\);\s*\}/u);
+// A failed close must hand the permit back, otherwise the next one is refused.
+assert.match(nativeMenuHook, /catch \(error\) \{\s*closingWindowRef\.current = false;\s*permit\?\.release\(\);/u);
 
 console.log("source editing window lifecycle tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1153,8 +1153,10 @@ assert.match(appDirtyGridHook, /Close Without Saving/);
 assert.match(appDirtyGridHook, /await message\(detail/);
 assert.match(appDirtyGridHook, /beginWindowCloseTransition\(\)/);
 assert.match(appDirtyGridHook, /transition\.pendingDocumentIds/);
-assert.match(appShellActionsHook, /await permit\.waitForPending\(documentIds\)/);
-assert.match(appShellActionsHook, /permit\.release\(\)/);
+// Closing must not be gated on in-flight mutations: an unbounded wait here used
+// to strand the window with the grid overlay up and every later close refused.
+assert.doesNotMatch(appShellActionsHook, /waitForPending/);
+assert.match(appShellActionsHook, /const completeClose = \(permit: WindowCloseMutationPermit, close: \(\) => void\) => \{\s*try \{\s*close\(\);\s*\} finally \{\s*permit\.release\(\);/s);
 assert.match(appGridWorkflowsHook, /if \(result\.recordsAppended > 0\) updateDirtyGridDocument\(targetDocument\.id, true\);\s*notifyGridRecordsAppended\(targetDocument\.id, result\)/s);
 assert.match(appKetcherActionsHook, /updateDirtyGridDocument\(request\.documentId, true\);\s*iframe\.contentWindow\.postMessage/s);
 assert.match(appKetcherActionsHook, /isGridDocumentCloseTransitionActive\(request\.documentId\)/);
@@ -2059,7 +2061,11 @@ assert.doesNotMatch(styles, /\.splitter::after \{ background: var\(--sidebar-div
 // The workbench card's edge shadow lives on the sidebar handle now: the center
 // ResizablePanel clips its children (overflow: hidden), so a box-shadow on
 // .workbench itself can never reach over the sidebar.
-assert.match(styles, /\.workbench \{[^}]*background: var\(--bg-base\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;/s);
+assert.match(styles, /\.workbench \{[^}]*background: var\(--bg\);[^}]*overflow: hidden;[^}]*border-left: 1px solid var\(--workspace-edge-border\);[^}]*border-radius: 20px 0 0 20px;/s);
+// The surfaces that tile the window follow the Translucent preference. Painting
+// `--bg-base` here covers the translucent shell with an opaque sheet.
+assert.match(styles, /\.main-stage \{[^}]*background: var\(--bg\);/s);
+assert.match(styles, /\.dock-panel \{[^}]*background: var\(--bg\);/s);
 assert.doesNotMatch(styles, /\.workbench \{[^}]*box-shadow: -12px 0 28px/s);
 assert.match(styles, /\.workspace-sidebar-handle::before \{[^}]*box-shadow: -12px 0 28px var\(--workspace-edge-shadow\);[^}]*pointer-events: none;/s);
 assert.match(appLayout, /className="workspace-sidebar-handle"/);
@@ -5936,18 +5942,16 @@ assert.match(appNativeMenuHook, /getCurrentWindow\(\)\.onFocusChanged/);
 assert.match(appNativeMenuHook, /getCurrentWindow\(\)\.onCloseRequested/);
 assert.match(appNativeMenuHook, /event\.preventDefault\(\);[\s\S]*await confirmCloseWindowRef\.current\(\)/);
 assert.match(appNativeMenuHook, /confirmCloseWindowRef\.current\(\)/);
-assert.match(appNativeMenuHook, /setGridDocumentCloseTransition\(documentIds, true\)/);
-assert.match(appNativeMenuHook, /setWindowShellCloseTransition\(true\)/);
-assert.match(appNativeMenuHook, /await currentWindow\.setEnabled\(false\)/);
-assert.match(appNativeMenuHook, /if \(await currentWindow\.isEnabled\(\)\)/);
-assert.match(appNativeMenuHook, /await permit\.waitForPending\(\)/);
-assert.match(appNativeMenuHook, /sameWindowItemIds\(documentIds, windowDocumentIdsRef\.current\)/);
-assert.match(appNativeMenuHook, /sameWindowItemIds\(tabIds, windowTabIdsRef\.current\)/);
-assert.match(appNativeMenuHook, /finalDirtySnapshot\.closeGuardRevision !== closeGuardRevision/);
+// The close button always closes. Nothing between the prompt and close() may
+// wait on other work, freeze the shell, or disable the window.
 assert.match(
   appNativeMenuHook,
-  /if \(windowInteractionPaused\) \{\s*await currentWindow\.setEnabled\(true\);\s*windowInteractionPaused = false;\s*\}\s*await currentWindow\.close\(\)/,
+  /if \(!permit\) return;\s*permit\.release\(\);\s*closingWindowRef\.current = true;\s*await getCurrentWindow\(\)\.close\(\)/s,
 );
+assert.doesNotMatch(appNativeMenuHook, /waitForPending/);
+assert.doesNotMatch(appNativeMenuHook, /setEnabled/);
+assert.doesNotMatch(appNativeMenuHook, /setWindowShellCloseTransition/);
+assert.doesNotMatch(appNativeMenuHook, /setGridDocumentCloseTransition/);
 assert.match(appNativeMenuHook, /if \(closingWindowRef\.current\) return;/);
 assert.match(appNativeMenuHook, /listen<ExitPreflightRequest>\(EXIT_PREFLIGHT_EVENT/);
 assert.match(appNativeMenuHook, /invoke<string>\("register_exit_preflight_listener"\)/);

--- a/tests/test-window-mutation-barrier.mjs
+++ b/tests/test-window-mutation-barrier.mjs
@@ -8,10 +8,8 @@ import {
   replayPendingGridCloseTransitionRequests,
   resumeWindowMutations,
   runWindowMutation,
-  sameWindowItemIds,
   sealWindowMutations,
   setGridDocumentCloseTransition,
-  setWindowShellCloseTransition,
   waitForGridDocumentCloseTransition,
 } from "../apps/desktop/src/lib/window-mutation-barrier.ts";
 
@@ -51,16 +49,17 @@ assert.deepEqual({
 });
 assert.throws(() => barrier.begin("grid-late-close"), ExitTransitionActiveError);
 
-let pendingSettled = false;
-const pending = closeTransition.waitForPending(["grid-closing"]).then(() => {
-  pendingSettled = true;
-});
-await Promise.resolve();
-assert.equal(pendingSettled, false);
-releasePending();
-await pending;
-assert.equal(pendingSettled, true);
+// Close transitions overlap instead of refusing each other: a tab's unsaved
+// prompt must never make the window close button a no-op. The barrier only
+// reports itself idle once every permit has been released.
+const overlappingCloseTransition = barrier.beginCloseTransition();
+assert.equal(overlappingCloseTransition.closeTransitionActive, true);
+overlappingCloseTransition.release();
+overlappingCloseTransition.release();
+assert.equal(barrier.seal().closeTransitionActive, true);
+barrier.resume();
 
+releasePending();
 barrier.seal();
 closeTransition.release();
 closeTransition.release();
@@ -78,39 +77,19 @@ await assert.rejects(
 assert.equal(sealWindowMutations().pendingCount, 0);
 resumeWindowMutations();
 
+// An unfinished save must not hold a close back — the permit is handed out
+// while the mutation is still in flight and reports what is pending so the
+// prompt can mention it.
 let finishSave;
 const saveOperation = runWindowMutation("grid-save", () => new Promise((resolve) => {
   finishSave = resolve;
 }));
+await new Promise((resolve) => setTimeout(resolve, 0));
 const closeDuringSave = beginWindowCloseTransition();
-let closeDuringSaveSettled = false;
-const waitForSave = closeDuringSave.waitForPending(["grid-save"]).then(() => {
-  closeDuringSaveSettled = true;
-});
-await Promise.resolve();
-assert.equal(closeDuringSaveSettled, false);
+assert.deepEqual(closeDuringSave.pendingDocumentIds, ["grid-save"]);
+closeDuringSave.release();
 finishSave();
 await saveOperation;
-await waitForSave;
-assert.equal(closeDuringSaveSettled, true);
-closeDuringSave.release();
-
-let finishUnmaterializedWrite;
-const unmaterializedWrite = runWindowMutation("/tmp/new-collection.sdf", () => new Promise((resolve) => {
-  finishUnmaterializedWrite = resolve;
-}));
-const closeDuringUnmaterializedWrite = beginWindowCloseTransition();
-let unmaterializedWriteSettled = false;
-const waitForUnmaterializedWrite = closeDuringUnmaterializedWrite.waitForPending().then(() => {
-  unmaterializedWriteSettled = true;
-});
-await Promise.resolve();
-assert.equal(unmaterializedWriteSettled, false);
-finishUnmaterializedWrite();
-await unmaterializedWrite;
-await waitForUnmaterializedWrite;
-assert.equal(unmaterializedWriteSettled, true);
-closeDuringUnmaterializedWrite.release();
 
 const mutationOrder = [];
 let finishFirstMutation;
@@ -130,27 +109,6 @@ assert.deepEqual(mutationOrder, ["first-start"]);
 finishFirstMutation();
 await Promise.all([firstMutation, secondMutation]);
 assert.deepEqual(mutationOrder, ["first-start", "first-end", "second"]);
-
-assert.equal(sameWindowItemIds(["doc-a", "doc-b"], ["doc-a", "doc-b"]), true);
-assert.equal(sameWindowItemIds(["doc-a", "doc-b"], ["doc-b", "doc-a"]), false);
-assert.equal(sameWindowItemIds(["doc-a"], ["doc-a", "doc-b"]), false);
-
-const shellAttributes = new Set();
-const shell = {
-  inert: false,
-  toggleAttribute(name, active) {
-    if (active) shellAttributes.add(name);
-    else shellAttributes.delete(name);
-  },
-};
-globalThis.document = { querySelector: () => shell };
-setWindowShellCloseTransition(true);
-assert.equal(shell.inert, true);
-assert.equal(shellAttributes.has("aria-busy"), true);
-setWindowShellCloseTransition(false);
-assert.equal(shell.inert, false);
-assert.equal(shellAttributes.has("aria-busy"), false);
-delete globalThis.document;
 
 const iframeAttributes = new Set();
 const postedMessages = [];


### PR DESCRIPTION
## Problem

Two defects reported together: the close button did nothing, and the Translucent preference had no visible effect.

**Closing could wedge permanently.** Every close ran through the close-transition barrier and awaited `permit.waitForPending()`, which has no timeout. When an in-flight window mutation never settled, the window-close guard left the shell `inert`, the native window `setEnabled(false)` and the "Finishing current change…" grid overlay up for good — so nothing in the app responded to clicks. Worse, the stuck transition made every later `beginCloseTransition()` throw, and callers turn that into a silent `return`, so subsequent close attempts were dropped without any message.

One concrete way to reach it: `saveGridAs` opens the native save dialog *inside* `runWindowMutation`, holding a lease for as long as the sheet is up. Attempting to close then disabled the window, which made the sheet impossible to dismiss, so the wait never ended.

**Translucency only reached the sidebar.** `.workbench`, `.main-stage` and `.dock-panel` painted `var(--bg-base)` — the raw theme color, which ignores the preference — covering the whole window with an opaque sheet. Measured at Translucent = 100: `--bg-opacity` correctly resolved to `0.05` and `.app-shell` to `rgba(255,255,255,0.05)`, but those three surfaces still computed to opaque `rgb(255,255,255)`.

## Change

- Closing runs to completion as soon as the unsaved-changes prompt approves it. No waiting on in-flight work, no freezing the shell, no disabling the window, no "window contents changed" revalidation.
- Close transitions are counted instead of exclusive, so a tab's open prompt can no longer make the window close button a no-op.
- Removed the machinery that became dead: `waitForPending` and its waiter queue, `sameWindowItemIds`, `setWindowShellCloseTransition`, `closeGuardRevision`.
- The workbench, stage and docks paint `var(--bg)`, so the Translucent preference governs the whole window. At the default (30) they land at `0.715` and stack with the shell, keeping the workbench card denser than the sidebar glass.

The "Finishing current change…" overlay is no longer used on any close path. It remains only for the Ketcher collection-file replacement, which waits with a 2 s timeout.

## Tradeoff

Closing no longer gives an in-flight file write a grace period. The unsaved-changes prompt still appears and still counts pending mutations, but a save that is mid-write when the window closes is not waited for. This is deliberate: the grace period was unbounded and was the cause of the freeze.

## Verification

- Measured in the running app at Translucent = 100: all three surfaces now compute `color(srgb 1 1 1 / 0.05)` instead of opaque white; at the default 30 they compute `0.715`.
- Both dock close buttons close their dock and it stays closed; the tab close button closes the tab with no lingering `aria-busy` overlay and the shell not `inert`.
- `tsc --noEmit` clean, all 37 `test:ui` files pass, pre-commit hooks pass.
- The Tauri `onCloseRequested` path cannot run in browser-dev, so it is covered by contract tests and code review rather than by running a macOS build.