### PR TITLE
Preview a colour theme by hovering it

### DIFF
--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -3558,6 +3558,74 @@ body.buret-viewport-corner-active .msp-plugin .msp-viewport-top-left-controls {
   flex: 1 1 auto;
   min-width: 0;
 }
+.buret-tree-picker-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+  height: 22px;
+  border: 1px solid var(--buret-molstar-border);
+  border-radius: 6px;
+  padding: 0 7px;
+  overflow: hidden;
+  color: var(--buret-molstar-text);
+  background: var(--buret-molstar-field-background);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.buret-tree-picker-trigger:hover,
+.buret-tree-picker-trigger[aria-expanded="true"] {
+  background: var(--buret-molstar-hover-background);
+}
+.buret-tree-picker-trigger:focus-visible {
+  outline: 2px solid var(--buret-molstar-accent);
+  outline-offset: 1px;
+}
+/* Opens in place inside the menu rather than as a floating layer: the menu already
+   scrolls, and a portalled popup would need its own placement and dismissal. */
+.buret-tree-picker-list {
+  display: grid;
+  gap: 1px;
+  max-height: 180px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  margin: 0 4px 2px;
+  border-radius: 7px;
+  padding: 2px;
+  background: var(--buret-molstar-field-background);
+}
+.buret-tree-picker-list[hidden] {
+  display: none;
+}
+.buret-tree-picker-item {
+  min-height: 22px;
+  border: 0;
+  border-radius: 5px;
+  padding: 0 7px;
+  color: var(--buret-molstar-text);
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+.buret-tree-picker-item:hover {
+  background: var(--buret-molstar-hover-background);
+}
+.buret-tree-picker-item[aria-selected="true"] {
+  color: var(--buret-molstar-accent);
+}
+.buret-tree-picker-item:focus-visible {
+  outline: 2px solid var(--buret-molstar-accent);
+  outline-offset: -1px;
+}
 .buret-tree-swatches {
   display: flex;
   flex-wrap: wrap;

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -5389,7 +5389,13 @@
 
   function closeSceneTreeMenu() {
     sceneTreeMenuRef = '';
-    document.getElementById('buret-scene-tree-menu')?.remove();
+    const menu = document.getElementById('buret-scene-tree-menu');
+    // Dismissing the menu mid-hover must not leave the previewed theme behind: the
+    // pointer never reached a row to click, so nothing was chosen.
+    for (const list of menu?.querySelectorAll('[data-scene-tree-picker-list]') || []) {
+      closeSceneTreePicker(list, { restore: true });
+    }
+    menu?.remove();
   }
 
   function sceneTreeNodeByRef(nodes, ref) {
@@ -5458,6 +5464,45 @@
     else control.selectedIndex = -1;
     row.append(caption, control);
     menu.appendChild(row);
+  }
+
+  // A native <select> cannot preview: its popup is drawn by the OS, its <option>
+  // elements have no layout box, and no pointer event ever reaches them. Colour
+  // themes are the one list here worth seeing before committing to, so this row is
+  // a list of our own — hovering paints the scene, leaving puts it back.
+  function sceneTreeMenuThemePicker(menu, label, action, options, current) {
+    const row = document.createElement('div');
+    row.className = 'buret-tree-menu-field buret-tree-menu-picker';
+    const caption = document.createElement('span');
+    caption.textContent = label;
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'buret-tree-picker-trigger';
+    trigger.dataset.sceneTreePicker = action;
+    trigger.setAttribute('aria-expanded', 'false');
+    const chosen = options.find(option => option.name === current);
+    trigger.textContent = chosen ? chosen.label : 'Mixed';
+    trigger.title = trigger.textContent;
+    row.append(caption, trigger);
+    menu.appendChild(row);
+
+    const list = document.createElement('div');
+    list.className = 'buret-tree-picker-list';
+    list.dataset.sceneTreePickerList = action;
+    list.dataset.current = current || '';
+    list.hidden = true;
+    list.setAttribute('role', 'listbox');
+    for (const option of options) {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'buret-tree-picker-item';
+      item.setAttribute('role', 'option');
+      item.dataset.sceneTreePickerValue = option.name;
+      item.setAttribute('aria-selected', option.name === current ? 'true' : 'false');
+      item.textContent = option.label;
+      list.appendChild(item);
+    }
+    menu.appendChild(list);
   }
 
   function sceneTreeMenuSlider(menu, label, slider, value) {
@@ -5796,6 +5841,39 @@
     ], active);
   }
 
+  // Painting a whole structure is a state commit, and a pointer crossing a list
+  // asks for one per row. Newer hovers fold into the one in flight, the same way
+  // the opacity drag does, so the scene follows the cursor instead of a backlog.
+  let sceneTreeThemeInFlight = false;
+  let sceneTreePendingTheme = null;
+  async function streamSceneTreeTheme(ref, action, name) {
+    sceneTreePendingTheme = { ref, action, name };
+    if (sceneTreeThemeInFlight) return;
+    sceneTreeThemeInFlight = true;
+    try {
+      while (sceneTreePendingTheme) {
+        const next = sceneTreePendingTheme;
+        sceneTreePendingTheme = null;
+        await (next.action === 'representation-color'
+          ? applySceneTreeReprColor(next.ref, next.name, null)
+          : applySceneTreeColorTheme(next.ref, next.name, null));
+      }
+    } finally {
+      sceneTreeThemeInFlight = false;
+    }
+  }
+
+  function closeSceneTreePicker(list, { restore } = {}) {
+    if (!list || list.hidden) return;
+    const trigger = list.parentElement?.querySelector(`[data-scene-tree-picker="${list.dataset.sceneTreePickerList}"]`);
+    if (restore && list.dataset.current) {
+      const ref = list.closest('[data-ref]')?.dataset.ref;
+      if (ref) streamSceneTreeTheme(ref, list.dataset.sceneTreePickerList, list.dataset.current);
+    }
+    list.hidden = true;
+    trigger?.setAttribute('aria-expanded', 'false');
+  }
+
   function applySceneTreeReprParam(ref, name, value) {
     return updateSceneTreeRepresentation(ref, old => ({
       ...old, type: { ...old.type, params: { ...old.type.params, [name]: value } }
@@ -5821,7 +5899,7 @@
     sceneTreeMenuSlider(menu, 'Opacity', 'opacity', Math.round(alpha * 100));
 
     sceneTreeMenuSection(menu, 'Colour');
-    sceneTreeMenuSelect(menu, 'Theme', 'representation-color',
+    sceneTreeMenuThemePicker(menu, 'Theme', 'representation-color',
       sceneTreeColorThemes(viewer, [target.component]), String(params?.colorTheme?.name || ''));
     sceneTreeMenuSwatches(menu, node.label, 'rep-tint-color', sceneTreeRepresentationTint(target.representation));
 
@@ -5885,7 +5963,7 @@
       }
       if (components.length) {
         sceneTreeMenuSection(menu, 'Colour');
-        sceneTreeMenuSelect(menu, 'Theme', 'color-theme', sceneTreeColorThemes(viewer, components), node.theme);
+        sceneTreeMenuThemePicker(menu, 'Theme', 'color-theme', sceneTreeColorThemes(viewer, components), node.theme);
         sceneTreeMenuSwatches(menu, node.label, 'tint-color', node.value);
       }
     }
@@ -5937,6 +6015,42 @@
   }
 
   function onSceneTreeClick(event) {
+    const menu = document.getElementById('buret-scene-tree-menu');
+    const trigger = event.target.closest?.('[data-scene-tree-picker]');
+    if (trigger && menu?.contains(trigger)) {
+      const list = menu.querySelector(`[data-scene-tree-picker-list="${trigger.dataset.sceneTreePicker}"]`);
+      if (!list) return;
+      const opening = list.hidden;
+      // Only one list open at a time, and the one being closed goes back to the
+      // theme it started from — a hover that was never clicked is not a choice.
+      for (const other of menu.querySelectorAll('[data-scene-tree-picker-list]')) {
+        if (other !== list) closeSceneTreePicker(other, { restore: true });
+      }
+      if (opening) {
+        list.hidden = false;
+        trigger.setAttribute('aria-expanded', 'true');
+      } else {
+        closeSceneTreePicker(list, { restore: true });
+      }
+      return;
+    }
+    const picked = event.target.closest?.('[data-scene-tree-picker-value]');
+    if (picked && menu?.contains(picked)) {
+      const list = picked.closest('[data-scene-tree-picker-list]');
+      const ref = picked.closest('[data-ref]')?.dataset.ref;
+      const name = picked.dataset.sceneTreePickerValue;
+      if (list && ref) {
+        list.dataset.current = name;
+        streamSceneTreeTheme(ref, list.dataset.sceneTreePickerList, name);
+        closeSceneTreePicker(list);
+        const owner = menu.querySelector(`[data-scene-tree-picker="${list.dataset.sceneTreePickerList}"]`);
+        if (owner) { owner.textContent = picked.textContent; owner.title = picked.textContent; }
+        for (const item of list.children) {
+          item.setAttribute('aria-selected', item === picked ? 'true' : 'false');
+        }
+      }
+      return;
+    }
     const control = event.target.closest('[data-scene-tree-action]');
     if (!control) return;
     const ref = control.closest('[data-ref]')?.dataset.ref;
@@ -6672,6 +6786,27 @@
         if (!control || !ref || control.dataset.sceneTreeParamType === 'number') return;
         const value = control.dataset.sceneTreeParamType === 'boolean' ? control.checked : control.value;
         applySceneTreeReprParam(ref, control.dataset.sceneTreeParam, value);
+      });
+      // The point of the theme list: the scene takes each theme as the pointer
+      // passes over it, and gets its own back when the pointer leaves without
+      // choosing. Bound on the document because the menu is portalled to <body>.
+      document.addEventListener('pointerover', event => {
+        const item = event.target.closest?.('[data-scene-tree-picker-value]');
+        const list = item?.closest('[data-scene-tree-picker-list]');
+        const ref = list?.closest('[data-ref]')?.dataset.ref;
+        if (!list || list.hidden || !ref) return;
+        streamSceneTreeTheme(ref, list.dataset.sceneTreePickerList, item.dataset.sceneTreePickerValue);
+      });
+      document.addEventListener('pointerout', event => {
+        const list = event.target.closest?.('[data-scene-tree-picker-list]');
+        if (!list || list.hidden) return;
+        // Only when the pointer has actually left the list, not on the way between
+        // two of its rows.
+        if (event.relatedTarget && list.contains(event.relatedTarget)) return;
+        const ref = list.closest('[data-ref]')?.dataset.ref;
+        if (ref && list.dataset.current) {
+          streamSceneTreeTheme(ref, list.dataset.sceneTreePickerList, list.dataset.current);
+        }
       });
       // Opacity streams as the thumb moves; the slider sits inside the menu, so the
       // outside-click dismissal never sees these events and the menu stays open.


### PR DESCRIPTION
Picking a colour theme meant reading a name and hoping. The theme row is now a
list of our own, and the scene takes each theme as the pointer passes over it.

- Hovering a row paints the structure with that theme.
- Leaving the list without clicking puts the previous theme back.
- Clicking commits: the trigger takes the new name, the list closes, the menu
  stays open.
- Dismissing the whole menu mid-hover also restores — the pointer never reached a
  row to click, so nothing was chosen.

Applies to both theme rows: the per-representation one and the component one.

## Why not the native select

`<option>` elements have no layout box — their popup is drawn by the OS, outside
the DOM — so no pointer event from a real mouse ever reaches them. Measured on a
probe select: `getBoundingClientRect()` returns a zero-size rect. Hover preview is
unreachable with `<select>`; a list of our own is the only way to get it.

The list opens in place inside the menu rather than as a floating layer: the menu
already scrolls, and a portalled popup would need its own placement and dismissal.

## Cost

Painting a structure is a state commit, and a pointer crossing 31 rows asks for
one per row. Hover updates share the latest-wins queue the opacity drag uses, so
newer hovers fold into the one in flight and the scene follows the cursor instead
of a backlog.

## Verification

Live against `samples/structures/proteins/1htb.pdb`:

| Step | Result |
|---|---|
| Hover Hydrophobicity / Secondary Structure / Residue Name | theme applied on each |
| Leave without clicking | back to `chain-id` |
| Click Hydrophobicity | committed; trigger reads "Hydrophobicity"; survives leaving |
| Hover, then dismiss the menu | back to `chain-id` |

`bun run test:ui` (41 suites) and `bun run check:js` pass.
