### PR TITLE
Remove Ketcher photo library access

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -474,7 +474,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -524,7 +524,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -545,7 +545,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -568,7 +568,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "base64 0.22.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "base64 0.22.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.0.2"
+version = "2.0.3"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/components/ketcher-editor.tsx
+++ b/apps/desktop/src/components/ketcher-editor.tsx
@@ -40,6 +40,7 @@ export type KetcherEditorApi = {
 
 type KetcherReactModule = typeof import("ketcher-react");
 type KetcherReactInstance = Parameters<NonNullable<ComponentProps<KetcherReactModule["Editor"]>["onInit"]>>[0];
+type KetcherButtonsConfig = NonNullable<ComponentProps<KetcherReactModule["Editor"]>["buttons"]>;
 type EveModule = typeof import("eve-raphael");
 type RaphaelModule = typeof import("raphael");
 type KetcherCoreModule = typeof import("ketcher-core");
@@ -81,6 +82,10 @@ type KetcherWithEditorStruct = Ketcher & {
   changeEvent?: KetcherSubscription;
 };
 const KETCHER_INSTANCE_RETRY_DELAYS_MS = [0, 250, 500, 1000, 1500, 2500, 4000, 6000] as const;
+const BURETTE_KETCHER_BUTTONS = {
+  // Ketcher 3.15 supports this runtime key, but omits it from ButtonName.
+  images: { hidden: true },
+} as unknown as KetcherButtonsConfig;
 
 declare global {
   interface Window {
@@ -507,6 +512,7 @@ export function KetcherEditor({
       <Editor
         staticResourcesUrl={import.meta.env.BASE_URL}
         structServiceProvider={structServiceProvider}
+        buttons={BURETTE_KETCHER_BUTTONS}
         onInit={handleInit}
         errorHandler={handleError}
       />

--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/tests/test-ketcher-native-open-contract.mjs
+++ b/tests/test-ketcher-native-open-contract.mjs
@@ -10,6 +10,9 @@ assert.match(editor, /addEventListener\("click",[\s\S]*true\)/);
 assert.match(editor, /\[data-testid=['"]open-file-button['"]\]/);
 assert.match(editor, /preventDefault\(\)/);
 assert.match(editor, /stopPropagation\(\)/);
+assert.match(editor, /const BURETTE_KETCHER_BUTTONS = \{/);
+assert.match(editor, /images:\s*\{\s*hidden:\s*true\s*\}/);
+assert.match(editor, /buttons=\{BURETTE_KETCHER_BUTTONS\}/);
 
 assert.match(page, /invoke<string\[\]>\("pick_open_targets"\)/);
 assert.match(page, /actions\.openKetcherWithStructures\(paths\)/);


### PR DESCRIPTION
## Summary

- hide Ketcher’s image-upload tool in the desktop editor so macOS no longer asks for Photo Library access
- keep molecule Open routed through Burette’s native structure picker
- synchronize release metadata to 2.0.3

## Why

Ketcher 3.15 exposes an `Add Image` tool that creates an `input[type=file]` accepting images. WebKit maps that chooser to the macOS Photo Library permission surface, even though Burette does not need photo access for molecular workflows.

## Verification

- `bun tests/test-ketcher-native-open-contract.mjs`
- `bun run check:release`
- `bun run --cwd apps/desktop build`
- `bun run ci:fast` (459 Rust tests passed, 6 manual GPU tests ignored)
- browser-dev UI: `Add Image` buttons = 0; image-accepting file inputs = 0; visible `Open a molecule file` button = 1

## Release

This PR prepares patch release 2.0.3 following the 2.0.2 legacy-path migration release.