### PR TITLE
Keep large project scans off the UI thread

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -474,7 +474,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -524,7 +524,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -545,7 +545,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -568,7 +568,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "base64 0.22.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "base64 0.22.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.1.1"
+version = "2.1.2"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/commands/documents.rs
+++ b/apps/desktop/src-tauri/src/commands/documents.rs
@@ -773,7 +773,15 @@ fn expand_open_document_paths(paths: Vec<String>) -> (Vec<PathBuf>, Vec<String>)
 }
 
 #[tauri::command]
-pub(crate) fn list_project_structure_files(
+pub(crate) async fn list_project_structure_files(
+    paths: Vec<String>,
+) -> Result<Vec<ProjectStructureFile>, String> {
+    tauri::async_runtime::spawn_blocking(move || list_project_structure_files_blocking(paths))
+        .await
+        .map_err(|error| format!("Project structure scan task failed: {error}"))?
+}
+
+fn list_project_structure_files_blocking(
     paths: Vec<String>,
 ) -> Result<Vec<ProjectStructureFile>, String> {
     let mut files = BTreeSet::new();
@@ -2989,7 +2997,7 @@ mod tests {
         conformer_python_candidates, conformer_python_runtime_spec,
         conformer_python_status_candidates, copy_file_atomically, expand_open_document_paths,
         expand_open_targets, expand_project_structure_targets, generated_conformer_title,
-        list_project_structure_files, looks_like_supported_structure_file,
+        list_project_structure_files_blocking, looks_like_supported_structure_file,
         normalize_inline_structure_extension, open_text_structure_for_window_label,
         open_with_provisional_claim, open_with_provisional_read_claims, read_sdf_file_with_limit,
         smiles_from_sheet_data, supported_open_target_extensions,
@@ -3508,7 +3516,7 @@ mod tests {
         fs::write(&txt, "ignore\n").unwrap();
 
         let canonical_root = root.canonicalize().unwrap();
-        let files = list_project_structure_files(vec![root.to_string_lossy().to_string()])
+        let files = list_project_structure_files_blocking(vec![root.to_string_lossy().to_string()])
             .expect("project files should be listed");
         assert_eq!(files.len(), 2);
         assert_eq!(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -531,7 +531,12 @@ assert.match(previewGridStore, /fn infers_smiles_columns_without_smiles_headers/
 assert.match(previewGridStore, /fn uses_explicit_column_for_ambiguous_delimited_table/);
 assert.match(previewGridStore, /fn lists_delimited_structure_column_choices/);
 assert.match(documentsCommand, /#\[tauri::command\]\s+pub\(crate\) fn sync_viewer_preferences/);
-assert.match(documentsCommand, /#\[tauri::command\]\s+pub\(crate\) fn list_project_structure_files/);
+assert.match(documentsCommand, /#\[tauri::command\]\s+pub\(crate\) async fn list_project_structure_files/);
+assert.match(
+  documentsCommand,
+  /spawn_blocking\(move \|\| list_project_structure_files_blocking\(paths\)\)/,
+  "restored project roots must scan off the Tauri command thread",
+);
 assert.match(lib, /commands::documents::list_project_structure_files/);
 assert.match(tauriPermissionSource, /"list_project_structure_files"/);
 assert.match(documentsCommand, /"molstarStyle"/);


### PR DESCRIPTION
## Why

Restoring or dropping a large project folder could freeze the native window because the recursive project scan ran synchronously on the Tauri command thread.

## What Changed

- run project-structure scans on Tauri's blocking worker pool
- preserve the existing bounded traversal, supported-format filtering, and symlink boundary
- release the desktop app and package metadata as 2.1.2

## Verification

- `bun run ci-fast`
- `bun run test:update`
- `bun run check:release`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib` — 468 passed, 7 hardware-only tests ignored
- packaged macOS app restored a real project tree with more than 400 directories; the window opened, project search expanded, and search input remained responsive while scanning
- no Photos or Music permission dialogs appeared during the native project-root check

## Notes / Follow-Up

- A signed/notarized bundle and updater assets will be verified from the release workflow after merge.
