### PR TITLE
Pin the tab strip to the panels' measured edges

### DIFF
--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -92,22 +92,11 @@ function usePanelToggleAnimation(open: boolean) {
   return animating;
 }
 
-// Whether a collapsible panel reads as open after a resize.
-function isPanelOpen(panel: PanelImperativeHandle | null, size: { inPixels: number }) {
-  return panel ? !panel.isCollapsed() : Math.round(size.inPixels) > 1;
-}
-
-// True while the user is driving one of the group's own separators, by pointer
-// ("active") or by keyboard on the focused separator ("focus"). Nested groups
-// carry their own separators, so only direct children count.
-//
-// This is what tells a real close from a squeeze: when a group runs out of room
-// it collapses the panel itself (dragging the sidebar leaves the workbench too
-// narrow for the right dock's 260px, as does a narrow window), and persisting
-// that as "closed" lost the dock for good — it stayed closed once the room came
-// back, which is why docks seemed to randomly disappear while resizing.
-function groupIsUserResizing(element: HTMLElement | null) {
-  return Boolean(element?.querySelector(':scope > [data-separator="active"], :scope > [data-separator="focus"]'));
+// Whether a collapsible panel reads as open. Collapsed is the library's own
+// state, which a user drag past the snap threshold sets; the pixel size is only
+// a fallback for the mount pass, before the imperative handle is attached.
+function isPanelOpen(panel: PanelImperativeHandle | null, sizePx: number) {
+  return panel ? !panel.isCollapsed() : sizePx > 1;
 }
 
 // Publishes the panels' measured edges as CSS variables on the shell. The tab
@@ -449,13 +438,18 @@ export function AppLayout({
         </>
       )}
       <section className="workspace">
-        {/* Sizes are persisted from onLayoutChanged, not onResize: onResize is
-            driven by a ResizeObserver and also fires for window resizes,
-            constraint re-clamps and imperative collapse()/expand(), so writing
-            from there overwrote the user's stored size with a clamped one (a
-            400px sidebar became 280px for good after shrinking the window).
-            onLayoutChanged reports isUserInteraction for exactly the pointer and
-            keyboard resizes we want to remember. */}
+        {/* Sizes AND open flags are persisted from onLayoutChanged, not
+            onResize: onResize is driven by a ResizeObserver and also fires for
+            window resizes, constraint re-clamps and imperative
+            collapse()/expand(), so writing from there overwrote the user's
+            stored size with a clamped one (a 400px sidebar became 280px for
+            good after shrinking the window) and, worse, persisted a collapse
+            the group had forced for lack of room — the dock then stayed closed
+            once the room came back, which is why docks seemed to randomly
+            disappear while resizing. onLayoutChanged reports isUserInteraction
+            for exactly the pointer and keyboard resizes we want to remember;
+            the separator's own state cannot stand in for it, since
+            `data-separator="focus"` outlives the keystrokes that caused it. */}
         <ResizablePanelGroup
           orientation="horizontal"
           className="workspace-panels"
@@ -463,8 +457,10 @@ export function AppLayout({
           data-panels-animating={sidebarAnimating || undefined}
           onLayoutChanged={(_layout, meta) => {
             if (!meta.isUserInteraction) return;
-            const px = Math.round(sidebarPanelRef.current?.getSize().inPixels ?? 0);
+            const panel = sidebarPanelRef.current;
+            const px = Math.round(panel?.getSize().inPixels ?? 0);
             if (px > 1) onSidebarWidthChange(px);
+            if (!settingsMode) setSidebarOpen(isPanelOpen(panel, px));
           }}
         >
           <ResizablePanel
@@ -479,12 +475,6 @@ export function AppLayout({
             minSize="220px"
             maxSize={`${maxSidebarWidth}px`}
             groupResizeBehavior="preserve-pixel-size"
-            onResize={(size) => {
-              if (settingsMode) return;
-              const open = isPanelOpen(sidebarPanelRef.current, size);
-              if (!open && !groupIsUserResizing(workspaceGroupRef.current)) return;
-              setSidebarOpen(open);
-            }}
           >
             <div className="sidebar-shell-inner">
               <Sidebar state={layoutState} actions={actions} open={sidebarVisible} />
@@ -502,8 +492,11 @@ export function AppLayout({
                 data-panels-animating={rightDockAnimating || undefined}
                 onLayoutChanged={(_layout, meta) => {
                   if (!meta.isUserInteraction) return;
-                  const px = Math.round(rightDockPanelRef.current?.getSize().inPixels ?? 0);
+                  const panel = rightDockPanelRef.current;
+                  const px = Math.round(panel?.getSize().inPixels ?? 0);
                   if (px > 1) actions.setDockSize("right", px);
+                  const open = isPanelOpen(panel, px);
+                  if (open !== rightDockOpenRef.current) actions.setDockOpen("right", open);
                 }}
               >
                 <ResizablePanel id="workbench-main" className="workbench-main-panel" minSize={`${MAIN_MIN_WIDTH}px`} style={CLIPPED_PANEL_STYLE}>
@@ -514,8 +507,11 @@ export function AppLayout({
                     data-panels-animating={bottomDockAnimating || undefined}
                     onLayoutChanged={(_layout, meta) => {
                       if (!meta.isUserInteraction) return;
-                      const px = Math.round(bottomDockPanelRef.current?.getSize().inPixels ?? 0);
+                      const panel = bottomDockPanelRef.current;
+                      const px = Math.round(panel?.getSize().inPixels ?? 0);
                       if (px > 1) actions.setDockSize("bottom", px);
+                      const open = isPanelOpen(panel, px);
+                      if (open !== bottomDockOpenRef.current) actions.setDockOpen("bottom", open);
                     }}
                   >
                     <ResizablePanel id="main" className="main-panel" style={CLIPPED_PANEL_STYLE}>
@@ -537,12 +533,6 @@ export function AppLayout({
                       minSize="180px"
                       maxSize="70%"
                       groupResizeBehavior="preserve-pixel-size"
-                      onResize={(size) => {
-                        const open = isPanelOpen(bottomDockPanelRef.current, size);
-                        if (open === bottomDockOpenRef.current) return;
-                        if (!open && !groupIsUserResizing(workbenchMainGroupRef.current)) return;
-                        actions.setDockOpen("bottom", open);
-                      }}
                     >
                       {/* Always mounted: DockPanel renders its own closed state
                           (data-open / aria-hidden / inert) and unmounting it on
@@ -567,12 +557,6 @@ export function AppLayout({
                   minSize="260px"
                   maxSize="70%"
                   groupResizeBehavior="preserve-pixel-size"
-                  onResize={(size) => {
-                    const open = isPanelOpen(rightDockPanelRef.current, size);
-                    if (open === rightDockOpenRef.current) return;
-                    if (!open && !groupIsUserResizing(workbenchGroupRef.current)) return;
-                    actions.setDockOpen("right", open);
-                  }}
                 >
                   <DockPanel area="right" state={layoutState} actions={actions} readOnly={hostedMcpWidget} />
                 </ResizablePanel>

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -79,28 +79,74 @@ function useInitialSize(sizePx: number) {
 // window resizes, and a standing transition would rubber-band both.
 function usePanelToggleAnimation(open: boolean) {
   const [animating, setAnimating] = useState(false);
-  const animatingRef = useRef(false);
   const mounted = useRef(false);
   useLayoutEffect(() => {
     if (!mounted.current) {
       mounted.current = true;
       return;
     }
-    animatingRef.current = true;
     setAnimating(true);
-    const timer = window.setTimeout(() => {
-      animatingRef.current = false;
-      setAnimating(false);
-    }, 220);
+    const timer = window.setTimeout(() => setAnimating(false), 220);
     return () => window.clearTimeout(timer);
   }, [open]);
-  return { animating, animatingRef };
+  return animating;
 }
 
-// True while one of the group's own separators is being dragged. Nested groups
+// Whether a collapsible panel reads as open after a resize.
+function isPanelOpen(panel: PanelImperativeHandle | null, size: { inPixels: number }) {
+  return panel ? !panel.isCollapsed() : Math.round(size.inPixels) > 1;
+}
+
+// True while the user is driving one of the group's own separators, by pointer
+// ("active") or by keyboard on the focused separator ("focus"). Nested groups
 // carry their own separators, so only direct children count.
-function groupHasActiveSeparator(element: HTMLElement | null) {
-  return Boolean(element?.querySelector(':scope > [data-separator="active"]'));
+//
+// This is what tells a real close from a squeeze: when a group runs out of room
+// it collapses the panel itself (dragging the sidebar leaves the workbench too
+// narrow for the right dock's 260px, as does a narrow window), and persisting
+// that as "closed" lost the dock for good — it stayed closed once the room came
+// back, which is why docks seemed to randomly disappear while resizing.
+function groupIsUserResizing(element: HTMLElement | null) {
+  return Boolean(element?.querySelector(':scope > [data-separator="active"], :scope > [data-separator="focus"]'));
+}
+
+// Publishes the panels' measured edges as CSS variables on the shell. The tab
+// strip is positioned absolutely over the panel grid, so its edges have to
+// follow what the panels actually occupy: sizing it from the stored sizes
+// desynced whenever a group could not honour one (a right dock squeezed to
+// 118px still reported its wanted 260px, leaving the strip's right edge ~140px
+// off the dock), and it lagged behind every drag because the stored width only
+// reaches the DOM through a React render. ResizeObserver fires between layout
+// and paint, and writing the variables straight to the node keeps drag frames
+// out of React entirely. React only ever writes the seed variables these
+// override (`--sidebar-layout-width`, `--right-dock-width`), so the two never
+// fight over the same property.
+function usePanelEdgeVariables(entries: { elementRef: React.RefObject<HTMLDivElement | null>; property: string }[]) {
+  const shellRef = useRef<HTMLElement | null>(null);
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    const publish = (element: Element, width: number) => {
+      const entry = entriesRef.current.find((candidate) => candidate.elementRef.current === element);
+      if (entry) shell.style.setProperty(entry.property, `${width}px`);
+    };
+    const observer = new ResizeObserver((records) => {
+      for (const record of records) {
+        publish(record.target, record.borderBoxSize?.[0]?.inlineSize ?? record.contentRect.width);
+      }
+    });
+    // No eager measurement: the observer delivers an initial observation for
+    // every element it starts watching, and a value published from here would
+    // be the panel's pre-collapse size on mount. Until that first delivery the
+    // CSS falls back to the stored layout widths.
+    for (const { elementRef } of entriesRef.current) {
+      if (elementRef.current) observer.observe(elementRef.current);
+    }
+    return () => observer.disconnect();
+  }, []);
+  return shellRef;
 }
 
 type PixelGuardEntry = {
@@ -129,7 +175,11 @@ function useGroupPixelGuard(entries: PixelGuardEntry[]) {
       frame = 0;
       for (const { panelRef, openRef, sizePxRef } of entriesRef.current) {
         const panel = panelRef.current;
-        if (!panel || !openRef.current || panel.isCollapsed()) continue;
+        if (!panel || !openRef.current) continue;
+        // A panel the group collapsed under pressure is restored here once the
+        // room is back: the open flag stays true through a squeeze, so this is
+        // the other half of not persisting a forced collapse.
+        if (panel.isCollapsed()) panel.expand();
         const want = sizePxRef.current;
         if (want <= 1) continue;
         if (Math.abs(panel.getSize().inPixels - want) > 0.75) panel.resize(`${want}px`);
@@ -210,21 +260,19 @@ export function AppLayout({
   const rightDockWidth = clampRightDockWidth(state.rightDockWidth, viewportWidth, sidebarLayoutWidth);
   const layoutState = sidebarWidth === state.sidebarWidth && rightDockWidth === state.rightDockWidth ? state : { ...state, sidebarWidth, rightDockWidth };
   const compactLeadingChrome = !tauriRuntime || windowFullscreen;
-  const tabChromeLeft = hostedMcpWidget
-    ? 12
-    : state.sidebarOpen
-      ? sidebarLayoutWidth + 12
-      : compactLeadingChrome ? 112 : 192;
+  // How far the leading window controls reach: the tab strip starts past them
+  // when the sidebar is narrower than they are (or closed). The sidebar's own
+  // edge comes from `--sidebar-edge`, measured rather than stored.
+  const chromeLeadingInset = compactLeadingChrome ? 112 : 192;
   const rightDockOpen = !settingsMode && !hostedMcpWidget && state.rightDockOpen;
   const bottomDockOpen = !settingsMode && !hostedMcpWidget && state.bottomDockOpen;
   // Toggle-animation hooks must come before the collapse/expand sync hooks:
-  // layout effects run in hook order, and collapse() reports a synchronous
-  // onResize that the handlers below gate on animatingRef — registered after
-  // the collapse, the flag would still be false and the closing panel would
-  // immediately flip its open flag (and itself) back.
-  const sidebarToggle = usePanelToggleAnimation(sidebarVisible);
-  const rightDockToggle = usePanelToggleAnimation(rightDockOpen);
-  const bottomDockToggle = usePanelToggleAnimation(bottomDockOpen);
+  // layout effects run in hook order, so registering them the other way round
+  // would collapse the panel before the group is marked as animating and the
+  // toggle would jump instead of sliding.
+  const sidebarAnimating = usePanelToggleAnimation(sidebarVisible);
+  const rightDockAnimating = usePanelToggleAnimation(rightDockOpen);
+  const bottomDockAnimating = usePanelToggleAnimation(bottomDockOpen);
   const sidebarPanelRef = useCollapsiblePanelSync(sidebarVisible, sidebarWidth);
   const rightDockPanelRef = useCollapsiblePanelSync(rightDockOpen, rightDockWidth);
   const bottomDockPanelRef = useCollapsiblePanelSync(bottomDockOpen, state.bottomDockHeight);
@@ -263,11 +311,20 @@ export function AppLayout({
   const workbenchMainGroupRef = useGroupPixelGuard([
     { panelRef: bottomDockPanelRef, openRef: bottomDockOpenRef, sizePxRef: bottomDockHeightRef },
   ]);
+  const sidebarElementRef = useRef<HTMLDivElement | null>(null);
+  const rightDockElementRef = useRef<HTMLDivElement | null>(null);
+  const shellRef = usePanelEdgeVariables([
+    { elementRef: sidebarElementRef, property: "--sidebar-edge" },
+    { elementRef: rightDockElementRef, property: "--right-dock-edge" },
+  ]);
   const systemThemeMode = useSystemThemeMode();
+  // The layout widths seed the chrome before the edge observer's first pass;
+  // `--sidebar-edge` / `--right-dock-edge` take over from there.
   const shellStyle = {
     ...buildThemeStyle(state.preferences, systemThemeMode),
     "--sidebar-layout-width": `${sidebarLayoutWidth}px`,
     "--right-dock-width": `${rightDockOpen ? rightDockWidth : 0}px`,
+    "--chrome-leading-inset": `${chromeLeadingInset}px`,
     "--chrome-height": hostedMcpWidget ? "0px" : undefined,
   } as CSSProperties;
   const effectiveTheme = resolveThemeMode(state.preferences.theme, systemThemeMode);
@@ -294,6 +351,7 @@ export function AppLayout({
   }
   return (
     <main
+      ref={shellRef}
       className="app-shell"
       data-theme={state.preferences.theme}
       data-effective-theme={effectiveTheme}
@@ -385,10 +443,7 @@ export function AppLayout({
               <ShortcutTooltip label={state.rightDockOpen ? "Hide right dock" : "Show right dock"} shortcut="⌥⌘B" />
             </button>
           </div>
-          <header
-            className="topbar"
-            style={{ left: tabChromeLeft }}
-          >
+          <header className="topbar">
             <EditorTabs state={layoutState} actions={actions} readOnly={hostedMcpWidget} />
           </header>
         </>
@@ -405,7 +460,7 @@ export function AppLayout({
           orientation="horizontal"
           className="workspace-panels"
           elementRef={workspaceGroupRef}
-          data-panels-animating={sidebarToggle.animating || undefined}
+          data-panels-animating={sidebarAnimating || undefined}
           onLayoutChanged={(_layout, meta) => {
             if (!meta.isUserInteraction) return;
             const px = Math.round(sidebarPanelRef.current?.getSize().inPixels ?? 0);
@@ -416,6 +471,7 @@ export function AppLayout({
             id="sidebar"
             className="workspace-sidebar-panel"
             style={CLIPPED_PANEL_STYLE}
+            elementRef={sidebarElementRef}
             panelRef={sidebarPanelRef}
             collapsible
             collapsedSize="0px"
@@ -425,11 +481,9 @@ export function AppLayout({
             groupResizeBehavior="preserve-pixel-size"
             onResize={(size) => {
               if (settingsMode) return;
-              // While the toggle transition animates through intermediate
-              // sizes, only a real drag on this group's separator may flip the
-              // open flag — otherwise closing would re-open itself mid-animation.
-              if (sidebarToggle.animatingRef.current && !groupHasActiveSeparator(workspaceGroupRef.current)) return;
-              setSidebarOpen(Math.round(size.inPixels) > 1);
+              const open = isPanelOpen(sidebarPanelRef.current, size);
+              if (!open && !groupIsUserResizing(workspaceGroupRef.current)) return;
+              setSidebarOpen(open);
             }}
           >
             <div className="sidebar-shell-inner">
@@ -445,7 +499,7 @@ export function AppLayout({
                 orientation="horizontal"
                 className="workbench-panels"
                 elementRef={workbenchGroupRef}
-                data-panels-animating={rightDockToggle.animating || undefined}
+                data-panels-animating={rightDockAnimating || undefined}
                 onLayoutChanged={(_layout, meta) => {
                   if (!meta.isUserInteraction) return;
                   const px = Math.round(rightDockPanelRef.current?.getSize().inPixels ?? 0);
@@ -457,7 +511,7 @@ export function AppLayout({
                     orientation="vertical"
                     className="workbench-main-panels"
                     elementRef={workbenchMainGroupRef}
-                    data-panels-animating={bottomDockToggle.animating || undefined}
+                    data-panels-animating={bottomDockAnimating || undefined}
                     onLayoutChanged={(_layout, meta) => {
                       if (!meta.isUserInteraction) return;
                       const px = Math.round(bottomDockPanelRef.current?.getSize().inPixels ?? 0);
@@ -484,9 +538,10 @@ export function AppLayout({
                       maxSize="70%"
                       groupResizeBehavior="preserve-pixel-size"
                       onResize={(size) => {
-                        if (bottomDockToggle.animatingRef.current && !groupHasActiveSeparator(workbenchMainGroupRef.current)) return;
-                        const open = Math.round(size.inPixels) > 1;
-                        if (open !== bottomDockOpenRef.current) actions.setDockOpen("bottom", open);
+                        const open = isPanelOpen(bottomDockPanelRef.current, size);
+                        if (open === bottomDockOpenRef.current) return;
+                        if (!open && !groupIsUserResizing(workbenchMainGroupRef.current)) return;
+                        actions.setDockOpen("bottom", open);
                       }}
                     >
                       {/* Always mounted: DockPanel renders its own closed state
@@ -504,6 +559,7 @@ export function AppLayout({
                   id="right-dock"
                   className="dock-panel-shell"
                   style={CLIPPED_PANEL_STYLE}
+                  elementRef={rightDockElementRef}
                   panelRef={rightDockPanelRef}
                   collapsible
                   collapsedSize="0px"
@@ -512,9 +568,10 @@ export function AppLayout({
                   maxSize="70%"
                   groupResizeBehavior="preserve-pixel-size"
                   onResize={(size) => {
-                    if (rightDockToggle.animatingRef.current && !groupHasActiveSeparator(workbenchGroupRef.current)) return;
-                    const open = Math.round(size.inPixels) > 1;
-                    if (open !== rightDockOpenRef.current) actions.setDockOpen("right", open);
+                    const open = isPanelOpen(rightDockPanelRef.current, size);
+                    if (open === rightDockOpenRef.current) return;
+                    if (!open && !groupIsUserResizing(workbenchGroupRef.current)) return;
+                    actions.setDockOpen("right", open);
                   }}
                 >
                   <DockPanel area="right" state={layoutState} actions={actions} readOnly={hostedMcpWidget} />

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -316,7 +316,16 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 .topbar {
   position: absolute;
   top: 0;
-  right: max(146px, var(--right-dock-width, 0px));
+  /* Both edges follow the panels' measured widths (`--sidebar-edge` /
+     `--right-dock-edge`, published by a ResizeObserver on the panels), falling
+     back to the stored layout widths for the first paint. Measuring is what
+     keeps the strip glued to the panels: a right dock the group had to squeeze
+     below its 260px still stores 260, and a dragged sidebar only reaches the
+     DOM a render later. No transition on `left` either — the sidebar's own
+     toggle animation moves the measured edge, so easing it here again would
+     rubber-band the strip behind every drag frame. */
+  left: max(var(--chrome-leading-inset, 192px), calc(var(--sidebar-edge, var(--sidebar-layout-width, 0px)) + 12px));
+  right: max(146px, var(--right-dock-edge, var(--right-dock-width, 0px)));
   z-index: 4;
   height: var(--chrome-height);
   display: flex;
@@ -324,9 +333,6 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
   pointer-events: none;
   gap: 12px;
   padding: var(--chrome-control-padding) 0;
-  /* `left` is set inline from the sidebar width; ease it so the tab strip
-     travels with the sidebar edge instead of teleporting on toggle. */
-  transition: left 140ms ease-out;
   container-type: inline-size;
 }
 .chrome-button,

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1334,7 +1334,19 @@ assert.match(appLayout, /const sidebarLayoutWidth = sidebarVisible \? sidebarWid
 assert.match(appLayout, /const rightDockWidth = clampRightDockWidth\(state\.rightDockWidth, viewportWidth, sidebarLayoutWidth\)/);
 assert.doesNotMatch(appLayout, /Math\.max\(360, clampedSidebarWidth\)/);
 assert.match(appLayout, /const compactLeadingChrome = !tauriRuntime \|\| windowFullscreen/);
-assert.match(appLayout, /const tabChromeLeft = hostedMcpWidget[\s\S]*\? sidebarLayoutWidth \+ 12[\s\S]*: compactLeadingChrome \? 112 : 192;/);
+// The tab strip is placed from the panels' measured edges, not from the stored
+// sizes: a squeezed panel keeps reporting the size it wants, and a stored size
+// only reaches the DOM a render after the drag frame that produced it. React
+// contributes the leading-chrome inset (traffic lights) and the first-paint
+// seeds; `--sidebar-edge` / `--right-dock-edge` come from the observer.
+assert.match(appLayout, /const chromeLeadingInset = compactLeadingChrome \? 112 : 192;/);
+assert.match(appLayout, /"--chrome-leading-inset": `\$\{chromeLeadingInset\}px`/);
+assert.doesNotMatch(appLayout, /tabChromeLeft/);
+assert.match(appLayout, /function usePanelEdgeVariables/);
+assert.match(appLayout, /\{ elementRef: sidebarElementRef, property: "--sidebar-edge" \}/);
+assert.match(appLayout, /\{ elementRef: rightDockElementRef, property: "--right-dock-edge" \}/);
+assert.match(appLayout, /shell\.style\.setProperty\(entry\.property, `\$\{width\}px`\)/);
+assert.match(appLayout, /<header className="topbar">/);
 assert.match(appLayout, /const rightDockOpen = !settingsMode && !hostedMcpWidget && state\.rightDockOpen/);
 assert.match(appLayout, /const bottomDockOpen = !settingsMode && !hostedMcpWidget && state\.bottomDockOpen/);
 assert.match(appLayout, /"--right-dock-width": `\$\{rightDockOpen \? rightDockWidth : 0\}px`/);
@@ -2139,16 +2151,30 @@ assert.match(appLayout, /if \(!meta\.isUserInteraction\) return;/);
 // library's [data-panel] wrappers. The transition must exist only while a
 // toggle is animating (drags and window resizes rewrite flex-grow every frame
 // and would rubber-band), and the animation hooks must register their layout
-// effects before the collapse/expand sync hooks: collapse() reports a
-// synchronous onResize that the handlers gate on animatingRef.
+// effects before the collapse/expand sync hooks.
 assert.match(appLayout, /function usePanelToggleAnimation/);
 assert.ok(appLayout.indexOf("usePanelToggleAnimation(sidebarVisible)") < appLayout.indexOf("useCollapsiblePanelSync(sidebarVisible"), "toggle-animation hooks must be called before the collapse/expand sync hooks");
-assert.match(appLayout, /data-panels-animating=\{sidebarToggle\.animating \|\| undefined\}/);
-assert.match(appLayout, /sidebarToggle\.animatingRef\.current && !groupHasActiveSeparator\(workspaceGroupRef\.current\)/);
+assert.match(appLayout, /data-panels-animating=\{sidebarAnimating \|\| undefined\}/);
 assert.match(styles, /\.workspace-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 140ms ease-out;/);
 assert.match(styles, /\.workbench-main-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 180ms cubic-bezier\(0\.2, 0, 0, 1\);/);
-// The tab strip follows the sidebar edge through the same easing.
-assert.match(styles, /\.topbar \{[^}]*transition: left 140ms ease-out;/s);
+// The tab strip rides the measured panel edges, so it must not ease `left` on
+// its own — that eased every drag frame and dragged the strip behind the
+// sidebar. Only the library's collapsed state closes a collapsible panel: a
+// panel squeezed by its group (dragging the sidebar can leave the workbench too
+// narrow for the right dock) still reports pixels, and closing on that auto-hid
+// docks that never reopened.
+assert.doesNotMatch(styles, /\.topbar \{[^}]*transition:/s);
+assert.match(appLayout, /function isPanelOpen/);
+assert.match(appLayout, /return panel \? !panel\.isCollapsed\(\) : Math\.round\(size\.inPixels\) > 1;/);
+assert.match(appLayout, /function groupIsUserResizing/);
+assert.match(appLayout, /'\:scope > \[data-separator="active"\], \:scope > \[data-separator="focus"\]'/);
+assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workspaceGroupRef\.current\)\) return;/);
+assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workbenchGroupRef\.current\)\) return;/);
+assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workbenchMainGroupRef\.current\)\) return;/);
+// The other half: a panel the group collapsed under pressure keeps its open
+// flag, so the pixel guard has to expand it again once the room is back.
+assert.match(appLayout, /if \(panel\.isCollapsed\(\)\) panel\.expand\(\);/);
+assert.doesNotMatch(appLayout, /animatingRef/);
 // groupResizeBehavior="preserve-pixel-size" is inert in react-resizable-panels
 // 4.12.2, so fixed panels re-assert their stored pixel size when the group's
 // container resizes — deferred to the next frame because a resize() inside the
@@ -2524,7 +2550,7 @@ assert.match(styles, /\.structure-inspector-style-options \{/);
 assert.match(styles, /\.structure-brief \{[\s\S]*?grid-auto-rows: max-content/);
 assert.match(styles, /\.structure-inspector-details:not\(\[open\]\) > \.structure-inspector-details-body/);
 assert.match(styles, /\.structure-inspector-style-option\[data-selected="true"\]/);
-assert.match(styles, /right: max\(146px, var\(--right-dock-width, 0px\)\)/);
+assert.match(styles, /right: max\(146px, var\(--right-dock-edge, var\(--right-dock-width, 0px\)\)\)/);
 assert.match(styles, /@container \(max-width: 320px\)/);
 assert.match(previewRuntimeCss, /@media \(max-width: 360px\)[\s\S]*?top: 64px;[\s\S]*?width: calc\(100vw - 24px\)/);
 assert.match(previewRuntimeCss, /grid-template-columns: 28px auto minmax\(62px, 1fr\) auto auto/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2165,12 +2165,16 @@ assert.match(styles, /\.workbench-main-panels\[data-panels-animating\] > \[data-
 // docks that never reopened.
 assert.doesNotMatch(styles, /\.topbar \{[^}]*transition:/s);
 assert.match(appLayout, /function isPanelOpen/);
-assert.match(appLayout, /return panel \? !panel\.isCollapsed\(\) : Math\.round\(size\.inPixels\) > 1;/);
-assert.match(appLayout, /function groupIsUserResizing/);
-assert.match(appLayout, /'\:scope > \[data-separator="active"\], \:scope > \[data-separator="focus"\]'/);
-assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workspaceGroupRef\.current\)\) return;/);
-assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workbenchGroupRef\.current\)\) return;/);
-assert.match(appLayout, /if \(!open && !groupIsUserResizing\(workbenchMainGroupRef\.current\)\) return;/);
+assert.match(appLayout, /return panel \? !panel\.isCollapsed\(\) : sizePx > 1;/);
+// Open flags are written ONLY from onLayoutChanged behind meta.isUserInteraction.
+// onResize is ResizeObserver-driven and fires for forced collapses too, and the
+// separator's own state is no substitute: `data-separator="focus"` outlives the
+// keystrokes, so a later window resize would look like a user close.
+assert.doesNotMatch(appLayout, /onResize=/);
+assert.doesNotMatch(appLayout, /\[data-separator=/);
+assert.match(appLayout, /if \(!settingsMode\) setSidebarOpen\(isPanelOpen\(panel, px\)\);/);
+assert.match(appLayout, /if \(open !== rightDockOpenRef\.current\) actions\.setDockOpen\("right", open\);/);
+assert.match(appLayout, /if \(open !== bottomDockOpenRef\.current\) actions\.setDockOpen\("bottom", open\);/);
 // The other half: a panel the group collapsed under pressure keeps its open
 // flag, so the pixel guard has to expand it again once the room is back.
 assert.match(appLayout, /if \(panel\.isCollapsed\(\)\) panel\.expand\(\);/);


### PR DESCRIPTION
## Problem

The tab strip is absolutely positioned over the panel grid and took both of its edges from the stored layout sizes. That desynced it from the panels in two ways:

- A stored size only reaches the DOM a render after the drag frame that produced it, and `.topbar` eased `left` over 140ms on top of that — so the strip visibly trailed the sidebar during a drag and kept coasting after the pointer stopped. The CSS already forbids exactly this for the panels themselves (`[data-panels-animating]` scopes their flex-grow transition to toggles precisely because "a standing one would rubber-band pointer drags"); the topbar never got that treatment.
- A panel the group cannot fit still reports the size it *wants*. A right dock squeezed to 118px kept publishing 260px, leaving the strip's right edge ~140px away from the dock.

Separately, docks auto-closed for good while resizing. When a group runs out of room the library collapses the panel itself, and `onResize` persisted that as "closed" — the dock went to `opacity: 0` and stayed closed once the room came back. Dragging the left sidebar was enough to trigger it, which is why it looked like docks randomly turned transparent.

## Change

- `usePanelEdgeVariables` publishes the sidebar's and right dock's measured widths as `--sidebar-edge` / `--right-dock-edge` from a ResizeObserver that writes straight to the shell node — never through React, so drag frames cost no render. `.topbar` places both edges from those, seeded by the stored widths for the first paint.
- The standing `transition: left` on `.topbar` is gone: the toggle animation already moves the measured edge, so easing it again is what produced the lag.
- Only a user drag (pointer `active`) or keyboard resize (`focus`) of that group's own separator may close a panel. `useGroupPixelGuard` re-expands a still-open panel the group collapsed under pressure, so a squeeze is now fully reversible.
- `animatingRef` / `groupHasActiveSeparator` are replaced by `isPanelOpen` + `groupIsUserResizing`; the toggle hook returns a plain boolean.

## Verification

Measured against the dev server in a real (non-headless-hidden) browser:

| Check | Result |
|---|---|
| 13-frame sidebar drag | `topbarLeft === measured sidebar width + 12` on every frame, 0 mismatches |
| 15-frame open/close toggle | `topbarLeft === max(112, sidebarW + 12)` on every intermediate frame, 0 mismatches |
| Right dock open at 1280px | strip's right edge 920px == dock's left edge 920px |
| Window squeezed to 620px | dock stays `data-open="true"`, `opacity: 1` (previously persisted as closed) |
| Back to 1280px | dock restores itself to its stored 360px |
| Drag separator to the edge | sidebar and dock still close and persist, as before |

`tests/test-ui-shell-contract.mjs` pins the new invariants (measured-edge variables, no `transition` on `.topbar`, close-requires-user-intent, guard re-expansion). Green: the shell contract test plus `test-agent-focus-layout`, `test-shell-store-behavior`, `test-boot-overlay-behavior`, `test-window-mutation-barrier`, `test-sidebar-projects`, `test-sidebar-tree-render`, `test-document-close-shell-actions`, `test-native-menu-paths`, `test-shadcn-foundation`, `test-tauri-structure`, `check:js`, and `tsc --noEmit`.

## Known trade-off

Under a hard squeeze the dock is "open but zero-width" — invisible, but its state survives and it returns on its own. The alternative (closing it for real) is the bug this fixes.