### PR TITLE
Join the grid ingest worker before deleting its runtime directory

### DIFF
--- a/apps/desktop/src-tauri/src/compute/commands.rs
+++ b/apps/desktop/src-tauri/src/compute/commands.rs
@@ -120,6 +120,7 @@ pub(crate) fn compute_register_inline_source<R: Runtime>(
         grid_store.database_path,
         grid_store.summary.format,
         grid_store.cancel_token,
+        grid_store.ingest_worker,
     ) {
         let _ = fs::remove_dir_all(&runtime_dir);
         return Err(error);

--- a/apps/desktop/src-tauri/src/compute/coordinator_tests.rs
+++ b/apps/desktop/src-tauri/src/compute/coordinator_tests.rs
@@ -53,6 +53,7 @@ fn semiempirical_grid_workflow_fails_closed_without_native_metal_runtime() {
             handle.database_path,
             "sdf",
             handle.cancel_token,
+            handle.ingest_worker,
         )
         .expect("register Grid fixture");
     let viewer_root =
@@ -98,6 +99,7 @@ fn conformer_submission_streams_raw_extraction_into_a_durable_job() {
             handle.database_path,
             "csv",
             handle.cancel_token,
+            handle.ingest_worker,
         )
         .expect("register Grid fixture");
     let viewer_root =
@@ -424,6 +426,7 @@ fn cluster_v1_runs_end_to_end_and_writes_results_back_to_grid() {
             handle.database_path,
             "csv",
             handle.cancel_token,
+            handle.ingest_worker,
         )
         .expect("register Grid fixture");
 

--- a/apps/desktop/src-tauri/src/preview/grid_store.rs
+++ b/apps/desktop/src-tauri/src/preview/grid_store.rs
@@ -31,11 +31,20 @@ struct RegisteredGridRuntime {
     database_path: PathBuf,
     format: &'static str,
     cancel_token: Arc<AtomicBool>,
+    ingest_worker: Option<thread::JoinHandle<()>>,
 }
 
 impl Drop for RegisteredGridRuntime {
     fn drop(&mut self) {
+        // Signal cancellation, then wait for the ingest worker to stop before
+        // deleting the runtime directory. The worker holds a WAL-mode SQLite
+        // connection, so removing the directory while it is still writing races
+        // its `-wal`/`-shm` files: `remove_dir_all` can lose to a concurrently
+        // re-created file and silently leave the directory behind.
         self.cancel_token.store(true, Ordering::Relaxed);
+        if let Some(worker) = self.ingest_worker.take() {
+            let _ = worker.join();
+        }
         if let Some(runtime_dir) = self.database_path.parent() {
             let _ = std::fs::remove_dir_all(runtime_dir);
         }
@@ -74,6 +83,7 @@ pub(crate) struct GridCollectionSummary {
 pub(crate) struct GridStoreHandle {
     pub(crate) database_path: PathBuf,
     pub(crate) cancel_token: Arc<AtomicBool>,
+    pub(crate) ingest_worker: Option<thread::JoinHandle<()>>,
     pub(crate) summary: GridCollectionSummary,
 }
 
@@ -252,11 +262,13 @@ impl GridRuntimeRegistry {
         database_path: PathBuf,
         format: &'static str,
         cancel_token: Arc<AtomicBool>,
+        ingest_worker: Option<thread::JoinHandle<()>>,
     ) -> Result<(), String> {
         let runtime = Arc::new(RegisteredGridRuntime {
             database_path,
             format,
             cancel_token,
+            ingest_worker,
         });
         let existing = self
             .entries
@@ -433,10 +445,11 @@ pub(crate) fn build_grid_store_with_options(
         let _ = std::fs::remove_file(&database_path);
         return Ok(None);
     }
-    if first_batch.complete {
+    let ingest_worker = if first_batch.complete {
         grid_identity::finalize_source_revision(&connection)?;
+        None
     } else {
-        spawn_grid_ingest_worker(
+        Some(spawn_grid_ingest_worker(
             database_path.clone(),
             extension.to_string(),
             text,
@@ -444,11 +457,12 @@ pub(crate) fn build_grid_store_with_options(
             first_batch.next_index,
             options.smiles_column.clone(),
             cancel_token.clone(),
-        );
-    }
+        ))
+    };
     Ok(Some(GridStoreHandle {
         database_path,
         cancel_token,
+        ingest_worker,
         summary: GridCollectionSummary {
             format,
             records_total: records_indexed,
@@ -982,7 +996,7 @@ fn spawn_grid_ingest_worker(
     mut next_index: usize,
     smiles_column: Option<String>,
     cancel_token: Arc<AtomicBool>,
-) {
+) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let Ok(connection) = open_grid_database(&database_path) else {
             return;
@@ -1029,7 +1043,7 @@ fn spawn_grid_ingest_worker(
                 return;
             }
         }
-    });
+    })
 }
 
 fn initialize_schema(connection: &Connection) -> Result<(), String> {
@@ -3846,6 +3860,7 @@ mod tests {
                 handle.database_path.clone(),
                 handle.summary.format,
                 handle.cancel_token.clone(),
+                handle.ingest_worker,
             )
             .expect("register grid runtime");
         registry
@@ -3886,6 +3901,7 @@ mod tests {
                 handle.database_path,
                 handle.summary.format,
                 handle.cancel_token,
+                handle.ingest_worker,
             )
             .expect("register grid runtime");
         let lease = registry
@@ -3929,6 +3945,7 @@ mod tests {
                 old_handle.database_path,
                 old_handle.summary.format,
                 old_handle.cancel_token,
+                old_handle.ingest_worker,
             )
             .expect("register old grid runtime");
         let old_lease = registry
@@ -3947,6 +3964,7 @@ mod tests {
                 new_handle.database_path,
                 new_handle.summary.format,
                 new_handle.cancel_token,
+                new_handle.ingest_worker,
             )
             .expect("replace grid runtime");
 
@@ -3989,6 +4007,7 @@ mod tests {
                 handle.database_path,
                 handle.summary.format,
                 handle.cancel_token,
+                handle.ingest_worker,
             )
             .expect("register namespaced grid runtime");
 

--- a/apps/desktop/src-tauri/src/preview/runtime_grid.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime_grid.rs
@@ -79,6 +79,7 @@ pub(crate) fn create_grid_runtime_with_options<R: Runtime>(
             grid_store.database_path,
             collection.format,
             grid_store.cancel_token,
+            grid_store.ingest_worker,
         )?;
     let rdkit_wasm = runtime.join("RDKit_minimal.wasm");
     fs::copy(assets.join("rdkit").join("RDKit_minimal.wasm"), &rdkit_wasm)

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -1360,7 +1360,7 @@ assert.match(previewRuntimeGrid, /build_grid_store/);
 assert.match(previewRuntimeGrid, /include_single_sdf: options\.include_single_sdf\s*\|\|\s*normalize_renderer_mode\(&preferences\.renderer_mode\) == "grid2d"/);
 assert.match(previewGridStore, /!options\.include_single_sdf\s*&& \(\(extension == "sdf" \|\| extension == "sd"\) && records_indexed <= 1\)/);
 assert.match(previewRuntimeGrid, /"sourcePath": file_path\.to_string_lossy\(\)/);
-assert.match(previewRuntimeGrid, /register\(\s*registry_document_id,\s*grid_store\.database_path,\s*collection\.format,\s*grid_store\.cancel_token,\s*\)/);
+assert.match(previewRuntimeGrid, /register\(\s*registry_document_id,\s*grid_store\.database_path,\s*collection\.format,\s*grid_store\.cancel_token,\s*grid_store\.ingest_worker,\s*\)/);
 assert.match(previewRuntimeGrid, /"gridDataMode": "bridge"/);
 assert.match(previewRuntimeGrid, /"recordsIndexed": collection\.records_indexed/);
 assert.match(previewRuntimeGrid, /"indexReady": collection\.index_ready/);


### PR DESCRIPTION
## Symptom

`preview::grid_store::tests::unregister_cancels_and_removes_grid_runtime` was flaky: it failed intermittently (~1 run in 5) on the single-threaded lib suite that the lefthook pre-push gate runs (`cargo test --lib -- --test-threads=1`), blocking `git push`, while passing in isolation.

## Root cause

A race inside `RegisteredGridRuntime::drop` — **not** shared state between tests. Each test uses a UUID-unique `temp_runtime_dir`, and this path never calls `prune_runtime_dirs`, so the original "interleaving tests share a base dir" theory does not hold.

`Drop` set the cancel flag and immediately `remove_dir_all`'d the runtime directory, but never waited for the ingest worker thread to stop. That worker (`spawn_grid_ingest_worker`) holds a **WAL-mode** SQLite connection and only observes the cancel flag at 1000-row batch boundaries, so `remove_dir_all` ran concurrently with its `-wal`/`-shm` writes. A file re-created mid-deletion makes the final `rmdir` fail; the error is ignored (`let _ =`), leaving the directory behind → `!runtime_dir.exists()` intermittently false.

Why single-threaded yet flaky: `--test-threads=1` never serializes a thread spawned *inside* a test, and the 2000-molecule fixture keeps the worker mid-flight at unregister.

## Fix

Own the worker's `JoinHandle` — threaded through `GridStoreHandle` and `register` into `RegisteredGridRuntime` — and **join it in `Drop`**, after signalling cancellation and before removing the directory. The worker releases its SQLite connection before deletion, so removal is race-free. This also hardens the production teardown path: closing or replacing a grid mid-ingest could previously orphan runtime directories on disk.

The worker checks cancellation each batch, so the join adds at most one batch of latency; workers for fully-indexed inputs are `None` and skip the join entirely.

## Verification

- Reproduced the flake first (full single-threaded suite failed on run 5/12).
- Post-fix: single-threaded lib suite **15/15 green** (452 tests each), focused Drop-path stress **120/120**, `cargo clippy -D warnings` and `cargo fmt --check` clean. The pre-push `ci:fast` gate — which runs the same single-threaded suite — passed.

Pre-existing on main; unrelated to the grid toolbar redesign (#490).

🤖 Generated with [Claude Code](https://claude.com/claude-code)