### PR TITLE
Redesign the update progress panel

### DIFF
--- a/apps/desktop/src-tauri/src/commands/update_progress.rs
+++ b/apps/desktop/src-tauri/src/commands/update_progress.rs
@@ -7,8 +7,43 @@ use std::sync::{LazyLock, Mutex};
 #[derive(Clone, Copy)]
 struct NativeUpdateProgressWindow {
     window: usize,
-    message_label: usize,
+    title_label: usize,
+    detail_label: usize,
     progress_indicator: usize,
+}
+
+/// Panel geometry. Every vertical position is derived from these heights so the
+/// content block stays centered instead of relying on hand-placed coordinates.
+#[cfg(target_os = "macos")]
+mod layout {
+    pub(super) const WINDOW_WIDTH: f64 = 400.0;
+    pub(super) const WINDOW_HEIGHT: f64 = 104.0;
+    pub(super) const CORNER_RADIUS: f64 = 12.0;
+    pub(super) const HORIZONTAL_PADDING: f64 = 20.0;
+    pub(super) const ICON_SIZE: f64 = 36.0;
+    pub(super) const ICON_TEXT_GAP: f64 = 12.0;
+    pub(super) const TITLE_HEIGHT: f64 = 17.0;
+    pub(super) const TITLE_BAR_GAP: f64 = 8.0;
+    /// Thickness the progress bar occupies in the layout.
+    pub(super) const BAR_HEIGHT: f64 = 6.0;
+    /// `NSProgressIndicator` draws a thin bar centered in a taller intrinsic
+    /// frame, so the view is centered on the layout slot rather than matching it.
+    pub(super) const BAR_VIEW_HEIGHT: f64 = 20.0;
+    pub(super) const BAR_DETAIL_GAP: f64 = 7.0;
+    pub(super) const DETAIL_HEIGHT: f64 = 14.0;
+
+    pub(super) const CONTENT_HEIGHT: f64 =
+        TITLE_HEIGHT + TITLE_BAR_GAP + BAR_HEIGHT + BAR_DETAIL_GAP + DETAIL_HEIGHT;
+    pub(super) const CONTENT_BOTTOM: f64 = (WINDOW_HEIGHT - CONTENT_HEIGHT) / 2.0;
+
+    pub(super) const DETAIL_Y: f64 = CONTENT_BOTTOM;
+    pub(super) const BAR_Y: f64 = DETAIL_Y + DETAIL_HEIGHT + BAR_DETAIL_GAP;
+    pub(super) const BAR_VIEW_Y: f64 = BAR_Y + (BAR_HEIGHT - BAR_VIEW_HEIGHT) / 2.0;
+    pub(super) const TITLE_Y: f64 = BAR_Y + BAR_HEIGHT + TITLE_BAR_GAP;
+    pub(super) const ICON_Y: f64 = CONTENT_BOTTOM + (CONTENT_HEIGHT - ICON_SIZE) / 2.0;
+
+    pub(super) const TEXT_X: f64 = HORIZONTAL_PADDING + ICON_SIZE + ICON_TEXT_GAP;
+    pub(super) const TEXT_WIDTH: f64 = WINDOW_WIDTH - TEXT_X - HORIZONTAL_PADDING;
 }
 
 #[cfg(target_os = "macos")]
@@ -18,7 +53,16 @@ static PROGRESS_WINDOW: LazyLock<Mutex<Option<NativeUpdateProgressWindow>>> =
 static PROGRESS_WINDOW_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn show(app: &tauri::AppHandle, message: impl Into<String>, progress: Option<f64>) {
-    show_platform(app, message.into(), progress);
+    show_with_detail(app, message, String::new(), progress);
+}
+
+pub(crate) fn show_with_detail(
+    app: &tauri::AppHandle,
+    message: impl Into<String>,
+    detail: impl Into<String>,
+    progress: Option<f64>,
+) {
+    show_platform(app, message.into(), detail.into(), progress);
 }
 
 pub(crate) fn close(app: &tauri::AppHandle) {
@@ -26,20 +70,26 @@ pub(crate) fn close(app: &tauri::AppHandle) {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn show_platform(_app: &tauri::AppHandle, _message: String, _progress: Option<f64>) {}
+fn show_platform(
+    _app: &tauri::AppHandle,
+    _message: String,
+    _detail: String,
+    _progress: Option<f64>,
+) {
+}
 
 #[cfg(not(target_os = "macos"))]
 fn close_platform(_app: &tauri::AppHandle) {}
 
 #[cfg(target_os = "macos")]
-fn show_platform(app: &tauri::AppHandle, message: String, progress: Option<f64>) {
+fn show_platform(app: &tauri::AppHandle, message: String, detail: String, progress: Option<f64>) {
     PROGRESS_WINDOW_ACTIVE.store(true, Ordering::SeqCst);
     let _ = app.run_on_main_thread(move || unsafe {
         if !PROGRESS_WINDOW_ACTIVE.load(Ordering::SeqCst) {
             return;
         }
         let window = ensure_progress_window();
-        update_progress_window(window, &message, progress);
+        update_progress_window(window, &message, &detail, progress);
     });
 }
 
@@ -80,47 +130,66 @@ unsafe fn create_progress_window() -> NativeUpdateProgressWindow {
     use cocoa::base::{id, nil, NO, YES};
     use cocoa::foundation::{NSPoint, NSRect, NSSize};
     use objc::{class, msg_send, sel, sel_impl};
-    use std::os::raw::c_void;
 
-    let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(620.0, 214.0));
+    use layout::*;
+
+    // Borderless keeps the panel free of an empty titlebar strip, and a
+    // borderless window cannot become key, so it can never steal focus.
+    let frame = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    );
     let window: id = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
         frame,
-        NSWindowStyleMask::NSTitledWindowMask,
+        NSWindowStyleMask::NSBorderlessWindowMask,
         NSBackingStoreType::NSBackingStoreBuffered,
         NO,
     );
     window.setTitle_(nsstring("Updating Burette"));
     let _: () = msg_send![window, setReleasedWhenClosed: NO];
     let _: () = msg_send![window, setMovableByWindowBackground: YES];
-    let _: () = msg_send![window, setTitleVisibility: 0u64];
-    let _: () = msg_send![window, setTitlebarAppearsTransparent: NO];
-    hide_standard_button(window, 0);
-    hide_standard_button(window, 1);
-    hide_standard_button(window, 2);
+    let _: () = msg_send![window, setOpaque: NO];
+    let clear_color: id = msg_send![class!(NSColor), clearColor];
+    let _: () = msg_send![window, setBackgroundColor: clear_color];
+    let _: () = msg_send![window, setHasShadow: YES];
+    // NSFloatingWindowLevel: above the app window, without activating the app.
+    let _: () = msg_send![window, setLevel: 3i64];
+    let _: () = msg_send![window, setHidesOnDeactivate: NO];
 
-    let content: id = msg_send![class!(NSView), alloc];
+    let content: id = msg_send![class!(NSVisualEffectView), alloc];
     let content: id = msg_send![content, initWithFrame: frame];
+    // NSVisualEffectMaterialPopover / BehindWindow / StateActive.
+    let _: () = msg_send![content, setMaterial: 6i64];
+    let _: () = msg_send![content, setBlendingMode: 0i64];
+    let _: () = msg_send![content, setState: 1i64];
+    let _: () = msg_send![content, setWantsLayer: YES];
+    let layer: id = msg_send![content, layer];
+    let _: () = msg_send![layer, setCornerRadius: CORNER_RADIUS];
+    let _: () = msg_send![layer, setMasksToBounds: YES];
     let _: () = msg_send![window, setContentView: content];
-    let _: () = msg_send![content, release];
 
     let icon: id = msg_send![NSApp(), applicationIconImage];
     let icon_view: id = msg_send![class!(NSImageView), imageViewWithImage: icon];
-    let _: () = msg_send![icon_view, setFrame: rect(34.0, 78.0, 78.0, 78.0)];
+    let _: () =
+        msg_send![icon_view, setFrame: rect(HORIZONTAL_PADDING, ICON_Y, ICON_SIZE, ICON_SIZE)];
     let _: () = msg_send![content, addSubview: icon_view];
 
-    let message_label: id = msg_send![
+    let title_label: id = msg_send![
         class!(NSTextField),
         labelWithString: nsstring("Preparing update...")
     ];
-    let _: () = msg_send![message_label, setFrame: rect(134.0, 130.0, 430.0, 30.0)];
-    let font: id = msg_send![class!(NSFont), systemFontOfSize: 17.0f64];
-    let _: () = msg_send![message_label, setFont: font];
-    let _: () = msg_send![message_label, setLineBreakMode: 4u64];
-    let _: () = msg_send![content, addSubview: message_label];
+    let _: () = msg_send![title_label, setFrame: rect(TEXT_X, TITLE_Y, TEXT_WIDTH, TITLE_HEIGHT)];
+    // NSFontWeightSemibold.
+    let title_font: id = msg_send![class!(NSFont), systemFontOfSize: 13.0f64 weight: 0.3f64];
+    let _: () = msg_send![title_label, setFont: title_font];
+    let _: () = msg_send![title_label, setLineBreakMode: 4u64];
+    let _: () = msg_send![content, addSubview: title_label];
 
     let progress_indicator: id = msg_send![class!(NSProgressIndicator), alloc];
-    let progress_indicator: id =
-        msg_send![progress_indicator, initWithFrame: rect(134.0, 90.0, 430.0, 14.0)];
+    let progress_indicator: id = msg_send![
+        progress_indicator,
+        initWithFrame: rect(TEXT_X, BAR_VIEW_Y, TEXT_WIDTH, BAR_VIEW_HEIGHT)
+    ];
     let _: () = msg_send![progress_indicator, setStyle: 0u64];
     let _: () = msg_send![progress_indicator, setMinValue: 0.0f64];
     let _: () = msg_send![progress_indicator, setMaxValue: 100.0f64];
@@ -128,40 +197,69 @@ unsafe fn create_progress_window() -> NativeUpdateProgressWindow {
     let _: () = msg_send![content, addSubview: progress_indicator];
     let _: () = msg_send![progress_indicator, release];
 
-    let cancel_button: id = msg_send![
-        class!(NSButton),
-        buttonWithTitle: nsstring("Cancel")
-        target: nil
-        action: std::ptr::null::<c_void>()
-    ];
-    let _: () = msg_send![cancel_button, setFrame: rect(450.0, 28.0, 114.0, 32.0)];
-    let _: () = msg_send![cancel_button, setEnabled: NO];
-    let _: () = msg_send![content, addSubview: cancel_button];
+    let detail_label: id = msg_send![class!(NSTextField), labelWithString: nsstring("")];
+    let _: () =
+        msg_send![detail_label, setFrame: rect(TEXT_X, DETAIL_Y, TEXT_WIDTH, DETAIL_HEIGHT)];
+    let detail_font: id = msg_send![class!(NSFont), systemFontOfSize: 11.0f64];
+    let _: () = msg_send![detail_label, setFont: detail_font];
+    let detail_color: id = msg_send![class!(NSColor), secondaryLabelColor];
+    let _: () = msg_send![detail_label, setTextColor: detail_color];
+    let _: () = msg_send![detail_label, setLineBreakMode: 4u64];
+    let _: () = msg_send![content, addSubview: detail_label];
 
-    let _: () = msg_send![window, center];
-    let _: () = msg_send![window, makeKeyAndOrderFront: nil];
-    let _: () = msg_send![NSApp(), activateIgnoringOtherApps: YES];
+    let _: () = msg_send![content, release];
+
+    position_progress_window(window);
+    let _: () = msg_send![window, orderFrontRegardless];
 
     NativeUpdateProgressWindow {
         window: window as usize,
-        message_label: message_label as usize,
+        title_label: title_label as usize,
+        detail_label: detail_label as usize,
         progress_indicator: progress_indicator as usize,
     }
+}
+
+/// Centers the panel over the app's main window, nudged above the midpoint the
+/// way system dialogs sit. Falls back to the screen center when no main window
+/// is available.
+#[cfg(target_os = "macos")]
+unsafe fn position_progress_window(window: cocoa::base::id) {
+    use cocoa::appkit::{NSApp, NSWindow};
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::NSPoint;
+    use objc::{msg_send, sel, sel_impl};
+
+    let host: id = msg_send![NSApp(), mainWindow];
+    if host == nil {
+        let _: () = msg_send![window, center];
+        return;
+    }
+
+    let host_frame = NSWindow::frame(host);
+    let panel_frame = NSWindow::frame(window);
+    let x = host_frame.origin.x + (host_frame.size.width - panel_frame.size.width) / 2.0;
+    let centered_y = host_frame.origin.y + (host_frame.size.height - panel_frame.size.height) / 2.0;
+    let y = centered_y + host_frame.size.height * 0.10;
+    let origin = NSPoint::new(x.round(), y.round());
+    let _: () = msg_send![window, setFrameOrigin: origin];
 }
 
 #[cfg(target_os = "macos")]
 unsafe fn update_progress_window(
     window: NativeUpdateProgressWindow,
     message: &str,
+    detail: &str,
     progress: Option<f64>,
 ) {
     use cocoa::base::{id, nil, NO, YES};
     use objc::{msg_send, sel, sel_impl};
 
-    let message_label = window.message_label as id;
+    let title_label = window.title_label as id;
+    let detail_label = window.detail_label as id;
     let progress_indicator = window.progress_indicator as id;
-    let ns_window = window.window as id;
-    let _: () = msg_send![message_label, setStringValue: nsstring(message)];
+    let _: () = msg_send![title_label, setStringValue: nsstring(message)];
+    let _: () = msg_send![detail_label, setStringValue: nsstring(detail)];
     if let Some(progress) = progress {
         let value = progress.clamp(0.0, 1.0) * 100.0;
         let _: () = msg_send![progress_indicator, setIndeterminate: NO];
@@ -170,18 +268,6 @@ unsafe fn update_progress_window(
     } else {
         let _: () = msg_send![progress_indicator, setIndeterminate: YES];
         let _: () = msg_send![progress_indicator, startAnimation: nil];
-    }
-    let _: () = msg_send![ns_window, orderFrontRegardless];
-}
-
-#[cfg(target_os = "macos")]
-unsafe fn hide_standard_button(window: cocoa::base::id, button: u64) {
-    use cocoa::base::{id, YES};
-    use objc::{msg_send, sel, sel_impl};
-
-    let standard_button: id = msg_send![window, standardWindowButton: button];
-    if !standard_button.is_null() {
-        let _: () = msg_send![standard_button, setHidden: YES];
     }
 }
 

--- a/apps/desktop/src-tauri/src/commands/updater.rs
+++ b/apps/desktop/src-tauri/src/commands/updater.rs
@@ -284,14 +284,17 @@ fn download_update(
     remove_path_if_exists(&temporary)?;
     remove_path_if_exists(&archive)?;
 
-    update_progress::show(
+    let title = download_title(&request.tag_name);
+    update_progress::show_with_detail(
         app,
-        format_download_message(0, request.size, 0.0),
+        title.clone(),
+        format_download_detail(0, request.size, 0.0),
         Some(DOWNLOAD_PROGRESS_START),
     );
     download_asset_with_progress(
         app,
         package_version,
+        &title,
         &request.browser_download_url,
         &temporary,
         request.size,
@@ -462,6 +465,7 @@ fn download_asset(package_version: &str, url: &str, target: &Path) -> Result<(),
 fn download_asset_with_progress(
     app: &tauri::AppHandle,
     package_version: &str,
+    title: &str,
     url: &str,
     target: &Path,
     total_size: u64,
@@ -477,7 +481,7 @@ fn download_asset_with_progress(
             .map_err(|err| format!("Could not check curl status: {err}"))?
         {
             Some(status) => {
-                show_download_progress(app, target, total_size, started_at);
+                show_download_progress(app, title, target, total_size, started_at);
                 if status.success() {
                     return Ok(());
                 }
@@ -485,7 +489,7 @@ fn download_asset_with_progress(
             }
             None => {
                 thread::sleep(DOWNLOAD_PROGRESS_POLL_INTERVAL);
-                show_download_progress(app, target, total_size, started_at);
+                show_download_progress(app, title, target, total_size, started_at);
             }
         }
     }
@@ -518,6 +522,7 @@ fn curl_download_command(package_version: &str, url: &str, target: &Path) -> Com
 
 fn show_download_progress(
     app: &tauri::AppHandle,
+    title: &str,
     target: &Path,
     total_size: u64,
     started_at: Instant,
@@ -533,9 +538,10 @@ fn show_download_progress(
         downloaded as f64 / elapsed.as_secs_f64().max(0.001)
     };
 
-    update_progress::show(
+    update_progress::show_with_detail(
         app,
-        format_download_message(downloaded, total_size, speed),
+        title,
+        format_download_detail(downloaded, total_size, speed),
         Some(download_progress_value(downloaded, total_size)),
     );
 }
@@ -549,19 +555,37 @@ fn download_progress_value(downloaded: u64, total_size: u64) -> f64 {
     DOWNLOAD_PROGRESS_START + (DOWNLOAD_PROGRESS_END - DOWNLOAD_PROGRESS_START) * fraction
 }
 
-fn format_download_message(downloaded: u64, total_size: u64, bytes_per_second: f64) -> String {
+fn download_title(tag_name: &str) -> String {
     format!(
-        "Downloading update... {}% at {}",
-        download_percent(downloaded, total_size),
+        "Downloading Burette {}",
+        tag_name.strip_prefix('v').unwrap_or(tag_name)
+    )
+}
+
+fn format_download_detail(downloaded: u64, total_size: u64, bytes_per_second: f64) -> String {
+    format!(
+        "{} of {} · {}",
+        format_download_size(downloaded.min(total_size)),
+        format_download_size(total_size),
         format_download_speed(bytes_per_second)
     )
 }
 
-fn download_percent(downloaded: u64, total_size: u64) -> u64 {
-    if total_size == 0 {
-        return 0;
+fn format_download_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+
+    let size = bytes as f64;
+    if size < KIB {
+        format!("{size:.0} B")
+    } else if size < MIB {
+        format_download_unit(size / KIB, "KiB")
+    } else if size < GIB {
+        format_download_unit(size / MIB, "MiB")
+    } else {
+        format_download_unit(size / GIB, "GiB")
     }
-    (((downloaded.min(total_size) as f64 / total_size as f64) * 100.0).floor() as u64).min(100)
 }
 
 fn format_download_speed(bytes_per_second: f64) -> String {
@@ -1702,11 +1726,9 @@ mod tests {
     }
 
     #[test]
-    fn download_percent_reports_floor_clamped_percentage() {
-        assert_eq!(download_percent(0, 203_428_538), 0);
-        assert_eq!(download_percent(16_855_040, 203_428_538), 8);
-        assert_eq!(download_percent(203_428_538, 203_428_538), 100);
-        assert_eq!(download_percent(250_000_000, 203_428_538), 100);
+    fn download_title_drops_the_tag_prefix() {
+        assert_eq!(download_title("v1.0.32"), "Downloading Burette 1.0.32");
+        assert_eq!(download_title("1.0.32"), "Downloading Burette 1.0.32");
     }
 
     #[test]
@@ -1720,14 +1742,18 @@ mod tests {
     }
 
     #[test]
-    fn format_download_message_includes_percent_and_speed() {
+    fn format_download_detail_includes_transferred_size_and_speed() {
         assert_eq!(
-            format_download_message(16_855_040, 203_428_538, 64_204.8),
-            "Downloading update... 8% at 63 KiB/s"
+            format_download_detail(16_855_040, 203_428_538, 64_204.8),
+            "16 MiB of 194 MiB · 63 KiB/s"
         );
         assert_eq!(
-            format_download_message(2_621_440, 203_428_538, 1_310_720.0),
-            "Downloading update... 1% at 1.2 MiB/s"
+            format_download_detail(2_621_440, 203_428_538, 1_310_720.0),
+            "2.5 MiB of 194 MiB · 1.2 MiB/s"
+        );
+        assert_eq!(
+            format_download_detail(250_000_000, 203_428_538, 0.0),
+            "194 MiB of 194 MiB · 0 B/s"
         );
     }
 

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -593,7 +593,7 @@ assert.match(shellCommand, /#\[tauri::command\]\s+pub\(crate\) fn write_base64_f
 assert.match(shellCommand, /#\[tauri::command\]\s+pub\(crate\) fn write_text_file/);
 assert.match(quickLookCommand, /#\[tauri::command\]\s+pub\(crate\) fn reset_quick_look/);
 assert.match(updaterCommand, /#\[tauri::command\]\s+pub\(crate\) async fn install_update/);
-assert.match(updaterCommand, /format_download_message\(0, request\.size, 0\.0\)/);
+assert.match(updaterCommand, /format_download_detail\(0, request\.size, 0\.0\)/);
 assert.match(updaterCommand, /download_asset_with_progress\(/);
 assert.match(updaterCommand, /"--connect-timeout"/);
 assert.match(updaterCommand, /"--speed-limit"/);


### PR DESCRIPTION
## Problem

The update progress window was a hand-built Cocoa window that looked out of place:

- **620×214 pt** — the footprint of a full dialog for one line of text and a progress bar.
- A **78 pt** app icon that was not vertically aligned with the text or the bar.
- A **Cancel button wired to nothing**: `target: nil`, `action: null`, `setEnabled: NO`. It offered the user an escape hatch that did not exist.
- `NSTitledWindowMask` with the title and all three traffic lights hidden, leaving an empty titlebar strip at the top.
- `activateIgnoringOtherApps: YES` on creation plus `orderFrontRegardless` on **every** progress tick — the window yanked focus out of whatever the user was doing, dozens of times over a download.
- Every subview placed at hardcoded absolute coordinates, so nothing centered and nothing survived a change in system font size.

## Change

A compact **400×104 pt** borderless panel:

- `NSVisualEffectView` background (material `.popover`, state `.active`) with a 12 pt corner radius.
- 36 pt app icon, vertically centered against the text block.
- Two-line status: a semibold title over a secondary detail line.
- Every vertical position is derived from element heights (`CONTENT_HEIGHT`, `CONTENT_BOTTOM`, …), so the content block centers itself instead of relying on hand-placed numbers.
- A borderless window **cannot become key**, so the panel is now structurally incapable of stealing focus. `activateIgnoringOtherApps` is gone, and `orderFrontRegardless` fires once at creation rather than on every tick.
- The panel is centered over the app's main window (nudged above the midpoint, the way system dialogs sit) instead of the screen center; it falls back to the screen center when there is no main window.
- The dead Cancel button is removed. Working cancellation is a separate piece of work — it needs curl interruption, partial-download rollback, and releasing `UpdateInstallLease`.

## Status text

`update_progress::show` keeps its signature and now delegates to a new `show_with_detail`, so 12 of the 13 call sites are untouched. Only the download path changes:

| | Before | After |
|---|---|---|
| Title | `Downloading update... 8% at 63 KiB/s` | `Downloading Burette 1.0.32` |
| Detail | — | `16 MiB of 194 MiB · 63 KiB/s` |

All other stages (`Validating update...`, `Restarting Burette...`, …) keep their existing single-line text with an empty detail line. The detail line always occupies its slot even when empty, so the layout does not jump between stages.

`download_percent` is dropped — the bar already carries the percentage. Its unit test is replaced by coverage for `download_title` and `format_download_detail`.

## Verification

- `cargo check -p burette` — clean.
- `cargo test -p burette --lib -- --test-threads=1` — **455 passed, 0 failed**.
- `bun run test:tauri-structure`, `tests/test-update-versioning.mjs`, `tests/test-update-auto-prompt-contract.mjs` — pass.
- The contract assertion in `tests/test-tauri-structure.mjs` is updated from `format_download_message` to `format_download_detail`; the ordering assertions around `update_progress::show(` still hold.

Note: `cargo test` without `--test-threads=1` shows pre-existing flakiness in `preview::runtime::document_open_tests` (different tests fail on each run, all with missing temp files). It is unrelated to this change — `scripts/ci-fast.sh` already pins `--test-threads=1` to work around it.

Not verified: the panel has not been rendered on screen, which needs a signed build and a real update to download.
