### PR TITLE
Keep viewport controls attached to the draggable toolbar

### DIFF
--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -537,7 +537,9 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
-  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
+  /* The top toolbar can be dragged. This rail belongs to the viewport edge,
+     so its horizontal position must respond directly to viewport resizing. */
+  right: var(--buret-control-island-right);
   z-index: 40;
   box-sizing: border-box;
   display: flex;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -538,7 +538,8 @@ body.burette-mobile-host #buret-scene-tree {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
   /* The rail is the vertical part of the draggable toolbar group. */
-  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
+  right: auto;
+  left: var(--buret-viewport-rail-left, auto);
   z-index: 40;
   box-sizing: border-box;
   display: flex;
@@ -1478,7 +1479,7 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 }
 #buret-toolbar {
   position: absolute; top: calc(var(--buret-toolbar-safe-top) + var(--buret-viewport-top-inset, 0px)); right: var(--buret-control-island-right); left: auto; z-index: 2147483646;
-  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 3px 0;
+  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 3px;
   border: 1px solid var(--buret-toolbar-border);
   border-radius: 12px; color: var(--buret-toolbar-color);
   background: var(--buret-toolbar-background);

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -537,9 +537,8 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
-  /* The top toolbar can be dragged. This rail belongs to the viewport edge,
-     so its horizontal position must respond directly to viewport resizing. */
-  right: var(--buret-control-island-right);
+  /* The rail is the vertical part of the draggable toolbar group. */
+  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
   z-index: 40;
   box-sizing: border-box;
   display: flex;
@@ -567,6 +566,10 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail.hidden,
 .buret-selection-bar.hidden {
   display: none;
+}
+body.buret-toolbar-collapsed #buret-viewport-rail,
+body.buret-toolbar-collapsed #buret-selection-bar {
+  display: none !important;
 }
 .buret-rail-button {
   position: relative;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -556,6 +556,13 @@ body.burette-mobile-host #buret-scene-tree {
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+.buret-viewport-rail.buret-dragging,
+.buret-viewport-rail.buret-dragging .buret-rail-button {
+  cursor: grabbing;
 }
 .buret-viewport-rail.hidden,
 .buret-selection-bar.hidden {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -8,6 +8,7 @@
   const SDF_GRID_PADDING = 4.0;
   const TOOLBAR_POSITION_VERSION = '13';
   const TOOLBAR_COLLAPSED_VERSION = '5';
+  const VIEWPORT_RAIL_POSITION_VERSION = '1';
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
@@ -6830,12 +6831,126 @@
     if (changed) updateFloatingLayoutOffsets();
   }
 
+  function applyViewportRailPosition(rail, right, top) {
+    const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
+    const height = rail.offsetHeight || rail.getBoundingClientRect().height || 170;
+    const maxRight = Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
+    const maxTop = Math.max(TOOLBAR_MARGIN, window.innerHeight - height - TOOLBAR_MARGIN);
+    rail.style.left = 'auto';
+    rail.style.right = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, right), maxRight)) + 'px';
+    rail.style.top = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, top), maxTop)) + 'px';
+  }
+
+  function saveViewportRailPosition(rail) {
+    try {
+      const rect = rail.getBoundingClientRect();
+      window.localStorage && window.localStorage.setItem('buret.viewportRail.position', JSON.stringify({
+        right: Math.round(window.innerWidth - rect.right),
+        top: Math.round(rect.top),
+        mode: 'custom'
+      }));
+      window.localStorage && window.localStorage.setItem('buret.viewportRail.position.version', VIEWPORT_RAIL_POSITION_VERSION);
+    } catch (_) {}
+  }
+
+  function restoreViewportRailPosition(rail) {
+    try {
+      const raw = window.localStorage && window.localStorage.getItem('buret.viewportRail.position');
+      const version = window.localStorage && window.localStorage.getItem('buret.viewportRail.position.version');
+      if (raw && version === VIEWPORT_RAIL_POSITION_VERSION) {
+        const saved = JSON.parse(raw);
+        if (saved.mode === 'custom' && Number.isFinite(saved.right) && Number.isFinite(saved.top)) {
+          rail.dataset.defaultPosition = '0';
+          applyViewportRailPosition(rail, saved.right, saved.top);
+          return;
+        }
+      } else if (raw) {
+        window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
+      }
+    } catch (_) {}
+    rail.dataset.defaultPosition = '1';
+    rail.style.removeProperty('left');
+    rail.style.removeProperty('right');
+    rail.style.removeProperty('top');
+  }
+
+  function initViewportRailDrag(rail) {
+    restoreViewportRailPosition(rail);
+    let drag = null;
+    let suppressClickUntil = 0;
+    const onPointerDown = event => {
+      if (event.button !== 0) return;
+      const rect = rail.getBoundingClientRect();
+      drag = {
+        pointerId: event.pointerId,
+        dx: event.clientX - rect.left,
+        dy: event.clientY - rect.top,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false
+      };
+      rail.setPointerCapture(event.pointerId);
+      rail.classList.add('buret-dragging');
+      event.preventDefault();
+    };
+    const onPointerMove = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      if (!drag.moved) {
+        drag.moved = Math.abs(event.clientX - drag.startX) > 4 || Math.abs(event.clientY - drag.startY) > 4;
+      }
+      if (!drag.moved) return;
+      rail.dataset.defaultPosition = '0';
+      closeViewportMenu();
+      const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
+      const left = event.clientX - drag.dx;
+      applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
+      updateFloatingLayoutOffsets();
+      event.preventDefault();
+    };
+    const finishDrag = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      const moved = drag.moved;
+      try { rail.releasePointerCapture(event.pointerId); } catch (_) {}
+      rail.classList.remove('buret-dragging');
+      drag = null;
+      if (!moved) return;
+      suppressClickUntil = Date.now() + 300;
+      saveViewportRailPosition(rail);
+    };
+    const cancelDrag = () => {
+      rail.classList.remove('buret-dragging');
+      drag = null;
+    };
+    rail.addEventListener('pointerdown', onPointerDown);
+    rail.addEventListener('pointermove', onPointerMove);
+    rail.addEventListener('pointerup', finishDrag);
+    rail.addEventListener('pointercancel', cancelDrag);
+    rail.addEventListener('lostpointercapture', cancelDrag);
+    window.addEventListener('pointermove', onPointerMove, true);
+    window.addEventListener('pointerup', finishDrag, true);
+    window.addEventListener('pointercancel', cancelDrag, true);
+    rail.addEventListener('click', event => {
+      if (Date.now() > suppressClickUntil) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+    window.addEventListener('resize', () => {
+      if (rail.dataset.defaultPosition === '1') return;
+      applyViewportRailPosition(
+        rail,
+        Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
+        Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
+      );
+    });
+  }
+
   function initViewportControls(viewer) {
     const rail = document.getElementById('buret-viewport-rail');
     const bar = document.getElementById('buret-selection-bar');
     if (!rail || !bar) return;
     if (rail.dataset.viewportControlsBound !== '1') {
       rail.dataset.viewportControlsBound = '1';
+      initViewportRailDrag(rail);
       const level = bar.querySelector('[data-buret-selection-level]');
       for (const [name, label] of VIEWPORT_GRANULARITIES) {
         const option = document.createElement('option');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6366,6 +6366,19 @@
     }
   }
 
+  function positionOpenViewportMenu(rail = document.getElementById('buret-viewport-rail')) {
+    const menu = document.getElementById('buret-viewport-menu');
+    const trigger = rail?.querySelector('[aria-expanded="true"]');
+    if (!menu || !trigger) return;
+    const anchor = trigger.getBoundingClientRect();
+    const rect = menu.getBoundingClientRect();
+    // Keep the portalled menu attached to its rail button while the rail moves or
+    // the host resizes the preview viewport.
+    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
+    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
+    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+  }
+
   function openViewportMenu(trigger, label, build) {
     const wasOpen = trigger.getAttribute('aria-expanded') === 'true';
     closeViewportMenu();
@@ -6378,13 +6391,7 @@
     build(menu);
     document.body.appendChild(menu);
     trigger.setAttribute('aria-expanded', 'true');
-    const anchor = trigger.getBoundingClientRect();
-    const rect = menu.getBoundingClientRect();
-    // The rail lives on the right edge, so its menus open leftwards rather than
-    // running off the window and being clamped back over their own button.
-    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
-    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
-    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+    positionOpenViewportMenu(trigger.closest('#buret-viewport-rail'));
   }
 
   function viewportMenuItem(menu, label, action, options = {}) {
@@ -6900,11 +6907,11 @@
       }
       if (!drag.moved) return;
       rail.dataset.defaultPosition = '0';
-      closeViewportMenu();
       const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
       const left = event.clientX - drag.dx;
       applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
       updateFloatingLayoutOffsets();
+      positionOpenViewportMenu(rail);
       event.preventDefault();
     };
     const finishDrag = event => {
@@ -6935,12 +6942,14 @@
       event.stopImmediatePropagation();
     }, true);
     window.addEventListener('resize', () => {
-      if (rail.dataset.defaultPosition === '1') return;
-      applyViewportRailPosition(
-        rail,
-        Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
-        Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
-      );
+      if (rail.dataset.defaultPosition !== '1') {
+        applyViewportRailPosition(
+          rail,
+          Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
+          Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
+        );
+      }
+      positionOpenViewportMenu(rail);
     });
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -8,7 +8,6 @@
   const SDF_GRID_PADDING = 4.0;
   const TOOLBAR_POSITION_VERSION = '13';
   const TOOLBAR_COLLAPSED_VERSION = '5';
-  const VIEWPORT_RAIL_POSITION_VERSION = '1';
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
@@ -4075,6 +4074,7 @@
     if (collapsed) {
       setXyzrenderPopoverVisibility(toolbar, false);
       hideGenerate3DMenu();
+      closeViewportMenu();
     }
     toolbar.classList.toggle('collapsed', collapsed);
     document.body?.classList.toggle('buret-toolbar-collapsed', collapsed);
@@ -4322,6 +4322,10 @@
       Math.max(180, Math.floor(window.innerWidth - selectionBarLeft - TOOLBAR_MARGIN)) + 'px');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
+    const viewportRailRight = toolbarRect
+      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right))
+      : TOOLBAR_MARGIN;
+    root.style.setProperty('--buret-viewport-rail-right', viewportRailRight + 'px');
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const viewportControlRailRect = visibleRect('.msp-plugin .msp-viewport-controls-buttons');
@@ -4356,15 +4360,16 @@
       : defaultViewportTop;
     const viewportControlsTop = Math.max(TOOLBAR_MARGIN, Math.ceil(viewportControlsViewportTop - mainTop));
     root.style.setProperty('--buret-viewport-controls-top', viewportControlsTop + 'px');
-    // The rail is positioned against the window rather than the layout region, so it
-    // takes the unshifted figure — the one that already steps below the toolbar and
-    // the selection bar.
-    root.style.setProperty('--buret-viewport-rail-top', Math.ceil(viewportControlsViewportTop) + 'px');
+    const viewportRailTop = selectionToolbarRect
+      ? Math.max(defaultViewportTop, Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP))
+      : Math.max(defaultViewportTop, Math.ceil(toolbarBottom));
+    root.style.setProperty('--buret-viewport-rail-top', viewportRailTop + 'px');
     repositionDockingPoseControlsForLayout(mainRect);
 
     const bottomLimit = visibleRectTop('.msp-plugin .msp-layout-bottom') || window.innerHeight;
     const panelMaxHeight = Math.max(160, Math.floor(bottomLimit - viewportControlsViewportTop - FLOATING_LAYOUT_GAP));
     root.style.setProperty('--buret-viewport-panel-max-height', panelMaxHeight + 'px');
+    positionOpenViewportMenu();
   }
 
   function visibleRectTop(selector) {
@@ -6838,62 +6843,23 @@
     if (changed) updateFloatingLayoutOffsets();
   }
 
-  function applyViewportRailPosition(rail, right, top) {
-    const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
-    const height = rail.offsetHeight || rail.getBoundingClientRect().height || 170;
-    const maxRight = Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
-    const maxTop = Math.max(TOOLBAR_MARGIN, window.innerHeight - height - TOOLBAR_MARGIN);
-    rail.style.left = 'auto';
-    rail.style.right = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, right), maxRight)) + 'px';
-    rail.style.top = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, top), maxTop)) + 'px';
-  }
-
-  function saveViewportRailPosition(rail) {
+  function initViewportRailDrag(rail, toolbar) {
+    if (!toolbar) return;
     try {
-      const rect = rail.getBoundingClientRect();
-      window.localStorage && window.localStorage.setItem('buret.viewportRail.position', JSON.stringify({
-        right: Math.round(window.innerWidth - rect.right),
-        top: Math.round(rect.top),
-        mode: 'custom'
-      }));
-      window.localStorage && window.localStorage.setItem('buret.viewportRail.position.version', VIEWPORT_RAIL_POSITION_VERSION);
+      window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
+      window.localStorage && window.localStorage.removeItem('buret.viewportRail.position.version');
     } catch (_) {}
-  }
-
-  function restoreViewportRailPosition(rail) {
-    try {
-      const raw = window.localStorage && window.localStorage.getItem('buret.viewportRail.position');
-      const version = window.localStorage && window.localStorage.getItem('buret.viewportRail.position.version');
-      if (raw && version === VIEWPORT_RAIL_POSITION_VERSION) {
-        const saved = JSON.parse(raw);
-        if (saved.mode === 'custom' && Number.isFinite(saved.right) && Number.isFinite(saved.top)) {
-          rail.dataset.defaultPosition = '0';
-          applyViewportRailPosition(rail, saved.right, saved.top);
-          return;
-        }
-      } else if (raw) {
-        window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
-      }
-    } catch (_) {}
-    rail.dataset.defaultPosition = '1';
-    rail.style.removeProperty('left');
-    rail.style.removeProperty('right');
-    rail.style.removeProperty('top');
-  }
-
-  function initViewportRailDrag(rail) {
-    restoreViewportRailPosition(rail);
     let drag = null;
     let suppressClickUntil = 0;
     const onPointerDown = event => {
       if (event.button !== 0) return;
-      const rect = rail.getBoundingClientRect();
+      const toolbarRect = toolbar.getBoundingClientRect();
       drag = {
         pointerId: event.pointerId,
-        dx: event.clientX - rect.left,
-        dy: event.clientY - rect.top,
         startX: event.clientX,
         startY: event.clientY,
+        toolbarLeft: toolbarRect.left,
+        toolbarTop: toolbarRect.top,
         moved: false
       };
       rail.setPointerCapture(event.pointerId);
@@ -6906,12 +6872,15 @@
         drag.moved = Math.abs(event.clientX - drag.startX) > 4 || Math.abs(event.clientY - drag.startY) > 4;
       }
       if (!drag.moved) return;
-      rail.dataset.defaultPosition = '0';
-      const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
-      const left = event.clientX - drag.dx;
-      applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
-      updateFloatingLayoutOffsets();
-      positionOpenViewportMenu(rail);
+      if (toolbar.dataset.defaultPosition === '1') {
+        toolbar.dataset.defaultPosition = '0';
+        undockToolbar(toolbar);
+      }
+      moveToolbar(
+        toolbar,
+        drag.toolbarLeft + event.clientX - drag.startX,
+        drag.toolbarTop + event.clientY - drag.startY
+      );
       event.preventDefault();
     };
     const finishDrag = event => {
@@ -6922,7 +6891,7 @@
       drag = null;
       if (!moved) return;
       suppressClickUntil = Date.now() + 300;
-      saveViewportRailPosition(rail);
+      saveToolbarPosition(toolbar);
     };
     const cancelDrag = () => {
       rail.classList.remove('buret-dragging');
@@ -6941,16 +6910,6 @@
       event.preventDefault();
       event.stopImmediatePropagation();
     }, true);
-    window.addEventListener('resize', () => {
-      if (rail.dataset.defaultPosition !== '1') {
-        applyViewportRailPosition(
-          rail,
-          Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
-          Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
-        );
-      }
-      positionOpenViewportMenu(rail);
-    });
   }
 
   function initViewportControls(viewer) {
@@ -6959,7 +6918,7 @@
     if (!rail || !bar) return;
     if (rail.dataset.viewportControlsBound !== '1') {
       rail.dataset.viewportControlsBound = '1';
-      initViewportRailDrag(rail);
+      initViewportRailDrag(rail, document.getElementById('buret-toolbar'));
       const level = bar.querySelector('[data-buret-selection-level]');
       for (const [name, label] of VIEWPORT_GRANULARITIES) {
         const option = document.createElement('option');

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -4331,9 +4331,6 @@
       ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - railRect.left + FLOATING_LAYOUT_GAP * 2))
       : 70;
     root.style.setProperty('--buret-generate-3d-control-right', generate3DControlRight + 'px');
-    root.style.setProperty('--buret-viewport-rail-right', toolbarRect
-      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right)) + 'px'
-      : 'var(--buret-control-island-right)');
     const selectionToolbarRect = visibleRect('.msp-plugin .msp-selection-viewport-controls > .msp-flex-row')
       || visibleRect('#buret-selection-bar');
     // The squared-off join only makes sense while the two actually meet; rolled up,

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -11,6 +11,9 @@
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
+  const TOOLBAR_CORNER_SNAP_DISTANCE = 64;
+  const TOOLBAR_CORNER_RELEASE_DISTANCE = 96;
+  const TOOLBAR_ORIENTATION_HYSTERESIS = 48;
   const PANEL_CLOSE_HIT_WIDTH = 38;
   const MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX = 4;
   const MOLSTAR_TOUCH_CONTEXT_MENU_DELAY_MS = 520;
@@ -4091,7 +4094,7 @@
         window.localStorage && window.localStorage.removeItem('buret.toolbar.position');
       } catch (_) {}
     }
-    toolbar.dataset.defaultPosition = '1';
+    if (persist || collapsed) toolbar.dataset.defaultPosition = '1';
     repositionToolbar(toolbar);
     updateFloatingLayoutOffsets();
     scheduleViewerResize(viewer, 40);
@@ -4129,6 +4132,16 @@
           toolbar.style.top = saved.top + 'px';
           toolbar.style.right = 'auto';
           toolbar.dataset.defaultPosition = '0';
+          if (isToolbarCorner(saved.corner)) {
+            toolbar.dataset.dockCorner = saved.corner;
+            positionToolbarAtCorner(toolbar, saved.corner);
+          } else {
+            const inferredCorner = toolbarCornerWithinSnapDistance(toolbar);
+            if (inferredCorner) {
+              toolbar.dataset.dockCorner = inferredCorner;
+              positionToolbarAtCorner(toolbar, inferredCorner);
+            }
+          }
           hasSavedPosition = true;
         }
       } else if (raw) {
@@ -4200,6 +4213,7 @@
         ignoreNextGripClick = startedOnHandle;
         toolbar.dataset.defaultPosition = '0';
         undockToolbar(toolbar);
+        snapToolbarToCorner(toolbar);
         saveToolbarPosition(toolbar);
       }
     });
@@ -4242,6 +4256,11 @@
       applyDefaultToolbarPosition(toolbar);
       return;
     }
+    if (isToolbarCorner(toolbar.dataset.dockCorner)) {
+      positionToolbarAtCorner(toolbar, toolbar.dataset.dockCorner);
+      saveToolbarPosition(toolbar);
+      return;
+    }
 
     const rect = toolbar.getBoundingClientRect();
     moveToolbar(toolbar, rect.left, rect.top);
@@ -4255,11 +4274,75 @@
     const width = toolbar.offsetWidth || toolbar.getBoundingClientRect().width || 320;
     const rightEdge = window.innerWidth;
     const left = Math.max(TOOLBAR_MARGIN, Math.round(rightEdge - width - TOOLBAR_MARGIN));
+    delete toolbar.dataset.dockCorner;
     toolbar.dataset.defaultPosition = '1';
     toolbar.style.left = left + 'px';
     toolbar.style.right = 'auto';
     toolbar.style.top = top + 'px';
     updateFloatingLayoutOffsets();
+  }
+
+  function isToolbarCorner(value) {
+    return ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(value);
+  }
+
+  function toolbarCornerWithinDistance(toolbar, distance) {
+    const rect = toolbar.getBoundingClientRect();
+    const horizontal = rect.left <= distance
+      ? 'left'
+      : window.innerWidth - rect.right <= distance
+      ? 'right'
+      : '';
+    const vertical = rect.top - toolbarSafeTop() <= distance
+      ? 'top'
+      : window.innerHeight - rect.bottom <= distance
+      ? 'bottom'
+      : '';
+    return horizontal && vertical ? `${vertical}-${horizontal}` : '';
+  }
+
+  function toolbarCornerWithinSnapDistance(toolbar) {
+    return toolbarCornerWithinDistance(toolbar, TOOLBAR_CORNER_SNAP_DISTANCE);
+  }
+
+  function updateToolbarCornerIntent(toolbar) {
+    const current = toolbar.dataset.dockCorner;
+    if (isToolbarCorner(current)) {
+      if (toolbarCornerWithinDistance(toolbar, TOOLBAR_CORNER_RELEASE_DISTANCE) === current) return;
+      delete toolbar.dataset.dockCorner;
+    }
+    const corner = toolbarCornerWithinSnapDistance(toolbar);
+    if (corner) toolbar.dataset.dockCorner = corner;
+  }
+
+  function positionToolbarAtCorner(toolbar, corner) {
+    fitToolbarToViewport(toolbar);
+    const width = toolbar.offsetWidth || toolbar.getBoundingClientRect().width || 320;
+    const height = toolbar.offsetHeight || toolbar.getBoundingClientRect().height || 36;
+    const horizontal = corner.endsWith('left') ? 'left' : 'right';
+    const vertical = corner.startsWith('bottom') ? 'bottom' : 'top';
+    const left = horizontal === 'left'
+      ? TOOLBAR_MARGIN
+      : Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
+    const top = vertical === 'top'
+      ? toolbarSafeTop()
+      : Math.max(toolbarSafeTop(), window.innerHeight - height - TOOLBAR_MARGIN);
+    toolbar.style.left = Math.round(left) + 'px';
+    toolbar.style.top = Math.round(top) + 'px';
+    toolbar.style.right = 'auto';
+    updateFloatingLayoutOffsets();
+  }
+
+  function snapToolbarToCorner(toolbar) {
+    const corner = toolbarCornerWithinSnapDistance(toolbar);
+    if (!corner) {
+      delete toolbar.dataset.dockCorner;
+      updateFloatingLayoutOffsets();
+      return false;
+    }
+    toolbar.dataset.dockCorner = corner;
+    positionToolbarAtCorner(toolbar, corner);
+    return true;
   }
 
   function moveToolbar(toolbar, left, top) {
@@ -4271,6 +4354,7 @@
     toolbar.style.left = Math.min(Math.max(margin, left), maxLeft) + 'px';
     toolbar.style.top = Math.min(Math.max(safeTop, top), maxTop) + 'px';
     toolbar.style.right = 'auto';
+    updateToolbarCornerIntent(toolbar);
     updateFloatingLayoutOffsets();
   }
 
@@ -4322,10 +4406,38 @@
       Math.max(180, Math.floor(window.innerWidth - selectionBarLeft - TOOLBAR_MARGIN)) + 'px');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
-    const viewportRailRight = toolbarRect
-      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right))
-      : TOOLBAR_MARGIN;
-    root.style.setProperty('--buret-viewport-rail-right', viewportRailRight + 'px');
+    const viewportRail = document.getElementById('buret-viewport-rail');
+    const viewportRailHeight = viewportRail?.offsetHeight || viewportRail?.getBoundingClientRect().height || 172;
+    const viewportRailWidth = viewportRail?.offsetWidth || viewportRail?.getBoundingClientRect().width || 36;
+    const dockCorner = toolbar?.dataset.dockCorner;
+    const toolbarCenterX = toolbarRect ? toolbarRect.left + toolbarRect.width / 2 : window.innerWidth;
+    let railHorizontal = dockCorner?.endsWith('left') ? 'left'
+      : dockCorner?.endsWith('right') ? 'right'
+      : viewportRail?.dataset.horizontalPlacement || (toolbarCenterX < window.innerWidth / 2 ? 'left' : 'right');
+    if (!dockCorner && toolbarRect) {
+      if (railHorizontal === 'left' && toolbarCenterX > window.innerWidth / 2 + TOOLBAR_ORIENTATION_HYSTERESIS) railHorizontal = 'right';
+      if (railHorizontal === 'right' && toolbarCenterX < window.innerWidth / 2 - TOOLBAR_ORIENTATION_HYSTERESIS) railHorizontal = 'left';
+    }
+    const spaceBelowToolbar = toolbarRect ? window.innerHeight - toolbarRect.bottom - TOOLBAR_MARGIN : window.innerHeight;
+    const spaceAboveToolbar = toolbarRect ? toolbarRect.top - toolbarSafeTop() : 0;
+    const requiredRailSpace = viewportRailHeight + FLOATING_LAYOUT_GAP;
+    let railVertical = dockCorner?.startsWith('bottom') ? 'above'
+      : dockCorner?.startsWith('top') ? 'below'
+      : viewportRail?.dataset.verticalPlacement || (spaceBelowToolbar >= requiredRailSpace ? 'below' : 'above');
+    if (!dockCorner && toolbarRect) {
+      if (railVertical === 'below' && spaceBelowToolbar < requiredRailSpace && spaceAboveToolbar > spaceBelowToolbar + TOOLBAR_ORIENTATION_HYSTERESIS) railVertical = 'above';
+      if (railVertical === 'above' && spaceBelowToolbar > requiredRailSpace + TOOLBAR_ORIENTATION_HYSTERESIS) railVertical = 'below';
+    }
+    if (viewportRail) {
+      viewportRail.dataset.horizontalPlacement = railHorizontal;
+      viewportRail.dataset.verticalPlacement = railVertical;
+    }
+    const viewportRailLeft = toolbarRect
+      ? railHorizontal === 'left'
+        ? toolbarRect.left
+        : toolbarRect.right - viewportRailWidth
+      : window.innerWidth - TOOLBAR_MARGIN - viewportRailWidth;
+    root.style.setProperty('--buret-viewport-rail-left', Math.round(viewportRailLeft) + 'px');
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const viewportControlRailRect = visibleRect('.msp-plugin .msp-viewport-controls-buttons');
@@ -4360,9 +4472,15 @@
       : defaultViewportTop;
     const viewportControlsTop = Math.max(TOOLBAR_MARGIN, Math.ceil(viewportControlsViewportTop - mainTop));
     root.style.setProperty('--buret-viewport-controls-top', viewportControlsTop + 'px');
-    const viewportRailTop = selectionToolbarRect
-      ? Math.max(defaultViewportTop, Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP))
-      : Math.max(defaultViewportTop, Math.ceil(toolbarBottom));
+    const preferredViewportRailTop = toolbarRect && railVertical === 'above'
+      ? toolbarRect.top - FLOATING_LAYOUT_GAP - viewportRailHeight
+      : selectionToolbarRect
+      ? selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP
+      : toolbarBottom;
+    const viewportRailTop = Math.min(
+      Math.max(toolbarSafeTop(), Math.ceil(preferredViewportRailTop)),
+      Math.max(toolbarSafeTop(), window.innerHeight - viewportRailHeight - TOOLBAR_MARGIN)
+    );
     root.style.setProperty('--buret-viewport-rail-top', viewportRailTop + 'px');
     repositionDockingPoseControlsForLayout(mainRect);
 
@@ -4523,7 +4641,12 @@
   function saveToolbarPosition(toolbar) {
     try {
       const rect = toolbar.getBoundingClientRect();
-      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({ left: rect.left, top: rect.top, mode: 'custom' }));
+      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({
+        left: rect.left,
+        top: rect.top,
+        mode: 'custom',
+        corner: isToolbarCorner(toolbar.dataset.dockCorner) ? toolbar.dataset.dockCorner : null
+      }));
       window.localStorage && window.localStorage.setItem('buret.toolbar.position.version', TOOLBAR_POSITION_VERSION);
     } catch (_) {}
   }
@@ -6379,9 +6502,14 @@
     const rect = menu.getBoundingClientRect();
     // Keep the portalled menu attached to its rail button while the rail moves or
     // the host resizes the preview viewport.
-    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
-    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
-    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+    const preferredLeft = rail.dataset.horizontalPlacement === 'right'
+      ? anchor.right - rect.width
+      : anchor.left;
+    const preferredTop = rail.dataset.verticalPlacement === 'above'
+      ? anchor.top - rect.height - 4
+      : anchor.bottom + 4;
+    menu.style.left = `${Math.round(Math.max(6, Math.min(preferredLeft, window.innerWidth - rect.width - 6)))}px`;
+    menu.style.top = `${Math.round(Math.max(6, Math.min(preferredTop, window.innerHeight - rect.height - 6)))}px`;
   }
 
   function openViewportMenu(trigger, label, build) {
@@ -6891,6 +7019,7 @@
       drag = null;
       if (!moved) return;
       suppressClickUntil = Date.now() + 300;
+      snapToolbarToCorner(toolbar);
       saveToolbarPosition(toolbar);
     };
     const cancelDrag = () => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -638,12 +638,15 @@ button:focus-visible > .shortcut-tooltip {
    swap that value instantly; easing it recreates the pre-refactor slide. The
    transition only exists while the app marks the group as animating a toggle —
    a standing one would rubber-band pointer drags and window resizes, where the
-   library rewrites flex-grow every frame. Timings match the old .sidebar-shell
-   (140ms ease-out) and .dock-panel (180ms) rules. */
+   library rewrites flex-grow every frame. The right dock closes quickly so
+   canvas-anchored controls reach their new edge without a visible glide; the
+   bottom dock keeps the roomier legacy timing. */
 .workspace-panels[data-panels-animating] > [data-panel] {
   transition: flex-grow 140ms ease-out;
 }
-.workbench-panels[data-panels-animating] > [data-panel],
+.workbench-panels[data-panels-animating] > [data-panel] {
+  transition: flex-grow 90ms ease-out;
+}
 .workbench-main-panels[data-panels-animating] > [data-panel] {
   transition: flex-grow 180ms cubic-bezier(0.2, 0, 0, 1);
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -638,15 +638,12 @@ button:focus-visible > .shortcut-tooltip {
    swap that value instantly; easing it recreates the pre-refactor slide. The
    transition only exists while the app marks the group as animating a toggle —
    a standing one would rubber-band pointer drags and window resizes, where the
-   library rewrites flex-grow every frame. The right dock closes quickly so
-   canvas-anchored controls reach their new edge without a visible glide; the
-   bottom dock keeps the roomier legacy timing. */
+   library rewrites flex-grow every frame. Timings match the old .sidebar-shell
+   (140ms ease-out) and .dock-panel (180ms) rules. */
 .workspace-panels[data-panels-animating] > [data-panel] {
   transition: flex-grow 140ms ease-out;
 }
-.workbench-panels[data-panels-animating] > [data-panel] {
-  transition: flex-grow 90ms ease-out;
-}
+.workbench-panels[data-panels-animating] > [data-panel],
 .workbench-main-panels[data-panels-animating] > [data-panel] {
   transition: flex-grow 180ms cubic-bezier(0.2, 0, 0, 1);
 }

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -537,7 +537,9 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
-  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
+  /* The top toolbar can be dragged. This rail belongs to the viewport edge,
+     so its horizontal position must respond directly to viewport resizing. */
+  right: var(--buret-control-island-right);
   z-index: 40;
   box-sizing: border-box;
   display: flex;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -538,7 +538,8 @@ body.burette-mobile-host #buret-scene-tree {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
   /* The rail is the vertical part of the draggable toolbar group. */
-  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
+  right: auto;
+  left: var(--buret-viewport-rail-left, auto);
   z-index: 40;
   box-sizing: border-box;
   display: flex;
@@ -1478,7 +1479,7 @@ body.burette-mobile-host .buret-molecule-context-menu button:focus {
 }
 #buret-toolbar {
   position: absolute; top: calc(var(--buret-toolbar-safe-top) + var(--buret-viewport-top-inset, 0px)); right: var(--buret-control-island-right); left: auto; z-index: 2147483646;
-  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 3px 0;
+  display: flex; align-items: center; flex-wrap: nowrap; max-width: calc(100vw - (var(--buret-control-island-right) * 2)); gap: var(--buret-control-island-gap); padding: 3px;
   border: 1px solid var(--buret-toolbar-border);
   border-radius: 12px; color: var(--buret-toolbar-color);
   background: var(--buret-toolbar-background);

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -537,9 +537,8 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail {
   position: fixed;
   top: var(--buret-viewport-rail-top, calc(var(--buret-toolbar-safe-top) + 42px));
-  /* The top toolbar can be dragged. This rail belongs to the viewport edge,
-     so its horizontal position must respond directly to viewport resizing. */
-  right: var(--buret-control-island-right);
+  /* The rail is the vertical part of the draggable toolbar group. */
+  right: var(--buret-viewport-rail-right, var(--buret-control-island-right));
   z-index: 40;
   box-sizing: border-box;
   display: flex;
@@ -567,6 +566,10 @@ body.burette-mobile-host #buret-scene-tree {
 .buret-viewport-rail.hidden,
 .buret-selection-bar.hidden {
   display: none;
+}
+body.buret-toolbar-collapsed #buret-viewport-rail,
+body.buret-toolbar-collapsed #buret-selection-bar {
+  display: none !important;
 }
 .buret-rail-button {
   position: relative;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -556,6 +556,13 @@ body.burette-mobile-host #buret-scene-tree {
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+.buret-viewport-rail.buret-dragging,
+.buret-viewport-rail.buret-dragging .buret-rail-button {
+  cursor: grabbing;
 }
 .buret-viewport-rail.hidden,
 .buret-selection-bar.hidden {

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -8,6 +8,7 @@
   const SDF_GRID_PADDING = 4.0;
   const TOOLBAR_POSITION_VERSION = '13';
   const TOOLBAR_COLLAPSED_VERSION = '5';
+  const VIEWPORT_RAIL_POSITION_VERSION = '1';
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
@@ -6830,12 +6831,126 @@
     if (changed) updateFloatingLayoutOffsets();
   }
 
+  function applyViewportRailPosition(rail, right, top) {
+    const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
+    const height = rail.offsetHeight || rail.getBoundingClientRect().height || 170;
+    const maxRight = Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
+    const maxTop = Math.max(TOOLBAR_MARGIN, window.innerHeight - height - TOOLBAR_MARGIN);
+    rail.style.left = 'auto';
+    rail.style.right = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, right), maxRight)) + 'px';
+    rail.style.top = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, top), maxTop)) + 'px';
+  }
+
+  function saveViewportRailPosition(rail) {
+    try {
+      const rect = rail.getBoundingClientRect();
+      window.localStorage && window.localStorage.setItem('buret.viewportRail.position', JSON.stringify({
+        right: Math.round(window.innerWidth - rect.right),
+        top: Math.round(rect.top),
+        mode: 'custom'
+      }));
+      window.localStorage && window.localStorage.setItem('buret.viewportRail.position.version', VIEWPORT_RAIL_POSITION_VERSION);
+    } catch (_) {}
+  }
+
+  function restoreViewportRailPosition(rail) {
+    try {
+      const raw = window.localStorage && window.localStorage.getItem('buret.viewportRail.position');
+      const version = window.localStorage && window.localStorage.getItem('buret.viewportRail.position.version');
+      if (raw && version === VIEWPORT_RAIL_POSITION_VERSION) {
+        const saved = JSON.parse(raw);
+        if (saved.mode === 'custom' && Number.isFinite(saved.right) && Number.isFinite(saved.top)) {
+          rail.dataset.defaultPosition = '0';
+          applyViewportRailPosition(rail, saved.right, saved.top);
+          return;
+        }
+      } else if (raw) {
+        window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
+      }
+    } catch (_) {}
+    rail.dataset.defaultPosition = '1';
+    rail.style.removeProperty('left');
+    rail.style.removeProperty('right');
+    rail.style.removeProperty('top');
+  }
+
+  function initViewportRailDrag(rail) {
+    restoreViewportRailPosition(rail);
+    let drag = null;
+    let suppressClickUntil = 0;
+    const onPointerDown = event => {
+      if (event.button !== 0) return;
+      const rect = rail.getBoundingClientRect();
+      drag = {
+        pointerId: event.pointerId,
+        dx: event.clientX - rect.left,
+        dy: event.clientY - rect.top,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false
+      };
+      rail.setPointerCapture(event.pointerId);
+      rail.classList.add('buret-dragging');
+      event.preventDefault();
+    };
+    const onPointerMove = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      if (!drag.moved) {
+        drag.moved = Math.abs(event.clientX - drag.startX) > 4 || Math.abs(event.clientY - drag.startY) > 4;
+      }
+      if (!drag.moved) return;
+      rail.dataset.defaultPosition = '0';
+      closeViewportMenu();
+      const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
+      const left = event.clientX - drag.dx;
+      applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
+      updateFloatingLayoutOffsets();
+      event.preventDefault();
+    };
+    const finishDrag = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      const moved = drag.moved;
+      try { rail.releasePointerCapture(event.pointerId); } catch (_) {}
+      rail.classList.remove('buret-dragging');
+      drag = null;
+      if (!moved) return;
+      suppressClickUntil = Date.now() + 300;
+      saveViewportRailPosition(rail);
+    };
+    const cancelDrag = () => {
+      rail.classList.remove('buret-dragging');
+      drag = null;
+    };
+    rail.addEventListener('pointerdown', onPointerDown);
+    rail.addEventListener('pointermove', onPointerMove);
+    rail.addEventListener('pointerup', finishDrag);
+    rail.addEventListener('pointercancel', cancelDrag);
+    rail.addEventListener('lostpointercapture', cancelDrag);
+    window.addEventListener('pointermove', onPointerMove, true);
+    window.addEventListener('pointerup', finishDrag, true);
+    window.addEventListener('pointercancel', cancelDrag, true);
+    rail.addEventListener('click', event => {
+      if (Date.now() > suppressClickUntil) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+    window.addEventListener('resize', () => {
+      if (rail.dataset.defaultPosition === '1') return;
+      applyViewportRailPosition(
+        rail,
+        Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
+        Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
+      );
+    });
+  }
+
   function initViewportControls(viewer) {
     const rail = document.getElementById('buret-viewport-rail');
     const bar = document.getElementById('buret-selection-bar');
     if (!rail || !bar) return;
     if (rail.dataset.viewportControlsBound !== '1') {
       rail.dataset.viewportControlsBound = '1';
+      initViewportRailDrag(rail);
       const level = bar.querySelector('[data-buret-selection-level]');
       for (const [name, label] of VIEWPORT_GRANULARITIES) {
         const option = document.createElement('option');

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -6366,6 +6366,19 @@
     }
   }
 
+  function positionOpenViewportMenu(rail = document.getElementById('buret-viewport-rail')) {
+    const menu = document.getElementById('buret-viewport-menu');
+    const trigger = rail?.querySelector('[aria-expanded="true"]');
+    if (!menu || !trigger) return;
+    const anchor = trigger.getBoundingClientRect();
+    const rect = menu.getBoundingClientRect();
+    // Keep the portalled menu attached to its rail button while the rail moves or
+    // the host resizes the preview viewport.
+    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
+    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
+    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+  }
+
   function openViewportMenu(trigger, label, build) {
     const wasOpen = trigger.getAttribute('aria-expanded') === 'true';
     closeViewportMenu();
@@ -6378,13 +6391,7 @@
     build(menu);
     document.body.appendChild(menu);
     trigger.setAttribute('aria-expanded', 'true');
-    const anchor = trigger.getBoundingClientRect();
-    const rect = menu.getBoundingClientRect();
-    // The rail lives on the right edge, so its menus open leftwards rather than
-    // running off the window and being clamped back over their own button.
-    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
-    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
-    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+    positionOpenViewportMenu(trigger.closest('#buret-viewport-rail'));
   }
 
   function viewportMenuItem(menu, label, action, options = {}) {
@@ -6900,11 +6907,11 @@
       }
       if (!drag.moved) return;
       rail.dataset.defaultPosition = '0';
-      closeViewportMenu();
       const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
       const left = event.clientX - drag.dx;
       applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
       updateFloatingLayoutOffsets();
+      positionOpenViewportMenu(rail);
       event.preventDefault();
     };
     const finishDrag = event => {
@@ -6935,12 +6942,14 @@
       event.stopImmediatePropagation();
     }, true);
     window.addEventListener('resize', () => {
-      if (rail.dataset.defaultPosition === '1') return;
-      applyViewportRailPosition(
-        rail,
-        Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
-        Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
-      );
+      if (rail.dataset.defaultPosition !== '1') {
+        applyViewportRailPosition(
+          rail,
+          Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
+          Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
+        );
+      }
+      positionOpenViewportMenu(rail);
     });
   }
 

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -8,7 +8,6 @@
   const SDF_GRID_PADDING = 4.0;
   const TOOLBAR_POSITION_VERSION = '13';
   const TOOLBAR_COLLAPSED_VERSION = '5';
-  const VIEWPORT_RAIL_POSITION_VERSION = '1';
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
@@ -4075,6 +4074,7 @@
     if (collapsed) {
       setXyzrenderPopoverVisibility(toolbar, false);
       hideGenerate3DMenu();
+      closeViewportMenu();
     }
     toolbar.classList.toggle('collapsed', collapsed);
     document.body?.classList.toggle('buret-toolbar-collapsed', collapsed);
@@ -4322,6 +4322,10 @@
       Math.max(180, Math.floor(window.innerWidth - selectionBarLeft - TOOLBAR_MARGIN)) + 'px');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
+    const viewportRailRight = toolbarRect
+      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right))
+      : TOOLBAR_MARGIN;
+    root.style.setProperty('--buret-viewport-rail-right', viewportRailRight + 'px');
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const viewportControlRailRect = visibleRect('.msp-plugin .msp-viewport-controls-buttons');
@@ -4356,15 +4360,16 @@
       : defaultViewportTop;
     const viewportControlsTop = Math.max(TOOLBAR_MARGIN, Math.ceil(viewportControlsViewportTop - mainTop));
     root.style.setProperty('--buret-viewport-controls-top', viewportControlsTop + 'px');
-    // The rail is positioned against the window rather than the layout region, so it
-    // takes the unshifted figure — the one that already steps below the toolbar and
-    // the selection bar.
-    root.style.setProperty('--buret-viewport-rail-top', Math.ceil(viewportControlsViewportTop) + 'px');
+    const viewportRailTop = selectionToolbarRect
+      ? Math.max(defaultViewportTop, Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP))
+      : Math.max(defaultViewportTop, Math.ceil(toolbarBottom));
+    root.style.setProperty('--buret-viewport-rail-top', viewportRailTop + 'px');
     repositionDockingPoseControlsForLayout(mainRect);
 
     const bottomLimit = visibleRectTop('.msp-plugin .msp-layout-bottom') || window.innerHeight;
     const panelMaxHeight = Math.max(160, Math.floor(bottomLimit - viewportControlsViewportTop - FLOATING_LAYOUT_GAP));
     root.style.setProperty('--buret-viewport-panel-max-height', panelMaxHeight + 'px');
+    positionOpenViewportMenu();
   }
 
   function visibleRectTop(selector) {
@@ -6838,62 +6843,23 @@
     if (changed) updateFloatingLayoutOffsets();
   }
 
-  function applyViewportRailPosition(rail, right, top) {
-    const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
-    const height = rail.offsetHeight || rail.getBoundingClientRect().height || 170;
-    const maxRight = Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
-    const maxTop = Math.max(TOOLBAR_MARGIN, window.innerHeight - height - TOOLBAR_MARGIN);
-    rail.style.left = 'auto';
-    rail.style.right = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, right), maxRight)) + 'px';
-    rail.style.top = Math.round(Math.min(Math.max(TOOLBAR_MARGIN, top), maxTop)) + 'px';
-  }
-
-  function saveViewportRailPosition(rail) {
+  function initViewportRailDrag(rail, toolbar) {
+    if (!toolbar) return;
     try {
-      const rect = rail.getBoundingClientRect();
-      window.localStorage && window.localStorage.setItem('buret.viewportRail.position', JSON.stringify({
-        right: Math.round(window.innerWidth - rect.right),
-        top: Math.round(rect.top),
-        mode: 'custom'
-      }));
-      window.localStorage && window.localStorage.setItem('buret.viewportRail.position.version', VIEWPORT_RAIL_POSITION_VERSION);
+      window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
+      window.localStorage && window.localStorage.removeItem('buret.viewportRail.position.version');
     } catch (_) {}
-  }
-
-  function restoreViewportRailPosition(rail) {
-    try {
-      const raw = window.localStorage && window.localStorage.getItem('buret.viewportRail.position');
-      const version = window.localStorage && window.localStorage.getItem('buret.viewportRail.position.version');
-      if (raw && version === VIEWPORT_RAIL_POSITION_VERSION) {
-        const saved = JSON.parse(raw);
-        if (saved.mode === 'custom' && Number.isFinite(saved.right) && Number.isFinite(saved.top)) {
-          rail.dataset.defaultPosition = '0';
-          applyViewportRailPosition(rail, saved.right, saved.top);
-          return;
-        }
-      } else if (raw) {
-        window.localStorage && window.localStorage.removeItem('buret.viewportRail.position');
-      }
-    } catch (_) {}
-    rail.dataset.defaultPosition = '1';
-    rail.style.removeProperty('left');
-    rail.style.removeProperty('right');
-    rail.style.removeProperty('top');
-  }
-
-  function initViewportRailDrag(rail) {
-    restoreViewportRailPosition(rail);
     let drag = null;
     let suppressClickUntil = 0;
     const onPointerDown = event => {
       if (event.button !== 0) return;
-      const rect = rail.getBoundingClientRect();
+      const toolbarRect = toolbar.getBoundingClientRect();
       drag = {
         pointerId: event.pointerId,
-        dx: event.clientX - rect.left,
-        dy: event.clientY - rect.top,
         startX: event.clientX,
         startY: event.clientY,
+        toolbarLeft: toolbarRect.left,
+        toolbarTop: toolbarRect.top,
         moved: false
       };
       rail.setPointerCapture(event.pointerId);
@@ -6906,12 +6872,15 @@
         drag.moved = Math.abs(event.clientX - drag.startX) > 4 || Math.abs(event.clientY - drag.startY) > 4;
       }
       if (!drag.moved) return;
-      rail.dataset.defaultPosition = '0';
-      const width = rail.offsetWidth || rail.getBoundingClientRect().width || 36;
-      const left = event.clientX - drag.dx;
-      applyViewportRailPosition(rail, window.innerWidth - left - width, event.clientY - drag.dy);
-      updateFloatingLayoutOffsets();
-      positionOpenViewportMenu(rail);
+      if (toolbar.dataset.defaultPosition === '1') {
+        toolbar.dataset.defaultPosition = '0';
+        undockToolbar(toolbar);
+      }
+      moveToolbar(
+        toolbar,
+        drag.toolbarLeft + event.clientX - drag.startX,
+        drag.toolbarTop + event.clientY - drag.startY
+      );
       event.preventDefault();
     };
     const finishDrag = event => {
@@ -6922,7 +6891,7 @@
       drag = null;
       if (!moved) return;
       suppressClickUntil = Date.now() + 300;
-      saveViewportRailPosition(rail);
+      saveToolbarPosition(toolbar);
     };
     const cancelDrag = () => {
       rail.classList.remove('buret-dragging');
@@ -6941,16 +6910,6 @@
       event.preventDefault();
       event.stopImmediatePropagation();
     }, true);
-    window.addEventListener('resize', () => {
-      if (rail.dataset.defaultPosition !== '1') {
-        applyViewportRailPosition(
-          rail,
-          Number.parseFloat(rail.style.right) || TOOLBAR_MARGIN,
-          Number.parseFloat(rail.style.top) || TOOLBAR_MARGIN
-        );
-      }
-      positionOpenViewportMenu(rail);
-    });
   }
 
   function initViewportControls(viewer) {
@@ -6959,7 +6918,7 @@
     if (!rail || !bar) return;
     if (rail.dataset.viewportControlsBound !== '1') {
       rail.dataset.viewportControlsBound = '1';
-      initViewportRailDrag(rail);
+      initViewportRailDrag(rail, document.getElementById('buret-toolbar'));
       const level = bar.querySelector('[data-buret-selection-level]');
       for (const [name, label] of VIEWPORT_GRANULARITIES) {
         const option = document.createElement('option');

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -4331,9 +4331,6 @@
       ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - railRect.left + FLOATING_LAYOUT_GAP * 2))
       : 70;
     root.style.setProperty('--buret-generate-3d-control-right', generate3DControlRight + 'px');
-    root.style.setProperty('--buret-viewport-rail-right', toolbarRect
-      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right)) + 'px'
-      : 'var(--buret-control-island-right)');
     const selectionToolbarRect = visibleRect('.msp-plugin .msp-selection-viewport-controls > .msp-flex-row')
       || visibleRect('#buret-selection-bar');
     // The squared-off join only makes sense while the two actually meet; rolled up,

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -11,6 +11,9 @@
   const DOCKING_POSE_POSITION_VERSION = '8';
   const TOOLBAR_MARGIN = 12;
   const FLOATING_LAYOUT_GAP = 12;
+  const TOOLBAR_CORNER_SNAP_DISTANCE = 64;
+  const TOOLBAR_CORNER_RELEASE_DISTANCE = 96;
+  const TOOLBAR_ORIENTATION_HYSTERESIS = 48;
   const PANEL_CLOSE_HIT_WIDTH = 38;
   const MOLSTAR_CONTEXT_MENU_DRAG_THRESHOLD_PX = 4;
   const MOLSTAR_TOUCH_CONTEXT_MENU_DELAY_MS = 520;
@@ -4091,7 +4094,7 @@
         window.localStorage && window.localStorage.removeItem('buret.toolbar.position');
       } catch (_) {}
     }
-    toolbar.dataset.defaultPosition = '1';
+    if (persist || collapsed) toolbar.dataset.defaultPosition = '1';
     repositionToolbar(toolbar);
     updateFloatingLayoutOffsets();
     scheduleViewerResize(viewer, 40);
@@ -4129,6 +4132,16 @@
           toolbar.style.top = saved.top + 'px';
           toolbar.style.right = 'auto';
           toolbar.dataset.defaultPosition = '0';
+          if (isToolbarCorner(saved.corner)) {
+            toolbar.dataset.dockCorner = saved.corner;
+            positionToolbarAtCorner(toolbar, saved.corner);
+          } else {
+            const inferredCorner = toolbarCornerWithinSnapDistance(toolbar);
+            if (inferredCorner) {
+              toolbar.dataset.dockCorner = inferredCorner;
+              positionToolbarAtCorner(toolbar, inferredCorner);
+            }
+          }
           hasSavedPosition = true;
         }
       } else if (raw) {
@@ -4200,6 +4213,7 @@
         ignoreNextGripClick = startedOnHandle;
         toolbar.dataset.defaultPosition = '0';
         undockToolbar(toolbar);
+        snapToolbarToCorner(toolbar);
         saveToolbarPosition(toolbar);
       }
     });
@@ -4242,6 +4256,11 @@
       applyDefaultToolbarPosition(toolbar);
       return;
     }
+    if (isToolbarCorner(toolbar.dataset.dockCorner)) {
+      positionToolbarAtCorner(toolbar, toolbar.dataset.dockCorner);
+      saveToolbarPosition(toolbar);
+      return;
+    }
 
     const rect = toolbar.getBoundingClientRect();
     moveToolbar(toolbar, rect.left, rect.top);
@@ -4255,11 +4274,75 @@
     const width = toolbar.offsetWidth || toolbar.getBoundingClientRect().width || 320;
     const rightEdge = window.innerWidth;
     const left = Math.max(TOOLBAR_MARGIN, Math.round(rightEdge - width - TOOLBAR_MARGIN));
+    delete toolbar.dataset.dockCorner;
     toolbar.dataset.defaultPosition = '1';
     toolbar.style.left = left + 'px';
     toolbar.style.right = 'auto';
     toolbar.style.top = top + 'px';
     updateFloatingLayoutOffsets();
+  }
+
+  function isToolbarCorner(value) {
+    return ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(value);
+  }
+
+  function toolbarCornerWithinDistance(toolbar, distance) {
+    const rect = toolbar.getBoundingClientRect();
+    const horizontal = rect.left <= distance
+      ? 'left'
+      : window.innerWidth - rect.right <= distance
+      ? 'right'
+      : '';
+    const vertical = rect.top - toolbarSafeTop() <= distance
+      ? 'top'
+      : window.innerHeight - rect.bottom <= distance
+      ? 'bottom'
+      : '';
+    return horizontal && vertical ? `${vertical}-${horizontal}` : '';
+  }
+
+  function toolbarCornerWithinSnapDistance(toolbar) {
+    return toolbarCornerWithinDistance(toolbar, TOOLBAR_CORNER_SNAP_DISTANCE);
+  }
+
+  function updateToolbarCornerIntent(toolbar) {
+    const current = toolbar.dataset.dockCorner;
+    if (isToolbarCorner(current)) {
+      if (toolbarCornerWithinDistance(toolbar, TOOLBAR_CORNER_RELEASE_DISTANCE) === current) return;
+      delete toolbar.dataset.dockCorner;
+    }
+    const corner = toolbarCornerWithinSnapDistance(toolbar);
+    if (corner) toolbar.dataset.dockCorner = corner;
+  }
+
+  function positionToolbarAtCorner(toolbar, corner) {
+    fitToolbarToViewport(toolbar);
+    const width = toolbar.offsetWidth || toolbar.getBoundingClientRect().width || 320;
+    const height = toolbar.offsetHeight || toolbar.getBoundingClientRect().height || 36;
+    const horizontal = corner.endsWith('left') ? 'left' : 'right';
+    const vertical = corner.startsWith('bottom') ? 'bottom' : 'top';
+    const left = horizontal === 'left'
+      ? TOOLBAR_MARGIN
+      : Math.max(TOOLBAR_MARGIN, window.innerWidth - width - TOOLBAR_MARGIN);
+    const top = vertical === 'top'
+      ? toolbarSafeTop()
+      : Math.max(toolbarSafeTop(), window.innerHeight - height - TOOLBAR_MARGIN);
+    toolbar.style.left = Math.round(left) + 'px';
+    toolbar.style.top = Math.round(top) + 'px';
+    toolbar.style.right = 'auto';
+    updateFloatingLayoutOffsets();
+  }
+
+  function snapToolbarToCorner(toolbar) {
+    const corner = toolbarCornerWithinSnapDistance(toolbar);
+    if (!corner) {
+      delete toolbar.dataset.dockCorner;
+      updateFloatingLayoutOffsets();
+      return false;
+    }
+    toolbar.dataset.dockCorner = corner;
+    positionToolbarAtCorner(toolbar, corner);
+    return true;
   }
 
   function moveToolbar(toolbar, left, top) {
@@ -4271,6 +4354,7 @@
     toolbar.style.left = Math.min(Math.max(margin, left), maxLeft) + 'px';
     toolbar.style.top = Math.min(Math.max(safeTop, top), maxTop) + 'px';
     toolbar.style.right = 'auto';
+    updateToolbarCornerIntent(toolbar);
     updateFloatingLayoutOffsets();
   }
 
@@ -4322,10 +4406,38 @@
       Math.max(180, Math.floor(window.innerWidth - selectionBarLeft - TOOLBAR_MARGIN)) + 'px');
     root.style.setProperty('--buret-selection-controls-top', toolbarRect ? Math.ceil(toolbarRect.bottom - 1) + 'px' : `calc(var(--buret-toolbar-safe-top) + 48px)`);
     const toolbarBottom = toolbarRect ? toolbarRect.bottom + FLOATING_LAYOUT_GAP : toolbarSafeTop() + 40;
-    const viewportRailRight = toolbarRect
-      ? Math.max(TOOLBAR_MARGIN, Math.ceil(window.innerWidth - toolbarRect.right))
-      : TOOLBAR_MARGIN;
-    root.style.setProperty('--buret-viewport-rail-right', viewportRailRight + 'px');
+    const viewportRail = document.getElementById('buret-viewport-rail');
+    const viewportRailHeight = viewportRail?.offsetHeight || viewportRail?.getBoundingClientRect().height || 172;
+    const viewportRailWidth = viewportRail?.offsetWidth || viewportRail?.getBoundingClientRect().width || 36;
+    const dockCorner = toolbar?.dataset.dockCorner;
+    const toolbarCenterX = toolbarRect ? toolbarRect.left + toolbarRect.width / 2 : window.innerWidth;
+    let railHorizontal = dockCorner?.endsWith('left') ? 'left'
+      : dockCorner?.endsWith('right') ? 'right'
+      : viewportRail?.dataset.horizontalPlacement || (toolbarCenterX < window.innerWidth / 2 ? 'left' : 'right');
+    if (!dockCorner && toolbarRect) {
+      if (railHorizontal === 'left' && toolbarCenterX > window.innerWidth / 2 + TOOLBAR_ORIENTATION_HYSTERESIS) railHorizontal = 'right';
+      if (railHorizontal === 'right' && toolbarCenterX < window.innerWidth / 2 - TOOLBAR_ORIENTATION_HYSTERESIS) railHorizontal = 'left';
+    }
+    const spaceBelowToolbar = toolbarRect ? window.innerHeight - toolbarRect.bottom - TOOLBAR_MARGIN : window.innerHeight;
+    const spaceAboveToolbar = toolbarRect ? toolbarRect.top - toolbarSafeTop() : 0;
+    const requiredRailSpace = viewportRailHeight + FLOATING_LAYOUT_GAP;
+    let railVertical = dockCorner?.startsWith('bottom') ? 'above'
+      : dockCorner?.startsWith('top') ? 'below'
+      : viewportRail?.dataset.verticalPlacement || (spaceBelowToolbar >= requiredRailSpace ? 'below' : 'above');
+    if (!dockCorner && toolbarRect) {
+      if (railVertical === 'below' && spaceBelowToolbar < requiredRailSpace && spaceAboveToolbar > spaceBelowToolbar + TOOLBAR_ORIENTATION_HYSTERESIS) railVertical = 'above';
+      if (railVertical === 'above' && spaceBelowToolbar > requiredRailSpace + TOOLBAR_ORIENTATION_HYSTERESIS) railVertical = 'below';
+    }
+    if (viewportRail) {
+      viewportRail.dataset.horizontalPlacement = railHorizontal;
+      viewportRail.dataset.verticalPlacement = railVertical;
+    }
+    const viewportRailLeft = toolbarRect
+      ? railHorizontal === 'left'
+        ? toolbarRect.left
+        : toolbarRect.right - viewportRailWidth
+      : window.innerWidth - TOOLBAR_MARGIN - viewportRailWidth;
+    root.style.setProperty('--buret-viewport-rail-left', Math.round(viewportRailLeft) + 'px');
     const viewportControls = document.querySelector('.msp-plugin .msp-viewport-controls');
     const viewportControlsRect = viewportControls ? viewportControls.getBoundingClientRect() : null;
     const viewportControlRailRect = visibleRect('.msp-plugin .msp-viewport-controls-buttons');
@@ -4360,9 +4472,15 @@
       : defaultViewportTop;
     const viewportControlsTop = Math.max(TOOLBAR_MARGIN, Math.ceil(viewportControlsViewportTop - mainTop));
     root.style.setProperty('--buret-viewport-controls-top', viewportControlsTop + 'px');
-    const viewportRailTop = selectionToolbarRect
-      ? Math.max(defaultViewportTop, Math.ceil(selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP))
-      : Math.max(defaultViewportTop, Math.ceil(toolbarBottom));
+    const preferredViewportRailTop = toolbarRect && railVertical === 'above'
+      ? toolbarRect.top - FLOATING_LAYOUT_GAP - viewportRailHeight
+      : selectionToolbarRect
+      ? selectionToolbarRect.bottom + FLOATING_LAYOUT_GAP
+      : toolbarBottom;
+    const viewportRailTop = Math.min(
+      Math.max(toolbarSafeTop(), Math.ceil(preferredViewportRailTop)),
+      Math.max(toolbarSafeTop(), window.innerHeight - viewportRailHeight - TOOLBAR_MARGIN)
+    );
     root.style.setProperty('--buret-viewport-rail-top', viewportRailTop + 'px');
     repositionDockingPoseControlsForLayout(mainRect);
 
@@ -4523,7 +4641,12 @@
   function saveToolbarPosition(toolbar) {
     try {
       const rect = toolbar.getBoundingClientRect();
-      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({ left: rect.left, top: rect.top, mode: 'custom' }));
+      window.localStorage && window.localStorage.setItem('buret.toolbar.position', JSON.stringify({
+        left: rect.left,
+        top: rect.top,
+        mode: 'custom',
+        corner: isToolbarCorner(toolbar.dataset.dockCorner) ? toolbar.dataset.dockCorner : null
+      }));
       window.localStorage && window.localStorage.setItem('buret.toolbar.position.version', TOOLBAR_POSITION_VERSION);
     } catch (_) {}
   }
@@ -6379,9 +6502,14 @@
     const rect = menu.getBoundingClientRect();
     // Keep the portalled menu attached to its rail button while the rail moves or
     // the host resizes the preview viewport.
-    const preferred = anchor.left > window.innerWidth / 2 ? anchor.right - rect.width : anchor.left;
-    menu.style.left = `${Math.round(Math.max(6, Math.min(preferred, window.innerWidth - rect.width - 6)))}px`;
-    menu.style.top = `${Math.round(Math.max(6, Math.min(anchor.bottom + 4, window.innerHeight - rect.height - 6)))}px`;
+    const preferredLeft = rail.dataset.horizontalPlacement === 'right'
+      ? anchor.right - rect.width
+      : anchor.left;
+    const preferredTop = rail.dataset.verticalPlacement === 'above'
+      ? anchor.top - rect.height - 4
+      : anchor.bottom + 4;
+    menu.style.left = `${Math.round(Math.max(6, Math.min(preferredLeft, window.innerWidth - rect.width - 6)))}px`;
+    menu.style.top = `${Math.round(Math.max(6, Math.min(preferredTop, window.innerHeight - rect.height - 6)))}px`;
   }
 
   function openViewportMenu(trigger, label, build) {
@@ -6891,6 +7019,7 @@
       drag = null;
       if (!moved) return;
       suppressClickUntil = Date.now() + 300;
+      snapToolbarToCorner(toolbar);
       saveToolbarPosition(toolbar);
     };
     const cancelDrag = () => {

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4951,25 +4951,24 @@ assert.match(previewRuntimeCss, /body:has\(\.msp-viewport-controls-buttons \.msp
 assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*hideGenerate3DMenu\(\);/);
 assert.match(previewViewer, /const viewportControlRailRect = visibleRect\('\.msp-plugin \.msp-viewport-controls-buttons'\);/);
 assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail'\) \|\| viewportControlRailRect;/);
-// The vertical viewport rail belongs to the canvas edge. It must not inherit the
-// draggable top toolbar's saved right offset or wait for JS layout measurement
-// while the host sidebar resizes the preview iframe.
-assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: var\(--buret-control-island-right\);/s);
-assert.doesNotMatch(previewRuntimeCss, /--buret-viewport-rail-right/);
-assert.doesNotMatch(previewViewer, /--buret-viewport-rail-right/);
+// The vertical viewport rail is the second half of the top toolbar group: it
+// keeps the same right edge, follows either drag handle, and rolls up with it.
+assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: var\(--buret-viewport-rail-right, var\(--buret-control-island-right\)\);/s);
+assert.match(previewViewer, /root\.style\.setProperty\('--buret-viewport-rail-right', viewportRailRight \+ 'px'\);/);
+assert.match(previewViewer, /const viewportRailTop = selectionToolbarRect[\s\S]*Math\.ceil\(toolbarBottom\)/);
 assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*cursor: grab;[^}]*touch-action: none;/s);
 assert.match(previewRuntimeCss, /\.buret-viewport-rail\.buret-dragging,[\s\S]*cursor: grabbing;/);
-assert.match(previewViewer, /const VIEWPORT_RAIL_POSITION_VERSION = '1';/);
-assert.match(previewViewer, /function initViewportRailDrag\(rail\) \{/);
-assert.match(previewViewer, /right: Math\.round\(window\.innerWidth - rect\.right\)/);
-assert.match(previewViewer, /window\.localStorage && window\.localStorage\.setItem\('buret\.viewportRail\.position'/);
-assert.match(previewViewer, /applyViewportRailPosition\(\s*rail,\s*Number\.parseFloat\(rail\.style\.right\)/s);
-assert.match(previewViewer, /initViewportRailDrag\(rail\);/);
+assert.match(previewRuntimeCss, /body\.buret-toolbar-collapsed #buret-viewport-rail,[\s\S]*#buret-selection-bar \{\s*display: none !important;/);
+assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*closeViewportMenu\(\);/);
+assert.doesNotMatch(previewViewer, /VIEWPORT_RAIL_POSITION_VERSION/);
+assert.doesNotMatch(previewViewer, /localStorage\.setItem\('buret\.viewportRail\.position'/);
+assert.match(previewViewer, /function initViewportRailDrag\(rail, toolbar\) \{/);
+assert.match(previewViewer, /moveToolbar\(\s*toolbar,\s*drag\.toolbarLeft \+ event\.clientX - drag\.startX,\s*drag\.toolbarTop \+ event\.clientY - drag\.startY\s*\);/s);
+assert.match(previewViewer, /saveToolbarPosition\(toolbar\);/);
+assert.match(previewViewer, /initViewportRailDrag\(rail, document\.getElementById\('buret-toolbar'\)\);/);
 assert.match(previewViewer, /function positionOpenViewportMenu\(rail = document\.getElementById\('buret-viewport-rail'\)\) \{/);
-assert.match(previewViewer, /positionOpenViewportMenu\(rail\);/);
+assert.match(previewViewer, /root\.style\.setProperty\('--buret-viewport-panel-max-height', panelMaxHeight \+ 'px'\);\s*positionOpenViewportMenu\(\);/);
 assert.match(previewViewer, /positionOpenViewportMenu\(trigger\.closest\('#buret-viewport-rail'\)\);/);
-assert.doesNotMatch(previewViewer, /rail\.dataset\.defaultPosition = '0';\s*closeViewportMenu\(\);/);
-assert.match(previewViewer, /applyViewportRailPosition\(rail,[\s\S]*?updateFloatingLayoutOffsets\(\);\s*positionOpenViewportMenu\(rail\);/);
 // The rail carries its own animation button, the way Mol*'s viewport controls did:
 // a trackball that keeps turning plus the plugin's timed animations, each listed
 // once and each able to say why it is unavailable.

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4951,15 +4951,26 @@ assert.match(previewRuntimeCss, /body:has\(\.msp-viewport-controls-buttons \.msp
 assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*hideGenerate3DMenu\(\);/);
 assert.match(previewViewer, /const viewportControlRailRect = visibleRect\('\.msp-plugin \.msp-viewport-controls-buttons'\);/);
 assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail'\) \|\| viewportControlRailRect;/);
-// The vertical viewport rail is the second half of the top toolbar group: it
-// keeps the same right edge, follows either drag handle, and rolls up with it.
-assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: var\(--buret-viewport-rail-right, var\(--buret-control-island-right\)\);/s);
-assert.match(previewViewer, /root\.style\.setProperty\('--buret-viewport-rail-right', viewportRailRight \+ 'px'\);/);
-assert.match(previewViewer, /const viewportRailTop = selectionToolbarRect[\s\S]*Math\.ceil\(toolbarBottom\)/);
+// The vertical viewport rail is the second half of the toolbar group: it follows
+// either drag handle, flips toward the canvas at each corner, and rolls up with it.
+assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: auto;[^}]*left: var\(--buret-viewport-rail-left, auto\);/s);
+assert.match(previewViewer, /const TOOLBAR_CORNER_SNAP_DISTANCE = 64;/);
+assert.match(previewViewer, /const TOOLBAR_CORNER_RELEASE_DISTANCE = 96;/);
+assert.match(previewViewer, /const TOOLBAR_ORIENTATION_HYSTERESIS = 48;/);
+assert.match(previewViewer, /function updateToolbarCornerIntent\(toolbar\) \{/);
+assert.match(previewViewer, /function toolbarCornerWithinSnapDistance\(toolbar\) \{/);
+assert.match(previewViewer, /function positionToolbarAtCorner\(toolbar, corner\) \{/);
+assert.match(previewViewer, /function snapToolbarToCorner\(toolbar\) \{/);
+assert.match(previewViewer, /viewportRail\.dataset\.horizontalPlacement = railHorizontal;/);
+assert.match(previewViewer, /viewportRail\.dataset\.verticalPlacement = railVertical;/);
+assert.match(previewViewer, /root\.style\.setProperty\('--buret-viewport-rail-left', Math\.round\(viewportRailLeft\) \+ 'px'\);/);
+assert.match(previewViewer, /const preferredViewportRailTop = toolbarRect && railVertical === 'above'/);
+assert.match(previewViewer, /corner: isToolbarCorner\(toolbar\.dataset\.dockCorner\) \? toolbar\.dataset\.dockCorner : null/);
 assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*cursor: grab;[^}]*touch-action: none;/s);
 assert.match(previewRuntimeCss, /\.buret-viewport-rail\.buret-dragging,[\s\S]*cursor: grabbing;/);
 assert.match(previewRuntimeCss, /body\.buret-toolbar-collapsed #buret-viewport-rail,[\s\S]*#buret-selection-bar \{\s*display: none !important;/);
 assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*closeViewportMenu\(\);/);
+assert.match(previewViewer, /if \(persist \|\| collapsed\) toolbar\.dataset\.defaultPosition = '1';\s*repositionToolbar\(toolbar\);/);
 assert.doesNotMatch(previewViewer, /VIEWPORT_RAIL_POSITION_VERSION/);
 assert.doesNotMatch(previewViewer, /localStorage\.setItem\('buret\.viewportRail\.position'/);
 assert.match(previewViewer, /function initViewportRailDrag\(rail, toolbar\) \{/);
@@ -4967,6 +4978,8 @@ assert.match(previewViewer, /moveToolbar\(\s*toolbar,\s*drag\.toolbarLeft \+ eve
 assert.match(previewViewer, /saveToolbarPosition\(toolbar\);/);
 assert.match(previewViewer, /initViewportRailDrag\(rail, document\.getElementById\('buret-toolbar'\)\);/);
 assert.match(previewViewer, /function positionOpenViewportMenu\(rail = document\.getElementById\('buret-viewport-rail'\)\) \{/);
+assert.match(previewViewer, /rail\.dataset\.horizontalPlacement === 'right'/);
+assert.match(previewViewer, /rail\.dataset\.verticalPlacement === 'above'/);
 assert.match(previewViewer, /root\.style\.setProperty\('--buret-viewport-panel-max-height', panelMaxHeight \+ 'px'\);\s*positionOpenViewportMenu\(\);/);
 assert.match(previewViewer, /positionOpenViewportMenu\(trigger\.closest\('#buret-viewport-rail'\)\);/);
 // The rail carries its own animation button, the way Mol*'s viewport controls did:
@@ -5033,7 +5046,7 @@ assert.match(previewRuntimeCss, /#buret-toolbar\.buret-toolbar-docked \{/);
 assert.match(previewRuntimeCss, /width: auto/);
 assert.match(previewRuntimeCss, /max-width: calc\(100vw - 24px\)/);
 assert.match(previewRuntimeCss, /#buret-toolbar \{[\s\S]*flex-wrap: nowrap;[\s\S]*max-width: calc\(100vw - 24px\)/);
-assert.match(previewRuntimeCss, /#buret-toolbar \{[^}]*padding: 3px 0;/s);
+assert.match(previewRuntimeCss, /#buret-toolbar \{[^}]*padding: 3px;/s);
 assert.match(previewRuntimeCss, /#buret-toolbar \.buret-toolbar-content \{/);
 assert.match(previewRuntimeCss, /flex: 0 1 auto/);
 assert.match(previewRuntimeCss, /max-width: calc\(100vw - 72px\)/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4957,6 +4957,14 @@ assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail
 assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: var\(--buret-control-island-right\);/s);
 assert.doesNotMatch(previewRuntimeCss, /--buret-viewport-rail-right/);
 assert.doesNotMatch(previewViewer, /--buret-viewport-rail-right/);
+assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*cursor: grab;[^}]*touch-action: none;/s);
+assert.match(previewRuntimeCss, /\.buret-viewport-rail\.buret-dragging,[\s\S]*cursor: grabbing;/);
+assert.match(previewViewer, /const VIEWPORT_RAIL_POSITION_VERSION = '1';/);
+assert.match(previewViewer, /function initViewportRailDrag\(rail\) \{/);
+assert.match(previewViewer, /right: Math\.round\(window\.innerWidth - rect\.right\)/);
+assert.match(previewViewer, /window\.localStorage && window\.localStorage\.setItem\('buret\.viewportRail\.position'/);
+assert.match(previewViewer, /applyViewportRailPosition\(\s*rail,\s*Number\.parseFloat\(rail\.style\.right\)/s);
+assert.match(previewViewer, /initViewportRailDrag\(rail\);/);
 // The rail carries its own animation button, the way Mol*'s viewport controls did:
 // a trackball that keeps turning plus the plugin's timed animations, each listed
 // once and each able to say why it is unavailable.

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -4965,6 +4965,11 @@ assert.match(previewViewer, /right: Math\.round\(window\.innerWidth - rect\.righ
 assert.match(previewViewer, /window\.localStorage && window\.localStorage\.setItem\('buret\.viewportRail\.position'/);
 assert.match(previewViewer, /applyViewportRailPosition\(\s*rail,\s*Number\.parseFloat\(rail\.style\.right\)/s);
 assert.match(previewViewer, /initViewportRailDrag\(rail\);/);
+assert.match(previewViewer, /function positionOpenViewportMenu\(rail = document\.getElementById\('buret-viewport-rail'\)\) \{/);
+assert.match(previewViewer, /positionOpenViewportMenu\(rail\);/);
+assert.match(previewViewer, /positionOpenViewportMenu\(trigger\.closest\('#buret-viewport-rail'\)\);/);
+assert.doesNotMatch(previewViewer, /rail\.dataset\.defaultPosition = '0';\s*closeViewportMenu\(\);/);
+assert.match(previewViewer, /applyViewportRailPosition\(rail,[\s\S]*?updateFloatingLayoutOffsets\(\);\s*positionOpenViewportMenu\(rail\);/);
 // The rail carries its own animation button, the way Mol*'s viewport controls did:
 // a trackball that keeps turning plus the plugin's timed animations, each listed
 // once and each able to say why it is unavailable.

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2187,7 +2187,6 @@ assert.match(appLayout, /function usePanelToggleAnimation/);
 assert.ok(appLayout.indexOf("usePanelToggleAnimation(sidebarVisible)") < appLayout.indexOf("useCollapsiblePanelSync(sidebarVisible"), "toggle-animation hooks must be called before the collapse/expand sync hooks");
 assert.match(appLayout, /data-panels-animating=\{sidebarAnimating \|\| undefined\}/);
 assert.match(styles, /\.workspace-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 140ms ease-out;/);
-assert.match(styles, /\.workbench-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 90ms ease-out;/);
 assert.match(styles, /\.workbench-main-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 180ms cubic-bezier\(0\.2, 0, 0, 1\);/);
 // The tab strip rides the measured panel edges, so it must not ease `left` on
 // its own — that eased every drag frame and dragged the strip behind the
@@ -4952,6 +4951,12 @@ assert.match(previewRuntimeCss, /body:has\(\.msp-viewport-controls-buttons \.msp
 assert.match(previewViewer, /if \(collapsed\) \{[\s\S]*hideGenerate3DMenu\(\);/);
 assert.match(previewViewer, /const viewportControlRailRect = visibleRect\('\.msp-plugin \.msp-viewport-controls-buttons'\);/);
 assert.match(previewViewer, /const railRect = visibleRect\('#buret-viewport-rail'\) \|\| viewportControlRailRect;/);
+// The vertical viewport rail belongs to the canvas edge. It must not inherit the
+// draggable top toolbar's saved right offset or wait for JS layout measurement
+// while the host sidebar resizes the preview iframe.
+assert.match(previewRuntimeCss, /\.buret-viewport-rail \{[^}]*right: var\(--buret-control-island-right\);/s);
+assert.doesNotMatch(previewRuntimeCss, /--buret-viewport-rail-right/);
+assert.doesNotMatch(previewViewer, /--buret-viewport-rail-right/);
 // The rail carries its own animation button, the way Mol*'s viewport controls did:
 // a trackball that keeps turning plus the plugin's timed animations, each listed
 // once and each able to say why it is unavailable.

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2187,6 +2187,7 @@ assert.match(appLayout, /function usePanelToggleAnimation/);
 assert.ok(appLayout.indexOf("usePanelToggleAnimation(sidebarVisible)") < appLayout.indexOf("useCollapsiblePanelSync(sidebarVisible"), "toggle-animation hooks must be called before the collapse/expand sync hooks");
 assert.match(appLayout, /data-panels-animating=\{sidebarAnimating \|\| undefined\}/);
 assert.match(styles, /\.workspace-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 140ms ease-out;/);
+assert.match(styles, /\.workbench-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 90ms ease-out;/);
 assert.match(styles, /\.workbench-main-panels\[data-panels-animating\] > \[data-panel\] \{\s*transition: flex-grow 180ms cubic-bezier\(0\.2, 0, 0, 1\);/);
 // The tab strip rides the measured panel edges, so it must not ease `left` on
 // its own — that eased every drag frame and dragged the strip behind the


### PR DESCRIPTION
## Why

The viewport control rail could lag behind or remain detached when the main preview toolbar moved, especially while the right inspector changed the canvas width. The two controls should behave as one movable group.

## What Changed

- Attach the vertical viewport rail to the draggable preview toolbar.
- Snap the group into all four viewport corners and flip the rail inward above or below the toolbar as space changes.
- Keep Camera and other portalled menus attached to the moving rail.
- Persist the selected corner across reloads and keep the group aligned while the preview viewport resizes.
- Collapse the rail and its open menu together with the main toolbar.
- Mirror the preview runtime changes into the packaged Burette agent plugin and extend the UI shell contract.

Affected surfaces: Finder Quick Look preview runtime, browser-dev preview, and the packaged agent-plugin browser preview.

## Verification

- `bun tests/test-ui-shell-contract.mjs`
- `bun run check:js`
- `bun tests/test-burette-agent-plugin.mjs`
- Browser-dev visual verification at all four corners, with the Camera menu open, after right-dock resize, after collapse/expand, and after reload persistence.

## Notes / Follow-Up

Native Finder Quick Look was not rebuilt for this browser-runtime-only interaction change; CI remains the merge gate for the shared runtime.
