### PR TITLE
Fix early-switch camera framing, apply Mol* style live, and add the surface preset to settings

### DIFF
--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2910,12 +2910,16 @@
     return MOLSTAR_STYLE_OPTIONS.find(option => option.value === value)?.label || value;
   }
 
+  // A structure that has not been focused yet still reports the default camera
+  // (radius 0 at the origin). Restoring that after a reload leaves the scene
+  // empty, so it is treated as "no snapshot" and the caller refocuses instead.
   function captureMolstarCameraSnapshot(viewer) {
     const camera = viewer?.plugin?.canvas3d?.camera;
     if (!camera || typeof camera.getSnapshot !== 'function') return null;
     try {
       const snapshot = camera.getSnapshot();
       if (!snapshot) return null;
+      if (!(Number(snapshot.radius) > 0)) return null;
       return {
         ...snapshot,
         position: snapshot.position?.slice?.() || snapshot.position,
@@ -2937,6 +2941,33 @@
     } catch (_) {}
   }
 
+  // Used when the style switch happens before the structure was ever focused, so
+  // there is no camera worth keeping. The retries reach past the initial delays
+  // because framing needs scene bounds, and a heavy visual such as the molecular
+  // surface only reports them once its geometry is built.
+  const STYLE_SWITCH_FOCUS_DELAYS = [0, 240, 800, 2000, 4000];
+
+  function focusMolstarStructureAfterReload(viewer) {
+    if (molstarAutoFocusEnabled(activeConfig) && !hasMolstarContextFocus(activeConfig)) {
+      scheduleMolstarStructureFocus(viewer, {
+        reason: 'style-switch',
+        durationMs: 0,
+        delays: STYLE_SWITCH_FOCUS_DELAYS
+      });
+      return;
+    }
+    for (const delayMs of STYLE_SWITCH_FOCUS_DELAYS) {
+      window.setTimeout(() => {
+        const canvas3d = viewer?.plugin?.canvas3d;
+        if (!canvas3d || Number(canvas3d.camera?.getSnapshot?.()?.radius) > 0) return;
+        try {
+          canvas3d.requestCameraReset({ durationMs: 0 });
+          canvas3d.requestDraw?.();
+        } catch (_) {}
+      }, delayMs);
+    }
+  }
+
   async function reloadMolstarStyle(viewer, style, serial) {
     const prepared = activeMolstarPrepared;
     if (!prepared) {
@@ -2956,7 +2987,8 @@
     applyLayoutState(viewer);
     scheduleLayoutStateReapply(viewer);
     try { viewer.handleResize(); } catch (_) {}
-    restoreMolstarCameraSnapshot(viewer, cameraSnapshot);
+    if (cameraSnapshot) restoreMolstarCameraSnapshot(viewer, cameraSnapshot);
+    else focusMolstarStructureAfterReload(viewer);
     setStatus(`[web] Applied Mol* ${molstarStyleLabel(style)} style`);
     setTimeout(hideStatus, isQuickLookHost() ? 0 : 700);
   }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -2065,6 +2065,13 @@
       setViewerTheme(nextTheme, activeViewer);
       return;
     }
+    // Applied in place so the default-style preference never rebuilds the viewer.
+    // requestMolstarStyle updates the config, the toolbar selector, and re-renders
+    // through the same path the toolbar dropdown uses.
+    if (body.type === 'setViewerStyle') {
+      requestMolstarStyle(body.value);
+      return;
+    }
     if (body.type === 'setXyzrenderControls') {
       const config = activeConfig || window.BurreteConfig || {};
       const documentId = String(config.documentId || '');

--- a/apps/desktop/src/components/settings-panel/index.tsx
+++ b/apps/desktop/src/components/settings-panel/index.tsx
@@ -159,7 +159,7 @@ export function SettingsPanel({ location, state, actions }: { location: Settings
                   title="Structure Rendering"
                   rows={[
                     preferenceRow<"rendererMode">("Mode", "Choose the renderer used for newly opened structures.", preferences.rendererMode, defaultRendererModeOptions, defaultPreferences.rendererMode, (rendererMode) => actions.setPreference("rendererMode", rendererMode)),
-                    preferenceRow<"molstarStyle">("Mol* style", "Default appearance preset for the Mol* renderer.", preferences.molstarStyle, ["default", "illustrative"], defaultPreferences.molstarStyle, (molstarStyle) => actions.setPreference("molstarStyle", molstarStyle)),
+                    preferenceRow<"molstarStyle">("Mol* style", "Default appearance preset for the Mol* renderer.", preferences.molstarStyle, ["default", "illustrative", "illustrative-surface"], defaultPreferences.molstarStyle, (molstarStyle) => actions.setPreference("molstarStyle", molstarStyle)),
                     {
                       label: "Desktop preview limit",
                       description: "Maximum source file size the desktop app opens in the structure viewer.",

--- a/apps/desktop/src/hooks/use-app-preference-effects.ts
+++ b/apps/desktop/src/hooks/use-app-preference-effects.ts
@@ -8,30 +8,36 @@ import type { OpenDocumentsResult, ViewerPreferences } from "../types";
 type PushErrorStatus = (error: unknown, prefix?: string, details?: string[]) => void;
 type OpenDocuments = (paths: string[]) => Promise<OpenDocumentsResult | null | undefined>;
 
-// Preferences the mounted viewers can apply without being rebuilt. Everything
-// else is baked into the viewer runtime HTML, so changing it still reopens the
-// document. `theme` qualifies because the runtime already carries the token sets
-// for both themes and switches between them at runtime.
-const LIVE_APPLIED_PREFERENCE_KEYS = ["theme"] as const satisfies readonly (keyof ViewerPreferences)[];
+// Preferences the mounted viewers can apply without being rebuilt, each mapped to
+// the runtime message that applies it. Everything else is baked into the viewer
+// runtime HTML, so changing it still reopens the document. `theme` qualifies
+// because the runtime carries the token sets for both themes; `molstarStyle`
+// because the runtime can re-render into any style in place.
+const LIVE_APPLIED_PREFERENCE_MESSAGES = {
+  theme: "setViewerTheme",
+  molstarStyle: "setViewerStyle",
+} as const satisfies Partial<Record<keyof ViewerPreferences, string>>;
 
-function onlyLiveAppliedPreferencesChanged(previous: ViewerPreferences, next: ViewerPreferences) {
-  const live = new Set<string>(LIVE_APPLIED_PREFERENCE_KEYS);
-  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
-  let liveChanged = false;
-  for (const key of keys) {
-    if (previous[key as keyof ViewerPreferences] === next[key as keyof ViewerPreferences]) continue;
-    if (!live.has(key)) return false;
-    liveChanged = true;
+type LiveAppliedPreferenceKey = keyof typeof LIVE_APPLIED_PREFERENCE_MESSAGES;
+
+function changedLiveAppliedKeys(previous: ViewerPreferences, next: ViewerPreferences) {
+  const changed: LiveAppliedPreferenceKey[] = [];
+  for (const key of Object.keys(next) as (keyof ViewerPreferences)[]) {
+    if (previous[key] === next[key]) continue;
+    if (!(key in LIVE_APPLIED_PREFERENCE_MESSAGES)) return null;
+    changed.push(key as LiveAppliedPreferenceKey);
   }
-  return liveChanged;
+  return changed.length ? changed : null;
 }
 
-function broadcastViewerTheme(theme: ViewerPreferences["theme"]) {
+function broadcastLiveAppliedPreferences(keys: LiveAppliedPreferenceKey[], preferences: ViewerPreferences) {
   for (const frame of document.querySelectorAll<HTMLIFrameElement>("iframe[data-document-id]")) {
-    frame.contentWindow?.postMessage({
-      source: "burrete-host",
-      body: { type: "setViewerTheme", value: theme },
-    }, "*");
+    for (const key of keys) {
+      frame.contentWindow?.postMessage({
+        source: "burrete-host",
+        body: { type: LIVE_APPLIED_PREFERENCE_MESSAGES[key], value: preferences[key] },
+      }, "*");
+    }
   }
 }
 
@@ -72,8 +78,9 @@ export function useAppPreferenceEffects({
     }
     // Reopening would drop the live Mol* scene (camera, components, selections),
     // so preferences the mounted viewers can apply themselves are pushed instead.
-    if (onlyLiveAppliedPreferencesChanged(previousPreferences, preferences)) {
-      broadcastViewerTheme(preferences.theme);
+    const liveKeys = changedLiveAppliedKeys(previousPreferences, preferences);
+    if (liveKeys) {
+      broadcastLiveAppliedPreferences(liveKeys, preferences);
       return;
     }
     const path = activeTab?.location.kind === "file" && !isTemporaryDocumentPath(activeTab.location.path)

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -71,7 +71,7 @@ export type ViewerReloadOptions = {
   sdfPoseControlLabel?: string | null;
   trajectoryAutoPlayOnce?: boolean | null;
   activeModel?: number | null;
-  molstarStyle?: "default" | "illustrative" | "polymer-ligand" | "cartoon" | "ball-and-stick" | "spacefill" | "line" | "molecular-surface" | null;
+  molstarStyle?: "default" | "illustrative" | "illustrative-surface" | "polymer-ligand" | "cartoon" | "ball-and-stick" | "spacefill" | "line" | "molecular-surface" | null;
 };
 
 export type DockingSceneMode = "structureAll" | "structurePoses";
@@ -422,7 +422,7 @@ export type ViewerPreferences = {
   canvasBackground: "auto" | "black" | "graphite" | "white" | "transparent";
   openInDefaultDestination: "default-app" | "finder" | `editor:${string}`;
   rendererMode: "auto" | "grid2d" | "molstar" | "xyzrender-external";
-  molstarStyle: "default" | "illustrative" | "polymer-ligand" | "cartoon" | "ball-and-stick" | "spacefill" | "line" | "molecular-surface";
+  molstarStyle: "default" | "illustrative" | "illustrative-surface" | "polymer-ligand" | "cartoon" | "ball-and-stick" | "spacefill" | "line" | "molecular-surface";
   desktopPreviewLimitMiB: number;
   conformerEngine: "datamol" | "rdkit";
   conformerCandidateCount: number;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3614,7 +3614,7 @@ assert.match(themesSection, /Window opacity mapping used by Writer-style glass\.
 assert.match(settingsPanel, /const defaultRendererModeOptions: Array<ViewerPreferences\["rendererMode"\]> = \["auto", "molstar", "xyzrender-external"\]/);
 assert.match(settingsPanel, /const conformerEngineOptions: Array<ViewerPreferences\["conformerEngine"\]> = \["datamol", "rdkit"\]/);
 assert.doesNotMatch(settingsPanel, /function visibleRendererModeOptions\(current: ViewerPreferences\["rendererMode"\]\)/);
-assert.match(settingsPanel, /preferenceRow<"molstarStyle">\("Mol\* style", "Default appearance preset for the Mol\* renderer\.", preferences\.molstarStyle, \["default", "illustrative"\], defaultPreferences\.molstarStyle, \(molstarStyle\) => actions\.setPreference\("molstarStyle", molstarStyle\)\)/);
+assert.match(settingsPanel, /preferenceRow<"molstarStyle">\("Mol\* style", "Default appearance preset for the Mol\* renderer\.", preferences\.molstarStyle, \["default", "illustrative", "illustrative-surface"\], defaultPreferences\.molstarStyle, \(molstarStyle\) => actions\.setPreference\("molstarStyle", molstarStyle\)\)/);
 assert.match(settingsPanel, /Desktop preview limit/);
 assert.match(settingsPanel, /suffix="MiB"/);
 assert.match(settingsPanel, /actions\.setPreference\("desktopPreviewLimitMiB", desktopPreviewLimitMiB\)/);
@@ -6346,15 +6346,17 @@ assert.doesNotMatch(app, /void openDocuments\(\[path\]\)\.then/);
 assert.match(appPreferenceEffectsHook, /Preferences refresh only the mounted file runtime\. Inactive file tabs are unloaded\./);
 assert.match(appPreferenceEffectsHook, /if \(skipNextPreferenceRefreshRef\.current\) \{\s*skipNextPreferenceRefreshRef\.current = false;\s*return;\s*\}/s);
 assert.match(appPreferenceEffectsHook, /void openDocuments\(\[path\]\)\.then/);
-// A theme change must reach mounted viewers as a message instead of reopening the
-// document, otherwise the live Mol* scene (camera, components, selections) is lost.
-assert.match(appPreferenceEffectsHook, /const LIVE_APPLIED_PREFERENCE_KEYS = \["theme"\] as const/);
-assert.match(appPreferenceEffectsHook, /function onlyLiveAppliedPreferencesChanged\(previous: ViewerPreferences, next: ViewerPreferences\)/);
+// Theme and Mol* style changes must reach mounted viewers as messages instead of
+// reopening the document, otherwise the live Mol* scene (camera, components,
+// selections) is lost.
+assert.match(appPreferenceEffectsHook, /const LIVE_APPLIED_PREFERENCE_MESSAGES = \{\s*theme: "setViewerTheme",\s*molstarStyle: "setViewerStyle",\s*\}/s);
+assert.match(appPreferenceEffectsHook, /function changedLiveAppliedKeys\(previous: ViewerPreferences, next: ViewerPreferences\)/);
 assert.match(appPreferenceEffectsHook, /querySelectorAll<HTMLIFrameElement>\("iframe\[data-document-id\]"\)/);
-assert.match(appPreferenceEffectsHook, /body: \{ type: "setViewerTheme", value: theme \}/);
-assert.match(appPreferenceEffectsHook, /if \(onlyLiveAppliedPreferencesChanged\(previousPreferences, preferences\)\) \{\s*broadcastViewerTheme\(preferences\.theme\);\s*return;\s*\}/s);
+assert.match(appPreferenceEffectsHook, /body: \{ type: LIVE_APPLIED_PREFERENCE_MESSAGES\[key\], value: preferences\[key\] \}/);
+assert.match(appPreferenceEffectsHook, /const liveKeys = changedLiveAppliedKeys\(previousPreferences, preferences\);\s*if \(liveKeys\) \{\s*broadcastLiveAppliedPreferences\(liveKeys, preferences\);\s*return;\s*\}/s);
 assert.match(previewViewer, /if \(body\.type === 'setViewerTheme'\) \{\s*const nextTheme = normalizeViewerTheme\(body\.value\);/s);
 assert.match(previewViewer, /setViewerTheme\(nextTheme, activeViewer\);/);
+assert.match(previewViewer, /if \(body\.type === 'setViewerStyle'\) \{\s*requestMolstarStyle\(body\.value\);/s);
 assert.match(appMaintenanceHook, /Quick Look reset completed/);
 assert.match(appMaintenanceHook, /Quick Look reset reported issues/);
 assert.doesNotMatch(app, /Quick Look reset requested/);


### PR DESCRIPTION
## Summary

Follow-ups to #486, closing the three gaps noted there: the camera no longer strands the structure off-screen on an early style switch, the default Mol* style applies live instead of rebuilding the viewer, and `Illustrative+Surface` is now selectable in Settings.

## Changes

**Camera survives an early style switch** (`PreviewExtension/Web/viewer.js`)

Switching style right after opening a document left the structure off-screen until a manual camera reset. The reload captured the current camera and restored it afterwards, but a structure that hasn't been focused yet reports the default camera (radius 0 at the origin); restoring that framed nothing.

`captureMolstarCameraSnapshot` now treats a zero-radius camera as "no snapshot". When there is nothing worth keeping, `reloadMolstarStyle` refocuses instead of restoring — honouring the auto-focus preference, falling back to a plain camera reset otherwise. Framing needs scene bounds, and a heavy visual like the molecular surface only reports them once its geometry is built, so the refocus retries across a short delay ladder.

Verified with a stashed A/B: without the change the scene stays scattered after an immediate switch; with it the structure is centred. Reproduced on stock `cartoon` too, confirming it was pre-existing.

**Default Mol* style applies live** (`use-app-preference-effects.ts`, `viewer.js`)

Generalises the live-preference path #486 added for `theme`. `LIVE_APPLIED_PREFERENCE_KEYS` became `LIVE_APPLIED_PREFERENCE_MESSAGES`, a key→message map, so each live-applicable preference is pushed to mounted viewers as its own runtime message. `molstarStyle` joins `theme`; the viewer handles `setViewerStyle` by calling the existing `requestMolstarStyle`, the same path the toolbar dropdown uses. Changing the default style no longer reopens the document or drops the scene.

**`Illustrative+Surface` in Settings** (`types.ts`, `settings-panel/index.tsx`)

Added the preset to both `molstarStyle` unions and to the Settings dropdown options, so it can be chosen as the default, not just per-tab from the toolbar.

## Verification

- `bun run check:js`, `bun run test:ui` (full suite), `tsc --noEmit` on `apps/desktop` — all green.
- Contract pins in `tests/test-ui-shell-contract.mjs` updated for the generalised broadcast and the new Settings option, plus a new pin on the `setViewerStyle` handler.
- Live-style change checked in the browser by marking each iframe in the DOM and its `window`: after changing the default style in Settings the marks survive (`m0/w0`) and the config style updates in place, i.e. no viewer rebuild.
- Settings dropdown confirmed to list `default / illustrative / illustrative-surface` and to apply the new preset.

## Note

`readStoredViewerTheme()` in `viewer.js` is still dead code from before this branch — left alone as unrelated cleanup.
