### PR TITLE
Hide native tooltip from sidebar file rows

### DIFF
--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -822,7 +822,6 @@ export function ProjectItem({
       onContextMenu={handleContextMenu}
       onKeyDown={handleKeyDown}
       aria-label={`${item.relativePath}, ${rendererLabel(item.renderer)}${item.isPinned ? ", pinned" : ""}`}
-      title={item.relativePath}
     >
       <span className="project-icon" data-file-kind={fileKind} aria-hidden="true">
         <FileKindIcon kind={fileKind} />

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -3598,6 +3598,7 @@ assert.match(sidebarSurface, /actions\.togglePinnedStructure\(item\.path\)/);
 assert.match(sidebarSurface, /actions\.togglePinnedProjectRoot\(project\.rootPath\)/);
 assert.match(sidebarSurface, /actions\.renameProjectRoot\(project\.rootPath, renameDraft\)/);
 assert.match(sidebarSurface, /actions\.renameProjectFolder\(folderPath, renameDraft\)/);
+assert.doesNotMatch(sidebarSurface, /title=\{item\.relativePath\}/);
 assert.match(sidebarSurface, /const \[renaming, setRenaming\] = useState\(false\)/);
 assert.match(sidebarSurface, /const renameInputRef = useRef<HTMLInputElement \| null>\(null\)/);
 assert.match(sidebarSurface, /const skipRenameCommitRef = useRef\(false\)/);


### PR DESCRIPTION
## Why

The browser-native file-name tooltip ignores Burette's theme and duplicates the visible sidebar label.

## What Changed

- Remove the native `title` tooltip from sidebar file rows.
- Preserve the accessible file and renderer label.
- Add a UI contract assertion preventing the tooltip from returning.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- Browser-dev check with `samples/mini.pdb`: the row remains visible and accessible, has no `title` attribute, and shows no tooltip after hover.
- `bun run ci:fast` via the pre-push hook (459 Rust tests passed; 6 ignored).