### PR TITLE
Rework the Molecular Inspector on shadcn and overhaul the Mol* viewer overlay

### DIFF
--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -590,6 +590,12 @@ body.burette-mobile-host #buret-scene-tree {
   color: var(--buret-molstar-accent);
   background: var(--buret-toolbar-hover);
 }
+/* A spinning scene is easy to miss on a still frame, so the camera button carries
+   the state while its menu is closed. */
+.buret-rail-button[data-motion="spin"],
+.buret-rail-button[data-motion="rock"] {
+  color: var(--buret-molstar-accent);
+}
 .buret-selection-bar {
   position: fixed;
   top: var(--buret-selection-controls-top, calc(var(--buret-toolbar-safe-top) + 48px));
@@ -3548,6 +3554,9 @@ body.buret-viewport-corner-active .msp-plugin .msp-viewport-top-left-controls {
   align-items: center;
   gap: 6px;
   padding: 2px 8px 6px;
+}
+.buret-tree-menu-field[hidden] {
+  display: none;
 }
 .buret-tree-menu-field > span {
   flex: 0 0 auto;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -1010,6 +1010,52 @@ body .msp-plugin ::-webkit-scrollbar-thumb {
   outline: 2px solid var(--buret-molstar-accent);
   outline-offset: 1px;
 }
+/* Minimized preview: a small pill parked in the bottom-left corner that pops the
+   same molecule back out when clicked. */
+.buret-molecule-preview-chip {
+  position: fixed;
+  left: 12px;
+  bottom: 12px;
+  z-index: 42;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  height: 30px;
+  padding: 0 11px 0 9px;
+  border: 1px solid var(--buret-molstar-border);
+  border-radius: 999px;
+  background: var(--buret-molstar-panel-background);
+  color: var(--buret-molstar-text);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+.buret-molecule-preview-chip:hover {
+  background: var(--buret-molstar-hover-background);
+  transform: translateY(-1px);
+}
+.buret-molecule-preview-chip:focus-visible {
+  outline: 2px solid var(--buret-molstar-accent);
+  outline-offset: 2px;
+}
+.buret-molecule-preview-chip > svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  color: var(--buret-molstar-accent);
+}
+.buret-molecule-preview-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+body.burette-mobile-host .buret-molecule-preview-chip {
+  display: none;
+}
 .buret-molecule-card-footer {
   display: flex;
   align-items: center;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -590,10 +590,11 @@ body.burette-mobile-host #buret-scene-tree {
   color: var(--buret-molstar-accent);
   background: var(--buret-toolbar-hover);
 }
-/* A spinning scene is easy to miss on a still frame, so the camera button carries
+/* A moving scene is easy to miss on a still frame, so the animate button carries
    the state while its menu is closed. */
 .buret-rail-button[data-motion="spin"],
-.buret-rail-button[data-motion="rock"] {
+.buret-rail-button[data-motion="rock"],
+.buret-rail-button[data-motion="playing"] {
   color: var(--buret-molstar-accent);
 }
 .buret-selection-bar {

--- a/PreviewExtension/Web/viewer-shell.js
+++ b/PreviewExtension/Web/viewer-shell.js
@@ -151,6 +151,10 @@
           <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z"/><path d="M12 1.8V4M12 20v2.2M4.2 4.2l1.6 1.6M18.2 18.2l1.6 1.6M1.8 12H4M20 12h2.2M4.2 19.8l1.6-1.6M18.2 5.8l1.6-1.6"/></svg>
           <span class="buret-tooltip" role="tooltip">Realistic lighting</span>
         </button>
+        <button class="buret-rail-button" type="button" data-buret-viewport-action="animate" aria-haspopup="menu" aria-expanded="false" data-motion="off" aria-label="Animate the scene" title="Animate the scene">
+          <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.6-6.1"/><path d="M20.8 3.9v4.3h-4.3"/><path d="m10.4 9.2 4.8 2.8-4.8 2.8Z"/></svg>
+          <span class="buret-tooltip" role="tooltip">Animate the scene</span>
+        </button>
         <button class="buret-rail-button" type="button" data-buret-viewport-action="select-mode" aria-pressed="false" aria-label="Selection mode" title="Selection mode">
           <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m5 3 14 7.2-6 1.6-1.6 6L5 3Z"/></svg>
           <span class="buret-tooltip" role="tooltip">Selection mode</span>

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6315,9 +6315,12 @@
     ['spin', 'Spin'],
     ['rock', 'Rock']
   ];
+  // Each animation reads more than a speed - spin needs an axis, rock an axis and
+  // a sweep angle - and a missing one leaves the maths on undefined, which is a
+  // scene that simply never moves. The rest of the payload travels with the speed.
   const VIEWPORT_MOTION_SPEEDS = {
-    spin: { value: 0.1, min: -2, max: 2, step: 0.01 },
-    rock: { value: 0.3, min: -5, max: 5, step: 0.1 }
+    spin: { value: 0.1, min: -2, max: 2, step: 0.01, params: { axis: [0, -1, 0] } },
+    rock: { value: 0.3, min: -5, max: 5, step: 0.1, params: { angle: 10, axis: [0, -1, 0] } }
   };
   // The plugin ships timed camera spin and rock too; the Motion switch covers the
   // same ground without a stopwatch, so they are not listed twice.
@@ -6454,7 +6457,13 @@
       // is just an entry you will never be able to use.
       .filter(entry => entry.applicability.canApply || entry.applicability.reason);
     if (!animations.length) return;
-    sceneTreeMenuSection(menu, 'Play once');
+    // Stop leads, because the thing you most need from this menu while something
+    // is moving is the way to make it stop.
+    if (playing) {
+      sceneTreeMenuSection(menu, 'Running');
+      viewportMenuItem(menu, 'Stop', 'animation-stop', { icon: VIEWPORT_ICON.stop });
+    }
+    sceneTreeMenuSection(menu, 'Animations');
     for (const entry of animations) {
       viewportMenuItem(menu, entry.animation.display.name, 'animation-play', {
         icon: VIEWPORT_ICON.play,
@@ -6465,9 +6474,17 @@
         title: entry.applicability.reason || entry.animation.display.description
       });
     }
-    if (!playing) return;
-    sceneTreeMenuSection(menu);
-    viewportMenuItem(menu, 'Stop', 'animation-stop', { icon: VIEWPORT_ICON.stop });
+  }
+
+  // play() with no params leaves each animation on its own defaults, and Mol*
+  // defaults Unwind Assembly to looping - a scene that keeps rebuilding itself
+  // under every click until someone finds the stop button.
+  function viewportAnimationParams(animation, plugin) {
+    const schema = typeof animation.params === 'function' ? animation.params(plugin) : animation.params;
+    const params = {};
+    for (const [key, value] of Object.entries(schema || {})) params[key] = value?.defaultValue;
+    if ('playOnce' in params) params.playOnce = true;
+    return params;
   }
 
   function viewportAnimationApplicability(animation, plugin) {
@@ -6485,8 +6502,7 @@
     const manager = plugin?.managers?.animation;
     const animation = manager?.animations?.[index];
     if (!animation) return;
-    const params = manager.getParams?.()?.params?.[animation.name];
-    Promise.resolve(manager.play(animation, params?.defaultValue ?? {}))
+    Promise.resolve(manager.play(animation, viewportAnimationParams(animation, plugin)))
       .then(() => updateViewportAnimateState())
       .catch(error => setStatus(`[web] Animation failed. ${error?.message || error}`, 'error'));
   }
@@ -6566,10 +6582,9 @@
     const trackball = plugin?.canvas3d?.props?.trackball;
     const limits = VIEWPORT_MOTION_SPEEDS[name];
     if (!trackball) return;
-    // Spin turns about an axis in camera space; rock only takes a speed.
-    const params = { speed: Number.isFinite(speed) ? speed : limits?.value };
-    if (name === 'spin') params.axis = [0, -1, 0];
-    const animate = limits ? { name, params } : { name: 'off', params: {} };
+    const animate = limits
+      ? { name, params: { ...limits.params, speed: Number.isFinite(speed) ? speed : limits.value } }
+      : { name: 'off', params: {} };
     plugin.canvas3d.setProps({ trackball: { ...trackball, animate } });
     updateViewportAnimateState();
   }

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6318,9 +6318,13 @@
   // Each animation reads more than a speed - spin needs an axis, rock an axis and
   // a sweep angle - and a missing one leaves the maths on undefined, which is a
   // scene that simply never moves. The rest of the payload travels with the speed.
+  // The library's bounds are symmetric (a negative speed reverses direction), which
+  // parks the default just right of centre and hands half the track to reverse
+  // spin nobody reaches for. This is a magnitude slider instead: slow on the left,
+  // fast on the right, floored just above zero so Off stays the only way to stop.
   const VIEWPORT_MOTION_SPEEDS = {
-    spin: { value: 0.1, min: -2, max: 2, step: 0.01, params: { axis: [0, -1, 0] } },
-    rock: { value: 0.3, min: -5, max: 5, step: 0.1, params: { angle: 10, axis: [0, -1, 0] } }
+    spin: { value: 0.1, min: 0.01, max: 1, step: 0.01, params: { axis: [0, -1, 0] } },
+    rock: { value: 0.3, min: 0.02, max: 1.5, step: 0.02, params: { angle: 10, axis: [0, -1, 0] } }
   };
   // The plugin ships timed camera spin and rock too; the Motion switch covers the
   // same ground without a stopwatch, so they are not listed twice.

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6319,13 +6319,21 @@
     spin: { value: 0.1, min: -2, max: 2, step: 0.01 },
     rock: { value: 0.3, min: -5, max: 5, step: 0.1 }
   };
+  // The plugin ships timed camera spin and rock too; the Motion switch covers the
+  // same ground without a stopwatch, so they are not listed twice.
+  const VIEWPORT_MOTION_ANIMATIONS = new Set([
+    'built-in.animate-camera-spin',
+    'built-in.animate-camera-rock'
+  ]);
   const VIEWPORT_ICON = {
     camera: ['M4.5 8.5h2.2l1.4-2.2h7.8l1.4 2.2h2.2A1.5 1.5 0 0 1 21 10v8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18v-8a1.5 1.5 0 0 1 1.5-1.5Z', 'M12 17a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z'],
     layFlat: ['M3 8.5 12 4l9 4.5-9 4.5Z', 'm3 15 9 4.5L21 15'],
     paint: ['M4 8.5A2.5 2.5 0 0 1 6.5 6H16a3 3 0 0 1 3 3v1.5H8.5A2.5 2.5 0 0 0 6 13v1', 'M9 14h4v4a2 2 0 0 1-4 0Z'],
     cube: ['M12 3 4.5 7v10L12 21l7.5-4V7Z', 'M4.5 7 12 11l7.5-4', 'M12 11v10'],
     scissors: ['M6.5 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z', 'M6.5 20.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z', 'm8.7 7.2 10.8 10.6', 'M19.5 6.2 8.7 16.8'],
-    undo: ['M4 9h11a5 5 0 0 1 0 10h-7', 'm8 5-4 4 4 4']
+    undo: ['M4 9h11a5 5 0 0 1 0 10h-7', 'm8 5-4 4 4 4'],
+    play: ['m8 5 11 7-11 7Z'],
+    stop: ['M6.5 6.5h11v11h-11Z']
   };
   let selectionQueryModifier = 'set';
   let viewportControlsDisposers = [];
@@ -6370,6 +6378,7 @@
     button.dataset.buretViewportMenu = action;
     Object.assign(button.dataset, options.data || {});
     if (options.disabled) button.disabled = true;
+    if (options.title) button.title = options.title;
     const icon = document.createElement('span');
     icon.className = 'buret-tree-menu-icon';
     if (options.icon) icon.appendChild(sceneTreeIconElement(options.icon));
@@ -6425,7 +6434,71 @@
     viewportMenuItem(menu, 'Reset zoom', 'camera-reset', { icon: SCENE_TREE_ICON.focus });
     viewportMenuItem(menu, 'Lay flat', 'camera-orient', { icon: VIEWPORT_ICON.layFlat });
     viewportMenuItem(menu, 'Reset axes', 'camera-axes', { icon: SCENE_TREE_ICON.restore });
+  }
+
+  // Mol*'s own animation button offered both a trackball that keeps turning and
+  // the plugin's timed animations. The rail keeps both, split by how they end:
+  // motion runs until it is switched off, the rest play once and stop themselves.
+  function viewportAnimateMenu(menu) {
     viewportMotionControls(menu);
+    const plugin = viewportPlugin();
+    const manager = plugin?.managers?.animation;
+    const playing = manager?.state?.animationState === 'playing';
+    const animations = (manager?.animations || [])
+      .map((animation, index) => ({ animation, index }))
+      // Camera spin and rock are the Motion switch above, only on a timer.
+      .filter(entry => !VIEWPORT_MOTION_ANIMATIONS.has(entry.animation?.name))
+      .map(entry => ({ ...entry, applicability: viewportAnimationApplicability(entry.animation, plugin) }))
+      .filter(entry => entry.animation?.display?.name)
+      // A greyed row earns its place by saying why it is greyed. One that cannot
+      // is just an entry you will never be able to use.
+      .filter(entry => entry.applicability.canApply || entry.applicability.reason);
+    if (!animations.length) return;
+    sceneTreeMenuSection(menu, 'Play once');
+    for (const entry of animations) {
+      viewportMenuItem(menu, entry.animation.display.name, 'animation-play', {
+        icon: VIEWPORT_ICON.play,
+        data: { animationIndex: String(entry.index) },
+        disabled: !entry.applicability.canApply,
+        // Mol* explains why an animation does not apply; a greyed row that keeps
+        // its reason to itself is the thing this rail set out to replace.
+        title: entry.applicability.reason || entry.animation.display.description
+      });
+    }
+    if (!playing) return;
+    sceneTreeMenuSection(menu);
+    viewportMenuItem(menu, 'Stop', 'animation-stop', { icon: VIEWPORT_ICON.stop });
+  }
+
+  function viewportAnimationApplicability(animation, plugin) {
+    if (typeof animation?.canApply !== 'function') return { canApply: true };
+    try {
+      return animation.canApply(plugin) || { canApply: true };
+    } catch (error) {
+      debug('animation applicability failed: ' + (error && error.message || String(error)));
+      return { canApply: false, reason: 'Unavailable for this scene' };
+    }
+  }
+
+  function playViewportAnimation(index) {
+    const plugin = viewportPlugin();
+    const manager = plugin?.managers?.animation;
+    const animation = manager?.animations?.[index];
+    if (!animation) return;
+    const params = manager.getParams?.()?.params?.[animation.name];
+    Promise.resolve(manager.play(animation, params?.defaultValue ?? {}))
+      .then(() => updateViewportAnimateState())
+      .catch(error => setStatus(`[web] Animation failed. ${error?.message || error}`, 'error'));
+  }
+
+  // The button carries whatever is moving - a running animation or the trackball -
+  // because a still frame cannot tell you the scene is in motion.
+  function updateViewportAnimateState() {
+    const plugin = viewportPlugin();
+    const playing = plugin?.managers?.animation?.state?.animationState === 'playing';
+    const motion = viewportMotionState().name;
+    document.querySelector('[data-buret-viewport-action="animate"]')
+      ?.setAttribute('data-motion', playing ? 'playing' : motion);
   }
 
   function viewportMotionState() {
@@ -6498,8 +6571,7 @@
     if (name === 'spin') params.axis = [0, -1, 0];
     const animate = limits ? { name, params } : { name: 'off', params: {} };
     plugin.canvas3d.setProps({ trackball: { ...trackball, animate } });
-    document.querySelector('[data-buret-viewport-action="camera"]')
-      ?.setAttribute('data-motion', limits ? name : 'off');
+    updateViewportAnimateState();
   }
 
   // The registry ships seventy queries, twenty of which are single amino acids;
@@ -6648,6 +6720,11 @@
       updateViewportMotionSpeed(viewportMotionState());
       // Motion is judged by watching it, so the menu stays up to be adjusted.
       return true;
+    } else if (action === 'animation-play') {
+      playViewportAnimation(Number(control.dataset.animationIndex));
+    } else if (action === 'animation-stop') {
+      plugin.managers.animation.stop();
+      updateViewportAnimateState();
     } else if (action === 'modifier') {
       selectionQueryModifier = control.dataset.modifier || 'set';
       for (const button of control.parentElement?.children || []) {
@@ -6679,6 +6756,8 @@
     if (!plugin) return;
     if (action === 'camera') {
       openViewportMenu(control, 'Camera', viewportCameraMenu);
+    } else if (action === 'animate') {
+      openViewportMenu(control, 'Animate', viewportAnimateMenu);
     } else if (action === 'screenshot') {
       Promise.resolve(plugin.helpers.viewportScreenshot?.download())
         .then(() => setStatus('[web] Screenshot saved.'))
@@ -6811,15 +6890,17 @@
     const subscriptions = [
       plugin?.behaviors?.interaction?.selectionMode?.subscribe?.(updateSelectionBar),
       plugin?.managers?.structure?.selection?.events?.changed?.subscribe?.(updateSelectionBar),
-      plugin?.managers?.interactivity?.events?.propsUpdated?.subscribe?.(updateSelectionBar)
+      plugin?.managers?.interactivity?.events?.propsUpdated?.subscribe?.(updateSelectionBar),
+      // Timed animations end on their own, so the button cannot be left holding a
+      // state nobody switched off.
+      plugin?.behaviors?.state?.isAnimating?.subscribe?.(updateViewportAnimateState)
     ].filter(Boolean);
     if (subscriptions.length) {
       viewportControlsDisposers.push(() => subscriptions.forEach(item => item?.unsubscribe?.()));
     }
     rail.querySelector('[data-buret-viewport-action="illumination"]')
       ?.setAttribute('aria-pressed', plugin?.canvas3d?.props?.illumination?.enabled === true ? 'true' : 'false');
-    rail.querySelector('[data-buret-viewport-action="camera"]')
-      ?.setAttribute('data-motion', viewportMotionState().name);
+    updateViewportAnimateState();
     updateSelectionBar();
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -146,7 +146,14 @@
   // and the corner the user dragged it to live out here instead of on the element.
   let molstarMoleculePreviewGeometry = null;
   let molstarMoleculePreviewSize = 's';
-  let molstarMoleculePreviewDismissedKey = '';
+  // Closing the card (×) leaves the selection alone but parks the card: nothing
+  // re-shows it until the next genuine click. Minimizing tucks it into a chip in
+  // the corner that the same molecule pops back out of.
+  let molstarMoleculePreviewSuppressed = false;
+  let molstarMoleculePreviewMinimized = false;
+  let molstarMoleculePreviewMinimizedTarget = null;
+  let molstarMoleculePreviewChip = null;
+  let molstarPreviewRevealStart = null;
   let molstarSelectionHostSignature = '';
   let molstarPreviewRdkit = null;
   let molstarPreviewRdkitPromise = null;
@@ -17025,6 +17032,8 @@
   };
   const MOLECULE_PREVIEW_ICON = {
     close: ['M18 6 6 18', 'm6 6 12 12'],
+    minimize: ['M6 17h12'],
+    molecule: ['m12 3 7.5 4.33v8.66L12 20.33 4.5 16V7.33Z'],
     ketcher: ['M12 3v4.5', 'm12 7.5 3.9 2.25', 'm12 7.5-3.9 2.25', 'M15.9 9.75v4.5L12 16.5l-3.9-2.25v-4.5', 'M4.2 6.75 12 2.25l7.8 4.5v9L12 20.25l-7.8-4.5Z'],
     copy: ['M9 9h9a1.5 1.5 0 0 1 1.5 1.5V19a1.5 1.5 0 0 1-1.5 1.5H9A1.5 1.5 0 0 1 7.5 19v-8.5A1.5 1.5 0 0 1 9 9Z', 'M4.5 15A1.5 1.5 0 0 1 3 13.5V5a1.5 1.5 0 0 1 1.5-1.5H13A1.5 1.5 0 0 1 14.5 5']
   };
@@ -17130,7 +17139,8 @@
           <span class="buret-molecule-card-subtitle">${escapeHTML(subtitle)}</span>
         </span>
         ${molstarMoleculePreviewNavHTML()}
-        <button type="button" class="buret-molecule-card-icon" data-buret-molecule-preview-action="close" aria-label="Hide preview" title="Hide preview">${molstarMoleculePreviewIconHTML(MOLECULE_PREVIEW_ICON.close)}</button>
+        <button type="button" class="buret-molecule-card-icon" data-buret-molecule-preview-action="minimize" aria-label="Minimize preview" title="Minimize preview">${molstarMoleculePreviewIconHTML(MOLECULE_PREVIEW_ICON.minimize)}</button>
+        <button type="button" class="buret-molecule-card-icon" data-buret-molecule-preview-action="close" aria-label="Close preview" title="Close preview">${molstarMoleculePreviewIconHTML(MOLECULE_PREVIEW_ICON.close)}</button>
       </div>
       <div class="buret-molstar-molecule-preview-image" data-buret-molecule-preview-drag>${image}</div>
       <div class="buret-molecule-card-footer">
@@ -17288,6 +17298,7 @@
 
   function runMolstarMoleculePreviewAction(action, control) {
     if (action === 'close') dismissMolstarMoleculePreview();
+    else if (action === 'minimize') minimizeMolstarMoleculePreview();
     else if (action === 'ketcher') openMolstarMoleculePreviewInKetcher(molstarMoleculePreviewTarget);
     else if (action === 'copy-smiles') void copyMolstarMoleculePreviewSmiles(molstarMoleculePreviewTarget);
     else if (action === 'size') setMolstarMoleculePreviewSize(control.dataset.size);
@@ -17295,18 +17306,55 @@
     else if (action === 'next') stepMolstarMoleculePreview(1);
   }
 
-  // The card is the selection's window, so closing it drops the selection too.
-  // Hiding it alone was not enough to make it stay hidden: any pointer event over
-  // the view re-resolves the card from whatever is still selected, so the only way
-  // to close it for good is to leave nothing selected.
+  // × closes the card but leaves the selection standing. A plain hide is not
+  // enough - the next pointer move re-resolves the card from whatever is still
+  // selected - so it also latches "suppressed", which every show path checks. The
+  // latch lifts on the next genuine click (see the reveal handler on pointerup).
   function dismissMolstarMoleculePreview() {
-    molstarMoleculePreviewDismissedKey = molstarMoleculePreview?.dataset?.buretPreviewKey || '';
+    molstarMoleculePreviewSuppressed = true;
     hideMolstarMoleculePreview({ force: true });
-    clearMolstarSelection();
-    // The host learns about selection through the selection manager's own events,
-    // and clearing this way does not reach it - so the inspector would keep
-    // showing the ligand as selected. Tell it directly.
-    notifyMolstarSelectionChanged(null);
+  }
+
+  // Minimize tucks the card into a small chip in the bottom-left corner. The
+  // selection stays, the card stays out of the way, and the chip is the one way
+  // back - hover will not pop it open again.
+  function minimizeMolstarMoleculePreview() {
+    const label = molstarMoleculePreview?.querySelector('.buret-molecule-card-title')?.textContent
+      || molstarMoleculePreviewTarget?.label || 'Molecule';
+    molstarMoleculePreviewMinimizedTarget = molstarMoleculePreviewTarget;
+    molstarMoleculePreviewMinimized = true;
+    hideMolstarMoleculePreview({ force: true });
+    showMolstarMoleculePreviewChip(label);
+  }
+
+  function restoreMolstarMoleculePreview() {
+    molstarMoleculePreviewMinimized = false;
+    molstarMoleculePreviewSuppressed = false;
+    removeMolstarMoleculePreviewChip();
+    // Prefer whatever is selected now, so restoring after picking a different
+    // ligand shows that one rather than the molecule that was parked.
+    const target = molstarSelectedMoleculePreviewTarget() || molstarMoleculePreviewMinimizedTarget;
+    molstarMoleculePreviewMinimizedTarget = null;
+    if (target) showMolstarMoleculePreview(target);
+    else scheduleMolstarSelectedMoleculePreview();
+  }
+
+  function showMolstarMoleculePreviewChip(label) {
+    removeMolstarMoleculePreviewChip();
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'buret-molecule-preview-chip';
+    chip.setAttribute('aria-label', `Restore ${label} preview`);
+    chip.title = `Restore ${label} preview`;
+    chip.innerHTML = `${molstarMoleculePreviewIconHTML(MOLECULE_PREVIEW_ICON.molecule)}<span class="buret-molecule-preview-chip-label">${escapeHTML(label)}</span>`;
+    chip.addEventListener('click', () => restoreMolstarMoleculePreview());
+    document.body.appendChild(chip);
+    molstarMoleculePreviewChip = chip;
+  }
+
+  function removeMolstarMoleculePreviewChip() {
+    molstarMoleculePreviewChip?.remove();
+    molstarMoleculePreviewChip = null;
   }
 
   function installMolstarMoleculePreviewResize(popover) {
@@ -17663,9 +17711,10 @@
       hideMolstarMoleculePreview();
       return;
     }
+    // Parked by × or tucked into the chip: stay hidden until the user asks for it
+    // back, not the moment the pointer drifts back over the selected ligand.
+    if (molstarMoleculePreviewSuppressed || molstarMoleculePreviewMinimized) return;
     const key = molstarPreviewKey(entry);
-    if (key === molstarMoleculePreviewDismissedKey) return;
-    molstarMoleculePreviewDismissedKey = '';
     const image = molstarPreviewSvgCache.get(key) || '';
     const label = target?.label || entry?.label || (target?.scope === 'ion' ? 'Ion' : 'Ligand');
     const subtitle = target?.scope === 'ion' ? 'Ion' : 'Small molecule';
@@ -17775,6 +17824,13 @@
     const hasCandidate = Boolean(molstarSelectedMoleculePreviewTarget() || fallbackTarget);
     if (!hasCandidate) {
       hideMolstarMoleculePreview({ force: true });
+      // Nothing left to preview means nothing left to restore, so the parked chip
+      // goes with it.
+      if (molstarMoleculePreviewMinimized) {
+        molstarMoleculePreviewMinimized = false;
+        molstarMoleculePreviewMinimizedTarget = null;
+        removeMolstarMoleculePreviewChip();
+      }
       return;
     }
     if (showMolstarSelectedMoleculePreview(fallbackTarget)) return;
@@ -17797,6 +17853,10 @@
   }
 
   function clearMolstarPersistentMoleculePreview() {
+    molstarMoleculePreviewSuppressed = false;
+    molstarMoleculePreviewMinimized = false;
+    molstarMoleculePreviewMinimizedTarget = null;
+    removeMolstarMoleculePreviewChip();
     hideMolstarMoleculePreview({ force: true });
   }
 
@@ -17997,6 +18057,11 @@
     const onPointerDown = (event) => {
       beginMolstarSelectionPreserve(event);
       clearTouchContextPointer();
+      // Remember where a left press on the viewport began, so a click (not a drag
+      // to rotate) can lift a × dismissal on release.
+      molstarPreviewRevealStart = event.button === 0 && isMolstarContextMenuTarget(event.target)
+        ? { pointerId: event.pointerId, x: event.clientX, y: event.clientY }
+        : null;
       if (event.button === 2) {
         if (!viewer || !isMolstarContextMenuTarget(event.target)) {
           contextPointer = null;
@@ -18086,6 +18151,16 @@
     };
     const onPointerUp = (event) => {
       finishMolstarSelectionPreserve(event);
+      if (molstarPreviewRevealStart && event.pointerId === molstarPreviewRevealStart.pointerId) {
+        const moved = Math.hypot(event.clientX - molstarPreviewRevealStart.x, event.clientY - molstarPreviewRevealStart.y)
+          > MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX;
+        molstarPreviewRevealStart = null;
+        // A click - not a drag - is the "next click" that a × dismissal waits for.
+        if (!moved && molstarMoleculePreviewSuppressed && !molstarMoleculePreviewMinimized) {
+          molstarMoleculePreviewSuppressed = false;
+          scheduleMolstarSelectedMoleculePreview();
+        }
+      }
       if (touchContextPointer && event.pointerId === touchContextPointer.pointerId) {
         const opened = touchContextPointer.opened;
         clearTouchContextPointer();

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -17291,12 +17291,18 @@
     else if (action === 'next') stepMolstarMoleculePreview(1);
   }
 
-  // Closing the card is about the card, not the structure: the selection stays, and
-  // the same molecule simply stops asking to be drawn until a different one comes
-  // along — otherwise the next pointer move over the view brings it straight back.
+  // The card is the selection's window, so closing it drops the selection too.
+  // Hiding it alone was not enough to make it stay hidden: any pointer event over
+  // the view re-resolves the card from whatever is still selected, so the only way
+  // to close it for good is to leave nothing selected.
   function dismissMolstarMoleculePreview() {
     molstarMoleculePreviewDismissedKey = molstarMoleculePreview?.dataset?.buretPreviewKey || '';
     hideMolstarMoleculePreview({ force: true });
+    clearMolstarSelection();
+    // The host learns about selection through the selection manager's own events,
+    // and clearing this way does not reach it - so the inspector would keep
+    // showing the ligand as selected. Tell it directly.
+    notifyMolstarSelectionChanged(null);
   }
 
   function installMolstarMoleculePreviewResize(popover) {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6307,6 +6307,18 @@
     ['remove', 'Remove'],
     ['intersect', 'Keep']
   ];
+  // Mol* keeps scene motion in the trackball section of its viewport settings, and
+  // the rail replaced that panel — so the camera menu carries it instead. The
+  // speeds are the library's own defaults and bounds for each animation.
+  const VIEWPORT_MOTIONS = [
+    ['off', 'Off'],
+    ['spin', 'Spin'],
+    ['rock', 'Rock']
+  ];
+  const VIEWPORT_MOTION_SPEEDS = {
+    spin: { value: 0.1, min: -2, max: 2, step: 0.01 },
+    rock: { value: 0.3, min: -5, max: 5, step: 0.1 }
+  };
   const VIEWPORT_ICON = {
     camera: ['M4.5 8.5h2.2l1.4-2.2h7.8l1.4 2.2h2.2A1.5 1.5 0 0 1 21 10v8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18v-8a1.5 1.5 0 0 1 1.5-1.5Z', 'M12 17a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z'],
     layFlat: ['M3 8.5 12 4l9 4.5-9 4.5Z', 'm3 15 9 4.5L21 15'],
@@ -6413,6 +6425,81 @@
     viewportMenuItem(menu, 'Reset zoom', 'camera-reset', { icon: SCENE_TREE_ICON.focus });
     viewportMenuItem(menu, 'Lay flat', 'camera-orient', { icon: VIEWPORT_ICON.layFlat });
     viewportMenuItem(menu, 'Reset axes', 'camera-axes', { icon: SCENE_TREE_ICON.restore });
+    viewportMotionControls(menu);
+  }
+
+  function viewportMotionState() {
+    const animate = viewportPlugin()?.canvas3d?.props?.trackball?.animate;
+    const name = VIEWPORT_MOTION_SPEEDS[animate?.name] ? animate.name : 'off';
+    return { name, speed: Number(animate?.params?.speed) };
+  }
+
+  function viewportMotionControls(menu) {
+    const state = viewportMotionState();
+    sceneTreeMenuSection(menu, 'Motion');
+    const segment = document.createElement('div');
+    segment.className = 'buret-viewport-segment';
+    segment.setAttribute('role', 'group');
+    segment.setAttribute('aria-label', 'Scene motion');
+    for (const [name, label] of VIEWPORT_MOTIONS) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'buret-viewport-segment-button';
+      button.dataset.buretViewportMenu = 'camera-motion';
+      button.dataset.motion = name;
+      button.setAttribute('aria-pressed', name === state.name ? 'true' : 'false');
+      button.textContent = label;
+      segment.appendChild(button);
+    }
+    menu.appendChild(segment);
+
+    const row = document.createElement('label');
+    row.className = 'buret-tree-menu-field buret-tree-menu-slider';
+    row.dataset.buretViewportMotionSpeed = '1';
+    const caption = document.createElement('span');
+    caption.textContent = 'Speed';
+    const control = document.createElement('input');
+    control.type = 'range';
+    control.className = 'buret-tree-menu-range';
+    control.dataset.buretViewportSlider = 'motion-speed';
+    const readout = document.createElement('span');
+    readout.className = 'buret-tree-menu-slider-value';
+    row.append(caption, control, readout);
+    menu.appendChild(row);
+    // The menu is still detached at this point, so the row has to be handed over
+    // rather than looked up in the document.
+    updateViewportMotionSpeed(state, row);
+  }
+
+  // Spin and rock do not share a speed range, so the slider is re-scaled to the
+  // running animation and hidden altogether once motion is off.
+  function updateViewportMotionSpeed(state, target) {
+    const row = target || document.querySelector('[data-buret-viewport-motion-speed]');
+    const limits = VIEWPORT_MOTION_SPEEDS[state.name];
+    if (!row) return;
+    row.hidden = !limits;
+    if (!limits) return;
+    const speed = Number.isFinite(state.speed) ? state.speed : limits.value;
+    const control = row.querySelector('input');
+    control.min = String(limits.min);
+    control.max = String(limits.max);
+    control.step = String(limits.step);
+    control.value = String(speed);
+    row.querySelector('.buret-tree-menu-slider-value').textContent = `${speed.toFixed(2)}/s`;
+  }
+
+  function setViewportMotion(name, speed) {
+    const plugin = viewportPlugin();
+    const trackball = plugin?.canvas3d?.props?.trackball;
+    const limits = VIEWPORT_MOTION_SPEEDS[name];
+    if (!trackball) return;
+    // Spin turns about an axis in camera space; rock only takes a speed.
+    const params = { speed: Number.isFinite(speed) ? speed : limits?.value };
+    if (name === 'spin') params.axis = [0, -1, 0];
+    const animate = limits ? { name, params } : { name: 'off', params: {} };
+    plugin.canvas3d.setProps({ trackball: { ...trackball, animate } });
+    document.querySelector('[data-buret-viewport-action="camera"]')
+      ?.setAttribute('data-motion', limits ? name : 'off');
   }
 
   // The registry ships seventy queries, twenty of which are single amino acids;
@@ -6553,7 +6640,15 @@
     if (action === 'camera-reset') plugin.canvas3d?.requestCameraReset?.({ durationMs: 250 });
     else if (action === 'camera-orient') plugin.managers.camera.orientAxes(undefined, 250);
     else if (action === 'camera-axes') plugin.managers.camera.resetAxes(250);
-    else if (action === 'modifier') {
+    else if (action === 'camera-motion') {
+      setViewportMotion(control.dataset.motion);
+      for (const button of control.parentElement?.children || []) {
+        button.setAttribute('aria-pressed', button === control ? 'true' : 'false');
+      }
+      updateViewportMotionSpeed(viewportMotionState());
+      // Motion is judged by watching it, so the menu stays up to be adjusted.
+      return true;
+    } else if (action === 'modifier') {
       selectionQueryModifier = control.dataset.modifier || 'set';
       for (const button of control.parentElement?.children || []) {
         button.setAttribute('aria-pressed', button === control ? 'true' : 'false');
@@ -6678,6 +6773,14 @@
       // While filtering, the headings and the fold-away groups get in the way, so
       // the menu flattens to just what matched and restores itself when cleared.
       document.addEventListener('input', event => {
+        const slider = event.target.closest('[data-buret-viewport-slider="motion-speed"]');
+        if (slider) {
+          const speed = Number(slider.value);
+          setViewportMotion(viewportMotionState().name, speed);
+          const readout = slider.parentElement?.querySelector('.buret-tree-menu-slider-value');
+          if (readout) readout.textContent = `${speed.toFixed(2)}/s`;
+          return;
+        }
         const search = event.target.closest('[data-buret-viewport-search]');
         const menu = search?.closest('#buret-viewport-menu');
         if (!menu) return;
@@ -6715,6 +6818,8 @@
     }
     rail.querySelector('[data-buret-viewport-action="illumination"]')
       ?.setAttribute('aria-pressed', plugin?.canvas3d?.props?.illumination?.enabled === true ? 'true' : 'false');
+    rail.querySelector('[data-buret-viewport-action="camera"]')
+      ?.setAttribute('data-motion', viewportMotionState().name);
     updateSelectionBar();
   }
 

--- a/apps/desktop/src/components/folding-results-panel.tsx
+++ b/apps/desktop/src/components/folding-results-panel.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
 import { hasFoldingResultContent, readFoldingResultBundle } from "../lib/folding-results";
 import { readStructureText } from "../lib/structure-text";
 import type { FoldingArtifact, FoldingMatrixPreview, FoldingModel, FoldingProfile, FoldingResultBundle, ViewerDocument } from "../types";
@@ -170,14 +172,14 @@ export function FoldingResultsPanel({ state, actions }: { state: FoldingResultSt
               <strong>{activeModel.title}</strong>
               <span title={activeModel.structureTitle}>{activeModel.structureTitle}</span>
             </div>
-            <button type="button" className="structure-inspector-xtb-table-action" onClick={() => actions.openStructurePaths([activeModel.structurePath])}>
+            <Button type="button" variant="outline" size="xs" onClick={() => actions.openStructurePaths([activeModel.structurePath])}>
               Open
-            </button>
+            </Button>
           </div>
           {activeModel.matrixPreview ? (
-            <button type="button" className="dock-action folding-full-pae-button" onClick={() => actions.openDockTab("bottom", "folding")}>
+            <Button type="button" variant="secondary" size="sm" className="folding-full-pae-button w-full" onClick={() => actions.openDockTab("bottom", "folding")}>
               Full PAE
-            </button>
+            </Button>
           ) : null}
 
           {activeModel.metrics.length ? (
@@ -303,12 +305,12 @@ export function FoldingAnalysisPanel({ document, actions }: { document: ViewerDo
           <span>{bundle.source} · {modelCountLabel(bundle.models.length)}</span>
         </div>
         <div className="folding-analysis-actions">
-          <button type="button" className="dock-action dock-action-compact" onClick={() => actions.openStructurePaths([activeModel.structurePath])}>
+          <Button type="button" variant="secondary" size="sm" onClick={() => actions.openStructurePaths([activeModel.structurePath])}>
             Open model
-          </button>
-          <button type="button" className="dock-action dock-action-compact" onClick={() => actions.revealPath(bundle.rootPath, "Folding result")}>
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => actions.revealPath(bundle.rootPath, "Folding result")}>
             Reveal bundle
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -362,7 +364,9 @@ function FoldingModelSelector({
     <div className="folding-model-selector">
       <label>
         <span>Model / seed</span>
-        <select
+        <NativeSelect
+          className="settings-select w-full"
+          size="sm"
           value={activeModel.id}
           disabled={models.length <= 1}
           aria-label="Folding model or seed"
@@ -372,11 +376,11 @@ function FoldingModelSelector({
           }}
         >
           {models.map((model) => (
-            <option key={model.id} value={model.id}>
+            <NativeSelectOption key={model.id} value={model.id}>
               {modelOptionLabel(model)}
-            </option>
+            </NativeSelectOption>
           ))}
-        </select>
+        </NativeSelect>
       </label>
       <span className="folding-model-selector-count">{modelAvailabilityLabel(models.length)}</span>
     </div>
@@ -781,9 +785,9 @@ function FoldingSequenceStrip({
       {selectedResidues?.length ? (
         <div className="folding-sequence-selection">
           <span>{selectedResidues.length} {selectedResidues.length === 1 ? "residue" : "residues"} selected</span>
-          <button type="button" className="dock-action dock-action-compact" onClick={onClearSelection}>
+          <Button type="button" variant="outline" size="xs" onClick={onClearSelection}>
             Clear
-          </button>
+          </Button>
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/components/folding-results-panel.tsx
+++ b/apps/desktop/src/components/folding-results-panel.tsx
@@ -314,6 +314,15 @@ export function FoldingAnalysisPanel({ document, actions }: { document: ViewerDo
 
       <FoldingModelSelector models={bundle.models} activeModel={activeModel} onSelect={selectModel} />
 
+      {/* This panel is what the "Full PAE" button opens and what its own empty
+          state promises, but the matrix was never rendered here - only the
+          thumbnail in the side card. The large size was already designed for it. */}
+      {activeModel.matrixPreview ? (
+        <FoldingMatrixHeatmap preview={activeModel.matrixPreview} size="large" />
+      ) : (
+        <div className="dock-empty">This model has no PAE matrix.</div>
+      )}
+
       <FoldingSequenceStrip
         sequences={sequences}
         selectedResidues={selectedResidues}
@@ -752,6 +761,15 @@ function FoldingSequenceStrip({
                   data-residue-index={index}
                   aria-label={`Select Chain-${chain.chainId} residue ${residueNumber} ${residue}`}
                   aria-pressed={selected}
+                  // Selection was driven entirely by elementFromPoint inside the
+                  // container's pointer handlers, so these buttons looked focusable
+                  // and did nothing on Enter or Space. A keyboard-generated click
+                  // reports detail 0, which is what keeps this from firing a second
+                  // selection after the pointer handlers have already made one.
+                  onClick={(event) => {
+                    if (event.detail !== 0) return;
+                    onSelectResidue?.(chain, residueNumber, residue, index, { rangeFromAnchor: event.shiftKey });
+                  }}
                 >
                   {residue}
                 </button>

--- a/apps/desktop/src/components/settings-panel/setting-control.tsx
+++ b/apps/desktop/src/components/settings-panel/setting-control.tsx
@@ -87,17 +87,21 @@ export function SettingControl({ row }: { row: SettingRow }) {
 export function SelectControl({
   value,
   options,
+  labels,
   onChange,
 }: {
   value: string;
   options: string[];
+  // Chemistry settings carry raw engine tokens - "gfnff", "verytight", "ch2cl2" -
+  // which are what the executable wants but not what a reader wants.
+  labels?: Record<string, string>;
   onChange: (value: string) => void;
 }) {
   return (
     <NativeSelect className="settings-select" size="sm" value={value} onChange={(event) => onChange(event.target.value)}>
       {options.map((option) => (
         <NativeSelectOption key={option} value={option}>
-          {option}
+          {labels?.[option] ?? option}
         </NativeSelectOption>
       ))}
     </NativeSelect>

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -580,7 +580,7 @@ function ProjectTreeNodeView({
         title={node.path}
       >
         <span className="project-folder-icon" aria-hidden="true">
-          <HugeiconsIcon icon={Folder02Icon} size={16} color="currentColor" strokeWidth={2} />
+          <HugeiconsIcon icon={expanded ? Folder02Icon : Folder01Icon} size={16} color="currentColor" strokeWidth={2} />
         </span>
         {renaming ? (
           <input

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -10,6 +10,11 @@ import type { ShellActions, ShellViewState, StructureOverlayMode, StructureViewe
 import { structureBriefForDocument, type StructureBriefRow as BriefRow } from "../lib/structure-brief";
 import { parseStructureComposition, type StructureCompositionSummary, type StructureSummaryRow, type StructureViewerSelector } from "../lib/structure-composition";
 import { canInspectConformerEnsemble, canShowConformerWorkflow, canUseConformerWorkflow } from "../lib/conformer-ensemble";
+import { Alert, AlertAction, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { DIRECT_CHEMISTRY_JOB_ATOM_LIMIT, structureAtomCountFromSummary } from "../lib/direct-chemistry-guard";
 import { extensionForDocking } from "../lib/docking-documents";
 import { readBrowserDevVirtualTextDocument } from "../lib/browser-dev-documents";
@@ -279,7 +284,7 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
         <div className="structure-brief-kicker">Molecular Inspector</div>
         <div className="structure-brief-title-row">
           <h3 title={document.title}>{document.title}</h3>
-          <span>{brief.format}</span>
+          <Badge variant="secondary">{brief.format}</Badge>
           {!hostedMcpWidget && !document.virtual ? (
             <button
               type="button"
@@ -493,8 +498,13 @@ type StructurePoseControls = {
 
 function structurePoseControlsFor(document: ViewerDocument, summary: StructureCompositionSummary | null): StructurePoseControls | null {
   if (document.renderer !== "molstar") return null;
+  // molstarSceneStructureCount already returns 0 for anything that is not a
+  // virtual scene, so the count alone identifies one. Requiring !summary as well
+  // used the parser failing as the signal, and for a scene built from real files
+  // the receptor almost always parses - so the stepper went missing exactly when
+  // there were several structures to step through.
   const sceneStructureCount = molstarSceneStructureCount(document);
-  if (!summary && sceneStructureCount > 1 && sceneStructureCount <= INFO_TRAJECTORY_CONTROL_LIMIT) {
+  if (sceneStructureCount > 1 && sceneStructureCount <= INFO_TRAJECTORY_CONTROL_LIMIT) {
     return {
       kind: "frames",
       title: "Structures",
@@ -1960,39 +1970,42 @@ function InspectorEngineCard({
   children: ReactNode;
 }) {
   return (
-    <section className={`structure-brief-card ${className}`} data-collapsed={!open || undefined}>
+    <Collapsible
+      open={open}
+      onOpenChange={onToggle}
+      className={`structure-brief-card ${className}`}
+      data-collapsed={!open || undefined}
+    >
       <div className="structure-inspector-section-header">
-        <button type="button" className="structure-inspector-section-title-button" aria-expanded={open} onClick={onToggle}>
+        <CollapsibleTrigger className="structure-inspector-section-title-button">
           {title}
           <ShortcutTooltip label={tooltip} />
-        </button>
+        </CollapsibleTrigger>
         <span>{status}</span>
       </div>
-      {open ? (
-        <>
-          <div
-            className="structure-inspector-xtb-summary"
-            data-modified={summaryModified || undefined}
-            data-xtb-tooltip={summaryTooltip}
-          >
-            <span>{summary}</span>
-            {onReset ? (
-              <button type="button" className="structure-inspector-inline-action" onClick={onReset}>
-                Reset
-                <ShortcutTooltip label="Restore the default settings." />
-              </button>
-            ) : null}
-          </div>
-          {scope ? (
-            <div className="structure-brief-notes">
-              <span>{scope}</span>
-            </div>
+      <CollapsibleContent className="structure-inspector-engine-body">
+        <div
+          className="structure-inspector-xtb-summary"
+          data-modified={summaryModified || undefined}
+          data-xtb-tooltip={summaryTooltip}
+        >
+          <span>{summary}</span>
+          {onReset ? (
+            <button type="button" className="structure-inspector-inline-action" onClick={onReset}>
+              Reset
+              <ShortcutTooltip label="Restore the default settings." />
+            </button>
           ) : null}
-          {notice}
-          {children}
-        </>
-      ) : null}
-    </section>
+        </div>
+        {scope ? (
+          <div className="structure-brief-notes">
+            <span>{scope}</span>
+          </div>
+        ) : null}
+        {notice}
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -2009,22 +2022,24 @@ function EngineToolNotice({ tools, onCheck }: { tools: EngineTool[]; onCheck: ()
   const missing = tools.filter((tool) => !tool.installed);
   if (missing.length === 0) return null;
   return (
-    <div className="structure-inspector-engine-notice">
+    <div className="structure-inspector-engine-notices">
       {missing.map((tool) => (
-        <div key={tool.name} className="structure-inspector-engine-notice-row">
+        <Alert key={tool.name} className="structure-inspector-engine-notice">
           {/* Every hint the backend writes already names its own tool, so repeating
               the name here would only read as a stutter. */}
-          <span>{tool.hint || `${tool.name} is not installed.`}</span>
+          <AlertDescription>{tool.hint || `${tool.name} is not installed.`}</AlertDescription>
           {tool.install ? (
-            <button type="button" className="structure-inspector-inline-action" onClick={tool.install}>
-              Install {tool.name}
-            </button>
+            <AlertAction>
+              <Button type="button" variant="outline" size="xs" onClick={tool.install}>
+                Install
+              </Button>
+            </AlertAction>
           ) : null}
-        </div>
+        </Alert>
       ))}
-      <button type="button" className="structure-inspector-inline-action structure-inspector-engine-notice-check" onClick={onCheck}>
+      <Button type="button" variant="ghost" size="xs" className="justify-self-start" onClick={onCheck}>
         Check again
-      </button>
+      </Button>
     </div>
   );
 }
@@ -3049,19 +3064,22 @@ function InlineSegmentedControl({
   onChange: (value: string) => void;
 }) {
   return (
-    <div className="structure-inspector-segment" role="group" aria-label={ariaLabel}>
+    <ToggleGroup
+      type="single"
+      value={value}
+      aria-label={ariaLabel}
+      size="sm"
+      spacing={0}
+      className="structure-inspector-segment"
+      // A radio group is never empty: clicking the active item must not clear it.
+      onValueChange={(next) => { if (next) onChange(next); }}
+    >
       {options.map((option) => (
-        <button
-          key={option}
-          type="button"
-          className="structure-inspector-segment-button"
-          aria-pressed={option === value}
-          onClick={() => onChange(option)}
-        >
+        <ToggleGroupItem key={option} value={option} className="structure-inspector-segment-button">
           {labels[option] ?? option}
-        </button>
+        </ToggleGroupItem>
       ))}
-    </div>
+    </ToggleGroup>
   );
 }
 
@@ -3265,13 +3283,12 @@ type CompositionGroup = {
 // members behind it, and the panel used to render those as separate cards. They
 // are one hierarchy, so they are shown as one.
 function compositionGroups(summary: StructureCompositionSummary): CompositionGroup[] {
-  const ionRows = summary.solventRows.filter((row) => row.label !== "Water" && row.label !== "Ions");
   const groups = visibleComponentRows(summary.componentRows).map((row) => ({
     key: `component:${row.label}`,
     row,
     children: row.label === "Polymers" ? summary.polymerRows
       : row.label === "Ligands" ? summary.ligandRows
-      : row.label === "Ions" ? ionRows
+      : row.label === "Ions" ? summary.solventRows
       : [],
   }));
   const maestroRows = summary.maestroRows ?? [];

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -1189,21 +1189,26 @@ function ConformerInlineSettings({
       </div>
       <div className="structure-inspector-settings-status">{conformerStatusSummary(status)}</div>
       {showCrest ? (
-        <div className="structure-inspector-settings-category">
-          <h5>CREST</h5>
+        <InlineSettingsSection title="CREST">
           <InlineXtbSetting label="Method">
-            <SelectControl value={settings.method} options={["gfn2", "gfn1", "gfn0", "gfnff"]} onChange={(value) => updateSettings({ method: value as ConformerSettings["method"] })} />
+            <InlineSegmentedControl
+              value={settings.method}
+              options={["gfn2", "gfn1", "gfn0", "gfnff"]}
+              labels={XTB_METHOD_LABELS}
+              ariaLabel="CREST method"
+              onChange={(value) => updateSettings({ method: value as ConformerSettings["method"] })}
+            />
           </InlineXtbSetting>
           <InlineXtbSetting label="Sampling">
-            <SelectControl value={settings.samplingMode} options={["auto", "normal", "quick", "squick", "mquick"]} onChange={(value) => updateSettings({ samplingMode: value as ConformerSettings["samplingMode"] })} />
+            <SelectControl value={settings.samplingMode} options={["auto", "normal", "quick", "squick", "mquick"]} labels={CONFORMER_SAMPLING_LABELS} onChange={(value) => updateSettings({ samplingMode: value as ConformerSettings["samplingMode"] })} />
           </InlineXtbSetting>
           <InlineXtbSetting label="Solvent">
-            <SelectControl value={settings.solvent} options={["none", "water", "methanol", "acetonitrile", "dmso", "chloroform"]} onChange={(value) => updateSettings({ solvent: value as ConformerSettings["solvent"] })} />
+            <SelectControl value={settings.solvent} options={["none", "water", "methanol", "acetonitrile", "dmso", "chloroform"]} labels={CONFORMER_SOLVENT_LABELS} onChange={(value) => updateSettings({ solvent: value as ConformerSettings["solvent"] })} />
           </InlineXtbSetting>
           <InlineXtbSetting label="Charge">
             <RangeControl value={settings.charge} min={-8} max={8} step={1} onChange={(value) => updateSettings({ charge: value })} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="UHF">
+          <InlineXtbSetting label="Unpaired electrons">
             <RangeControl value={settings.uhf} min={0} max={12} step={1} onChange={(value) => updateSettings({ uhf: value })} />
           </InlineXtbSetting>
           <InlineXtbSetting label="Threads">
@@ -1212,21 +1217,20 @@ function ConformerInlineSettings({
           <InlineXtbSetting label="Energy window">
             <NumberXtbControl value={settings.energyWindowKcalMol} min={1} max={60} step={0.5} suffix="kcal/mol" onChange={(value) => updateSettings({ energyWindowKcalMol: value })} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="RMSD">
-            <NumberXtbControl value={settings.rmsdThresholdAngstrom} min={0.01} max={2} step={0.005} suffix="A" onChange={(value) => updateSettings({ rmsdThresholdAngstrom: value })} />
+          <InlineXtbSetting label="RMSD threshold">
+            <NumberXtbControl value={settings.rmsdThresholdAngstrom} min={0.01} max={2} step={0.005} suffix="Å" onChange={(value) => updateSettings({ rmsdThresholdAngstrom: value })} />
           </InlineXtbSetting>
-        </div>
+        </InlineSettingsSection>
       ) : null}
       {showPrism ? (
-        <div className="structure-inspector-settings-category">
-          <h5>PRISM</h5>
+        <InlineSettingsSection title="PRISM">
           <InlineXtbSetting label="Timeout">
-            <RangeControl value={settings.prismTimeoutSeconds} min={5} max={86400} step={5} onChange={(value) => updateSettings({ prismTimeoutSeconds: value })} />
+            <RangeControl value={settings.prismTimeoutSeconds} min={5} max={86400} step={5} suffix="s" onChange={(value) => updateSettings({ prismTimeoutSeconds: value })} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="Energy sort">
+          <InlineXtbSetting label="Sort by energy">
             <ToggleControl label="Sort by energy" checked={settings.prismEnergySort} onChange={(value) => updateSettings({ prismEnergySort: value })} />
           </InlineXtbSetting>
-        </div>
+        </InlineSettingsSection>
       ) : null}
     </div>
   );
@@ -2039,19 +2043,31 @@ function XtbInlineSettings({
       </div>
       {showCategories ? <XtbSettingsCategoryBar category={category} setCategory={setCategory} /> : null}
       {showCore ? (
-        <>
+        <XtbSettingsGroup title="Calculation" labelled={!showCategories}>
           <InlineXtbSetting label="Method" tooltip={XTB_SETTING_TOOLTIPS.method} reset={() => update("method", defaultXtbSettings.method)} modified={settings.method !== defaultXtbSettings.method}>
-            <SelectControl value={settings.method} options={["gfn2", "gfn1", "gfn0", "gfnff"]} onChange={(method) => update("method", method as XtbSettings["method"])} />
+            <InlineSegmentedControl
+              value={settings.method}
+              options={["gfn2", "gfn1", "gfn0", "gfnff"]}
+              labels={XTB_METHOD_LABELS}
+              ariaLabel="xTB method"
+              onChange={(method) => update("method", method as XtbSettings["method"])}
+            />
           </InlineXtbSetting>
           {showOptLevel ? (
-            <InlineXtbSetting label="Opt level" tooltip={XTB_SETTING_TOOLTIPS.optLevel} reset={() => update("optLevel", defaultXtbSettings.optLevel)} modified={settings.optLevel !== defaultXtbSettings.optLevel}>
-              <SelectControl value={settings.optLevel} options={["loose", "normal", "tight", "verytight"]} onChange={(optLevel) => update("optLevel", optLevel as XtbSettings["optLevel"])} />
+            <InlineXtbSetting label="Convergence" tooltip={XTB_SETTING_TOOLTIPS.optLevel} reset={() => update("optLevel", defaultXtbSettings.optLevel)} modified={settings.optLevel !== defaultXtbSettings.optLevel}>
+              <InlineSegmentedControl
+                value={settings.optLevel}
+                options={["loose", "normal", "tight", "verytight"]}
+                labels={XTB_OPT_LEVEL_LABELS}
+                ariaLabel="Optimization convergence"
+                onChange={(optLevel) => update("optLevel", optLevel as XtbSettings["optLevel"])}
+              />
             </InlineXtbSetting>
           ) : null}
           <InlineXtbSetting label="Charge" tooltip={XTB_SETTING_TOOLTIPS.charge} reset={() => update("charge", defaultXtbSettings.charge)} modified={settings.charge !== defaultXtbSettings.charge}>
             <RangeControl value={settings.charge} min={-5} max={5} step={1} onChange={(charge) => update("charge", charge)} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="UHF" tooltip={XTB_SETTING_TOOLTIPS.uhf} reset={() => update("uhf", defaultXtbSettings.uhf)} modified={settings.uhf !== defaultXtbSettings.uhf}>
+          <InlineXtbSetting label="Unpaired electrons" tooltip={XTB_SETTING_TOOLTIPS.uhf} reset={() => update("uhf", defaultXtbSettings.uhf)} modified={settings.uhf !== defaultXtbSettings.uhf}>
             <RangeControl value={settings.uhf} min={0} max={10} step={1} onChange={(uhf) => update("uhf", uhf)} />
           </InlineXtbSetting>
           <InlineXtbSetting label="Threads" tooltip={XTB_SETTING_TOOLTIPS.threads} reset={() => update("threads", defaultXtbSettings.threads)} modified={settings.threads !== defaultXtbSettings.threads}>
@@ -2060,22 +2076,29 @@ function XtbInlineSettings({
           <InlineXtbSetting label="Accuracy" tooltip={XTB_SETTING_TOOLTIPS.accuracy} reset={() => update("accuracy", defaultXtbSettings.accuracy)} modified={settings.accuracy !== defaultXtbSettings.accuracy}>
             <NumberXtbControl value={settings.accuracy} min={0.05} max={10} step={0.05} onChange={(accuracy) => update("accuracy", accuracy)} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="E-temp" tooltip={XTB_SETTING_TOOLTIPS.electronicTemperature} reset={() => update("electronicTemperature", defaultXtbSettings.electronicTemperature)} modified={settings.electronicTemperature !== defaultXtbSettings.electronicTemperature}>
-            <RangeControl value={settings.electronicTemperature} min={50} max={5000} step={50} onChange={(electronicTemperature) => update("electronicTemperature", electronicTemperature)} />
+          <InlineXtbSetting label="Electronic temp" tooltip={XTB_SETTING_TOOLTIPS.electronicTemperature} reset={() => update("electronicTemperature", defaultXtbSettings.electronicTemperature)} modified={settings.electronicTemperature !== defaultXtbSettings.electronicTemperature}>
+            <RangeControl value={settings.electronicTemperature} min={50} max={5000} step={50} suffix="K" onChange={(electronicTemperature) => update("electronicTemperature", electronicTemperature)} />
           </InlineXtbSetting>
-        </>
+        </XtbSettingsGroup>
       ) : null}
       {showSolvation ? (
-        <>
-          <InlineXtbSetting label="Solvation" tooltip={XTB_SETTING_TOOLTIPS.solvation} reset={() => update("solvationModel", defaultXtbSettings.solvationModel)} modified={settings.solvationModel !== defaultXtbSettings.solvationModel}>
-            <SelectControl value={settings.solvationModel} options={["none", "alpb", "gbsa", "cosmo", "cpcmx"]} onChange={(solvationModel) => update("solvationModel", solvationModel as XtbSettings["solvationModel"])} />
+        <XtbSettingsGroup title="Solvation" labelled={!showCategories}>
+          <InlineXtbSetting label="Model" tooltip={XTB_SETTING_TOOLTIPS.solvation} reset={() => update("solvationModel", defaultXtbSettings.solvationModel)} modified={settings.solvationModel !== defaultXtbSettings.solvationModel}>
+            <InlineSegmentedControl
+              value={settings.solvationModel}
+              options={["none", "alpb", "gbsa", "cosmo", "cpcmx"]}
+              labels={XTB_SOLVATION_LABELS}
+              ariaLabel="Solvation model"
+              onChange={(solvationModel) => update("solvationModel", solvationModel as XtbSettings["solvationModel"])}
+            />
           </InlineXtbSetting>
           <InlineXtbSetting label="Solvent" tooltip={XTB_SETTING_TOOLTIPS.solvent} reset={() => update("solvent", defaultXtbSettings.solvent)} modified={settings.solvent !== defaultXtbSettings.solvent}>
-            <SelectControl value={settings.solvent} options={XTB_SOLVENT_OPTIONS} onChange={(solvent) => update("solvent", solvent)} />
+            <SelectControl value={settings.solvent} options={XTB_SOLVENT_OPTIONS} labels={XTB_SOLVENT_LABELS} onChange={(solvent) => update("solvent", solvent)} />
           </InlineXtbSetting>
-        </>
+        </XtbSettingsGroup>
       ) : null}
       {showProperties ? (
+        <XtbSettingsGroup title="Properties" labelled={!showCategories}>
         <div className="structure-inspector-xtb-toggle-grid" aria-label="xTB property outputs" data-xtb-tooltip={XTB_SETTING_TOOLTIPS.properties}>
           <XtbToggle label="Dipole" tooltip={XTB_PROPERTY_TOOLTIPS.dipole} checked={settings.properties.dipole} onChange={(value) => updateProperty("dipole", value)} />
           <XtbToggle label="WBO" tooltip={XTB_PROPERTY_TOOLTIPS.wbo} checked={settings.properties.wbo} onChange={(value) => updateProperty("wbo", value)} />
@@ -2086,35 +2109,44 @@ function XtbInlineSettings({
           <XtbToggle label="ESP" tooltip={XTB_PROPERTY_TOOLTIPS.esp} checked={settings.properties.esp} onChange={(value) => updateProperty("esp", value)} />
           <XtbToggle label="Fukui" tooltip={XTB_PROPERTY_TOOLTIPS.fukui} checked={settings.properties.fukui} onChange={(value) => updateProperty("fukui", value)} />
         </div>
+        </XtbSettingsGroup>
       ) : null}
       {showMd ? (
-        <>
-          <InlineXtbSetting label="MD temp" tooltip={XTB_SETTING_TOOLTIPS.mdTemperature} reset={() => update("mdTemperature", defaultXtbSettings.mdTemperature)} modified={settings.mdTemperature !== defaultXtbSettings.mdTemperature}>
-            <RangeControl value={settings.mdTemperature} min={50} max={2000} step={10} onChange={(mdTemperature) => update("mdTemperature", mdTemperature)} />
+        <XtbSettingsGroup title="Dynamics" labelled={!showCategories}>
+          <InlineXtbSetting label="Temperature" tooltip={XTB_SETTING_TOOLTIPS.mdTemperature} reset={() => update("mdTemperature", defaultXtbSettings.mdTemperature)} modified={settings.mdTemperature !== defaultXtbSettings.mdTemperature}>
+            <RangeControl value={settings.mdTemperature} min={50} max={2000} step={10} suffix="K" onChange={(mdTemperature) => update("mdTemperature", mdTemperature)} />
           </InlineXtbSetting>
-          <InlineXtbSetting label="MD time" tooltip={XTB_SETTING_TOOLTIPS.mdTime} reset={() => update("mdTimePs", defaultXtbSettings.mdTimePs)} modified={settings.mdTimePs !== defaultXtbSettings.mdTimePs}>
+          <InlineXtbSetting label="Duration" tooltip={XTB_SETTING_TOOLTIPS.mdTime} reset={() => update("mdTimePs", defaultXtbSettings.mdTimePs)} modified={settings.mdTimePs !== defaultXtbSettings.mdTimePs}>
             <NumberXtbControl value={settings.mdTimePs} min={0.05} max={100} step={0.05} onChange={(mdTimePs) => update("mdTimePs", mdTimePs)} suffix="ps" />
           </InlineXtbSetting>
-          <InlineXtbSetting label="MD step" tooltip={XTB_SETTING_TOOLTIPS.mdStep} reset={() => update("mdStepFs", defaultXtbSettings.mdStepFs)} modified={settings.mdStepFs !== defaultXtbSettings.mdStepFs}>
+          <InlineXtbSetting label="Time step" tooltip={XTB_SETTING_TOOLTIPS.mdStep} reset={() => update("mdStepFs", defaultXtbSettings.mdStepFs)} modified={settings.mdStepFs !== defaultXtbSettings.mdStepFs}>
             <NumberXtbControl value={settings.mdStepFs} min={0.1} max={10} step={0.1} onChange={(mdStepFs) => update("mdStepFs", mdStepFs)} suffix="fs" />
           </InlineXtbSetting>
           <InlineXtbSetting label="Snapshots" tooltip={XTB_SETTING_TOOLTIPS.mdSnapshots} reset={() => update("mdSnapshots", defaultXtbSettings.mdSnapshots)} modified={settings.mdSnapshots !== defaultXtbSettings.mdSnapshots}>
             <RangeControl value={settings.mdSnapshots} min={1} max={1000} step={1} onChange={(mdSnapshots) => update("mdSnapshots", mdSnapshots)} />
           </InlineXtbSetting>
-        </>
+        </XtbSettingsGroup>
       ) : null}
       {showOutput ? (
-        <>
-          <InlineXtbSetting label="Save files" tooltip={XTB_SETTING_TOOLTIPS.saveRunFiles} reset={() => update("saveRunFiles", defaultXtbSettings.saveRunFiles)} modified={settings.saveRunFiles !== defaultXtbSettings.saveRunFiles}>
+        <XtbSettingsGroup title="Output" labelled={!showCategories}>
+          <InlineXtbSetting label="Keep run files" tooltip={XTB_SETTING_TOOLTIPS.saveRunFiles} reset={() => update("saveRunFiles", defaultXtbSettings.saveRunFiles)} modified={settings.saveRunFiles !== defaultXtbSettings.saveRunFiles}>
             <ToggleControl label="Save xTB run files" checked={settings.saveRunFiles} onChange={(saveRunFiles) => update("saveRunFiles", saveRunFiles)} />
           </InlineXtbSetting>
           <InlineXtbSetting label="Timeout" tooltip={XTB_SETTING_TOOLTIPS.timeout} reset={() => update("timeoutSeconds", defaultXtbSettings.timeoutSeconds)} modified={settings.timeoutSeconds !== defaultXtbSettings.timeoutSeconds}>
-            <RangeControl value={settings.timeoutSeconds} min={30} max={1200} step={30} onChange={(timeoutSeconds) => update("timeoutSeconds", timeoutSeconds)} />
+            <RangeControl value={settings.timeoutSeconds} min={30} max={1200} step={30} suffix="s" onChange={(timeoutSeconds) => update("timeoutSeconds", timeoutSeconds)} />
           </InlineXtbSetting>
-        </>
+        </XtbSettingsGroup>
       ) : null}
     </div>
   );
+}
+
+// In category mode the bar above already says which group you are in, so the
+// heading would only repeat it. Scoped mode stacks several groups at once and
+// needs them.
+function XtbSettingsGroup({ title, labelled, children }: { title: string; labelled: boolean; children: ReactNode }) {
+  if (!labelled) return <>{children}</>;
+  return <InlineSettingsSection title={title}>{children}</InlineSettingsSection>;
 }
 
 const XTB_SOLVENT_OPTIONS = [
@@ -2142,6 +2174,23 @@ const XTB_SOLVENT_OPTIONS = [
   "toluene",
   "thf",
 ];
+
+// Only the tokens whose spelling is not already the chemical name.
+const XTB_SOLVENT_LABELS: Record<string, string> = {
+  none: "Gas phase",
+  ch2cl2: "Dichloromethane",
+  chcl3: "Chloroform",
+  cs2: "Carbon disulfide",
+  dmf: "DMF",
+  dmso: "DMSO",
+  ether: "Diethyl ether",
+  ethylacetate: "Ethyl acetate",
+  furane: "Furan",
+  nitromethane: "Nitromethane",
+  thf: "THF",
+  ...Object.fromEntries(["water", "acetone", "acetonitrile", "aniline", "benzaldehyde", "benzene", "dioxane", "hexane", "methanol", "octanol", "phenol", "toluene"]
+    .map((solvent) => [solvent, solvent.charAt(0).toUpperCase() + solvent.slice(1)])),
+};
 
 function XtbToggle({ label, tooltip, checked, onChange }: { label: string; tooltip: string; checked: boolean; onChange: (checked: boolean) => void }) {
   return (
@@ -2924,6 +2973,65 @@ function formatMaybeNumber(value: unknown, suffix: string) {
 function formatDipole(value: unknown) {
   const rows = numericArray(value);
   return rows.length >= 3 ? rows.slice(0, 3).map((number) => number.toFixed(3)).join(", ") : "n/a";
+}
+
+// Engine tokens are what the executable wants; these are what a reader wants.
+const XTB_METHOD_LABELS: Record<string, string> = {
+  gfn2: "GFN2", gfn1: "GFN1", gfn0: "GFN0", gfnff: "GFN-FF",
+};
+const XTB_OPT_LEVEL_LABELS: Record<string, string> = {
+  loose: "Loose", normal: "Normal", tight: "Tight", verytight: "Very tight",
+};
+const XTB_SOLVATION_LABELS: Record<string, string> = {
+  none: "None", alpb: "ALPB", gbsa: "GBSA", cosmo: "COSMO", cpcmx: "CPCM-X",
+};
+const CONFORMER_SAMPLING_LABELS: Record<string, string> = {
+  auto: "Auto", normal: "Normal", quick: "Quick", squick: "Super quick", mquick: "Micro quick",
+};
+const CONFORMER_SOLVENT_LABELS: Record<string, string> = {
+  none: "Gas phase", water: "Water", methanol: "Methanol",
+  acetonitrile: "Acetonitrile", dmso: "DMSO", chloroform: "Chloroform",
+};
+
+// Small mutually exclusive sets read far better as one switch than as a dropdown
+// you have to open to see the alternatives - the same trade the viewport menus make.
+function InlineSegmentedControl({
+  value,
+  options,
+  labels,
+  ariaLabel,
+  onChange,
+}: {
+  value: string;
+  options: readonly string[];
+  labels: Record<string, string>;
+  ariaLabel: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="structure-inspector-segment" role="group" aria-label={ariaLabel}>
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          className="structure-inspector-segment-button"
+          aria-pressed={option === value}
+          onClick={() => onChange(option)}
+        >
+          {labels[option] ?? option}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function InlineSettingsSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="structure-inspector-settings-group">
+      <h5 className="structure-inspector-settings-group-title">{title}</h5>
+      {children}
+    </div>
+  );
 }
 
 function InlineXtbSetting({

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -200,6 +200,7 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
   const trajectoryDocument = isTrajectorySmoothingDocument(document, poseControls);
   const contextStyleCard = structureContextStyleCardFor(document, compositionSummary, structureOverlayMode);
   const latestXtbJob = latestXtbJobForDocument(document, xtbJobs);
+  const runningXtbJob = latestXtbJob?.status === "running" ? latestXtbJob : null;
   const structureXtbArtifact = xtbArtifactInfoForPath(document.path, document.extension);
   const clearSelection = () => {
     actions.runStructureViewerAction(document, { type: "clear_selection", label: "Clear selection" });
@@ -339,7 +340,7 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           className="structure-inspector-xtb-card"
           title="xTB"
           tooltip="Semiempirical quantum calculations for the current molecular scope."
-          status={xtbStatusLine(xtbStatus, isBrowserDev)}
+          status={runningXtbJob ? `Running ${operationTitle(runningXtbJob.operation).toLowerCase()}` : xtbStatusLine(xtbStatus, isBrowserDev)}
           open={xtbOpen}
           onToggle={() => setXtbOpen((open) => !open)}
           summary={xtbSettingsSummary(xtbSettings)}
@@ -348,7 +349,15 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           onReset={xtbSettingsModified(xtbSettings) ? () => actions.setXtbSettings(defaultXtbSettings) : undefined}
           // xTB takes the viewer's selection as its scope the same way CREST does,
           // and that changes what the run costs - worth saying out loud.
-          scope={jobScopedToSelection ? "Scope: selected object" : undefined}
+          scope={runningXtbJob ? (
+            <>
+              {runningXtbJob.inputLabel} is running.
+              {" "}
+              <button type="button" className="structure-inspector-inline-action" onClick={() => void actions.cancelXtbJob(runningXtbJob.id)}>
+                Cancel
+              </button>
+            </>
+          ) : jobScopedToSelection ? "Scope: selected object" : undefined}
           notice={(
             <EngineToolNotice
               tools={[...oversizedNotice, {
@@ -1939,7 +1948,7 @@ function InspectorEngineCard({
   className: string;
   title: string;
   tooltip: string;
-  status: string;
+  status: ReactNode;
   open: boolean;
   onToggle: () => void;
   summary: string;
@@ -1947,7 +1956,7 @@ function InspectorEngineCard({
   summaryModified?: boolean;
   onReset?: () => void;
   notice?: ReactNode;
-  scope?: string;
+  scope?: ReactNode;
   children: ReactNode;
 }) {
   return (
@@ -2598,14 +2607,17 @@ const XTB_PATTERN_ARTIFACTS: Record<string, Omit<XtbTextArtifactInfo, "runName">
 };
 
 function latestXtbJobForDocument(document: ViewerDocument, jobs: ShellViewState["xtbJobs"]) {
+  const documentPaths = [document.path, document.sourcePath].filter((path): path is string => Boolean(path));
   return jobs.find((job) => {
+    // The label is set when the job is queued; everything else only exists once
+    // it finishes. Testing it behind `result &&` meant a running job could never
+    // match its own document, so the panel stayed silent until the run ended.
+    if (job.inputLabel === document.title) return true;
     const result = job.result;
-    const documentPaths = [document.path, document.sourcePath].filter((path): path is string => Boolean(path));
-    return result && (
-      documentPaths.includes(result.primaryOpenPath ?? "")
-      || job.inputLabel === document.title
-      || result.command.some((part) => documentPaths.includes(part))
-      || result.artifacts.some((artifact) => documentPaths.includes(artifact.path))
+    return Boolean(result) && (
+      documentPaths.includes(result!.primaryOpenPath ?? "")
+      || result!.command.some((part) => documentPaths.includes(part))
+      || result!.artifacts.some((artifact) => documentPaths.includes(artifact.path))
     );
   }) ?? null;
 }
@@ -2624,21 +2636,14 @@ function XtbResultsPanel({ document, job, actions }: { document: ViewerDocument;
   const runName = xtbRunNameForPath(result.workDir) ?? fileName(result.workDir);
   const commandSummary = xtbCommandSummary(result.command);
   const openedInMs = Number.isFinite(result.elapsedMs) ? `${Math.max(0.1, result.elapsedMs / 1000).toFixed(1)} s` : "n/a";
-  const colorChargesInMolstar = () => {
+  // Both renderers took the same action with the same payload; only the button
+  // label differed.
+  const colorCharges = () => {
     actions.runStructureViewerAction(document, {
       type: "color_xtb_charges",
       label: "Color xTB charges",
       charges: allCharges,
       chargeFilePath: chargesArtifact?.path,
-    });
-  };
-  const colorChargesInXyzrender = () => {
-    if (!chargesArtifact) return;
-    actions.runStructureViewerAction(document, {
-      type: "color_xtb_charges",
-      label: "Color xTB charges",
-      charges: allCharges,
-      chargeFilePath: chargesArtifact.path,
     });
   };
   const colorFukuiInMolstar = (mode: "fplus" | "fminus" | "fzero") => {
@@ -2684,11 +2689,11 @@ function XtbResultsPanel({ document, job, actions }: { document: ViewerDocument;
           columns={["Atom", "Charge"]}
           rows={charges.map((charge, index) => [`#${index + 1}`, charge.toFixed(4)])}
           action={document.renderer === "molstar" ? (
-            <button type="button" className="structure-inspector-xtb-table-action" onClick={colorChargesInMolstar}>
+            <button type="button" className="structure-inspector-xtb-table-action" onClick={colorCharges}>
               Color in Mol*
             </button>
           ) : document.renderer === "xyzrender-external" && chargesArtifact ? (
-            <button type="button" className="structure-inspector-xtb-table-action" onClick={colorChargesInXyzrender}>
+            <button type="button" className="structure-inspector-xtb-table-action" onClick={colorCharges}>
               Color in xyzr
             </button>
           ) : null}
@@ -2853,6 +2858,15 @@ function xtbArtifactButtonTitle(artifact: XtbArtifact) {
   return info ? `${info.title}: ${info.summary}` : artifact.path;
 }
 
+// Keyed by the exact flags xtb_solvation_flag emits in the backend. The previous
+// list guessed "--cpcm", so a CPCM-X run was reported back as gas phase.
+const XTB_SOLVATION_FLAG_LABELS: Record<string, string> = {
+  "--alpb": "ALPB",
+  "--gbsa": "GBSA",
+  "--cosmo": "COSMO",
+  "--cpcmx": "CPCM-X",
+};
+
 function operationTitle(operation: XtbRunResult["operation"]) {
   switch (operation) {
     case "optimize":
@@ -2883,9 +2897,11 @@ function xtbCommandSummary(command: string[]) {
   const charge = chargeIndex >= 0 ? `charge ${command[chargeIndex + 1] ?? "0"}` : null;
   const uhfIndex = command.indexOf("--uhf");
   const uhf = uhfIndex >= 0 ? `UHF ${command[uhfIndex + 1] ?? "0"}` : null;
-  const solventFlag = command.find((part) => ["--alpb", "--gbsa", "--cosmo", "--cpcm"].includes(part.toLowerCase()));
+  const solventFlag = command.find((part) => XTB_SOLVATION_FLAG_LABELS[part.toLowerCase()]);
   const solventIndex = solventFlag ? command.indexOf(solventFlag) : -1;
-  const solvent = solventFlag ? `${solventFlag.replace("--", "").toUpperCase()} ${command[solventIndex + 1] ?? ""}`.trim() : "gas phase";
+  const solvent = solventFlag
+    ? `${XTB_SOLVATION_FLAG_LABELS[solventFlag.toLowerCase()]} ${command[solventIndex + 1] ?? ""}`.trim()
+    : "gas phase";
   return [method, opt, charge, uhf, solvent].filter(Boolean).join(" · ") || truncateInline(joined, 80);
 }
 

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -136,6 +136,14 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
     setTrajectoryPlayback(null);
   }, [document?.id]);
 
+  // Closing the molecule card clears the selection inside the viewer, so a row
+  // highlighted from a ligand click here has to let go of it too - otherwise the
+  // panel keeps claiming a scope the viewer no longer has.
+  useEffect(() => {
+    if (viewerLigandSelection) return;
+    setActiveActionKey((current) => current && current.includes("focus_ligand") ? null : current);
+  }, [viewerLigandSelection]);
+
   useEffect(() => {
     const handle = (event: Event) => {
       const detail = (event as CustomEvent<Record<string, unknown>>).detail;

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -10,6 +10,7 @@ import type { ShellActions, ShellViewState, StructureOverlayMode, StructureViewe
 import { structureBriefForDocument, type StructureBriefRow as BriefRow } from "../lib/structure-brief";
 import { parseStructureComposition, type StructureCompositionSummary, type StructureSummaryRow, type StructureViewerSelector } from "../lib/structure-composition";
 import { canInspectConformerEnsemble, canShowConformerWorkflow, canUseConformerWorkflow } from "../lib/conformer-ensemble";
+import { DIRECT_CHEMISTRY_JOB_ATOM_LIMIT, structureAtomCountFromSummary } from "../lib/direct-chemistry-guard";
 import { extensionForDocking } from "../lib/docking-documents";
 import { readBrowserDevVirtualTextDocument } from "../lib/browser-dev-documents";
 import { readStructureText } from "../lib/structure-text";
@@ -207,6 +208,20 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
   // Only a checked-and-missing binary disables the run buttons; an unchecked one
   // is not yet known to be missing.
   const xtbMissing = xtbStatus?.installed === false;
+  // A direct job on a whole protein is refused once it starts, with a message
+  // telling you to select something first. The atom count is already parsed, so
+  // the card can say that before the click instead of after it.
+  const structureAtoms = compositionSummary ? structureAtomCountFromSummary(compositionSummary) : null;
+  const jobScopedToSelection = Boolean(selectedEntity || viewerLigandSelection);
+  const oversizedForDirectJob = !jobScopedToSelection
+    && structureAtoms !== null
+    && structureAtoms > DIRECT_CHEMISTRY_JOB_ATOM_LIMIT;
+  const oversizedNotice: EngineTool[] = oversizedForDirectJob ? [{
+    name: "Scope",
+    installed: false,
+    hint: `This structure has ${structureAtoms.toLocaleString()} atoms. Select a ligand or chain first — direct runs are capped at ${DIRECT_CHEMISTRY_JOB_ATOM_LIMIT}.`,
+  }] : [];
+  const xtbBlocked = xtbMissing || oversizedForDirectJob;
   const openXtbSettingsFor = (scope: XtbSettingsScope) => {
     setXtbSettingsScope(scope);
     setXtbSettingsOpen(true);
@@ -316,6 +331,7 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           settings={conformerSettings}
           open={conformerOpen}
           setOpen={setConformerOpen}
+          oversizedNotice={oversizedNotice}
           actions={actions}
         />
 
@@ -330,9 +346,12 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           summaryTooltip="Hamiltonian, convergence, charge, spin, solvation, and parallelism for xTB calculations."
           summaryModified={xtbSettingsModified(xtbSettings)}
           onReset={xtbSettingsModified(xtbSettings) ? () => actions.setXtbSettings(defaultXtbSettings) : undefined}
+          // xTB takes the viewer's selection as its scope the same way CREST does,
+          // and that changes what the run costs - worth saying out loud.
+          scope={jobScopedToSelection ? "Scope: selected object" : undefined}
           notice={(
             <EngineToolNotice
-              tools={[{
+              tools={[...oversizedNotice, {
                 name: "xTB",
                 installed: xtbStatus?.installed !== false,
                 hint: xtbStatus?.installHint ?? "",
@@ -343,12 +362,12 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           )}
         >
           <div className="structure-brief-actions structure-brief-actions-grid">
-            <XtbActionButton label="Optimize" tooltip={XTB_ACTION_TOOLTIPS.optimize} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("optimize")} onContextMenu={showXtbSettingsFor("optimize")} />
-            <XtbActionButton label="Properties" tooltip={XTB_ACTION_TOOLTIPS.properties} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("properties")} onContextMenu={showXtbSettingsFor("properties")} />
-            <XtbActionButton label="Frequencies" tooltip={XTB_ACTION_TOOLTIPS["optimized-hessian"]} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("optimized-hessian")} onContextMenu={showXtbSettingsFor("optimized-hessian")} />
+            <XtbActionButton label="Optimize" tooltip={XTB_ACTION_TOOLTIPS.optimize} disabled={xtbBlocked} onClick={() => void actions.runXtbActiveOperation("optimize")} onContextMenu={showXtbSettingsFor("optimize")} />
+            <XtbActionButton label="Properties" tooltip={XTB_ACTION_TOOLTIPS.properties} disabled={xtbBlocked} onClick={() => void actions.runXtbActiveOperation("properties")} onContextMenu={showXtbSettingsFor("properties")} />
+            <XtbActionButton label="Frequencies" tooltip={XTB_ACTION_TOOLTIPS["optimized-hessian"]} disabled={xtbBlocked} onClick={() => void actions.runXtbActiveOperation("optimized-hessian")} onContextMenu={showXtbSettingsFor("optimized-hessian")} />
             {/* Four of the seven operations are specialist runs, and giving them the
                 same weight as Optimize made the card read as a wall of buttons. */}
-            <button type="button" className="dock-action" disabled={xtbMissing} onClick={showXtbMoreMenu}>
+            <button type="button" className="dock-action" disabled={xtbBlocked} onClick={showXtbMoreMenu}>
               More
               <ShortcutTooltip label="IP/EA, Fukui, molecular dynamics, and metadynamics runs." />
             </button>
@@ -1084,6 +1103,7 @@ function ConformerWorkflowCard({
   settings,
   open,
   setOpen,
+  oversizedNotice,
   actions,
 }: {
   document: ViewerDocument;
@@ -1093,6 +1113,7 @@ function ConformerWorkflowCard({
   settings: ShellViewState["conformerSettings"];
   open: boolean;
   setOpen: (updater: (open: boolean) => boolean) => void;
+  oversizedNotice: EngineTool[];
   actions: ShellActions;
 }) {
   const [settingsPanel, setSettingsPanel] = useState<"all" | "crest" | "prism" | null>(null);
@@ -1104,7 +1125,10 @@ function ConformerWorkflowCard({
   const canRunPrism = canInspectConformerEnsemble(document.extension);
   if (!canShowConformerWorkflow(document.extension, document.renderer) && !selectedConformerAction) return null;
   if (!canRunCrest && !canRunPrism) return null;
-  const crestDisabled = !canRunCrest || status?.crest.installed === false;
+  // CREST reads the whole structure the same way xTB does, so the atom cap
+  // applies to it too. PRISM only prunes an existing ensemble file.
+  const oversized = oversizedNotice.length > 0;
+  const crestDisabled = !canRunCrest || oversized || status?.crest.installed === false;
   const prismDisabled = !canRunPrism || status?.prism.installed === false;
   const showSettingsFor = (panel: "crest" | "prism") => (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -1123,7 +1147,7 @@ function ConformerWorkflowCard({
       scope={selectedConformerAction ? "Scope: selected object" : undefined}
       notice={(
         <EngineToolNotice
-          tools={conformerTools(status)}
+          tools={[...oversizedNotice, ...conformerTools(status)]}
           onCheck={() => void actions.checkConformerStatus()}
         />
       )}

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -204,9 +204,22 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
     actions.runStructureViewerAction(document, { type: "clear_selection", label: "Clear selection" });
     setActiveActionKey(null);
   };
+  // Only a checked-and-missing binary disables the run buttons; an unchecked one
+  // is not yet known to be missing.
+  const xtbMissing = xtbStatus?.installed === false;
   const openXtbSettingsFor = (scope: XtbSettingsScope) => {
     setXtbSettingsScope(scope);
     setXtbSettingsOpen(true);
+  };
+  const showXtbMoreMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    void showNativeContextMenu(XTB_MORE_OPERATIONS.map(([operation, text]) => ({
+      kind: "item" as const,
+      id: operation,
+      text,
+      detail: XTB_ACTION_TOOLTIPS[operation],
+      action: () => void actions.runXtbActiveOperation(operation),
+    })), { x: rect.left, y: rect.bottom + 6 }, { forceWeb: true });
   };
   const showXtbSettingsFor = (scope: XtbSettingsScope) => (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -306,69 +319,64 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           actions={actions}
         />
 
-        <section className="structure-brief-card structure-inspector-xtb-card" data-collapsed={!xtbOpen || undefined}>
-        <div className="structure-inspector-section-header">
-          <button
-            type="button"
-            className="structure-inspector-section-title-button"
-            aria-expanded={xtbOpen}
-            onClick={() => setXtbOpen((open) => !open)}
-          >
-            xTB
-            <ShortcutTooltip label="Semiempirical quantum calculations for the current molecular scope." />
-          </button>
-          <span>{xtbStatusLine(xtbStatus, isBrowserDev)}</span>
-        </div>
-        {xtbOpen ? (
-          <>
-            <div
-              className="structure-inspector-xtb-summary"
-              data-modified={xtbSettingsModified(xtbSettings) || undefined}
-              data-xtb-tooltip="Hamiltonian, convergence, charge, spin, solvation, and parallelism for xTB calculations."
+        <InspectorEngineCard
+          className="structure-inspector-xtb-card"
+          title="xTB"
+          tooltip="Semiempirical quantum calculations for the current molecular scope."
+          status={xtbStatusLine(xtbStatus, isBrowserDev)}
+          open={xtbOpen}
+          onToggle={() => setXtbOpen((open) => !open)}
+          summary={xtbSettingsSummary(xtbSettings)}
+          summaryTooltip="Hamiltonian, convergence, charge, spin, solvation, and parallelism for xTB calculations."
+          summaryModified={xtbSettingsModified(xtbSettings)}
+          onReset={xtbSettingsModified(xtbSettings) ? () => actions.setXtbSettings(defaultXtbSettings) : undefined}
+          notice={(
+            <EngineToolNotice
+              tools={[{
+                name: "xTB",
+                installed: xtbStatus?.installed !== false,
+                hint: xtbStatus?.installHint ?? "",
+                install: () => void actions.installXtb(),
+              }]}
+              onCheck={() => void actions.checkXtbStatus()}
+            />
+          )}
+        >
+          <div className="structure-brief-actions structure-brief-actions-grid">
+            <XtbActionButton label="Optimize" tooltip={XTB_ACTION_TOOLTIPS.optimize} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("optimize")} onContextMenu={showXtbSettingsFor("optimize")} />
+            <XtbActionButton label="Properties" tooltip={XTB_ACTION_TOOLTIPS.properties} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("properties")} onContextMenu={showXtbSettingsFor("properties")} />
+            <XtbActionButton label="Frequencies" tooltip={XTB_ACTION_TOOLTIPS["optimized-hessian"]} disabled={xtbMissing} onClick={() => void actions.runXtbActiveOperation("optimized-hessian")} onContextMenu={showXtbSettingsFor("optimized-hessian")} />
+            {/* Four of the seven operations are specialist runs, and giving them the
+                same weight as Optimize made the card read as a wall of buttons. */}
+            <button type="button" className="dock-action" disabled={xtbMissing} onClick={showXtbMoreMenu}>
+              More
+              <ShortcutTooltip label="IP/EA, Fukui, molecular dynamics, and metadynamics runs." />
+            </button>
+            <button
+              type="button"
+              className="dock-action"
+              aria-expanded={xtbSettingsOpen}
+              onClick={toggleGeneralXtbSettings}
             >
-              <span>{xtbSettingsSummary(xtbSettings)}</span>
-              {xtbSettingsModified(xtbSettings) ? (
-                <button type="button" className="structure-inspector-inline-action" onClick={() => actions.setXtbSettings(defaultXtbSettings)}>
-                  Reset
-                <ShortcutTooltip label="Restore the default GFN2 gas-phase calculation settings." />
-                </button>
-              ) : null}
-            </div>
-            <div className="structure-brief-actions structure-brief-actions-grid">
-              <XtbActionButton label="Optimize" tooltip={XTB_ACTION_TOOLTIPS.optimize} onClick={() => void actions.runXtbActiveOperation("optimize")} onContextMenu={showXtbSettingsFor("optimize")} />
-              <XtbActionButton label="Properties" tooltip={XTB_ACTION_TOOLTIPS.properties} onClick={() => void actions.runXtbActiveOperation("properties")} onContextMenu={showXtbSettingsFor("properties")} />
-              <XtbActionButton label="Frequencies" tooltip={XTB_ACTION_TOOLTIPS["optimized-hessian"]} onClick={() => void actions.runXtbActiveOperation("optimized-hessian")} onContextMenu={showXtbSettingsFor("optimized-hessian")} />
-              <XtbActionButton label="IP/EA" tooltip={XTB_ACTION_TOOLTIPS.vipea} onClick={() => void actions.runXtbActiveOperation("vipea")} onContextMenu={showXtbSettingsFor("vipea")} />
-              <XtbActionButton label="Fukui" tooltip={XTB_ACTION_TOOLTIPS.vfukui} onClick={() => void actions.runXtbActiveOperation("vfukui")} onContextMenu={showXtbSettingsFor("vfukui")} />
-              <XtbActionButton label="MD" tooltip={XTB_ACTION_TOOLTIPS.md} onClick={() => void actions.runXtbActiveOperation("md")} onContextMenu={showXtbSettingsFor("md")} />
-              <XtbActionButton label="Metadyn" tooltip={XTB_ACTION_TOOLTIPS.metadyn} onClick={() => void actions.runXtbActiveOperation("metadyn")} onContextMenu={showXtbSettingsFor("metadyn")} />
-              <button
-                type="button"
-                className="dock-action"
-                aria-expanded={xtbSettingsOpen}
-                onClick={toggleGeneralXtbSettings}
-              >
-                Settings
-                <ShortcutTooltip label="Hamiltonian, charge, spin, solvation, accuracy, property, and dynamics parameters." />
-              </button>
-              <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
-                Jobs
-                <ShortcutTooltip label="xTB calculation history, energies, properties, trajectories, and output artifacts." />
-              </button>
-            </div>
-            {xtbSettingsOpen ? (
-              <XtbInlineSettings
-                settings={xtbSettings}
-                scope={xtbSettingsScope}
-                xtbStatus={xtbStatus}
-                isBrowserDev={isBrowserDev}
-                actions={actions}
-                onClose={() => setXtbSettingsOpen(false)}
-              />
-            ) : null}
-          </>
-        ) : null}
-        </section>
+              Settings
+              <ShortcutTooltip label="Hamiltonian, charge, spin, solvation, accuracy, property, and dynamics parameters." />
+            </button>
+            <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
+              Jobs
+              <ShortcutTooltip label="xTB calculation history, energies, properties, trajectories, and output artifacts." />
+            </button>
+          </div>
+          {xtbSettingsOpen ? (
+            <XtbInlineSettings
+              settings={xtbSettings}
+              scope={xtbSettingsScope}
+              xtbStatus={xtbStatus}
+              isBrowserDev={isBrowserDev}
+              actions={actions}
+              onClose={() => setXtbSettingsOpen(false)}
+            />
+          ) : null}
+        </InspectorEngineCard>
 
         {latestXtbJob?.result ? (
           <XtbResultsPanel document={document} job={latestXtbJob} actions={actions} />
@@ -1104,47 +1112,57 @@ function ConformerWorkflowCard({
     setSettingsPanel((current) => current === panel ? null : panel);
   };
   return (
-    <section className="structure-brief-card conformer-inspector-card" data-collapsed={!open || undefined}>
-      <div className="structure-inspector-section-header">
-        <button type="button" className="structure-inspector-section-title-button" aria-expanded={open} onClick={() => setOpen((current) => !current)}>
-          Conformers
-          <ShortcutTooltip label="Conformer search and ensemble pruning for small molecules or selected objects." />
+    <InspectorEngineCard
+      className="conformer-inspector-card"
+      title="Conformers"
+      tooltip="Conformer search and ensemble pruning for small molecules or selected objects."
+      status={conformerStatusSummary(status)}
+      open={open}
+      onToggle={() => setOpen((current) => !current)}
+      summary={conformerSettingsSummary(settings)}
+      scope={selectedConformerAction ? "Scope: selected object" : undefined}
+      notice={(
+        <EngineToolNotice
+          tools={conformerTools(status)}
+          onCheck={() => void actions.checkConformerStatus()}
+        />
+      )}
+    >
+      <div className="structure-brief-actions structure-brief-actions-grid">
+        <button type="button" className="dock-action" disabled={crestDisabled} onClick={() => void actions.runConformerOperation("crest-generate", document, selectedConformerAction)} onContextMenu={showSettingsFor("crest")}>
+          CREST
+          <ShortcutTooltip label="Sample low-energy conformers with CREST." />
         </button>
-        <span>{conformerStatusSummary(status)}</span>
+        <button type="button" className="dock-action" disabled={prismDisabled} onClick={() => void actions.runConformerOperation("prism-prune", document)} onContextMenu={showSettingsFor("prism")}>
+          PRISM
+          <ShortcutTooltip label="Prune duplicate or redundant conformers." />
+        </button>
+        <button type="button" className="dock-action" aria-expanded={settingsPanel !== null} onClick={() => setSettingsPanel((current) => current === "all" ? null : "all")}>
+          Settings
+          <ShortcutTooltip label="CREST and PRISM run parameters." />
+        </button>
+        <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
+          Jobs
+          <ShortcutTooltip label="Calculation history and output artifacts." />
+        </button>
       </div>
-      {open ? (
-        <>
-          <div className="structure-inspector-xtb-summary">
-            <span>{conformerSettingsSummary(settings)}</span>
-          </div>
-          {selectedConformerAction ? (
-            <div className="structure-brief-notes">
-              <span>Scope: selected object</span>
-            </div>
-          ) : null}
-          <div className="structure-brief-actions structure-brief-actions-grid">
-            <button type="button" className="dock-action" disabled={crestDisabled} onClick={() => void actions.runConformerOperation("crest-generate", document, selectedConformerAction)} onContextMenu={showSettingsFor("crest")}>
-              CREST
-              <ShortcutTooltip label="Sample low-energy conformers with CREST." />
-            </button>
-            <button type="button" className="dock-action" disabled={prismDisabled} onClick={() => void actions.runConformerOperation("prism-prune", document)} onContextMenu={showSettingsFor("prism")}>
-              PRISM
-              <ShortcutTooltip label="Prune duplicate or redundant conformers." />
-            </button>
-            <button type="button" className="dock-action" aria-expanded={settingsPanel !== null} onClick={() => setSettingsPanel((current) => current === "all" ? null : "all")}>
-              Settings
-              <ShortcutTooltip label="CREST and PRISM run parameters." />
-            </button>
-            <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
-              Jobs
-              <ShortcutTooltip label="Calculation history and output artifacts." />
-            </button>
-          </div>
-          {settingsPanel ? <ConformerInlineSettings panel={settingsPanel} settings={settings} status={status} actions={actions} /> : null}
-        </>
-      ) : null}
-    </section>
+      {settingsPanel ? <ConformerInlineSettings panel={settingsPanel} settings={settings} status={status} actions={actions} /> : null}
+    </InspectorEngineCard>
   );
+}
+
+// Open Babel only appears once the backend has reported on it; the older status
+// payloads leave it out entirely.
+function conformerTools(status: ShellViewState["conformerStatus"]): EngineTool[] {
+  if (!status) return [];
+  const tools: EngineTool[] = [
+    { name: "CREST", installed: status.crest.installed, hint: status.crest.installHint },
+    { name: "PRISM Pruner", installed: status.prism.installed, hint: status.prism.installHint },
+  ];
+  if (status.openbabel) {
+    tools.push({ name: "Open Babel", installed: status.openbabel.installed, hint: status.openbabel.installHint });
+  }
+  return tools;
 }
 
 function ConformerInlineSettings({
@@ -1754,6 +1772,13 @@ const XTB_ACTION_TOOLTIPS = {
   metadyn: "Bias the xTB dynamics to explore conformational space beyond local minima.",
 } satisfies Record<string, string>;
 
+const XTB_MORE_OPERATIONS = [
+  ["vipea", "IP/EA"],
+  ["vfukui", "Fukui"],
+  ["md", "MD"],
+  ["metadyn", "Metadyn"],
+] as const satisfies readonly (readonly [keyof typeof XTB_ACTION_TOOLTIPS, string])[];
+
 const XTB_SETTING_TOOLTIPS = {
   method: "Choose the xTB Hamiltonian. GFN2 is the default balanced method; GFNFF is faster for large systems.",
   optLevel: "Controls geometry optimization convergence. Loose is faster; tight and verytight are more conservative.",
@@ -1847,19 +1872,123 @@ function XtbSettingsCategoryBar({
 function XtbActionButton({
   label,
   tooltip,
+  disabled,
   onClick,
   onContextMenu,
 }: {
   label: string;
   tooltip: string;
+  disabled?: boolean;
   onClick: () => void;
   onContextMenu: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {
   return (
-    <button type="button" className="dock-action structure-inspector-xtb-action" onClick={onClick} onContextMenu={onContextMenu}>
+    <button type="button" className="dock-action structure-inspector-xtb-action" disabled={disabled} onClick={onClick} onContextMenu={onContextMenu}>
       {label}
       <ShortcutTooltip label={tooltip} />
     </button>
+  );
+}
+
+// The conformer and xTB cards were the same card written twice: a collapsible
+// header with a status, a settings summary, a grid of runs and an inline
+// settings body. They now share one.
+function InspectorEngineCard({
+  className,
+  title,
+  tooltip,
+  status,
+  open,
+  onToggle,
+  summary,
+  summaryTooltip,
+  summaryModified,
+  onReset,
+  notice,
+  scope,
+  children,
+}: {
+  className: string;
+  title: string;
+  tooltip: string;
+  status: string;
+  open: boolean;
+  onToggle: () => void;
+  summary: string;
+  summaryTooltip?: string;
+  summaryModified?: boolean;
+  onReset?: () => void;
+  notice?: ReactNode;
+  scope?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`structure-brief-card ${className}`} data-collapsed={!open || undefined}>
+      <div className="structure-inspector-section-header">
+        <button type="button" className="structure-inspector-section-title-button" aria-expanded={open} onClick={onToggle}>
+          {title}
+          <ShortcutTooltip label={tooltip} />
+        </button>
+        <span>{status}</span>
+      </div>
+      {open ? (
+        <>
+          <div
+            className="structure-inspector-xtb-summary"
+            data-modified={summaryModified || undefined}
+            data-xtb-tooltip={summaryTooltip}
+          >
+            <span>{summary}</span>
+            {onReset ? (
+              <button type="button" className="structure-inspector-inline-action" onClick={onReset}>
+                Reset
+                <ShortcutTooltip label="Restore the default settings." />
+              </button>
+            ) : null}
+          </div>
+          {scope ? (
+            <div className="structure-brief-notes">
+              <span>{scope}</span>
+            </div>
+          ) : null}
+          {notice}
+          {children}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+type EngineTool = {
+  name: string;
+  installed: boolean;
+  hint: string;
+  install?: () => void;
+};
+
+// A disabled button with no explanation is a dead end. The backend already says
+// how to install each tool, so the card repeats that instead of swallowing it.
+function EngineToolNotice({ tools, onCheck }: { tools: EngineTool[]; onCheck: () => void }) {
+  const missing = tools.filter((tool) => !tool.installed);
+  if (missing.length === 0) return null;
+  return (
+    <div className="structure-inspector-engine-notice">
+      {missing.map((tool) => (
+        <div key={tool.name} className="structure-inspector-engine-notice-row">
+          {/* Every hint the backend writes already names its own tool, so repeating
+              the name here would only read as a stutter. */}
+          <span>{tool.hint || `${tool.name} is not installed.`}</span>
+          {tool.install ? (
+            <button type="button" className="structure-inspector-inline-action" onClick={tool.install}>
+              Install {tool.name}
+            </button>
+          ) : null}
+        </div>
+      ))}
+      <button type="button" className="structure-inspector-inline-action structure-inspector-engine-notice-check" onClick={onCheck}>
+        Check again
+      </button>
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -218,18 +218,23 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
   // Only a checked-and-missing binary disables the run buttons; an unchecked one
   // is not yet known to be missing.
   const xtbMissing = xtbStatus?.installed === false;
-  // A direct job on a whole protein is refused once it starts, with a message
-  // telling you to select something first. The atom count is already parsed, so
-  // the card can say that before the click instead of after it.
+  // A direct job is refused once it starts if the object it runs on is over the
+  // atom cap, with a message telling you to select something smaller. The count
+  // is already parsed, so the card can say that before the click. When something
+  // is selected the run scopes to it, so the cap applies to the selection's size
+  // - picking a whole chain or all polymers is still too big and must stay
+  // blocked, not just "a selection exists".
   const structureAtoms = compositionSummary ? structureAtomCountFromSummary(compositionSummary) : null;
   const jobScopedToSelection = Boolean(selectedEntity || viewerLigandSelection);
-  const oversizedForDirectJob = !jobScopedToSelection
-    && structureAtoms !== null
-    && structureAtoms > DIRECT_CHEMISTRY_JOB_ATOM_LIMIT;
+  const scopedAtoms = selectedScopeAtomCount(selectedEntity, viewerLigandSelection);
+  const effectiveAtoms = jobScopedToSelection ? scopedAtoms : structureAtoms;
+  const oversizedForDirectJob = effectiveAtoms !== null && effectiveAtoms > DIRECT_CHEMISTRY_JOB_ATOM_LIMIT;
   const oversizedNotice: EngineTool[] = oversizedForDirectJob ? [{
     name: "Scope",
     installed: false,
-    hint: `This structure has ${structureAtoms.toLocaleString()} atoms. Select a ligand or chain first — direct runs are capped at ${DIRECT_CHEMISTRY_JOB_ATOM_LIMIT}.`,
+    hint: jobScopedToSelection
+      ? `This selection has ${effectiveAtoms.toLocaleString()} atoms. Pick a single ligand or a smaller object — direct runs are capped at ${DIRECT_CHEMISTRY_JOB_ATOM_LIMIT}.`
+      : `This structure has ${effectiveAtoms.toLocaleString()} atoms. Select a ligand or chain first — direct runs are capped at ${DIRECT_CHEMISTRY_JOB_ATOM_LIMIT}.`,
   }] : [];
   const xtbBlocked = xtbMissing || oversizedForDirectJob;
   const openXtbSettingsFor = (scope: XtbSettingsScope) => {
@@ -3124,6 +3129,22 @@ function countFromSummaryValue(value: string | null, unit: string) {
   if (!value || value === "None detected") return null;
   const match = value.match(new RegExp(`(\\d[\\d,]*)\\s+${unit}\\b`, "u"));
   return match?.[1] ?? null;
+}
+
+// How many atoms a scoped run would actually touch. A ligand pick carries its
+// own count; a composition row (a chain, all polymers, all ligands) states it in
+// its value text. Used to keep the pre-click size gate honest for large
+// selections, not just for the whole structure.
+function selectedScopeAtomCount(
+  selectedEntity: SelectedStructureRow | null,
+  viewerLigandSelection: ShellViewState["viewerLigandSelection"],
+): number | null {
+  if (viewerLigandSelection?.atoms) return viewerLigandSelection.atoms;
+  if (selectedEntity) {
+    const atoms = countFromSummaryValue(selectedEntity.row.value, "atoms");
+    if (atoms) return Number(atoms.replace(/,/gu, ""));
+  }
+  return null;
 }
 
 function valueForLabel(rows: StructureSummaryRow[], label: string) {

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -8,7 +8,7 @@ import { FoldingResultsPanel, useFoldingResult } from "./folding-results-panel";
 import type { MenuItemSpec } from "./menu-types";
 import type { ShellActions, ShellViewState, StructureOverlayMode, StructureViewerAction } from "./types";
 import { structureBriefForDocument, type StructureBriefRow as BriefRow } from "../lib/structure-brief";
-import { parseStructureComposition, type StructureCompositionSummary, type StructureSummaryRow, type StructureViewerSelector } from "../lib/structure-composition";
+import { parseStructureComposition, type StructureCompositionSummary, type StructureSummaryRow } from "../lib/structure-composition";
 import { canInspectConformerEnsemble, canShowConformerWorkflow, canUseConformerWorkflow } from "../lib/conformer-ensemble";
 import { Alert, AlertAction, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -215,10 +215,6 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
   const latestXtbJob = latestXtbJobForDocument(document, xtbJobs);
   const runningXtbJob = latestXtbJob?.status === "running" ? latestXtbJob : null;
   const structureXtbArtifact = xtbArtifactInfoForPath(document.path, document.extension);
-  const clearSelection = () => {
-    actions.runStructureViewerAction(document, { type: "clear_selection", label: "Clear selection" });
-    setActiveActionKey(null);
-  };
   // Only a checked-and-missing binary disables the run buttons; an unchecked one
   // is not yet known to be missing.
   const xtbMissing = xtbStatus?.installed === false;
@@ -366,9 +362,9 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
             <>
               {runningXtbJob.inputLabel} is running.
               {" "}
-              <button type="button" className="structure-inspector-inline-action" onClick={() => void actions.cancelXtbJob(runningXtbJob.id)}>
+              <Button type="button" variant="outline" size="xs" onClick={() => void actions.cancelXtbJob(runningXtbJob.id)}>
                 Cancel
-              </button>
+              </Button>
             </>
           ) : jobScopedToSelection ? "Scope: selected object" : undefined}
           notice={(
@@ -389,23 +385,18 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
             <XtbActionButton label="Frequencies" tooltip={XTB_ACTION_TOOLTIPS["optimized-hessian"]} disabled={xtbBlocked} onClick={() => void actions.runXtbActiveOperation("optimized-hessian")} onContextMenu={showXtbSettingsFor("optimized-hessian")} />
             {/* Four of the seven operations are specialist runs, and giving them the
                 same weight as Optimize made the card read as a wall of buttons. */}
-            <button type="button" className="dock-action" disabled={xtbBlocked} onClick={showXtbMoreMenu}>
+            <Button type="button" variant="secondary" size="sm" className="structure-inspector-xtb-action w-full" disabled={xtbBlocked} onClick={showXtbMoreMenu}>
               More
               <ShortcutTooltip label="IP/EA, Fukui, molecular dynamics, and metadynamics runs." />
-            </button>
-            <button
-              type="button"
-              className="dock-action"
-              aria-expanded={xtbSettingsOpen}
-              onClick={toggleGeneralXtbSettings}
-            >
+            </Button>
+            <Button type="button" variant="outline" size="sm" className="structure-inspector-xtb-action w-full" aria-expanded={xtbSettingsOpen} onClick={toggleGeneralXtbSettings}>
               Settings
               <ShortcutTooltip label="Hamiltonian, charge, spin, solvation, accuracy, property, and dynamics parameters." />
-            </button>
-            <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
+            </Button>
+            <Button type="button" variant="outline" size="sm" className="structure-inspector-xtb-action w-full" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
               Jobs
               <ShortcutTooltip label="xTB calculation history, energies, properties, trajectories, and output artifacts." />
-            </button>
+            </Button>
           </div>
           {xtbSettingsOpen ? (
             <XtbInlineSettings
@@ -468,13 +459,6 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
             />
           ) : null}
         </>
-      ) : null}
-
-      {selectedEntity ? (
-        <SelectedEntityCard
-          selectedEntity={selectedEntity}
-          clearSelection={clearSelection}
-        />
       ) : null}
 
       <StructureDetailsSection
@@ -1180,22 +1164,22 @@ function ConformerWorkflowCard({
       )}
     >
       <div className="structure-brief-actions structure-brief-actions-grid">
-        <button type="button" className="dock-action" disabled={crestDisabled} onClick={() => void actions.runConformerOperation("crest-generate", document, selectedConformerAction)} onContextMenu={showSettingsFor("crest")}>
+        <Button type="button" variant="secondary" size="sm" className="structure-inspector-xtb-action w-full" disabled={crestDisabled} onClick={() => void actions.runConformerOperation("crest-generate", document, selectedConformerAction)} onContextMenu={showSettingsFor("crest")}>
           CREST
           <ShortcutTooltip label="Sample low-energy conformers with CREST." />
-        </button>
-        <button type="button" className="dock-action" disabled={prismDisabled} onClick={() => void actions.runConformerOperation("prism-prune", document)} onContextMenu={showSettingsFor("prism")}>
+        </Button>
+        <Button type="button" variant="secondary" size="sm" className="structure-inspector-xtb-action w-full" disabled={prismDisabled} onClick={() => void actions.runConformerOperation("prism-prune", document)} onContextMenu={showSettingsFor("prism")}>
           PRISM
           <ShortcutTooltip label="Prune duplicate or redundant conformers." />
-        </button>
-        <button type="button" className="dock-action" aria-expanded={settingsPanel !== null} onClick={() => setSettingsPanel((current) => current === "all" ? null : "all")}>
+        </Button>
+        <Button type="button" variant="outline" size="sm" className="structure-inspector-xtb-action w-full" aria-expanded={settingsPanel !== null} onClick={() => setSettingsPanel((current) => current === "all" ? null : "all")}>
           Settings
           <ShortcutTooltip label="CREST and PRISM run parameters." />
-        </button>
-        <button type="button" className="dock-action" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
+        </Button>
+        <Button type="button" variant="outline" size="sm" className="structure-inspector-xtb-action w-full" onClick={() => actions.toggleDockTab("bottom", "jobs")}>
           Jobs
           <ShortcutTooltip label="Calculation history and output artifacts." />
-        </button>
+        </Button>
       </div>
       {settingsPanel ? <ConformerInlineSettings panel={settingsPanel} settings={settings} status={status} actions={actions} /> : null}
     </InspectorEngineCard>
@@ -1234,9 +1218,9 @@ function ConformerInlineSettings({
     <div className="structure-inspector-xtb-settings conformer-inline-settings">
       <div className="structure-inspector-section-header">
         <h4>{panel === "crest" ? "CREST settings" : panel === "prism" ? "PRISM settings" : "Conformer settings"}</h4>
-        <button type="button" className="structure-inspector-inline-action" onClick={() => void actions.checkConformerStatus()}>
+        <Button type="button" variant="outline" size="xs" onClick={() => void actions.checkConformerStatus()}>
           Check
-        </button>
+        </Button>
       </div>
       <div className="structure-inspector-settings-status">{conformerStatusSummary(status)}</div>
       {showCrest ? (
@@ -1938,10 +1922,10 @@ function XtbActionButton({
   onContextMenu: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {
   return (
-    <button type="button" className="dock-action structure-inspector-xtb-action" disabled={disabled} onClick={onClick} onContextMenu={onContextMenu}>
+    <Button type="button" variant="secondary" size="sm" className="structure-inspector-xtb-action w-full" disabled={disabled} onClick={onClick} onContextMenu={onContextMenu}>
       {label}
       <ShortcutTooltip label={tooltip} />
-    </button>
+    </Button>
   );
 }
 
@@ -1999,10 +1983,10 @@ function InspectorEngineCard({
         >
           <span>{summary}</span>
           {onReset ? (
-            <button type="button" className="structure-inspector-inline-action" onClick={onReset}>
+            <Button type="button" variant="outline" size="xs" onClick={onReset}>
               Reset
               <ShortcutTooltip label="Restore the default settings." />
-            </button>
+            </Button>
           ) : null}
         </div>
         {scope ? (
@@ -2087,15 +2071,15 @@ function XtbInlineSettings({
     <div className="structure-inspector-xtb-settings">
       <div className="structure-inspector-xtb-settings-title">
         <span>{xtbSettingsScopeLabel(scope)} settings</span>
-        <button type="button" className="structure-inspector-inline-action" onClick={onClose}>
+        <Button type="button" variant="ghost" size="xs" onClick={onClose}>
           Close
-        </button>
+        </Button>
       </div>
       <div className="structure-inspector-xtb-runtime">
         <span>{xtbStatus?.executablePath ?? xtbStatus?.installHint ?? (isBrowserDev ? "Browser dev can run local xTB jobs." : "xTB status has not been checked.")}</span>
-        <button type="button" className="structure-inspector-inline-action" onClick={() => void actions.checkXtbStatus()}>
+        <Button type="button" variant="outline" size="xs" onClick={() => void actions.checkXtbStatus()}>
           Check
-        </button>
+        </Button>
       </div>
       {showCategories ? <XtbSettingsCategoryBar category={category} setCategory={setCategory} /> : null}
       {showCore ? (
@@ -2774,16 +2758,16 @@ function XtbResultsPanel({ document, job, actions }: { document: ViewerDocument;
       </div>
       <div className="dock-action-row structure-inspector-xtb-result-actions">
         {result.primaryOpenPath ? (
-          <button type="button" className="dock-action" onClick={() => void actions.openPaths([result.primaryOpenPath!])}>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void actions.openPaths([result.primaryOpenPath!])}>
             Open result
-          </button>
+          </Button>
         ) : null}
-        <button type="button" className="dock-action" onClick={() => void actions.revealPath(result.workDir, "xTB run folder")}>
+        <Button type="button" variant="secondary" size="sm" onClick={() => void actions.revealPath(result.workDir, "xTB run folder")}>
           Open run folder
-        </button>
-        <button type="button" className="dock-action" onClick={() => void actions.openTextPaths([result.logPath])}>
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={() => void actions.openTextPaths([result.logPath])}>
           Log
-        </button>
+        </Button>
       </div>
     </section>
   );
@@ -3181,71 +3165,6 @@ function selectedStructureRow(
   return null;
 }
 
-function SelectedEntityCard({
-  selectedEntity,
-  clearSelection,
-}: {
-  selectedEntity: SelectedStructureRow;
-  clearSelection: () => void;
-}) {
-  const copyIdentity = () => void navigator.clipboard?.writeText(`${selectedEntity.row.label}: ${selectedEntity.row.value}`);
-  return (
-    <section className="structure-brief-card structure-inspector-selected-card">
-      <StructureSectionHeader title="Selected entity" detail={selectedEntity.group} />
-      <div className="structure-inspector-selection-pill">
-        <span>Selected</span>
-        <strong>{selectedEntity.row.label}</strong>
-        <button type="button" className="structure-inspector-inline-action" onClick={clearSelection}>
-          Clear
-        </button>
-      </div>
-      <div className="structure-inspector-selected-meta">
-        <span>{selectedEntity.row.value}</span>
-        <span>{actionTypeLabel(selectedEntity.action)}</span>
-        <span>{selectorLabel(selectedEntity.action)}</span>
-      </div>
-      <div className="structure-brief-actions structure-brief-actions-secondary">
-        <button type="button" className="dock-action" onClick={copyIdentity}>
-          Copy id
-        </button>
-      </div>
-    </section>
-  );
-}
-
-function actionTypeLabel(action: StructureViewerAction) {
-  if (action.type === "focus_ligand") return "Focus in 3D";
-  if (action.type === "set_sdf_molecule") return "Show molecule";
-  if (action.type === "set_structure_pose") return "Show pose";
-  if (action.type === "select_residues") return "Residues";
-  if (action.type === "hide_waters") return "Hide water";
-  if (action.type === "show_waters") return "Show water";
-  if (action.type === "hide_components") return `Hide ${action.kind}`;
-  if (action.type === "show_components") return `Show ${action.kind}`;
-  return action.label;
-}
-
-function selectorLabel(action: StructureViewerAction) {
-  if (action.type === "set_sdf_molecule") return `Molecule ${action.index + 1}`;
-  if (action.type === "set_structure_pose") return `Pose ${action.index + 1}`;
-  if (!("selector" in action)) return "Scene action";
-  const chain = valueFromSelector(action.selector, "auth_asym_id") ?? valueFromSelector(action.selector, "label_asym_id");
-  const seq = valueFromSelector(action.selector, "auth_seq_id") ?? valueFromSelector(action.selector, "label_seq_id");
-  const comp = valueFromSelector(action.selector, "label_comp_id") ?? valueFromSelector(action.selector, "auth_comp_id");
-  const kind = valueFromSelector(action.selector, "kind");
-  return [comp, chain, seq, kind && `kind ${kind}`].filter(Boolean).join(" ") || "Selector";
-}
-
-function valueFromSelector(selector: StructureViewerSelector, key: string) {
-  const value = selector[key];
-  if (Array.isArray(value)) {
-    if (value.some((item) => typeof item === "object")) return null;
-    return value.join(", ");
-  }
-  if (value === undefined || value === null) return null;
-  return String(value);
-}
-
 function StructureBriefRow({ label, value }: BriefRow) {
   return (
     <div className="structure-brief-row">
@@ -3597,15 +3516,15 @@ function StructureDetailsSection({
         </div>
 
         {!hostedMcpWidget ? <div className="structure-brief-actions">
-          <button type="button" className="dock-action" onClick={() => void actions.showDocumentMetadata(document)}>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void actions.showDocumentMetadata(document)}>
             Show metadata
-          </button>
-          <button type="button" className="dock-action" onClick={() => void actions.revealDocument(document)}>
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void actions.revealDocument(document)}>
             Reveal file
-          </button>
-          <button type="button" className="dock-action" onClick={() => void actions.copyDocumentPath(document)}>
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={() => void actions.copyDocumentPath(document)}>
             Copy path
-          </button>
+          </Button>
         </div> : null}
       </div>
     </details>

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { showNativeContextMenu } from "./native-context-menu";
 import { formatBytes } from "./format";
@@ -281,20 +281,15 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
       ) : null}
 
       {(compositionSummary || compositionPending || compositionError) ? (
-        <section className="structure-brief-card">
-          <StructureSectionHeader title="Components" detail="Primary groups" />
-          {compositionSummary ? (
-            <StructureActionList
-              rows={visibleComponentRows(compositionSummary.componentRows)}
-              document={document}
-              actions={actions}
-              activeActionKey={activeActionKey}
-              setActiveActionKey={setActiveActionKey}
-            />
-          ) : (
-            <div className="dock-empty">{compositionPending ? "Reading structure text..." : `Composition unavailable: ${compositionError}`}</div>
-          )}
-        </section>
+        <StructureCompositionCard
+          summary={compositionSummary}
+          pending={compositionPending}
+          error={compositionError}
+          document={document}
+          actions={actions}
+          activeActionKey={activeActionKey}
+          setActiveActionKey={setActiveActionKey}
+        />
       ) : null}
 
       <FoldingResultsPanel state={foldingResult} actions={actions} />
@@ -431,61 +426,6 @@ export function StructureInfoPanel({ document, textDocument, dockDrops, conforme
           selectedEntity={selectedEntity}
           clearSelection={clearSelection}
         />
-      ) : null}
-
-      {compositionSummary?.maestroRows?.length ? (
-        <section className="structure-brief-card">
-          <StructureSectionHeader title="Maestro entries" detail={`${compositionSummary.maestroRows.length} CT ${plural(compositionSummary.maestroRows.length, "block")}`} />
-          <StructureActionList
-            rows={compositionSummary.maestroRows}
-            document={document}
-            actions={actions}
-            activeActionKey={activeActionKey}
-            setActiveActionKey={setActiveActionKey}
-            compact
-          />
-        </section>
-      ) : null}
-
-      {compositionSummary?.ligandRows.length ? (
-        <section className="structure-brief-card">
-          <StructureSectionHeader title="Ligands" detail={`${compositionSummary.ligandRows.length} ${plural(compositionSummary.ligandRows.length, "instance")}`} />
-          <StructureActionList
-            rows={compositionSummary.ligandRows}
-            document={document}
-            actions={actions}
-            activeActionKey={activeActionKey}
-            setActiveActionKey={setActiveActionKey}
-            compact
-          />
-        </section>
-      ) : null}
-
-      {compositionSummary?.polymerRows.length ? (
-        <section className="structure-brief-card">
-          <StructureSectionHeader title="Chains" detail={`${compositionSummary.polymerRows.length} ${plural(compositionSummary.polymerRows.length, "chain")}`} />
-          <StructureActionList
-            rows={compositionSummary.polymerRows}
-            document={document}
-            actions={actions}
-            activeActionKey={activeActionKey}
-            setActiveActionKey={setActiveActionKey}
-            compact
-          />
-        </section>
-      ) : null}
-
-      {compositionSummary?.solventRows.length ? (
-        <section className="structure-brief-card">
-          <StructureSectionHeader title="Water / ions" />
-          <StructureActionList
-            rows={compositionSummary.solventRows}
-            document={document}
-            actions={actions}
-            activeActionKey={activeActionKey}
-            setActiveActionKey={setActiveActionKey}
-          />
-        </section>
       ) : null}
 
       <StructureDetailsSection
@@ -3016,54 +2956,154 @@ function plural(count: number, noun: string) {
   return count === 1 ? noun : `${noun}s`;
 }
 
-function StructureActionList({
-  rows,
+// Arrow keys walk the rows of a list — and of the composition tree, where the
+// walk crosses group boundaries because the buttons are collected from the
+// container rather than from any one group.
+function structureRowsKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+  const target = event.target instanceof HTMLElement ? event.target : null;
+  const button = target?.closest<HTMLButtonElement>("button.structure-brief-action-row, button.structure-brief-chip-button");
+  if (!button || !event.currentTarget.contains(button)) return;
+  const buttons = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("button.structure-brief-action-row, button.structure-brief-chip-button"))
+    .filter((candidate) => !candidate.disabled);
+  const index = buttons.indexOf(button);
+  if (index < 0) return;
+  const nextIndex = event.key === "ArrowDown"
+    ? Math.min(buttons.length - 1, index + 1)
+    : Math.max(0, index - 1);
+  if (nextIndex === index) return;
+  event.preventDefault();
+  event.stopPropagation();
+  buttons[nextIndex].focus();
+  buttons[nextIndex].click();
+}
+
+type CompositionGroup = {
+  key: string;
+  row: StructureSummaryRow;
+  children: StructureSummaryRow[];
+};
+
+// The parser reports each group twice: once as a summary line and once as the
+// members behind it, and the panel used to render those as separate cards. They
+// are one hierarchy, so they are shown as one.
+function compositionGroups(summary: StructureCompositionSummary): CompositionGroup[] {
+  const ionRows = summary.solventRows.filter((row) => row.label !== "Water" && row.label !== "Ions");
+  const groups = visibleComponentRows(summary.componentRows).map((row) => ({
+    key: `component:${row.label}`,
+    row,
+    children: row.label === "Polymers" ? summary.polymerRows
+      : row.label === "Ligands" ? summary.ligandRows
+      : row.label === "Ions" ? ionRows
+      : [],
+  }));
+  const maestroRows = summary.maestroRows ?? [];
+  if (maestroRows.length === 0) return groups;
+  return [...groups, {
+    key: "maestro",
+    row: { label: "Maestro entries", value: `${maestroRows.length} CT ${plural(maestroRows.length, "block")}` },
+    children: maestroRows,
+  }];
+}
+
+// A handful of chains or ligands is what people open a structure to look at, so
+// those groups start open; a hundred of them would just be the old wall of rows.
+const COMPOSITION_AUTO_EXPAND_LIMIT = 8;
+
+function defaultExpandedCompositionGroups(groups: CompositionGroup[]) {
+  return new Set(groups
+    .filter((group) => group.children.length > 0 && group.children.length <= COMPOSITION_AUTO_EXPAND_LIMIT)
+    .map((group) => group.key));
+}
+
+function StructureCompositionCard({
+  summary,
+  pending,
+  error,
   document,
   actions,
   activeActionKey,
   setActiveActionKey,
-  compact = false,
 }: {
-  rows: StructureSummaryRow[];
+  summary: StructureCompositionSummary | null;
+  pending: boolean;
+  error: string | null;
   document: ViewerDocument;
   actions: ShellActions;
   activeActionKey: string | null;
   setActiveActionKey: (key: string | null) => void;
-  compact?: boolean;
 }) {
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
-    const target = event.target instanceof HTMLElement ? event.target : null;
-    const button = target?.closest<HTMLButtonElement>("button.structure-brief-action-row, button.structure-brief-chip-button");
-    if (!button || !event.currentTarget.contains(button)) return;
-    const buttons = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("button.structure-brief-action-row, button.structure-brief-chip-button"))
-      .filter((candidate) => !candidate.disabled);
-    const index = buttons.indexOf(button);
-    if (index < 0) return;
-    const nextIndex = event.key === "ArrowDown"
-      ? Math.min(buttons.length - 1, index + 1)
-      : Math.max(0, index - 1);
-    if (nextIndex === index) return;
-    event.preventDefault();
-    event.stopPropagation();
-    buttons[nextIndex].focus();
-    buttons[nextIndex].click();
-  };
+  const groups = useMemo(() => summary ? compositionGroups(summary) : [], [summary]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => defaultExpandedCompositionGroups(groups));
+  useEffect(() => {
+    setExpanded(defaultExpandedCompositionGroups(groups));
+  }, [groups]);
+  const toggle = (key: string) => setExpanded((current) => {
+    const next = new Set(current);
+    if (!next.delete(key)) next.add(key);
+    return next;
+  });
 
   return (
-    <div className={compact ? "structure-brief-chip-list" : "structure-brief-rows"} onKeyDown={handleKeyDown}>
-      {rows.map((row, index) => (
-        <StructureActionRow
-          key={structureActionRowKey(row, index)}
-          row={row}
-          document={document}
-          actions={actions}
-          activeActionKey={activeActionKey}
-          setActiveActionKey={setActiveActionKey}
-          compact={compact}
-        />
-      ))}
-    </div>
+    <section className="structure-brief-card">
+      <StructureSectionHeader title="Composition" detail={groups.length ? `${groups.length} ${plural(groups.length, "group")}` : undefined} />
+      {summary ? (
+        <div className="structure-brief-rows structure-inspector-tree" onKeyDown={structureRowsKeyDown}>
+          {groups.map((group) => {
+            const open = expanded.has(group.key);
+            return (
+              <div className="structure-inspector-tree-group" key={group.key}>
+                <StructureActionRow
+                  row={group.row}
+                  document={document}
+                  actions={actions}
+                  activeActionKey={activeActionKey}
+                  setActiveActionKey={setActiveActionKey}
+                  compact={false}
+                  leading={group.children.length > 0 ? (
+                    <button
+                      type="button"
+                      className="structure-inspector-tree-toggle"
+                      aria-expanded={open}
+                      aria-label={`${open ? "Collapse" : "Expand"} ${group.row.label}`}
+                      title={open ? "Collapse" : "Expand"}
+                      onClick={() => toggle(group.key)}
+                    >
+                      <TreeDisclosureIcon />
+                    </button>
+                  ) : <span className="structure-inspector-tree-spacer" aria-hidden="true" />}
+                />
+                {open && group.children.length > 0 ? (
+                  <div className="structure-inspector-tree-children">
+                    {group.children.map((child, index) => (
+                      <StructureActionRow
+                        key={structureActionRowKey(child, index)}
+                        row={child}
+                        document={document}
+                        actions={actions}
+                        activeActionKey={activeActionKey}
+                        setActiveActionKey={setActiveActionKey}
+                        compact
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="dock-empty">{pending ? "Reading structure text..." : `Composition unavailable: ${error}`}</div>
+      )}
+    </section>
+  );
+}
+
+function TreeDisclosureIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path d="M4.5 2.5 8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }
 
@@ -3079,6 +3119,7 @@ function StructureActionRow({
   activeActionKey,
   setActiveActionKey,
   compact,
+  leading,
 }: {
   row: StructureSummaryRow;
   document: ViewerDocument;
@@ -3086,6 +3127,7 @@ function StructureActionRow({
   activeActionKey: string | null;
   setActiveActionKey: (key: string | null) => void;
   compact: boolean;
+  leading?: ReactNode;
 }) {
   const content = () => (
     <span className="structure-inspector-row-content">
@@ -3094,6 +3136,19 @@ function StructureActionRow({
     </span>
   );
   if (!row.action) {
+    // A group heading with no action of its own still has to line up with the
+    // rows around it, so it keeps the entry layout instead of falling back to a
+    // plain row.
+    if (leading) {
+      return (
+        <div className="structure-brief-action-entry" data-leading="true">
+          {leading}
+          <div className="structure-brief-action-summary" title={`${row.label}: ${row.value}`}>
+            {content()}
+          </div>
+        </div>
+      );
+    }
     return compact ? (
       <span title={`${row.label}: ${row.value}`}>
         <strong>{row.label}</strong>
@@ -3137,7 +3192,8 @@ function StructureActionRow({
 
   if (secondaryAction) {
     return (
-      <div className="structure-brief-action-entry" data-actions="pair" data-selected={selected || undefined} onContextMenu={showContextMenu}>
+      <div className="structure-brief-action-entry" data-actions="pair" data-leading={leading ? "true" : undefined} data-selected={selected || undefined} onContextMenu={showContextMenu}>
+        {leading}
         <div
           className={compact ? "structure-brief-chip-summary" : "structure-brief-action-summary"}
           title={`${row.label}: ${row.value}`}
@@ -3165,7 +3221,8 @@ function StructureActionRow({
   }
 
   return (
-    <div className="structure-brief-action-entry" data-selected={selected || undefined} onContextMenu={showContextMenu}>
+    <div className="structure-brief-action-entry" data-leading={leading ? "true" : undefined} data-selected={selected || undefined} onContextMenu={showContextMenu}>
+      {leading}
       <button
         type="button"
         className={compact ? "structure-brief-chip-button" : "structure-brief-action-row"}

--- a/apps/desktop/src/components/ui/alert.tsx
+++ b/apps/desktop/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/desktop/src/components/ui/collapsible.tsx
+++ b/apps/desktop/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/apps/desktop/src/components/ui/toggle-group.tsx
+++ b/apps/desktop/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/desktop/src/components/ui/toggle.tsx
+++ b/apps/desktop/src/components/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/apps/desktop/src/hooks/use-app-chemistry-jobs.ts
+++ b/apps/desktop/src/hooks/use-app-chemistry-jobs.ts
@@ -50,6 +50,17 @@ export function useAppChemistryJobs({
   const cancelledConformerJobIdsRef = useRef(new Set<string>());
   const cancelledXtbJobIdsRef = useRef(new Set<string>());
 
+  // The inspector decides what it can offer from these, and until now they were
+  // only filled in after a job finished or the user opened a settings panel and
+  // pressed Check - so a fresh launch showed every tool as unknown. Probed here
+  // without a status line, since nobody asked for one.
+  useEffect(() => {
+    let cancelled = false;
+    void requestConformerStatus().then((status) => { if (!cancelled) setConformerStatus(status); }).catch(() => {});
+    void requestXtbStatus().then((status) => { if (!cancelled) setXtbStatus(status); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
   const setConformerSettings = useCallback((settings: ConformerSettings) => {
     const normalized = normalizeConformerSettings(settings);
     setConformerSettingsState(normalized);

--- a/apps/desktop/src/lib/direct-chemistry-guard.ts
+++ b/apps/desktop/src/lib/direct-chemistry-guard.ts
@@ -1,7 +1,7 @@
-import { parseStructureComposition } from "./structure-composition";
+import { parseStructureComposition, type StructureCompositionSummary } from "./structure-composition";
 import { readStructureText } from "./structure-text";
 
-const DIRECT_CHEMISTRY_JOB_ATOM_LIMIT = 300;
+export const DIRECT_CHEMISTRY_JOB_ATOM_LIMIT = 300;
 const DIRECT_CHEMISTRY_JOB_READ_LIMIT = 4 * 1024 * 1024;
 
 export async function directChemistryJobGuardMessage(
@@ -30,15 +30,22 @@ async function directChemistryJobAtomCount(
 function estimateStructureAtomCount(text: string, extension: string | null | undefined) {
   const normalizedExtension = String(extension || "").replace(/^\./u, "").toLowerCase();
   const summary = parseStructureComposition(text, normalizedExtension);
-  const summaryCounts = summary ? [
+  const summaryMax = summary ? structureAtomCountFromSummary(summary) : null;
+  return summaryMax ?? fallbackStructureAtomCount(text, normalizedExtension);
+}
+
+// The inspector has the same parsed summary in hand, so it can warn about an
+// oversized job before the click rather than letting the run fail into a toast.
+export function structureAtomCountFromSummary(summary: StructureCompositionSummary) {
+  const counts = [
     ...summary.rows,
     ...summary.componentRows,
     ...summary.polymerRows,
     ...summary.ligandRows,
     ...summary.solventRows,
-  ].flatMap((row) => atomCountsFromLabelValue(row.label, row.value)) : [];
-  const summaryMax = Math.max(0, ...summaryCounts);
-  return summaryMax > 0 ? summaryMax : fallbackStructureAtomCount(text, normalizedExtension);
+  ].flatMap((row) => atomCountsFromLabelValue(row.label, row.value));
+  const max = Math.max(0, ...counts);
+  return max > 0 ? max : null;
 }
 
 function atomCountsFromLabelValue(label: string, value: string) {

--- a/apps/desktop/src/lib/folding-results.ts
+++ b/apps/desktop/src/lib/folding-results.ts
@@ -14,5 +14,17 @@ export async function readFoldingResultBundle(path: string): Promise<FoldingResu
 }
 
 export function hasFoldingResultContent(bundle: FoldingResultBundle | null) {
-  return Boolean(bundle && (bundle.models.length > 0 || bundle.artifacts.length > 0));
+  if (!bundle) return false;
+  // A structure sitting next to a stray JSON sidecar (e.g. an xTB run marker) is
+  // not a folding result. The backend classifies any loose .json as "metadata"
+  // and would otherwise show the whole folder as folding output. Require real
+  // folding signal instead: a confidence profile, a PAE matrix, per-model
+  // metrics, or an artifact that is more than app metadata.
+  const isFoldingArtifact = (artifact: { kind: string }) => artifact.kind !== "metadata";
+  return bundle.models.some((model) =>
+    model.metrics.length > 0
+    || Boolean(model.plddtProfile)
+    || Boolean(model.matrixPreview)
+    || model.artifacts.some(isFoldingArtifact),
+  ) || bundle.artifacts.some(isFoldingArtifact);
 }

--- a/apps/desktop/src/lib/structure-composition.ts
+++ b/apps/desktop/src/lib/structure-composition.ts
@@ -468,21 +468,9 @@ function summarizeAtomRecords(records: AtomRecord[], modelCount: number): Struct
       };
     });
 
+  // Water and Ions already have their own rows in componentRows; this list is the
+  // individual ions behind that summary, not a second copy of it.
   const solventRows: StructureSummaryRow[] = [];
-  if (waterResidues > 0) {
-    solventRows.push({
-      label: "Water",
-      value: `${waterResidues} ${plural(waterResidues, "molecule")} / ${waterAtoms} atoms`,
-      action: { type: "hide_waters", label: "Hide water" },
-      secondaryAction: { type: "show_waters", label: "Show water" },
-    });
-  }
-  if (ionResidues > 0) {
-    solventRows.push({
-      label: "Ions",
-      value: `${formatNameCounts(ionGroups, 8)} / ${ionAtoms} atoms`,
-    });
-  }
   for (const [name, count] of [...ionGroups.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0])).slice(0, 8)) {
     solventRows.push({
       label: name,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3496,6 +3496,60 @@ img.radix-menu-item-icon {
 .structure-brief-action-entry[data-actions="pair"] {
   grid-template-columns: minmax(0, 1fr) auto auto;
 }
+.structure-brief-action-entry[data-leading] {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+.structure-brief-action-entry[data-leading][data-actions="pair"] {
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+}
+/* The composition tree stacks each group with its members, so the separator has
+   to move from the rows to the groups. */
+.structure-inspector-tree-group + .structure-inspector-tree-group {
+  border-top: 1px solid var(--line-subtler);
+}
+.structure-inspector-tree-toggle,
+.structure-inspector-tree-spacer {
+  width: 18px;
+  height: 18px;
+}
+.structure-inspector-tree-toggle {
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0;
+  cursor: default;
+  transition: background 120ms ease-out, color 120ms ease-out;
+}
+.structure-inspector-tree-toggle:hover {
+  background: var(--surface-subtle);
+  color: var(--text-primary);
+}
+.structure-inspector-tree-toggle svg {
+  transition: transform 140ms ease-out;
+}
+.structure-inspector-tree-toggle[aria-expanded="true"] svg {
+  transform: rotate(90deg);
+}
+.structure-inspector-tree-children {
+  position: relative;
+  padding: 0 0 2px 22px;
+}
+/* Same guide the sidebar tree uses, so nesting reads the same in both panels. */
+.structure-inspector-tree-children::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 4px;
+  left: 13px;
+  width: 1px;
+  background: var(--line-subtler);
+}
+.structure-inspector-tree-children .structure-brief-action-entry + .structure-brief-action-entry {
+  border-top: 0;
+}
 .structure-brief-action-row,
 .structure-brief-action-summary,
 .structure-brief-chip-button,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3109,17 +3109,26 @@ img.radix-menu-item-icon {
   position: relative;
   min-width: 0;
   display: grid;
-  grid-template-columns: 74px minmax(0, 1fr);
+  /* 74px ellipsized "Energy window" into "Energy win...". The label now gets room
+     to wrap instead, and the row keeps one height so sliders and selects line up. */
+  grid-template-columns: minmax(92px, 0.42fr) minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
+  gap: 4px 10px;
+  min-height: 32px;
+  border-radius: 7px;
+  padding: 2px 4px;
+  margin: 0 -4px;
+  transition: background 120ms ease-out;
+}
+.structure-inspector-xtb-setting-row:hover {
+  background: var(--surface-subtle);
 }
 .structure-inspector-xtb-setting-row > span {
   min-width: 0;
   color: var(--text-secondary);
   font-size: 12px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.25;
+  overflow-wrap: break-word;
 }
 .structure-inspector-xtb-setting-control {
   min-width: 0;
@@ -3127,6 +3136,89 @@ img.radix-menu-item-icon {
   align-items: center;
   justify-content: flex-end;
   gap: 6px;
+}
+/* Slider readouts sit in their own column so the numbers form a straight edge
+   down the panel instead of drifting with each track. */
+.structure-inspector-xtb-setting-control .settings-range-control {
+  gap: 8px;
+}
+.structure-inspector-xtb-setting-control .settings-range-control > span:not([data-slot]) {
+  min-width: 42px;
+  font-variant-numeric: tabular-nums;
+}
+/* Unit widths differ wildly ("A" vs "kcal/mol"). Reserving the same trailing
+   column keeps the input boxes themselves the same width down the panel. */
+.structure-inspector-xtb-setting-control .structure-inspector-number-control {
+  width: 100%;
+  max-width: 176px;
+}
+.structure-inspector-xtb-setting-control .structure-inspector-number-control > span {
+  min-width: 42px;
+}
+.structure-inspector-settings-group {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.structure-inspector-settings-group + .structure-inspector-settings-group {
+  margin-top: 4px;
+}
+/* Same small-caps heading with a hairline the viewport menus use to break a long
+   list into readable groups. */
+.structure-inspector-settings-group-title {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  margin: 2px 0 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.structure-inspector-settings-group-title::after {
+  content: "";
+  height: 1px;
+  background: var(--line-subtler);
+}
+.structure-inspector-segment {
+  min-width: 0;
+  width: 100%;
+  display: flex;
+  gap: 1px;
+  border-radius: 7px;
+  padding: 2px;
+  background: var(--surface-input);
+}
+.structure-inspector-segment-button {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 24px;
+  border: 0;
+  border-radius: 5px;
+  padding: 0 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: default;
+  transition: background 120ms ease-out, color 120ms ease-out;
+}
+.structure-inspector-segment-button:hover {
+  color: var(--text-secondary);
+}
+.structure-inspector-segment-button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--accent) 20%, var(--surface-card));
+  color: var(--text-primary);
+}
+.structure-inspector-segment-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
+  outline-offset: -2px;
 }
 .structure-inspector-xtb-setting-control .settings-select {
   width: 100%;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2633,33 +2633,26 @@ img.radix-menu-item-icon {
 .structure-inspector-section-title-button:focus-visible {
   color: var(--text-primary);
 }
-.structure-inspector-engine-notice {
+/* Collapsible wraps the card body in one more element, so the card's own row gap
+   has to be re-established inside it. */
+.structure-inspector-engine-body {
   min-width: 0;
   display: grid;
   gap: 6px;
-  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--line-subtler));
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--accent) 6%, var(--surface-subtle));
-  padding: 7px 8px;
-  justify-items: start;
 }
-.structure-inspector-engine-notice-row {
+.structure-inspector-engine-notices {
   min-width: 0;
-  width: 100%;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
-.structure-inspector-engine-notice-row span {
-  min-width: 0;
+.structure-inspector-engine-notice {
+  border-color: color-mix(in srgb, var(--accent) 26%, var(--line-subtler));
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface-subtle));
+}
+.structure-inspector-engine-notice [data-slot="alert-description"] {
   color: var(--text-secondary);
   font-size: 11px;
   line-height: 1.35;
-}
-.structure-inspector-engine-notice-row strong {
-  color: var(--text-primary);
-  font-weight: 500;
 }
 .structure-inspector-xtb-card[data-collapsed] {
   gap: 0;
@@ -3182,11 +3175,11 @@ img.radix-menu-item-icon {
   height: 1px;
   background: var(--line-subtler);
 }
+/* ToggleGroup sizes itself to its content; in a settings row it has to fill the
+   control column so the options divide it evenly. */
 .structure-inspector-segment {
-  min-width: 0;
   width: 100%;
-  display: flex;
-  gap: 1px;
+  min-width: 0;
   border-radius: 7px;
   padding: 2px;
   background: var(--surface-input);
@@ -3195,30 +3188,16 @@ img.radix-menu-item-icon {
   flex: 1 1 0;
   min-width: 0;
   height: 24px;
-  border: 0;
-  border-radius: 5px;
   padding: 0 4px;
-  background: transparent;
   color: var(--text-muted);
-  font: inherit;
   font-size: 11px;
-  line-height: 1;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
   cursor: default;
-  transition: background 120ms ease-out, color 120ms ease-out;
 }
-.structure-inspector-segment-button:hover {
-  color: var(--text-secondary);
-}
-.structure-inspector-segment-button[aria-pressed="true"] {
+.structure-inspector-segment-button[data-state="on"] {
   background: color-mix(in srgb, var(--accent) 20%, var(--surface-card));
   color: var(--text-primary);
-}
-.structure-inspector-segment-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
-  outline-offset: -2px;
 }
 .structure-inspector-xtb-setting-control .settings-select {
   width: 100%;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2550,32 +2550,6 @@ img.radix-menu-item-icon {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.structure-inspector-selection-pill {
-  min-width: 0;
-  border: 1px solid color-mix(in srgb, var(--accent) 48%, var(--line-subtler));
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--accent) 8%, var(--surface-card));
-  color: var(--text-primary);
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 7px;
-  align-items: center;
-  padding: 5px 6px 5px 8px;
-  font: inherit;
-  font-size: 12px;
-  text-align: left;
-}
-.structure-inspector-selection-pill span {
-  color: var(--text-secondary);
-  font-size: 11px;
-}
-.structure-inspector-selection-pill strong {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: 500;
-}
 .structure-inspector-inline-action {
   min-width: 0;
   height: 22px;
@@ -3777,12 +3751,6 @@ img.radix-menu-item-icon {
 .structure-brief-actions-grid {
   grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
 }
-.structure-brief-actions-secondary {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-.structure-inspector-selected-card {
-  border-color: color-mix(in srgb, var(--accent) 22%, var(--line-subtler));
-}
 .structure-inspector-context-style,
 .structure-inspector-display-style {
   gap: 7px;
@@ -4065,19 +4033,6 @@ img.radix-menu-item-icon {
   font-size: 11px;
   font-weight: 500;
   text-align: right;
-}
-.structure-inspector-selected-meta {
-  min-width: 0;
-  display: grid;
-  gap: 4px;
-}
-.structure-inspector-selected-meta span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--text-muted);
-  font-size: 12px;
 }
 .dock-drop-list {
   min-width: 0;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2633,6 +2633,34 @@ img.radix-menu-item-icon {
 .structure-inspector-section-title-button:focus-visible {
   color: var(--text-primary);
 }
+.structure-inspector-engine-notice {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--line-subtler));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface-subtle));
+  padding: 7px 8px;
+  justify-items: start;
+}
+.structure-inspector-engine-notice-row {
+  min-width: 0;
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+.structure-inspector-engine-notice-row span {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.structure-inspector-engine-notice-row strong {
+  color: var(--text-primary);
+  font-weight: 500;
+}
 .structure-inspector-xtb-card[data-collapsed] {
   gap: 0;
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3245,17 +3245,6 @@ img.radix-menu-item-icon {
   padding: 4px 7px;
   font-size: 11px;
 }
-.structure-inspector-settings-category {
-  min-width: 0;
-  display: grid;
-  gap: 6px;
-}
-.structure-inspector-settings-category h5 {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-}
 .structure-inspector-number-control {
   width: 100%;
   max-width: 150px;
@@ -3757,16 +3746,6 @@ img.radix-menu-item-icon {
   font-size: 12px;
   line-height: 1.3;
 }
-.structure-brief-chip-list {
-  min-width: 0;
-  display: grid;
-  gap: 0;
-  overflow: hidden;
-  border: 1px solid var(--line-subtler);
-  border-radius: 7px;
-  background: var(--surface-card);
-}
-.structure-brief-chip-list > span,
 .structure-brief-chip-button,
 .structure-brief-chip-summary {
   min-width: 0;
@@ -3779,13 +3758,6 @@ img.radix-menu-item-icon {
   font-size: 11px;
   line-height: 1.25;
 }
-.structure-brief-chip-list .structure-brief-action-entry {
-  border-top: 0;
-}
-.structure-brief-chip-list .structure-brief-action-entry + .structure-brief-action-entry {
-  border-top: 1px solid var(--line-subtler);
-}
-.structure-brief-chip-list > span > strong,
 .structure-brief-chip-button strong,
 .structure-brief-chip-summary strong {
   min-width: 0;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1915,7 +1915,23 @@ type BrowserDevConformerRunRequest = {
 async function browserDevConformerStatus() {
   const crest = resolveExecutable("crest");
   const prism = resolveExecutable("prism_pruner") ?? resolveExecutable("prism-pruner");
+  // Browser dev prepares CREST input with obabel just like the app does, so it
+  // has to report on it too - otherwise the panel can only say "unavailable".
+  const obabel = resolveExecutable("obabel");
   return {
+    openbabel: obabel
+      ? {
+          installed: true,
+          executable: obabel,
+          version: await browserDevExecutableVersion(obabel, ["--version"]),
+          installHint: "Open Babel is available for conformer input preparation.",
+        }
+      : {
+          installed: false,
+          executable: null,
+          version: null,
+          installHint: "Install Open Babel or expose obabel on PATH to prepare non-XYZ CREST inputs.",
+        },
     crest: crest
       ? {
           installed: true,

--- a/tests/test-structure-brief.mjs
+++ b/tests/test-structure-brief.mjs
@@ -179,7 +179,10 @@ assert.equal(rowValue(cmsComposition.componentRows, "Polymers"), "1 chain / 1 re
 assert.equal(rowValue(cmsComposition.componentRows, "Ligands"), "None detected");
 assert.equal(rowValue(cmsComposition.componentRows, "Water"), "1 molecule / 3 atoms");
 assert.equal(rowValue(cmsComposition.componentRows, "Ions"), "CL 1 / 1 atoms");
-assert.equal(rowValue(cmsComposition.solventRows, "Water"), "1 molecule / 3 atoms");
+// Water and the Ions summary live only in componentRows now; solventRows carries
+// just the individual ions behind that summary (no duplicate Water/Ions rows).
+assert.equal(cmsComposition.solventRows.find((row) => row.label === "Water"), undefined);
+assert.equal(cmsComposition.solventRows.find((row) => row.label === "Ions"), undefined);
 assert.equal(rowValue(cmsComposition.solventRows, "CL"), "1 ion");
 assert.deepEqual(cmsComposition.maestroRows.find((row) => row.label === "System")?.action?.selector, { kind: "all" });
 assert.deepEqual(cmsComposition.maestroRows.find((row) => row.label === "Solute")?.action?.selector, { structure: "primary" });
@@ -399,9 +402,12 @@ assert.equal(rowValue(miniGro.componentRows, "Polymers"), "1 chain / 1 residue /
 assert.match(rowValue(miniGro.componentRows, "Ions"), /NA 1/);
 assert.equal(miniGro.componentRows.find((row) => row.label === "Ions")?.action?.type, "select_residues");
 assert.equal(miniGro.componentRows.find((row) => row.label === "Ions")?.action?.selector.kind, "ion");
-assert.equal(rowValue(miniGro.solventRows, "Water"), "1 molecule / 2 atoms");
-assert.equal(miniGro.solventRows.find((row) => row.label === "Water")?.action?.type, "hide_waters");
-assert.equal(miniGro.solventRows.find((row) => row.label === "Water")?.secondaryAction?.type, "show_waters");
+// Water and its hide/show actions live on the componentRows summary now;
+// solventRows lists only the individual ions behind it.
+assert.equal(rowValue(miniGro.componentRows, "Water"), "1 molecule / 2 atoms");
+assert.equal(miniGro.componentRows.find((row) => row.label === "Water")?.action?.type, "hide_waters");
+assert.equal(miniGro.componentRows.find((row) => row.label === "Water")?.secondaryAction?.type, "show_waters");
+assert.equal(miniGro.solventRows.find((row) => row.label === "Water"), undefined);
 assert.equal(miniGro.solventRows.find((row) => row.label === "NA")?.action?.selector.kind, "ion");
 
 const histidineAliasGro = parseStructureComposition([

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -790,6 +790,9 @@ assert.match(browserDevDescriptors, /server\.middlewares\.use\("\/__burette\/des
 assert.match(browserDevDescriptors, /sendJsonError\(res, 500, error, "no-cache"\)/);
 assert.match(viteConfig, /registerBrowserDevConformerJobRoutes\(server,/);
 assert.match(browserDevConformerJobs, /server\.middlewares\.use\("\/__burette\/conformer-status"/);
+// Browser dev prepares CREST input with obabel, so its status payload reports on
+// it the same way the Tauri command does.
+assert.match(viteConfig, /const obabel = resolveExecutable\("obabel"\);\s*return \{\s*openbabel: obabel/);
 assert.match(browserDevConformerJobs, /server\.middlewares\.use\("\/__burette\/prepare-conformer-job"/);
 assert.match(viteConfig, /registerBrowserDevXtbRoutes\(server,/);
 assert.match(browserDevXtb, /server\.middlewares\.use\("\/__burette\/xtb-status"/);
@@ -1216,6 +1219,10 @@ assert.match(appChemistryJobsHook, /normalizeXtbSettings\(settings\)/);
 assert.match(appChemistryJobsHook, /saveXtbSettings\(normalized\)/);
 assert.match(appChemistryJobsHook, /requestConformerStatus\(\)/);
 assert.match(appChemistryJobsHook, /pushStatus\(conformerStatusLine\(status\)\)/);
+// Both statuses are probed at startup, silently - the inspector decides what it
+// can offer from them, so "not checked" is not a useful starting state.
+assert.match(appChemistryJobsHook, /let cancelled = false;\s*void requestConformerStatus\(\)\.then\(\(status\) => \{ if \(!cancelled\) setConformerStatus\(status\); \}\)/);
+assert.match(appChemistryJobsHook, /void requestXtbStatus\(\)\.then\(\(status\) => \{ if \(!cancelled\) setXtbStatus\(status\); \}\)/);
 assert.match(appChemistryJobsHook, /requestXtbStatus\(\)/);
 assert.match(appChemistryJobsHook, /installXtbRequest\(\)/);
 assert.match(appChemistryJobsHook, /cancelConformerRequest\(jobId\)/);
@@ -2436,6 +2443,15 @@ assert.match(structureInfoPanel, /actions\.copyDocumentPath\(document\)/);
 assert.match(structureInfoPanel, /structureBriefForDocument\(document, formatBytes\(document\.byteCount\)\)/);
 assert.match(structureInfoPanel, /readBrowserDevVirtualTextDocument\(document\.path\)/);
 assert.match(structureInfoPanel, /StructureSectionHeader title="Composition"/);
+// Conformers and xTB share one card shell, and a missing binary has to say what
+// it is and how to get it rather than leaving a dead disabled button.
+assert.match(structureInfoPanel, /function InspectorEngineCard\(\{/);
+assert.match(structureInfoPanel, /function EngineToolNotice\(\{ tools, onCheck \}/);
+assert.match(structureInfoPanel, /const missing = tools\.filter\(\(tool\) => !tool\.installed\)/);
+assert.match(structureInfoPanel, /const xtbMissing = xtbStatus\?\.installed === false/);
+assert.match(structureInfoPanel, /install: \(\) => void actions\.installXtb\(\)/);
+assert.match(structureInfoPanel, /function conformerTools\(status: ShellViewState\["conformerStatus"\]\): EngineTool\[\]/);
+assert.match(structureInfoPanel, /const XTB_MORE_OPERATIONS = \[/);
 assert.match(structureInfoPanel, /key: "maestro"/);
 assert.match(structureInfoPanel, /label: "Maestro entries"/);
 assert.match(structureInfoPanel, /\["Maestro entry", summary\.maestroRows \?\? \[\]\]/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -133,6 +133,7 @@ const [
   settingControl,
   dockPanel,
   structureInfoPanel,
+  foldingResultsPanel,
   closeIcon,
   shortcutTooltip,
   pageKinds,
@@ -337,6 +338,7 @@ const [
   source('apps/desktop/src/components/settings-panel/setting-control.tsx'),
   source('apps/desktop/src/components/dock-panel.tsx'),
   source('apps/desktop/src/components/structure-info-panel.tsx'),
+  source('apps/desktop/src/components/folding-results-panel.tsx'),
   source('apps/desktop/src/components/close-icon.tsx'),
   source('apps/desktop/src/components/shortcut-tooltip.tsx'),
   source('apps/desktop/src/components/editor-area/page-kinds/index.ts'),
@@ -2460,6 +2462,18 @@ assert.match(structureInfoPanel, /const xtbBlocked = xtbMissing \|\| oversizedFo
 assert.match(structureInfoPanel, /const crestDisabled = !canRunCrest \|\| oversized \|\| status\?\.crest\.installed === false/);
 assert.match(directChemistryGuard, /export const DIRECT_CHEMISTRY_JOB_ATOM_LIMIT = 300/);
 assert.match(directChemistryGuard, /export function structureAtomCountFromSummary\(summary: StructureCompositionSummary\)/);
+// The backend writes --cpcmx; the old list guessed --cpcm, so a solvated run was
+// reported back as gas phase.
+assert.match(structureInfoPanel, /"--cpcmx": "CPCM-X"/);
+assert.match(structureInfoPanel, /XTB_SOLVATION_FLAG_LABELS\[part\.toLowerCase\(\)\]/);
+// inputLabel exists from the moment a job is queued, so it must be testable
+// without a result - otherwise a running job never matches its own document.
+assert.match(structureInfoPanel, /if \(job\.inputLabel === document\.title\) return true;/);
+assert.match(structureInfoPanel, /const runningXtbJob = latestXtbJob\?\.status === "running" \? latestXtbJob : null/);
+// The panel the "Full PAE" button opens has to actually contain the matrix.
+assert.match(foldingResultsPanel, /<FoldingMatrixHeatmap preview=\{activeModel\.matrixPreview\} size="large" \/>/);
+// A keyboard-generated click reports detail 0; the pointer handlers own the rest.
+assert.match(foldingResultsPanel, /if \(event\.detail !== 0\) return;/);
 // Short mutually exclusive sets are switches, not dropdowns, and the engine's own
 // tokens ("gfnff", "verytight", "ch2cl2") never reach the reader untranslated.
 assert.match(structureInfoPanel, /function InlineSegmentedControl\(\{/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2435,11 +2435,16 @@ assert.match(structureInfoPanel, /actions\.revealDocument\(document\)/);
 assert.match(structureInfoPanel, /actions\.copyDocumentPath\(document\)/);
 assert.match(structureInfoPanel, /structureBriefForDocument\(document, formatBytes\(document\.byteCount\)\)/);
 assert.match(structureInfoPanel, /readBrowserDevVirtualTextDocument\(document\.path\)/);
-assert.match(structureInfoPanel, /compositionSummary\?\.maestroRows\?\.length/);
-assert.match(structureInfoPanel, /StructureSectionHeader title="Maestro entries"/);
+assert.match(structureInfoPanel, /StructureSectionHeader title="Composition"/);
+assert.match(structureInfoPanel, /key: "maestro"/);
+assert.match(structureInfoPanel, /label: "Maestro entries"/);
 assert.match(structureInfoPanel, /\["Maestro entry", summary\.maestroRows \?\? \[\]\]/);
 assert.match(structureInfoPanel, /valueForLabel\(summary\.rows, "Preview atoms"\)/);
-assert.match(structureInfoPanel, /StructureSectionHeader title="Chains"/);
+// Chains, ligands and ions hang off their own summary row rather than getting a
+// card each, which is what stops the panel repeating itself.
+assert.match(structureInfoPanel, /row\.label === "Polymers" \? summary\.polymerRows/);
+assert.match(structureInfoPanel, /row\.label === "Ligands" \? summary\.ligandRows/);
+assert.match(structureInfoPanel, /const COMPOSITION_AUTO_EXPAND_LIMIT = 8/);
 assert.match(structureInfoPanel, /StructureSectionHeader title="Selected entity"/);
 assert.match(structureInfoPanel, /const SDF_CONTEXT_STYLE_OPTIONS = \[/);
 assert.match(structureInfoPanel, /\{ value: "line", label: "Line" \}/);
@@ -2563,8 +2568,8 @@ assert.doesNotMatch(structureInfoPanel, /opacityDisabled/);
 assert.match(structureInfoPanel, /onInput=\{\(event\) => applyOpacity\(Number\(event\.currentTarget\.value\)\)\}/);
 assert.match(structureInfoPanel, /Math\.round\(opacity \* 100\)/);
 assert.ok(
-  structureInfoPanel.indexOf("<SdfContextStyleCard") < structureInfoPanel.indexOf('StructureSectionHeader title="Components"'),
-  "SDF all-background controls should appear above Components"
+  structureInfoPanel.indexOf("<SdfContextStyleCard") < structureInfoPanel.indexOf("<StructureCompositionCard"),
+  "SDF all-background controls should appear above the composition tree"
 );
 assert.match(styles, /\.structure-inspector-style-options \{/);
 assert.match(styles, /\.structure-brief \{[\s\S]*?grid-auto-rows: max-content/);
@@ -2588,13 +2593,13 @@ assert.match(structureInfoPanel, /const virtualText = source\.virtual \? readBro
 assert.match(structureInfoPanel, /return readStructureText\(source\.path, \{ maxBytes \}\)/);
 assert.match(structureInfoPanel, /return 12 \* 1024 \* 1024/);
 assert.match(structureInfoPanel, /const primaryAction = row\.action/);
-assert.match(structureInfoPanel, /key=\{structureActionRowKey\(row, index\)\}/);
+assert.match(structureInfoPanel, /key=\{structureActionRowKey\(child, index\)\}/);
 assert.match(structureInfoPanel, /function structureActionRowKey\(row: StructureSummaryRow, index: number\)/);
-assert.match(structureInfoPanel, /const handleKeyDown = \(event: KeyboardEvent<HTMLDivElement>\) => \{/);
+assert.match(structureInfoPanel, /function structureRowsKeyDown\(event: KeyboardEvent<HTMLDivElement>\) \{/);
 assert.match(structureInfoPanel, /event\.key !== "ArrowDown" && event\.key !== "ArrowUp"/);
 assert.match(structureInfoPanel, /buttons\[nextIndex\]\.focus\(\)/);
 assert.match(structureInfoPanel, /buttons\[nextIndex\]\.click\(\)/);
-assert.match(structureInfoPanel, /onKeyDown=\{handleKeyDown\}/);
+assert.match(structureInfoPanel, /onKeyDown=\{structureRowsKeyDown\}/);
 assert.match(structureInfoPanel, /const primaryActionKey = selectionActionKey\(document, primaryAction\)/);
 assert.match(structureInfoPanel, /primaryActionKey !== null && primaryActionKey === activeActionKey/);
 assert.match(structureInfoPanel, /data-selected=\{selected \|\| undefined\}/);
@@ -2608,7 +2613,9 @@ assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) ret
 assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return "Show molecule"/);
 assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return `Molecule \$\{action\.index \+ 1\}`/);
 assert.match(structureInfoPanel, /navigator\.clipboard\?\.writeText/);
-assert.match(structureInfoPanel, /Water \/ ions/);
+// Water and Ions already have summary rows, so the solvent list contributes only
+// the individual ions rather than repeating its own headings.
+assert.match(structureInfoPanel, /summary\.solventRows\.filter\(\(row\) => row\.label !== "Water" && row\.label !== "Ions"\)/);
 assert.match(structureInfoPanel, /structure-brief-mini-action/);
 assert.match(structureInfoPanel, /function visibleComponentRows\(rows: StructureSummaryRow\[\]\)/);
 assert.match(structureInfoPanel, /row\.value !== "None detected" \|\| row\.action/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4876,6 +4876,21 @@ assert.match(previewRuntimeCss, /body:has\(\.msp-viewport-controls-buttons \.msp
 assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*hideGenerate3DMenu\(\);/);
 assert.match(previewViewer, /const viewportControlRailRect = visibleRect\('\.msp-plugin \.msp-viewport-controls-buttons'\);/);
 assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail'\) \|\| viewportControlRailRect;/);
+// The rail carries its own animation button, the way Mol*'s viewport controls did:
+// a trackball that keeps turning plus the plugin's timed animations, each listed
+// once and each able to say why it is unavailable.
+assert.match(viewerShell, /data-buret-viewport-action="animate"/);
+assert.match(previewViewer, /openViewportMenu\(control, 'Animate', viewportAnimateMenu\)/);
+assert.match(previewViewer, /function viewportAnimateMenu\(menu\) \{/);
+assert.match(previewViewer, /const VIEWPORT_MOTION_ANIMATIONS = new Set\(\[/);
+assert.match(previewViewer, /'built-in\.animate-camera-spin'/);
+assert.match(previewViewer, /\.filter\(entry => entry\.applicability\.canApply \|\| entry\.applicability\.reason\)/);
+assert.match(previewViewer, /plugin\?\.behaviors\?\.state\?\.isAnimating\?\.subscribe\?\.\(updateViewportAnimateState\)/);
+// Motion lives on the animate button now, so the camera menu must not offer it too.
+assert.doesNotMatch(
+  previewViewer.slice(previewViewer.indexOf("function viewportCameraMenu"), previewViewer.indexOf("function viewportAnimateMenu")),
+  /viewportMotionControls/,
+);
 assert.match(previewViewer, /window\.innerWidth - railRect\.left \+ FLOATING_LAYOUT_GAP \* 2/);
 assert.match(previewViewer, /root\.style\.setProperty\('--buret-generate-3d-control-right', generate3DControlRight \+ 'px'\);/);
 assert.match(previewRuntimeCss, /background: color-mix\(in srgb, var\(--buret-toolbar-background\) 92%/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2507,7 +2507,10 @@ assert.match(structureInfoPanel, /valueForLabel\(summary\.rows, "Preview atoms"\
 assert.match(structureInfoPanel, /row\.label === "Polymers" \? summary\.polymerRows/);
 assert.match(structureInfoPanel, /row\.label === "Ligands" \? summary\.ligandRows/);
 assert.match(structureInfoPanel, /const COMPOSITION_AUTO_EXPAND_LIMIT = 8/);
-assert.match(structureInfoPanel, /StructureSectionHeader title="Selected entity"/);
+// The standalone "Selected entity" card was removed - the tree row highlight and
+// the run-scope line already say what is selected, so the card only repeated them.
+assert.doesNotMatch(structureInfoPanel, /StructureSectionHeader title="Selected entity"/);
+assert.doesNotMatch(structureInfoPanel, /function SelectedEntityCard\(/);
 assert.match(structureInfoPanel, /const SDF_CONTEXT_STYLE_OPTIONS = \[/);
 assert.match(structureInfoPanel, /\{ value: "line", label: "Line" \}/);
 assert.match(structureInfoPanel, /\{ value: "cartoon", label: "Cartoon" \}/);
@@ -2643,7 +2646,6 @@ assert.match(previewRuntimeCss, /@media \(max-width: 360px\)[\s\S]*?top: 64px;[\
 assert.match(previewRuntimeCss, /grid-template-columns: 28px auto minmax\(62px, 1fr\) auto auto/);
 assert.doesNotMatch(previewRuntimeCss, /\.buret-trajectory-smooth-button \{\s*grid-column:/);
 assert.match(styles, /\.structure-inspector-opacity-control \{/);
-assert.match(structureInfoPanel, /structure-inspector-selection-pill/);
 assert.match(structureInfoPanel, /inspectorSummaryLine\(brief\.kind, compositionSummary, compositionPending, compositionError\)/);
 assert.match(structureInfoPanel, /readBrowserDevVirtualTextDocument/);
 assert.match(structureInfoPanel, /function structureCompositionSourceForDocument\(document: ViewerDocument\): InspectorStructureTextSource/);
@@ -2672,8 +2674,6 @@ assert.match(structureInfoPanel, /type: "clear_selection", label: "Clear selecti
 assert.match(structureInfoPanel, /actions\.runStructureViewerAction\(document, action\)/);
 assert.match(structureInfoPanel, /selectionActionKey\(document: ViewerDocument, action: StructureViewerAction\)/);
 assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return JSON\.stringify\(\[document\.id, action\.type, action\.index\]\)/);
-assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return "Show molecule"/);
-assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return `Molecule \$\{action\.index \+ 1\}`/);
 assert.match(structureInfoPanel, /navigator\.clipboard\?\.writeText/);
 // Water and Ions already have their rows in componentRows, so the parser emits
 // solventRows as the individual ions only - no filtering needed downstream.
@@ -2717,7 +2717,6 @@ assert.match(structureBrief, /\["cube", "cub"\]/);
 assert.match(styles, /\.structure-brief-card \{/);
 assert.match(styles, /\.structure-brief-actions \{/);
 assert.match(styles, /\.structure-inspector-header \{/);
-assert.match(styles, /\.structure-inspector-selection-pill \{/);
 assert.doesNotMatch(structureInfoPanel, /structure-inspector-row-action/);
 assert.doesNotMatch(structureInfoPanel, /rowActionLabel/);
 assert.doesNotMatch(structureInfoPanel, /selectedEntity\.action\.type === "focus_ligand" \? "Focus" : "Select"/);
@@ -4927,8 +4926,8 @@ assert.match(previewViewer, /'built-in\.animate-camera-spin'/);
 assert.match(previewViewer, /\.filter\(entry => entry\.applicability\.canApply \|\| entry\.applicability\.reason\)/);
 // Rock reads an angle and an axis besides its speed; a partial payload leaves the
 // maths on undefined and the scene simply never moves.
-assert.match(previewViewer, /rock: \{ value: 0\.3, min: -5, max: 5, step: 0\.1, params: \{ angle: 10, axis: \[0, -1, 0\] \} \}/);
-assert.match(previewViewer, /spin: \{ value: 0\.1, min: -2, max: 2, step: 0\.01, params: \{ axis: \[0, -1, 0\] \} \}/);
+assert.match(previewViewer, /rock: \{ value: 0\.3, min: 0\.02, max: 1\.5, step: 0\.02, params: \{ angle: 10, axis: \[0, -1, 0\] \} \}/);
+assert.match(previewViewer, /spin: \{ value: 0\.1, min: 0\.01, max: 1, step: 0\.01, params: \{ axis: \[0, -1, 0\] \} \}/);
 // Mol* defaults Unwind Assembly to looping, so an animation started from here has
 // to be told to finish.
 assert.match(previewViewer, /if \('playOnce' in params\) params\.playOnce = true;/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2477,6 +2477,19 @@ assert.match(foldingResultsPanel, /if \(event\.detail !== 0\) return;/);
 // Short mutually exclusive sets are switches, not dropdowns, and the engine's own
 // tokens ("gfnff", "verytight", "ch2cl2") never reach the reader untranslated.
 assert.match(structureInfoPanel, /function InlineSegmentedControl\(\{/);
+// The panel builds on the shadcn registry rather than hand-rolled equivalents:
+// ToggleGroup brings roving focus to the segmented controls, Collapsible owns the
+// card open state, Alert carries the tool notices and Badge the format pill.
+assert.match(structureInfoPanel, /from "@\/components\/ui\/toggle-group"/);
+assert.match(structureInfoPanel, /from "@\/components\/ui\/collapsible"/);
+assert.match(structureInfoPanel, /from "@\/components\/ui\/alert"/);
+assert.match(structureInfoPanel, /from "@\/components\/ui\/badge"/);
+assert.match(structureInfoPanel, /<ToggleGroup\s+type="single"/);
+// A radio group is never empty: re-clicking the active option must not clear it.
+assert.match(structureInfoPanel, /onValueChange=\{\(next\) => \{ if \(next\) onChange\(next\); \}\}/);
+assert.match(structureInfoPanel, /<Badge variant="secondary">\{brief\.format\}<\/Badge>/);
+// The scene stepper is identified by the scene itself, not by the parser failing.
+assert.match(structureInfoPanel, /if \(sceneStructureCount > 1 && sceneStructureCount <= INFO_TRAJECTORY_CONTROL_LIMIT\)/);
 assert.match(structureInfoPanel, /function InlineSettingsSection\(\{ title, children \}/);
 assert.match(structureInfoPanel, /gfnff: "GFN-FF"/);
 assert.match(structureInfoPanel, /verytight: "Very tight"/);
@@ -2662,9 +2675,10 @@ assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) ret
 assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return "Show molecule"/);
 assert.match(structureInfoPanel, /if \(action\.type === "set_sdf_molecule"\) return `Molecule \$\{action\.index \+ 1\}`/);
 assert.match(structureInfoPanel, /navigator\.clipboard\?\.writeText/);
-// Water and Ions already have summary rows, so the solvent list contributes only
-// the individual ions rather than repeating its own headings.
-assert.match(structureInfoPanel, /summary\.solventRows\.filter\(\(row\) => row\.label !== "Water" && row\.label !== "Ions"\)/);
+// Water and Ions already have their rows in componentRows, so the parser emits
+// solventRows as the individual ions only - no filtering needed downstream.
+assert.match(structureInfoPanel, /row\.label === "Ions" \? summary\.solventRows/);
+assert.doesNotMatch(structureComposition, /label: "Ions",\s*value: `\$\{formatNameCounts\(ionGroups, 8\)\}/);
 assert.match(structureInfoPanel, /structure-brief-mini-action/);
 assert.match(structureInfoPanel, /function visibleComponentRows\(rows: StructureSummaryRow\[\]\)/);
 assert.match(structureInfoPanel, /row\.value !== "None detected" \|\| row\.action/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4885,6 +4885,14 @@ assert.match(previewViewer, /function viewportAnimateMenu\(menu\) \{/);
 assert.match(previewViewer, /const VIEWPORT_MOTION_ANIMATIONS = new Set\(\[/);
 assert.match(previewViewer, /'built-in\.animate-camera-spin'/);
 assert.match(previewViewer, /\.filter\(entry => entry\.applicability\.canApply \|\| entry\.applicability\.reason\)/);
+// Rock reads an angle and an axis besides its speed; a partial payload leaves the
+// maths on undefined and the scene simply never moves.
+assert.match(previewViewer, /rock: \{ value: 0\.3, min: -5, max: 5, step: 0\.1, params: \{ angle: 10, axis: \[0, -1, 0\] \} \}/);
+assert.match(previewViewer, /spin: \{ value: 0\.1, min: -2, max: 2, step: 0\.01, params: \{ axis: \[0, -1, 0\] \} \}/);
+// Mol* defaults Unwind Assembly to looping, so an animation started from here has
+// to be told to finish.
+assert.match(previewViewer, /if \('playOnce' in params\) params\.playOnce = true;/);
+assert.match(previewViewer, /manager\.play\(animation, viewportAnimationParams\(animation, plugin\)\)/);
 assert.match(previewViewer, /plugin\?\.behaviors\?\.state\?\.isAnimating\?\.subscribe\?\.\(updateViewportAnimateState\)/);
 // Motion lives on the animate button now, so the camera menu must not offer it too.
 assert.doesNotMatch(

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4927,7 +4927,17 @@ assert.match(previewViewer, /openViewportMenu\(control, 'Animate', viewportAnima
 assert.match(previewViewer, /function viewportAnimateMenu\(menu\) \{/);
 // Closing the molecule card drops the selection, and the host has to be told
 // directly because clearing this way does not reach the selection manager events.
-assert.match(previewViewer, /function dismissMolstarMoleculePreview\(\) \{[\s\S]*clearMolstarSelection\(\);[\s\S]*notifyMolstarSelectionChanged\(null\);/);
+// × parks the card without touching the selection: it latches "suppressed" and
+// hides, and the latch lifts on the next genuine click (pointerup, no drag).
+assert.match(previewViewer, /function dismissMolstarMoleculePreview\(\) \{\s*molstarMoleculePreviewSuppressed = true;\s*hideMolstarMoleculePreview\(\{ force: true \}\);\s*\}/);
+assert.doesNotMatch(previewViewer, /function dismissMolstarMoleculePreview\(\)[\s\S]{0,200}clearMolstarSelection\(\)/);
+assert.match(previewViewer, /if \(molstarMoleculePreviewSuppressed \|\| molstarMoleculePreviewMinimized\) return;/);
+assert.match(previewViewer, /if \(!moved && molstarMoleculePreviewSuppressed && !molstarMoleculePreviewMinimized\)/);
+// Minimize tucks the card into a corner chip that restores the same molecule.
+assert.match(previewViewer, /function minimizeMolstarMoleculePreview\(\)/);
+assert.match(previewViewer, /function restoreMolstarMoleculePreview\(\)/);
+assert.match(previewViewer, /data-buret-molecule-preview-action="minimize"/);
+assert.match(previewRuntimeCss, /\.buret-molecule-preview-chip \{/);
 assert.match(structureInfoPanel, /setActiveActionKey\(\(current\) => current && current\.includes\("focus_ligand"\) \? null : current\)/);
 assert.match(previewViewer, /const VIEWPORT_MOTION_ANIMATIONS = new Set\(\[/);
 assert.match(previewViewer, /'built-in\.animate-camera-spin'/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2452,6 +2452,17 @@ assert.match(structureInfoPanel, /const xtbMissing = xtbStatus\?\.installed === 
 assert.match(structureInfoPanel, /install: \(\) => void actions\.installXtb\(\)/);
 assert.match(structureInfoPanel, /function conformerTools\(status: ShellViewState\["conformerStatus"\]\): EngineTool\[\]/);
 assert.match(structureInfoPanel, /const XTB_MORE_OPERATIONS = \[/);
+// Short mutually exclusive sets are switches, not dropdowns, and the engine's own
+// tokens ("gfnff", "verytight", "ch2cl2") never reach the reader untranslated.
+assert.match(structureInfoPanel, /function InlineSegmentedControl\(\{/);
+assert.match(structureInfoPanel, /function InlineSettingsSection\(\{ title, children \}/);
+assert.match(structureInfoPanel, /gfnff: "GFN-FF"/);
+assert.match(structureInfoPanel, /verytight: "Very tight"/);
+assert.match(structureInfoPanel, /ch2cl2: "Dichloromethane"/);
+assert.match(structureInfoPanel, /none: "Gas phase"/);
+assert.match(structureInfoPanel, /function XtbSettingsGroup\(\{ title, labelled, children \}/);
+assert.match(settingControl, /labels\?: Record<string, string>/);
+assert.match(settingControl, /\{labels\?\.\[option\] \?\? option\}/);
 assert.match(structureInfoPanel, /key: "maestro"/);
 assert.match(structureInfoPanel, /label: "Maestro entries"/);
 assert.match(structureInfoPanel, /\["Maestro entry", summary\.maestroRows \?\? \[\]\]/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4918,6 +4918,10 @@ assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail
 assert.match(viewerShell, /data-buret-viewport-action="animate"/);
 assert.match(previewViewer, /openViewportMenu\(control, 'Animate', viewportAnimateMenu\)/);
 assert.match(previewViewer, /function viewportAnimateMenu\(menu\) \{/);
+// Closing the molecule card drops the selection, and the host has to be told
+// directly because clearing this way does not reach the selection manager events.
+assert.match(previewViewer, /function dismissMolstarMoleculePreview\(\) \{[\s\S]*clearMolstarSelection\(\);[\s\S]*notifyMolstarSelectionChanged\(null\);/);
+assert.match(structureInfoPanel, /setActiveActionKey\(\(current\) => current && current\.includes\("focus_ligand"\) \? null : current\)/);
 assert.match(previewViewer, /const VIEWPORT_MOTION_ANIMATIONS = new Set\(\[/);
 assert.match(previewViewer, /'built-in\.animate-camera-spin'/);
 assert.match(previewViewer, /\.filter\(entry => entry\.applicability\.canApply \|\| entry\.applicability\.reason\)/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -134,6 +134,7 @@ const [
   dockPanel,
   structureInfoPanel,
   foldingResultsPanel,
+  foldingResultsLib,
   closeIcon,
   shortcutTooltip,
   pageKinds,
@@ -339,6 +340,7 @@ const [
   source('apps/desktop/src/components/dock-panel.tsx'),
   source('apps/desktop/src/components/structure-info-panel.tsx'),
   source('apps/desktop/src/components/folding-results-panel.tsx'),
+  source('apps/desktop/src/lib/folding-results.ts'),
   source('apps/desktop/src/components/close-icon.tsx'),
   source('apps/desktop/src/components/shortcut-tooltip.tsx'),
   source('apps/desktop/src/components/editor-area/page-kinds/index.ts'),
@@ -2471,6 +2473,12 @@ assert.match(structureInfoPanel, /XTB_SOLVATION_FLAG_LABELS\[part\.toLowerCase\(
 assert.match(structureInfoPanel, /if \(job\.inputLabel === document\.title\) return true;/);
 assert.match(structureInfoPanel, /const runningXtbJob = latestXtbJob\?\.status === "running" \? latestXtbJob : null/);
 // The panel the "Full PAE" button opens has to actually contain the matrix.
+// A structure with only a stray metadata sidecar is not a folding result, so the
+// card requires real folding signal rather than "any model or artifact".
+assert.match(foldingResultsLib, /const isFoldingArtifact = \(artifact: \{ kind: string \}\) => artifact\.kind !== "metadata"/);
+assert.match(foldingResultsLib, /model\.metrics\.length > 0/);
+assert.match(foldingResultsLib, /\|\| bundle\.artifacts\.some\(isFoldingArtifact\)/);
+assert.doesNotMatch(foldingResultsLib, /bundle\.models\.length > 0 \|\| bundle\.artifacts\.length > 0/);
 assert.match(foldingResultsPanel, /<FoldingMatrixHeatmap preview=\{activeModel\.matrixPreview\} size="large" \/>/);
 // A keyboard-generated click reports detail 0; the pointer handlers own the rest.
 assert.match(foldingResultsPanel, /if \(event\.detail !== 0\) return;/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2452,6 +2452,14 @@ assert.match(structureInfoPanel, /const xtbMissing = xtbStatus\?\.installed === 
 assert.match(structureInfoPanel, /install: \(\) => void actions\.installXtb\(\)/);
 assert.match(structureInfoPanel, /function conformerTools\(status: ShellViewState\["conformerStatus"\]\): EngineTool\[\]/);
 assert.match(structureInfoPanel, /const XTB_MORE_OPERATIONS = \[/);
+// The runtime refuses a direct job above the atom cap and tells you to select
+// something; the card knows the count already, so it says so before the click.
+assert.match(structureInfoPanel, /structureAtomCountFromSummary\(compositionSummary\)/);
+assert.match(structureInfoPanel, /const oversizedForDirectJob = !jobScopedToSelection/);
+assert.match(structureInfoPanel, /const xtbBlocked = xtbMissing \|\| oversizedForDirectJob/);
+assert.match(structureInfoPanel, /const crestDisabled = !canRunCrest \|\| oversized \|\| status\?\.crest\.installed === false/);
+assert.match(directChemistryGuard, /export const DIRECT_CHEMISTRY_JOB_ATOM_LIMIT = 300/);
+assert.match(directChemistryGuard, /export function structureAtomCountFromSummary\(summary: StructureCompositionSummary\)/);
 // Short mutually exclusive sets are switches, not dropdowns, and the engine's own
 // tokens ("gfnff", "verytight", "ch2cl2") never reach the reader untranslated.
 assert.match(structureInfoPanel, /function InlineSegmentedControl\(\{/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2459,7 +2459,12 @@ assert.match(structureInfoPanel, /const XTB_MORE_OPERATIONS = \[/);
 // The runtime refuses a direct job above the atom cap and tells you to select
 // something; the card knows the count already, so it says so before the click.
 assert.match(structureInfoPanel, /structureAtomCountFromSummary\(compositionSummary\)/);
-assert.match(structureInfoPanel, /const oversizedForDirectJob = !jobScopedToSelection/);
+// The size gate judges the scoped object, so a whole-chain selection (over the
+// cap) stays blocked rather than "a selection exists" lifting it.
+assert.match(structureInfoPanel, /const scopedAtoms = selectedScopeAtomCount\(selectedEntity, viewerLigandSelection\)/);
+assert.match(structureInfoPanel, /const effectiveAtoms = jobScopedToSelection \? scopedAtoms : structureAtoms/);
+assert.match(structureInfoPanel, /const oversizedForDirectJob = effectiveAtoms !== null && effectiveAtoms > DIRECT_CHEMISTRY_JOB_ATOM_LIMIT/);
+assert.match(structureInfoPanel, /function selectedScopeAtomCount\(/);
 assert.match(structureInfoPanel, /const xtbBlocked = xtbMissing \|\| oversizedForDirectJob/);
 assert.match(structureInfoPanel, /const crestDisabled = !canRunCrest \|\| oversized \|\| status\?\.crest\.installed === false/);
 assert.match(directChemistryGuard, /export const DIRECT_CHEMISTRY_JOB_ATOM_LIMIT = 300/);


### PR DESCRIPTION
Builds on #497/#498 (Mol* scene tree + viewport controls) with a broad pass over the inspector panel and the viewer overlay.

## Molecular Inspector (`structure-info-panel.tsx`)
- **Rebuilt on the shadcn registry** — added `badge`, `collapsible`, `alert`, `toggle-group` and replaced hand-rolled equivalents. Segmented controls (method / convergence / solvation) are now a real `ToggleGroup` radio group with roving focus; engine cards use `Collapsible`; tool notices use `Alert`; the format pill is a `Badge`. Action buttons are shadcn `Button`s.
- **Composition folded into one tree** — the parser reported each group twice (a summary row + the members); the panel now renders one collapsible tree, and `structure-composition.ts` no longer duplicates Water/Ions into `solventRows`.
- **Engine cards share one shell** (`InspectorEngineCard`) for Conformers + xTB, and surface what's missing: a missing binary shows its install hint (and an Install button for xTB) instead of a dead disabled button. CREST/PRISM/xTB status is probed once at startup; browser-dev now reports Open Babel too.
- **Direct-job size gate** — CREST/xTB are capped at 300 atoms; the card now says so *before* the click and gates on the **scoped** object's size (a whole-chain selection stays blocked), not merely "a selection exists".
- Settings forms reworked (wrapping labels, humanised tokens — GFN-FF / Gas phase / Dichloromethane, units on sliders, section headings). Removed the redundant "Selected entity" card.
- **Folding card only shows for real folding results** (`folding-results.ts`) — a plain structure next to a stray `.json` sidecar no longer masquerades as folding output.

## Mol* viewer overlay (`viewer.js`, `viewer-shell.js`, `viewer-runtime.css`)
- **Scene animation returned as its own rail button** — Motion (trackball spin/rock, runs until off) + Play once (the plugin's timed animations, which stop themselves and show their unavailability reason). Fixed rock standing still (it needs axis + angle, not just speed).
- **Motion speed slider** made finer and magnitude-only (slow→fast, default off-centre).
- **Molecule preview card** — × closes it but keeps the selection and stays shut until the next genuine click (a drag to rotate doesn't count); added a **minimize** button that tucks it into a corner chip which restores the same molecule.
- Sidebar nested-folder icons follow their own expanded state.

## Fixes from an inspector audit
CPCM-X reported as gas phase; a running xTB job never matched its own document; Full PAE opened without the heatmap; the folding sequence strip took no keyboard; duplicate charge-colouring callbacks; orphaned CSS.

## Tests
Contract/brief/format tests updated to match. `test:ui` green, `tsc` clean (the only tsc errors are in #499's `toast.tsx` pending a local `@base-ui/react` install — resolved by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)