### PR TITLE
Make the compute root lease test prove and diagnose its own precondition

### DIFF
--- a/apps/desktop/src-tauri/src/compute/root_lease.rs
+++ b/apps/desktop/src-tauri/src/compute/root_lease.rs
@@ -1003,9 +1003,25 @@ mod tests {
                 .to_string_lossy()
                 .starts_with(SNAPSHOTS_TEMP_PREFIX)));
 
+        // Every contender clones the lease into its `ComputeRootChildDirectory`,
+        // so the lock is only released if this drop is the last reference. Assert
+        // that rather than trusting it: a leaked clone would otherwise surface as
+        // a confusing "owned by another Burette process" failure below.
+        let lease = Arc::into_inner(lease).expect("the test must hold the last lease reference");
         drop(lease);
         let reopened_lease = Arc::new(
-            ComputeRootLease::acquire(&test.compute_root).expect("reacquire compute root"),
+            ComputeRootLease::acquire(&test.compute_root).unwrap_or_else(|error| {
+                // The owner writes its pid into the lock file, so report it: it
+                // distinguishes a descriptor this process failed to close from a
+                // genuine foreign owner.
+                let owner = fs::read_to_string(test.compute_root.join(LOCK_FILE_NAME))
+                    .unwrap_or_else(|read_error| format!("<unreadable: {read_error}>"));
+                panic!(
+                    "reacquire compute root: {error:?}; this pid: {}; lock diagnostic: {}",
+                    std::process::id(),
+                    owner.trim()
+                )
+            }),
         );
         let reopened = reopened_lease
             .open_or_create_snapshots_directory()


### PR DESCRIPTION
## This does not fix the flake

`compute::root_lease::tests::concurrent_snapshots_creation_converges_and_reopens_the_same_identity` occasionally fails under load:

```
reacquire compute root: Unavailable("the compute root is already owned by another Burette process")
```

The cause is still unknown. I did not add a retry or otherwise paper over it: if the real cause is a defect in releasing the lock, a retry would hide it and the test would stop catching the regression.

## Both candidate causes were tested and ruled out

| Hypothesis | How it was tested | Result |
|---|---|---|
| A spawned thread still holds an `Arc` clone, so `drop()` is not the last reference | The test uses `thread::scope` with an explicit `join()` per handle — every contender has finished before the drop | Ruled out |
| A concurrent `fork` inherits the `flock` and holds it until `exec` | Targeted test: 300 `acquire`/`drop`/`reacquire` cycles while a thread spawned processes continuously | Ruled out, 0 failures |

Also ruled out: `TestRoot` paths are unique per test (UUID), `CHILD_PATH_ENV` is passed per-child through `.env()` rather than `set_var`, and the lock descriptors are `CLOEXEC` (the module already tests this via `fcntl_getfd`).

The failure did not reproduce once in 40 module runs, 50 full-suite runs, or the 300 targeted cycles — against a single original observation.

## What this changes instead

Make the next occurrence explain itself.

- **`Arc::into_inner` instead of `drop`.** "This is the last reference" is now asserted rather than assumed. A leaked clone — the one cause that *can* be excluded by construction — fails as `the test must hold the last lease reference` instead of as a confusing ownership error. This is the direction the original report suggested.
- **Report the owner on a failed reacquire.** The lease writes its pid into the lock file (`LockDiagnostic`), so the panic now prints this process's pid alongside that diagnostic. That distinguishes a descriptor this process failed to close from a genuine foreign owner — which is exactly the fact needed to pick between the remaining explanations.

## Verification

`cargo test -p burette --lib` — 455 passed, 6 consecutive runs. `cargo fmt --check` clean.

## `--test-threads=1` stays in scripts/ci-fast.sh

Two unexplained races remain, not one. Besides this test, hunting it surfaced `commands::conformer::tests::pre_cancelled_conformer_job_does_not_start_a_process` (1 failure in 50 full-suite runs, conformer.rs:1787).

For reference, the *other* preview flake — fixed in #513 — measured 3 failures in 15 loaded runs on current `main`, an order of magnitude more frequent than this one.