### PR TITLE
Unbreak the Vercel build and stop menus clipping their labels

### DIFF
--- a/apps/burette-public-plugin/scripts/build-molstar-csp.mjs
+++ b/apps/burette-public-plugin/scripts/build-molstar-csp.mjs
@@ -12,10 +12,12 @@ const SOURCE_ROOT = path.join(
 );
 const OUTPUT_ROOT = path.join(APP_ROOT, "public/burette-viewer");
 
+const MOLSTAR_VERSION = require("molstar/package.json").version;
+
 const EXPECTED_JAVASCRIPT_SHA256 =
-  "aa6ffbbcf6f544755d3703144f8f30c5cf2183216a2162e5fd6349f03d2c57d9";
+  "5567eb19fa8e7a7b3b161d4b96807c4db244cecd2f3e7c87f99c052b8b5b5b30";
 const EXPECTED_CSS_SHA256 =
-  "9269edea08fd43848229b971d8102df163858a76417c6823d987b8e25df127f9";
+  "5b68ceb6d3642549b4e9b2c071e58e41b98a5350ae269180587b39da86925d55";
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -45,14 +47,14 @@ async function main() {
   let javascript = javascriptSource;
   javascript = replaceExactlyOnce(
     javascript,
-    'new Function("body","return function "+T+`() {\n    "use strict";    return body.apply(this, arguments);\n};\n`)(M)',
-    "function(){return M.apply(this,arguments)}",
+    'new Function("body","return function "+P+`() {\n    "use strict";    return body.apply(this, arguments);\n};\n`)(k)',
+    "function(){return k.apply(this,arguments)}",
     "named-function",
   );
   javascript = replaceExactlyOnce(
     javascript,
-    'new Function("dynCall","rawFunction",Be+`};\n`)(W,M)',
-    "function(dynCall,rawFunction){return function(){return dynCall.apply(null,[rawFunction].concat(Array.prototype.slice.call(arguments)))}}(W,M)",
+    'new Function("dynCall","rawFunction",ye+`};\n`)(q,k)',
+    "function(dynCall,rawFunction){return function(){return dynCall.apply(null,[rawFunction].concat(Array.prototype.slice.call(arguments)))}}(q,k)",
     "dynamic-call",
   );
   javascript = replaceExactlyOnce(
@@ -89,7 +91,7 @@ async function main() {
     writeFile(path.join(OUTPUT_ROOT, "molstar.js"), javascript),
     writeFile(path.join(OUTPUT_ROOT, "molstar.css"), css),
   ]);
-  console.log("Generated CSP-compatible Mol* 5.7.0 assets.");
+  console.log(`Generated CSP-compatible Mol* ${MOLSTAR_VERSION} assets.`);
 }
 
 await main();

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,10 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        // Menus here hang off icon-sized triggers, so the upstream
+        // w-(--radix-dropdown-menu-trigger-width) would squeeze them and clip labels.
+        // They size to their content instead, the way the context menu already does.
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-46 max-w-[min(320px,calc(100vw_-_16px))] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1522,37 +1522,8 @@ kbd span { margin-left: 2px; }
 }
 .pin-hit:hover,
 .pin-hit.pinned { color: var(--text-muted); }
-.radix-menu {
-  z-index: 1000;
-  min-width: 184px;
-  max-width: min(320px, calc(100vw - 16px));
-  max-height: min(420px, calc(100vh - 16px));
-  overflow: auto;
-  padding: 6px;
-  border: 0;
-  border-radius: 9px;
-  background: var(--menu-surface);
-  color: var(--text-primary);
-  box-shadow: 0 16px 42px rgb(0 0 0 / 0.22);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  font-family: var(--ui-font);
-  font-size: 13px;
-  line-height: 1.2;
-  letter-spacing: 0;
-}
-.radix-menu-item {
-  min-height: 30px;
-  border-radius: 7px;
-  color: inherit;
-  padding: 5px 10px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  outline: none;
-  user-select: none;
-}
+/* The menu surface, rows and separators come from the shadcn menu components.
+   What stays here is the item's own two-line body, which shadcn does not model. */
 .radix-menu-item-body {
   min-width: 0;
   display: inline-flex;
@@ -1600,39 +1571,8 @@ img.radix-menu-item-icon {
   color: var(--text-faint);
   font-size: 11px;
 }
-.radix-menu-item kbd {
-  flex: 0 0 auto;
-  color: var(--text-faint);
-  font-size: 11px;
-}
-.radix-menu-item[data-highlighted] {
-  background: var(--surface-hover);
-  color: var(--text-primary);
-}
-.radix-menu-item[data-disabled] {
-  color: var(--text-faint);
-  opacity: 0.58;
-}
-.radix-menu-separator {
-  height: 1px;
-  margin: 5px 8px;
-  background: var(--line-subtler);
-}
-.open-editor-menu-content {
-  min-width: 224px;
-  max-width: min(268px, calc(100vw - 16px));
-  padding: 7px;
-  border: 1px solid color-mix(in srgb, var(--fg-base) calc(var(--contrast) * 28%), transparent);
-  border-radius: 14px;
-  background: var(--menu-surface);
-  box-shadow: 0 22px 62px rgb(0 0 0 / 0.36), inset 0 1px 0 rgb(255 255 255 / 0.06);
-}
-.open-editor-menu-content .radix-menu-item {
-  min-height: 36px;
-  border-radius: 9px;
-  padding: 5px 10px;
-  gap: 12px;
-}
+/* The surface itself is the shared shadcn menu; this class only scopes the
+   slightly larger app icons and labels that the editor targets need. */
 .open-editor-menu-content .radix-menu-item-body {
   gap: 10px;
 }
@@ -1656,9 +1596,6 @@ img.radix-menu-item-icon {
 .open-editor-menu-content .radix-menu-item-detail {
   font-size: 11px;
   line-height: 1.1;
-}
-.open-editor-menu-content .radix-menu-separator {
-  margin: 6px 10px;
 }
 .radix-context-menu-trigger {
   position: fixed;

--- a/tests/test-shadcn-foundation.mjs
+++ b/tests/test-shadcn-foundation.mjs
@@ -2,11 +2,12 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const [componentsJson, styles, portalContainer, alertDialog, desktopTsconfig, rootTsconfig] = await Promise.all([
+const [componentsJson, styles, portalContainer, alertDialog, dropdownMenu, desktopTsconfig, rootTsconfig] = await Promise.all([
   readFile("apps/desktop/components.json", "utf8"),
   readFile("apps/desktop/src/styles.css", "utf8"),
   readFile("apps/desktop/src/components/ui/portal-container.ts", "utf8"),
   readFile("apps/desktop/src/components/ui/alert-dialog.tsx", "utf8"),
+  readFile("apps/desktop/src/components/ui/dropdown-menu.tsx", "utf8"),
   readFile("apps/desktop/tsconfig.json", "utf8"),
   readFile("tsconfig.json", "utf8"),
 ]);
@@ -34,5 +35,14 @@ assert.match(styles, /--shadcn-disabled-opacity: 0\.48;/);
 assert.match(portalContainer, /document\.querySelector<HTMLElement>\("\.app-shell"\)/);
 assert.match(alertDialog, /useAppShellPortalContainer/);
 assert.match(alertDialog, /container=\{container \?\? appShellContainer\}/);
+
+// Menus hang off icon-sized triggers, so they must size to their content
+// instead of the trigger, or long entries get clipped.
+const dropdownContentClass = dropdownMenu.match(
+  /data-slot="dropdown-menu-content"[\s\S]*?className=\{cn\("([^"]*)"/,
+)?.[1];
+assert.ok(dropdownContentClass, "dropdown menu content class list not found");
+assert.doesNotMatch(dropdownContentClass, /(?:^|\s)w-\(--radix-dropdown-menu-trigger-width\)/);
+assert.match(dropdownContentClass, /min-w-46 max-w-\[min\(320px,calc\(100vw_-_16px\)\)\]/);
 
 console.log("shadcn foundation contract tests passed");

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3675,12 +3675,11 @@ assert.match(radixMenu, /export function useThemePortalContainer/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/menu/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/menuItem/);
 assert.match(nativeContextMenu, /@tauri-apps\/api\/menu\/predefinedMenuItem/);
-assert.match(styles, /\.radix-menu \{/);
-assert.match(styles, /\.radix-menu-item/);
-assert.match(styles, /\.radix-menu-separator/);
+assert.match(styles, /\.radix-menu-item-body/);
+assert.match(styles, /\.radix-menu-item-detail/);
 assert.match(styles, /--menu-surface: color-mix\(in srgb, var\(--bg-base\) 96%, var\(--fg-base\) 4%\);/);
-assert.match(styles, /\.radix-menu \{[^}]*background: var\(--menu-surface\);[^}]*backdrop-filter: none;/);
-assert.match(styles, /\.open-editor-menu-content \{[^}]*background: var\(--menu-surface\);/);
+assert.match(styles, /--shadcn-popover: var\(--menu-surface\);/);
+assert.match(styles, /\.open-editor-menu-content \.radix-menu-item-icon \{/);
 assert.match(styles, /\.native-context-menu \{[\s\S]*border: 0;/);
 assert.match(styles, /\.native-context-menu \{[^}]*background: var\(--menu-surface\);[^}]*backdrop-filter: none;/);
 assert.match(styles, /\.ketcher-collection-menu \{[^}]*background: var\(--menu-surface\);/);
@@ -4930,7 +4929,7 @@ assert.match(
   /body\.burette-mobile-host \.msp-plugin \.msp-layout-left,[\s\S]*?background: var\(--buret-menu-background\) !important;[\s\S]*?backdrop-filter: none !important;/,
 );
 assert.match(styles, /\.sidebar\s*\{[^}]*background: transparent;/s);
-assert.match(styles, /\.radix-menu\s*\{[^}]*background: var\(--menu-surface\);[^}]*backdrop-filter: none;/s);
+assert.doesNotMatch(styles, /\.radix-menu(?:-item)?\s*[,{]/);
 assert.match(previewRuntimeCss, /\.buret-molstar-transition-frame \{/);
 assert.match(previewRuntimeCss, /\.buret-molstar-transition-frame\.fade-out \{/);
 assert.match(previewRuntimeCss, /--buret-generate-3d-control-right: 70px;/);


### PR DESCRIPTION
Two red checks and one visible defect, none of which came from the branch that surfaced them.

## Vercel: the Mol* CSP patch was pinned to 5.7.0

`build-molstar-csp.mjs` takes Mol*'s prebuilt viewer bundle, checks its SHA-256, and surgically removes the four `new Function(...)` sites so the hosted viewer can run under CSP. Dependabot moved Mol* 5.7.0 → 5.10.1 (#465) and the hash guard tripped, which is exactly what it is for.

Reviewing the new bundle: all four dynamic-code sites are unchanged in substance, but minification renamed their identifiers, so two of the five replacements no longer matched.

| patch | 5.7.0 | 5.10.1 |
|---|---|---|
| named-function | `+T+ … )(M)` | `+P+ … )(k)` |
| dynamic-call | `Be+ … )(W,M)` | `ye+ … )(q,k)` |
| string-callback | unchanged | unchanged |
| template-interpolation | unchanged | unchanged |
| eager-h264-initialization | unchanged | unchanged |

Hashes and identifiers refreshed. The script's own invariants are the verification: every replacement must apply **exactly once**, and the emitted asset must contain **no `new Function`**. Both hold. The log line also reported a hard-coded `5.7.0`; it now reads the resolved version.

## Dropdown menus clipped their labels

shadcn's `DropdownMenuContent` carries `w-(--radix-dropdown-menu-trigger-width)` — sensible for a select, wrong for the icon-sized "⋯" triggers these menus hang off. With a 22px trigger the surface collapsed to its `min-w-32` floor of 128px and ellipsised entries such as "Open all in Mol* scene".

It now sizes to its content within the bounds the menus used before the shadcn migration (184–320px), matching what shadcn's own `ContextMenuContent` already does. Measured in the running app: content width 184px, no clipped labels, `backdrop-filter: none` intact.

## Dead menu CSS from the shadcn migration

- `.radix-menu`, `.radix-menu-item` (+ its `[data-highlighted]` / `[data-disabled]` / `kbd` variants) and `.radix-menu-separator` are no longer applied to anything — the shadcn components render their own surface, rows and separators.
- `.open-editor-menu-content`'s box rules lost to the utility classes outright: its `min-width`, `padding` and `border-radius` never took effect (confirmed against computed style, not by reading).

Both removed. The `.radix-menu-item-body` / `-icon` / `-copy` / `-label` / `-detail` rules stay — those elements are ours, nested inside the shadcn item — as do the scoped `.open-editor-menu-content` descendant rules for the larger app icons.

Contract pins moved onto the guarantees that are still live: `--shadcn-popover: var(--menu-surface)` (what keeps menus opaque), the surviving scoped rules, and a new pin so the trigger-width sizing cannot come back.

## Not in this PR

The `Native Bundle Build` failure on `eve-raphael` was the third problem; #512 landed the identical fix (same two declarations, same versions) while this was in progress, so the cherry-pick dropped it as already applied.

## Verification

- `bun run test:ui` — full suite passes on this base
- `bun run build` in `apps/burette-public-plugin` — assets, CSP patch and `next build` all complete
- desktop `bun run build` — completes
- `typecheck` — clean apart from a pre-existing repo-wide `TS5101` `baseUrl` deprecation, present on a clean tree too
- menus exercised in the running dev app: project dropdown and file context menu, opaque surface, no truncation