### PR TITLE
Stop preview tests from moving HOME out from under each other

### DIFF
--- a/apps/desktop/src-tauri/src/preview/runtime.rs
+++ b/apps/desktop/src-tauri/src/preview/runtime.rs
@@ -1355,6 +1355,30 @@ mod document_open_tests {
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+    /// Pins HOME to one empty directory for the whole test process.
+    ///
+    /// `app_cache_dir()` is derived from HOME, so every test that opens a
+    /// document writes its viewer cache below it. The fake-xyzrender helpers
+    /// used to point HOME at a temporary tree and delete that tree afterwards,
+    /// which removed the cache directory out from under tests running in
+    /// parallel — they failed with a missing RDKit asset or an unopenable
+    /// collection database, depending on where they happened to be.
+    ///
+    /// The directory deliberately contains no `.local/bin/xyzrender`, so
+    /// `resolve_xyzrender_executable` skips the HOME candidate and falls
+    /// through to PATH, which is where the fake executable is injected. It also
+    /// keeps the tests out of the real user cache.
+    fn isolated_test_home() -> &'static Path {
+        static TEST_HOME: OnceLock<PathBuf> = OnceLock::new();
+        TEST_HOME.get_or_init(|| {
+            let home =
+                std::env::temp_dir().join(format!("burette-test-home-{}", uuid::Uuid::new_v4()));
+            fs::create_dir_all(&home).expect("test home should be created");
+            std::env::set_var("HOME", &home);
+            home
+        })
+    }
+
     fn viewer_preferences() -> ViewerPreferences {
         ViewerPreferences {
             theme: "auto".to_string(),
@@ -1380,6 +1404,7 @@ mod document_open_tests {
     }
 
     fn mock_app_with_grid_registry() -> tauri::App<tauri::test::MockRuntime> {
+        isolated_test_home();
         let app = tauri::test::mock_app();
         app.manage(GridRuntimeRegistry::default());
         app.manage(OpenedSourceRegistry::default());
@@ -1467,30 +1492,28 @@ mod document_open_tests {
             .get_or_init(|| Mutex::new(()))
             .lock()
             .expect("env lock should not be poisoned");
-        let fake_home = prepend_fake_xyzrender_environment(script);
-        let old_home = std::env::var_os("HOME");
+        // HOME stays pinned to the shared test home: the fake executable is
+        // injected through PATH alone, so nothing a parallel test depends on
+        // moves while this test runs.
+        isolated_test_home();
+        let fake_bin_root = prepend_fake_xyzrender_environment(script);
         let old_path = std::env::var_os("PATH");
-        let mut joined_path = vec![fake_home.join(".local").join("bin")];
+        let mut joined_path = vec![fake_bin_root.join(".local").join("bin")];
         if let Some(path) = &old_path {
             joined_path.extend(std::env::split_paths(path));
         }
         let joined_path =
             std::env::join_paths(joined_path).expect("fake xyzrender path should be valid");
 
-        std::env::set_var("HOME", &fake_home);
         std::env::set_var("PATH", &joined_path);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(run));
 
-        match old_home {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
         match old_path {
             Some(value) => std::env::set_var("PATH", value),
             None => std::env::remove_var("PATH"),
         }
-        let _ = fs::remove_dir_all(fake_home);
+        let _ = fs::remove_dir_all(fake_bin_root);
 
         match result {
             Ok(value) => value,


### PR DESCRIPTION
## Problem

`preview::runtime::document_open_tests` failed intermittently under parallel execution. A different test failed on each run, always on a file that had vanished:

```
multi.sdf should open: unable to open database file:
/var/.../T/burette-open-document-<uuid>/Library/Caches/viewer/<uuid>/collection.sqlite
```

```
multi.sdf should open: No such file or directory (os error 2)
```

`scripts/ci-fast.sh` works around this with `--test-threads=1`, so CI is green but anyone running plain `cargo test` gets bitten.

## Root cause

The path in the first error is the giveaway — `app_cache_dir()` resolved to a directory under `/tmp/burette-open-document-<uuid>/`.

`with_fake_xyzrender_script` swapped the **process-wide** `HOME` so that `resolve_xyzrender_executable` would not pick up a real `~/.local/bin/xyzrender`. But `app_cache_dir()` is derived from `HOME`, so every other test running at that moment wrote its viewer cache inside that temporary tree — and the helper ended with `fs::remove_dir_all(fake_home)`, deleting it. Depending on where a parallel test happened to be, it then failed on a missing RDKit asset or an unopenable collection database.

`ENV_LOCK` did not cover this: only the three env-mutating tests take it, while the other 21 read the swapped `HOME` without any lock.

## Fix

Pin `HOME` to a single empty per-process directory, and inject the fake executable through `PATH` alone.

This works because `resolve_xyzrender_executable` checks `$HOME/.local/bin/xyzrender` *before* `PATH`, but falls through when that file does not exist — and the tests already put the fake bin directory first on `PATH`. An empty `HOME` hides the real binary just as well, without moving a directory that parallel tests depend on.

Side benefit: the suite no longer writes into the real user cache. `~/Library/Caches/viewer` had accumulated 97 stale runtime directories from past test runs.

## Verification

Reproduced first, then fixed. Repro: two concurrent `cargo test` processes, `--test-threads=24`, cold cache.

| | Before | After |
|---|---|---|
| Stress scenario | **5 failures / 10 runs** | **0 / 12** |
| `document_open_tests` alone | flaky | 24/24, repeatedly |
| Full lib suite, no `--test-threads=1` | failed | 455 passed, run concurrently with the stress loop |

## `--test-threads=1` stays, for now

The task that produced this fix also asked whether the flag can be dropped from `scripts/ci-fast.sh`. **Not yet.** Across 28 post-fix full-suite runs one failure remained, and hunting it down found an unrelated defect in another module:

```
compute::root_lease::tests::concurrent_snapshots_creation_converges_and_reopens_the_same_identity
Unavailable("the compute root is already owned by another Burette process")
```

That test drops an `Arc<ComputeRootLease>` to release the lease, but `drop()` on an `Arc` releases only one reference, and the `flock` is tied to the open file description — so if a thread the test spawned still holds a clone, the reacquire fails. Load-dependent, which matches. Tracked separately; the flag should be revisited once that one is fixed.