### PR TITLE
Add wiggle controls and smooth trajectory playback

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -474,7 +474,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -499,7 +499,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -524,7 +524,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -545,7 +545,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -568,7 +568,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.12;
+				MARKETING_VERSION = 2.1.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "base64 0.22.1",
  "burette-compute-core",

--- a/PreviewExtension/Web/trajectory-smoothing.js
+++ b/PreviewExtension/Web/trajectory-smoothing.js
@@ -137,17 +137,19 @@
     return Array.from({ length: target }, (_, index) => frames[Math.round(index * (frames.length - 1) / (target - 1))]);
   }
 
-  function interpolateFrames(source, keyframes) {
-    const output = new Array(source.length);
-    for (let segment = 1; segment < keyframes.length; segment += 1) {
+  function interpolateFrames(source, keyframes, outputFrameCount = source.length) {
+    const count = Math.max(2, Math.trunc(finiteNumber(outputFrameCount, source.length)));
+    const output = new Array(count);
+    let segment = 1;
+    for (let frameIndex = 0; frameIndex < count; frameIndex += 1) {
+      const sourcePosition = frameIndex * (source.length - 1) / (count - 1);
+      while (segment < keyframes.length - 1 && sourcePosition > keyframes[segment]) segment += 1;
       const start = keyframes[segment - 1];
       const end = keyframes[segment];
-      for (let frameIndex = start; frameIndex <= end; frameIndex += 1) {
-        const t = end === start ? 0 : (frameIndex - start) / (end - start);
-        output[frameIndex] = source[start].map((point, atom) => point.map((value, axis) => (
-          value + (source[end][atom][axis] - value) * t
-        )));
-      }
+      const t = end === start ? 0 : Math.max(0, Math.min(1, (sourcePosition - start) / (end - start)));
+      output[frameIndex] = source[start].map((point, atom) => point.map((value, axis) => (
+        value + (source[end][atom][axis] - value) * t
+      )));
     }
     return output;
   }
@@ -186,7 +188,11 @@
     const rawSignal = rmsdSeries(parsed.frames, referenceIndex, input.align !== false);
     const filteredSignal = smoothSeries(rawSignal, radius, preset.passes);
     const keyframes = thinKeyframes(extrema(filteredSignal), targetFrames);
-    const frames = interpolateFrames(parsed.frames, keyframes);
+    const outputFrameCount = Math.max(
+      parsed.frames.length,
+      Math.min(600, Math.trunc(finiteNumber(input.outputFrames, parsed.frames.length)))
+    );
+    const frames = interpolateFrames(parsed.frames, keyframes, outputFrameCount);
     return {
       data: parsed.format === 'pdb' ? formatPdb(parsed, frames) : formatXyz(parsed, frames),
       format: parsed.format,
@@ -195,6 +201,7 @@
       rawSignal,
       filteredSignal,
       targetFrames,
+      sourceFrameCount: parsed.frames.length,
       interpolation: 'linear'
     };
   }

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -608,7 +608,8 @@ body.buret-toolbar-collapsed #buret-selection-bar {
    the state while its menu is closed. */
 .buret-rail-button[data-motion="spin"],
 .buret-rail-button[data-motion="rock"],
-.buret-rail-button[data-motion="playing"] {
+.buret-rail-button[data-motion="playing"],
+.buret-rail-button[data-motion="wiggle"] {
   color: var(--buret-molstar-accent);
 }
 .buret-rail-button.buret-clear-selection {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6787,6 +6787,7 @@
     'built-in.animate-camera-spin',
     'built-in.animate-camera-rock'
   ]);
+  const VIEWPORT_WIGGLE_TAG = 'wiggle-controls';
   const VIEWPORT_ICON = {
     camera: ['M4.5 8.5h2.2l1.4-2.2h7.8l1.4 2.2h2.2A1.5 1.5 0 0 1 21 10v8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18v-8a1.5 1.5 0 0 1 1.5-1.5Z', 'M12 17a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z'],
     layFlat: ['M3 8.5 12 4l9 4.5-9 4.5Z', 'm3 15 9 4.5L21 15'],
@@ -6945,6 +6946,191 @@
         title: entry.applicability.reason || entry.animation.display.description
       });
     }
+    viewportWiggleControls(menu, plugin);
+  }
+
+  function viewportWiggleTransform() {
+    return window.molstar?.lib?.plugin?.StateTransforms?.Representation
+      ?.WiggleStructureRepresentation3DFromBundle || null;
+  }
+
+  function viewportWiggleCells(plugin) {
+    const transform = viewportWiggleTransform();
+    const cells = [];
+    if (!transform) return cells;
+    plugin?.state?.data?.cells?.forEach?.(cell => {
+      const tags = cell?.transform?.tags;
+      const tagged = Array.isArray(tags)
+        ? tags.includes(VIEWPORT_WIGGLE_TAG)
+        : tags?.has?.(VIEWPORT_WIGGLE_TAG) === true;
+      const transformer = cell?.transform?.transformer;
+      if (tagged && (transformer === transform || transformer?.id === transform.id)) cells.push(cell);
+    });
+    return cells;
+  }
+
+  function viewportWiggleMode(plugin = viewportPlugin()) {
+    const amplitude = Number(plugin?.managers?.structure?.component?.state?.options?.animation?.wiggleAmplitude);
+    if (amplitude > 0) return 'dynamics';
+    return viewportWiggleCells(plugin).length ? 'uncertainty' : 'clear';
+  }
+
+  function viewportWiggleControls(menu, plugin) {
+    sceneTreeMenuSection(menu, 'Apply Wiggle');
+    const segment = document.createElement('div');
+    segment.className = 'buret-viewport-segment';
+    segment.setAttribute('role', 'group');
+    segment.setAttribute('aria-label', 'Apply wiggle');
+    const active = viewportWiggleMode(plugin);
+    const actions = [
+      ['dynamics', 'Dynamics', 'Apply procedural molecular motion'],
+      ['uncertainty', 'Uncertainty', 'Scale motion by B-factor or RMSF uncertainty'],
+      ['clear', 'Clear', 'Remove procedural molecular motion']
+    ];
+    for (const [name, label, title] of actions) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'buret-viewport-segment-button';
+      button.dataset.buretViewportMenu = 'wiggle';
+      button.dataset.wiggle = name;
+      button.setAttribute('aria-pressed', name === active ? 'true' : 'false');
+      button.title = title;
+      button.textContent = label;
+      segment.appendChild(button);
+    }
+    menu.appendChild(segment);
+  }
+
+  async function clearViewportWiggleLayers(plugin) {
+    const cells = viewportWiggleCells(plugin);
+    if (!cells.length) return;
+    const update = plugin.state.data.build();
+    for (const cell of cells) update.delete(cell.transform.ref);
+    await update.commit({ doNotUpdateCurrent: true });
+  }
+
+  function viewportUncertaintyValue(unit, element, Unit) {
+    if (Unit.isAtomic(unit)) return unit.model.atomicConformation.B_iso_or_equiv.value(element);
+    if (Unit.isSpheres(unit)) return unit.model.coarseConformation.spheres.rmsf[element];
+    return 0;
+  }
+
+  function viewportUncertaintyLayers(structure, StructureElement, Unit) {
+    const root = structure.root;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const unit of root.units) {
+      for (const element of unit.elements) {
+        const value = viewportUncertaintyValue(unit, element, Unit);
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+    }
+    const range = max - min;
+    if (!Number.isFinite(range) || range <= 0) return [];
+
+    const buckets = new Map();
+    for (const unit of root.units) {
+      const unitBuckets = new Map();
+      for (let index = 0; index < unit.elements.length; index += 1) {
+        const value = viewportUncertaintyValue(unit, unit.elements[index], Unit);
+        const bucket = Math.min(255, Math.round(((value - min) / range) * 255));
+        if (!unitBuckets.has(bucket)) unitBuckets.set(bucket, []);
+        unitBuckets.get(bucket).push(index);
+      }
+      for (const [bucket, indices] of unitBuckets) {
+        if (!buckets.has(bucket)) buckets.set(bucket, []);
+        buckets.get(bucket).push({ unit, indices });
+      }
+    }
+
+    const layers = [];
+    for (const [bucket, unitIndices] of buckets) {
+      const elements = unitIndices.map(({ unit, indices }) => ({
+        unit,
+        indices: new Int32Array(indices)
+      }));
+      let loci = StructureElement.Loci(root, elements);
+      loci = StructureElement.Loci.remap(loci, structure);
+      if (StructureElement.Loci.isEmpty(loci)) continue;
+      loci = StructureElement.Loci.remap(loci, root);
+      layers.push({
+        bundle: StructureElement.Bundle.fromLoci(loci),
+        value: bucket / 255
+      });
+    }
+    return layers;
+  }
+
+  async function applyViewportUncertaintyWiggle(plugin) {
+    const transform = viewportWiggleTransform();
+    const StructureElement = window.molstar?.lib?.structure?.StructureElement;
+    const Unit = window.molstar?.lib?.structure?.Unit;
+    if (!transform || !StructureElement || !Unit) throw new Error('Mol* wiggle helpers are unavailable');
+
+    const components = plugin.managers.structure.hierarchy.selection.structures
+      .flatMap(structure => structure.components || []);
+    const update = plugin.state.data.build();
+    const layerCache = new Map();
+    let applied = 0;
+    for (const component of components) {
+      for (const representation of component.representations || []) {
+        const structure = representation.cell?.obj?.data?.sourceData;
+        if (!structure) continue;
+        let layers = layerCache.get(structure);
+        if (!layers) {
+          layers = viewportUncertaintyLayers(structure, StructureElement, Unit);
+          layerCache.set(structure, layers);
+        }
+        if (!layers.length) continue;
+        update.to(representation.cell.transform.ref).apply(
+          transform,
+          { kind: 'element-loci', layers },
+          { tags: VIEWPORT_WIGGLE_TAG }
+        );
+        applied += 1;
+      }
+    }
+    if (applied) await update.commit({ doNotUpdateCurrent: true });
+    return applied;
+  }
+
+  async function setViewportWiggle(mode) {
+    const plugin = viewportPlugin();
+    const manager = plugin?.managers?.structure?.component;
+    if (!plugin || !manager) return false;
+    const options = manager.state.options;
+    const animation = mode === 'dynamics'
+      ? { ...options.animation, wiggleSpeed: 7, wiggleAmplitude: 1, wiggleFrequency: 0.2 }
+      : { ...options.animation, wiggleAmplitude: 0, tumbleAmplitude: 0 };
+    await manager.setOptions({ ...options, animation });
+    await clearViewportWiggleLayers(plugin);
+    if (mode === 'uncertainty') {
+      const applied = await applyViewportUncertaintyWiggle(plugin);
+      if (!applied) {
+        setStatus('[web] This structure has no varying B-factor or RMSF uncertainty data.', 'info', {
+          visible: true, timeoutMs: 3500
+        });
+        updateViewportAnimateState();
+        return false;
+      }
+    }
+    updateViewportAnimateState();
+    return true;
+  }
+
+  function runViewportWiggle(mode, control) {
+    const buttons = Array.from(control.parentElement?.querySelectorAll('[data-wiggle]') || []);
+    for (const button of buttons) button.disabled = true;
+    Promise.resolve(setViewportWiggle(mode))
+      .then(applied => {
+        const active = applied ? mode : viewportWiggleMode();
+        for (const button of buttons) button.setAttribute('aria-pressed', button.dataset.wiggle === active ? 'true' : 'false');
+      })
+      .catch(error => setStatus(`[web] Applying wiggle failed. ${error?.message || error}`, 'error'))
+      .finally(() => {
+        for (const button of buttons) button.disabled = false;
+      });
   }
 
   // play() with no params leaves each animation on its own defaults, and Mol*
@@ -6984,8 +7170,9 @@
     const plugin = viewportPlugin();
     const playing = plugin?.managers?.animation?.state?.animationState === 'playing';
     const motion = viewportMotionState().name;
+    const state = playing ? 'playing' : (motion !== 'off' ? motion : (viewportWiggleMode(plugin) === 'clear' ? 'off' : 'wiggle'));
     document.querySelector('[data-buret-viewport-action="animate"]')
-      ?.setAttribute('data-motion', playing ? 'playing' : motion);
+      ?.setAttribute('data-motion', state);
   }
 
   function viewportMotionState() {
@@ -7211,6 +7398,9 @@
     } else if (action === 'animation-stop') {
       plugin.managers.animation.stop();
       updateViewportAnimateState();
+    } else if (action === 'wiggle') {
+      runViewportWiggle(control.dataset.wiggle, control);
+      return true;
     } else if (action === 'modifier') {
       selectionQueryModifier = control.dataset.modifier || 'set';
       for (const button of control.parentElement?.children || []) {
@@ -7470,6 +7660,8 @@
       plugin?.behaviors?.interaction?.selectionMode?.subscribe?.(updateSelectionBar),
       plugin?.managers?.structure?.selection?.events?.changed?.subscribe?.(updateSelectionBar),
       plugin?.managers?.interactivity?.events?.propsUpdated?.subscribe?.(updateSelectionBar),
+      plugin?.managers?.structure?.component?.events?.optionsUpdated?.subscribe?.(updateViewportAnimateState),
+      plugin?.state?.data?.events?.changed?.subscribe?.(updateViewportAnimateState),
       // Timed animations end on their own, so the button cannot be left holding a
       // state nobody switched off.
       plugin?.behaviors?.state?.isAnimating?.subscribe?.(updateViewportAnimateState)

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -6917,8 +6917,10 @@
   function viewportAnimateMenu(menu) {
     viewportMotionControls(menu);
     const plugin = viewportPlugin();
+    viewportWiggleControls(menu, plugin);
     const manager = plugin?.managers?.animation;
-    const playing = manager?.state?.animationState === 'playing';
+    const playing = manager?.state?.animationState === 'playing'
+      || activeTrajectoryPlaybackControl?.isPlaying() === true;
     const animations = (manager?.animations || [])
       .map((animation, index) => ({ animation, index }))
       // Camera spin and rock are the Motion switch above, only on a timer.
@@ -6946,7 +6948,6 @@
         title: entry.applicability.reason || entry.animation.display.description
       });
     }
-    viewportWiggleControls(menu, plugin);
   }
 
   function viewportWiggleTransform() {
@@ -7154,11 +7155,42 @@
     }
   }
 
+  function interpolatedTrajectoryFrameCount(sourceFrameCount) {
+    const count = Math.max(2, Math.trunc(Number(sourceFrameCount) || 2));
+    if (count >= 60) return count;
+    return Math.min(600, Math.max(60, (count - 1) * 8 + 1));
+  }
+
+  async function playViewportTrajectoryAnimation() {
+    let playback = activeTrajectoryPlaybackControl;
+    if (!playback) throw new Error('Trajectory playback controls are unavailable for this scene.');
+    playback.stop();
+    if (trajectorySmoothingState?.view === 'original') {
+      const restored = await setTrajectorySmoothingViewFromAction({ view: 'smoothed' });
+      if (!restored.ok) throw new Error(restored.error?.message || 'The smoothed trajectory could not be restored.');
+    } else if (!trajectorySmoothingState && playback.canInterpolate()) {
+      const smoothed = await applyTrajectorySmoothingFromAction({
+        preset: 'balanced',
+        outputFrames: interpolatedTrajectoryFrameCount(playback.frameCount())
+      });
+      if (!smoothed.ok) throw new Error(smoothed.error?.message || 'The trajectory could not be interpolated.');
+    }
+    playback = activeTrajectoryPlaybackControl;
+    if (!playback) throw new Error('Trajectory playback controls were lost while preparing the animation.');
+    playback.play();
+    updateViewportAnimateState();
+  }
+
   function playViewportAnimation(index) {
     const plugin = viewportPlugin();
     const manager = plugin?.managers?.animation;
     const animation = manager?.animations?.[index];
     if (!animation) return;
+    if (animation.name === 'built-in.animate-model-index' && activeTrajectoryPlaybackControl) {
+      Promise.resolve(playViewportTrajectoryAnimation())
+        .catch(error => setStatus(`[web] Trajectory animation failed. ${error?.message || error}`, 'error'));
+      return;
+    }
     Promise.resolve(manager.play(animation, viewportAnimationParams(animation, plugin)))
       .then(() => updateViewportAnimateState())
       .catch(error => setStatus(`[web] Animation failed. ${error?.message || error}`, 'error'));
@@ -7168,7 +7200,8 @@
   // because a still frame cannot tell you the scene is in motion.
   function updateViewportAnimateState() {
     const plugin = viewportPlugin();
-    const playing = plugin?.managers?.animation?.state?.animationState === 'playing';
+    const playing = plugin?.managers?.animation?.state?.animationState === 'playing'
+      || activeTrajectoryPlaybackControl?.isPlaying() === true;
     const motion = viewportMotionState().name;
     const state = playing ? 'playing' : (motion !== 'off' ? motion : (viewportWiggleMode(plugin) === 'clear' ? 'off' : 'wiggle'));
     document.querySelector('[data-buret-viewport-action="animate"]')
@@ -7397,6 +7430,7 @@
       playViewportAnimation(Number(control.dataset.animationIndex));
     } else if (action === 'animation-stop') {
       plugin.managers.animation.stop();
+      activeTrajectoryPlaybackControl?.stop();
       updateViewportAnimateState();
     } else if (action === 'wiggle') {
       runViewportWiggle(control.dataset.wiggle, control);
@@ -13507,6 +13541,7 @@
   let activeSdfCollectionPoseSetter = null;
   let activeStructurePoseSetter = null;
   let activeStructureAlignmentControl = null;
+  let activeTrajectoryPlaybackControl = null;
 
   function isDockingPoseKeyboardTarget(target) {
     const element = target instanceof Element ? target : null;
@@ -14018,6 +14053,7 @@
         format: originalPrepared.format,
         preset: action.preset,
         targetFrames: action.targetFrames,
+        outputFrames: action.outputFrames,
         referenceFrame: action.referenceFrame,
         align: action.align !== false
       });
@@ -14341,6 +14377,7 @@
     activeSdfCollectionPoseSetter = null;
     activeStructurePoseSetter = null;
     activeStructureAlignmentControl = null;
+    activeTrajectoryPlaybackControl = null;
     document.body.classList.remove('buret-docking-pose-controls-active');
     if (!prepared) return;
     const overlayAvailable = structureOverlayAvailable(prepared);
@@ -14690,6 +14727,7 @@
         sourcePath: activeSegment.segment?.sourcePath || prepared.smoothingSourcePath || '',
         playing: loopActive
       });
+      updateViewportAnimateState();
     };
     const setFileListOpen = (open) => {
       if (!fileList) return;
@@ -14739,6 +14777,7 @@
         sourcePath: activeSegment.segment?.sourcePath || prepared.smoothingSourcePath || '',
         playing: loopActive
       });
+      updateViewportAnimateState();
     };
     updateControls();
     updateSpeedMode();
@@ -14783,6 +14822,21 @@
         });
       }, Math.max(minimumTrajectoryLoopTimerDelay(prepared), delayMs));
     };
+    const trajectoryPlaybackControl = {
+      play: () => {
+        if (loopActive) return;
+        setLoopActive(true);
+        scheduleLoopStep();
+      },
+      stop: () => {
+        if (loopActive) setLoopActive(false);
+      },
+      isPlaying: () => loopActive,
+      frameCount: () => prepared.poseCount,
+      canInterpolate: () => (prepared.kind === 'trajectory' || prepared.kind === 'xyz-frame-overlay')
+        && (normalizeFormat(activeMolstarPrepared?.format) === 'pdb' || normalizeFormat(activeMolstarPrepared?.format) === 'xyz')
+    };
+    activeTrajectoryPlaybackControl = trajectoryPlaybackControl;
     const setPose = (index, options = {}) => {
       const requestedIndex = Math.max(0, Math.min(prepared.poseCount - 1, index));
       let queuedOptions = options;
@@ -15242,6 +15296,7 @@
       document.body.classList.remove('buret-docking-pose-controls-active');
       if (activeStructurePoseSetter === setPose) activeStructurePoseSetter = null;
       if (activeSdfCollectionPoseSetter === setPose) activeSdfCollectionPoseSetter = null;
+      if (activeTrajectoryPlaybackControl === trajectoryPlaybackControl) activeTrajectoryPlaybackControl = null;
     };
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -1143,6 +1143,7 @@
   let activeMolstarPrepared = null;
   let trajectorySmoothingState = null;
   let pendingTrajectoryPlaybackRestore = null;
+  let viewportTrajectoryAnimationEpoch = 0;
   let activeSdfPoseMode = 'single';
   let activeSdfCollectionVisibilityState = null;
   let activeXyzFrameOverlayState = null;
@@ -7146,6 +7147,12 @@
   }
 
   function viewportAnimationApplicability(animation, plugin) {
+    if (animation?.name === 'built-in.animate-model-index'
+      && activeTrajectoryPlaybackControl
+      && !trajectorySmoothingState
+      && !activeTrajectoryPlaybackControl.canInterpolate()) {
+      return { canApply: false, reason: 'Build a smoothed trajectory before animating this format' };
+    }
     if (typeof animation?.canApply !== 'function') return { canApply: true };
     try {
       return animation.canApply(plugin) || { canApply: true };
@@ -7161,20 +7168,28 @@
     return Math.min(600, Math.max(60, (count - 1) * 8 + 1));
   }
 
+  function cancelViewportTrajectoryAnimation() {
+    viewportTrajectoryAnimationEpoch += 1;
+  }
+
   async function playViewportTrajectoryAnimation() {
+    const animationEpoch = ++viewportTrajectoryAnimationEpoch;
+    const viewer = activeViewer;
     let playback = activeTrajectoryPlaybackControl;
     if (!playback) throw new Error('Trajectory playback controls are unavailable for this scene.');
     playback.stop();
     if (trajectorySmoothingState?.view === 'original') {
       const restored = await setTrajectorySmoothingViewFromAction({ view: 'smoothed' });
       if (!restored.ok) throw new Error(restored.error?.message || 'The smoothed trajectory could not be restored.');
-    } else if (!trajectorySmoothingState && playback.canInterpolate()) {
+    } else if (!trajectorySmoothingState) {
+      if (!playback.canInterpolate()) throw new Error('Build a smoothed trajectory before animating this format.');
       const smoothed = await applyTrajectorySmoothingFromAction({
         preset: 'balanced',
         outputFrames: interpolatedTrajectoryFrameCount(playback.frameCount())
       });
       if (!smoothed.ok) throw new Error(smoothed.error?.message || 'The trajectory could not be interpolated.');
     }
+    if (animationEpoch !== viewportTrajectoryAnimationEpoch || activeViewer !== viewer) return;
     playback = activeTrajectoryPlaybackControl;
     if (!playback) throw new Error('Trajectory playback controls were lost while preparing the animation.');
     playback.play();
@@ -7191,6 +7206,7 @@
         .catch(error => setStatus(`[web] Trajectory animation failed. ${error?.message || error}`, 'error'));
       return;
     }
+    cancelViewportTrajectoryAnimation();
     Promise.resolve(manager.play(animation, viewportAnimationParams(animation, plugin)))
       .then(() => updateViewportAnimateState())
       .catch(error => setStatus(`[web] Animation failed. ${error?.message || error}`, 'error'));
@@ -7429,6 +7445,7 @@
     } else if (action === 'animation-play') {
       playViewportAnimation(Number(control.dataset.animationIndex));
     } else if (action === 'animation-stop') {
+      cancelViewportTrajectoryAnimation();
       plugin.managers.animation.stop();
       activeTrajectoryPlaybackControl?.stop();
       updateViewportAnimateState();
@@ -20935,6 +20952,7 @@
   }
 
   function disposeActiveMolstarViewer() {
+    cancelViewportTrajectoryAnimation();
     cancelScheduledMolstarWaterRepresentation();
     notifyMolstarSelectionChanged(null);
     molstarSelectionHostSignature = '';

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.1.12"
+version = "2.1.13"
 dependencies = [
  "base64 0.22.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.1.12"
+version = "2.1.13"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/plugins/burette-agent/preview-web/trajectory-smoothing.js
+++ b/plugins/burette-agent/preview-web/trajectory-smoothing.js
@@ -137,17 +137,19 @@
     return Array.from({ length: target }, (_, index) => frames[Math.round(index * (frames.length - 1) / (target - 1))]);
   }
 
-  function interpolateFrames(source, keyframes) {
-    const output = new Array(source.length);
-    for (let segment = 1; segment < keyframes.length; segment += 1) {
+  function interpolateFrames(source, keyframes, outputFrameCount = source.length) {
+    const count = Math.max(2, Math.trunc(finiteNumber(outputFrameCount, source.length)));
+    const output = new Array(count);
+    let segment = 1;
+    for (let frameIndex = 0; frameIndex < count; frameIndex += 1) {
+      const sourcePosition = frameIndex * (source.length - 1) / (count - 1);
+      while (segment < keyframes.length - 1 && sourcePosition > keyframes[segment]) segment += 1;
       const start = keyframes[segment - 1];
       const end = keyframes[segment];
-      for (let frameIndex = start; frameIndex <= end; frameIndex += 1) {
-        const t = end === start ? 0 : (frameIndex - start) / (end - start);
-        output[frameIndex] = source[start].map((point, atom) => point.map((value, axis) => (
-          value + (source[end][atom][axis] - value) * t
-        )));
-      }
+      const t = end === start ? 0 : Math.max(0, Math.min(1, (sourcePosition - start) / (end - start)));
+      output[frameIndex] = source[start].map((point, atom) => point.map((value, axis) => (
+        value + (source[end][atom][axis] - value) * t
+      )));
     }
     return output;
   }
@@ -186,7 +188,11 @@
     const rawSignal = rmsdSeries(parsed.frames, referenceIndex, input.align !== false);
     const filteredSignal = smoothSeries(rawSignal, radius, preset.passes);
     const keyframes = thinKeyframes(extrema(filteredSignal), targetFrames);
-    const frames = interpolateFrames(parsed.frames, keyframes);
+    const outputFrameCount = Math.max(
+      parsed.frames.length,
+      Math.min(600, Math.trunc(finiteNumber(input.outputFrames, parsed.frames.length)))
+    );
+    const frames = interpolateFrames(parsed.frames, keyframes, outputFrameCount);
     return {
       data: parsed.format === 'pdb' ? formatPdb(parsed, frames) : formatXyz(parsed, frames),
       format: parsed.format,
@@ -195,6 +201,7 @@
       rawSignal,
       filteredSignal,
       targetFrames,
+      sourceFrameCount: parsed.frames.length,
       interpolation: 'linear'
     };
   }

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -608,7 +608,8 @@ body.buret-toolbar-collapsed #buret-selection-bar {
    the state while its menu is closed. */
 .buret-rail-button[data-motion="spin"],
 .buret-rail-button[data-motion="rock"],
-.buret-rail-button[data-motion="playing"] {
+.buret-rail-button[data-motion="playing"],
+.buret-rail-button[data-motion="wiggle"] {
   color: var(--buret-molstar-accent);
 }
 .buret-rail-button.buret-clear-selection {

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -1143,6 +1143,7 @@
   let activeMolstarPrepared = null;
   let trajectorySmoothingState = null;
   let pendingTrajectoryPlaybackRestore = null;
+  let viewportTrajectoryAnimationEpoch = 0;
   let activeSdfPoseMode = 'single';
   let activeSdfCollectionVisibilityState = null;
   let activeXyzFrameOverlayState = null;
@@ -6787,6 +6788,7 @@
     'built-in.animate-camera-spin',
     'built-in.animate-camera-rock'
   ]);
+  const VIEWPORT_WIGGLE_TAG = 'wiggle-controls';
   const VIEWPORT_ICON = {
     camera: ['M4.5 8.5h2.2l1.4-2.2h7.8l1.4 2.2h2.2A1.5 1.5 0 0 1 21 10v8a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18v-8a1.5 1.5 0 0 1 1.5-1.5Z', 'M12 17a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z'],
     layFlat: ['M3 8.5 12 4l9 4.5-9 4.5Z', 'm3 15 9 4.5L21 15'],
@@ -6916,8 +6918,10 @@
   function viewportAnimateMenu(menu) {
     viewportMotionControls(menu);
     const plugin = viewportPlugin();
+    viewportWiggleControls(menu, plugin);
     const manager = plugin?.managers?.animation;
-    const playing = manager?.state?.animationState === 'playing';
+    const playing = manager?.state?.animationState === 'playing'
+      || activeTrajectoryPlaybackControl?.isPlaying() === true;
     const animations = (manager?.animations || [])
       .map((animation, index) => ({ animation, index }))
       // Camera spin and rock are the Motion switch above, only on a timer.
@@ -6947,6 +6951,190 @@
     }
   }
 
+  function viewportWiggleTransform() {
+    return window.molstar?.lib?.plugin?.StateTransforms?.Representation
+      ?.WiggleStructureRepresentation3DFromBundle || null;
+  }
+
+  function viewportWiggleCells(plugin) {
+    const transform = viewportWiggleTransform();
+    const cells = [];
+    if (!transform) return cells;
+    plugin?.state?.data?.cells?.forEach?.(cell => {
+      const tags = cell?.transform?.tags;
+      const tagged = Array.isArray(tags)
+        ? tags.includes(VIEWPORT_WIGGLE_TAG)
+        : tags?.has?.(VIEWPORT_WIGGLE_TAG) === true;
+      const transformer = cell?.transform?.transformer;
+      if (tagged && (transformer === transform || transformer?.id === transform.id)) cells.push(cell);
+    });
+    return cells;
+  }
+
+  function viewportWiggleMode(plugin = viewportPlugin()) {
+    const amplitude = Number(plugin?.managers?.structure?.component?.state?.options?.animation?.wiggleAmplitude);
+    if (amplitude > 0) return 'dynamics';
+    return viewportWiggleCells(plugin).length ? 'uncertainty' : 'clear';
+  }
+
+  function viewportWiggleControls(menu, plugin) {
+    sceneTreeMenuSection(menu, 'Apply Wiggle');
+    const segment = document.createElement('div');
+    segment.className = 'buret-viewport-segment';
+    segment.setAttribute('role', 'group');
+    segment.setAttribute('aria-label', 'Apply wiggle');
+    const active = viewportWiggleMode(plugin);
+    const actions = [
+      ['dynamics', 'Dynamics', 'Apply procedural molecular motion'],
+      ['uncertainty', 'Uncertainty', 'Scale motion by B-factor or RMSF uncertainty'],
+      ['clear', 'Clear', 'Remove procedural molecular motion']
+    ];
+    for (const [name, label, title] of actions) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'buret-viewport-segment-button';
+      button.dataset.buretViewportMenu = 'wiggle';
+      button.dataset.wiggle = name;
+      button.setAttribute('aria-pressed', name === active ? 'true' : 'false');
+      button.title = title;
+      button.textContent = label;
+      segment.appendChild(button);
+    }
+    menu.appendChild(segment);
+  }
+
+  async function clearViewportWiggleLayers(plugin) {
+    const cells = viewportWiggleCells(plugin);
+    if (!cells.length) return;
+    const update = plugin.state.data.build();
+    for (const cell of cells) update.delete(cell.transform.ref);
+    await update.commit({ doNotUpdateCurrent: true });
+  }
+
+  function viewportUncertaintyValue(unit, element, Unit) {
+    if (Unit.isAtomic(unit)) return unit.model.atomicConformation.B_iso_or_equiv.value(element);
+    if (Unit.isSpheres(unit)) return unit.model.coarseConformation.spheres.rmsf[element];
+    return 0;
+  }
+
+  function viewportUncertaintyLayers(structure, StructureElement, Unit) {
+    const root = structure.root;
+    let min = Infinity;
+    let max = -Infinity;
+    for (const unit of root.units) {
+      for (const element of unit.elements) {
+        const value = viewportUncertaintyValue(unit, element, Unit);
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+    }
+    const range = max - min;
+    if (!Number.isFinite(range) || range <= 0) return [];
+
+    const buckets = new Map();
+    for (const unit of root.units) {
+      const unitBuckets = new Map();
+      for (let index = 0; index < unit.elements.length; index += 1) {
+        const value = viewportUncertaintyValue(unit, unit.elements[index], Unit);
+        const bucket = Math.min(255, Math.round(((value - min) / range) * 255));
+        if (!unitBuckets.has(bucket)) unitBuckets.set(bucket, []);
+        unitBuckets.get(bucket).push(index);
+      }
+      for (const [bucket, indices] of unitBuckets) {
+        if (!buckets.has(bucket)) buckets.set(bucket, []);
+        buckets.get(bucket).push({ unit, indices });
+      }
+    }
+
+    const layers = [];
+    for (const [bucket, unitIndices] of buckets) {
+      const elements = unitIndices.map(({ unit, indices }) => ({
+        unit,
+        indices: new Int32Array(indices)
+      }));
+      let loci = StructureElement.Loci(root, elements);
+      loci = StructureElement.Loci.remap(loci, structure);
+      if (StructureElement.Loci.isEmpty(loci)) continue;
+      loci = StructureElement.Loci.remap(loci, root);
+      layers.push({
+        bundle: StructureElement.Bundle.fromLoci(loci),
+        value: bucket / 255
+      });
+    }
+    return layers;
+  }
+
+  async function applyViewportUncertaintyWiggle(plugin) {
+    const transform = viewportWiggleTransform();
+    const StructureElement = window.molstar?.lib?.structure?.StructureElement;
+    const Unit = window.molstar?.lib?.structure?.Unit;
+    if (!transform || !StructureElement || !Unit) throw new Error('Mol* wiggle helpers are unavailable');
+
+    const components = plugin.managers.structure.hierarchy.selection.structures
+      .flatMap(structure => structure.components || []);
+    const update = plugin.state.data.build();
+    const layerCache = new Map();
+    let applied = 0;
+    for (const component of components) {
+      for (const representation of component.representations || []) {
+        const structure = representation.cell?.obj?.data?.sourceData;
+        if (!structure) continue;
+        let layers = layerCache.get(structure);
+        if (!layers) {
+          layers = viewportUncertaintyLayers(structure, StructureElement, Unit);
+          layerCache.set(structure, layers);
+        }
+        if (!layers.length) continue;
+        update.to(representation.cell.transform.ref).apply(
+          transform,
+          { kind: 'element-loci', layers },
+          { tags: VIEWPORT_WIGGLE_TAG }
+        );
+        applied += 1;
+      }
+    }
+    if (applied) await update.commit({ doNotUpdateCurrent: true });
+    return applied;
+  }
+
+  async function setViewportWiggle(mode) {
+    const plugin = viewportPlugin();
+    const manager = plugin?.managers?.structure?.component;
+    if (!plugin || !manager) return false;
+    const options = manager.state.options;
+    const animation = mode === 'dynamics'
+      ? { ...options.animation, wiggleSpeed: 7, wiggleAmplitude: 1, wiggleFrequency: 0.2 }
+      : { ...options.animation, wiggleAmplitude: 0, tumbleAmplitude: 0 };
+    await manager.setOptions({ ...options, animation });
+    await clearViewportWiggleLayers(plugin);
+    if (mode === 'uncertainty') {
+      const applied = await applyViewportUncertaintyWiggle(plugin);
+      if (!applied) {
+        setStatus('[web] This structure has no varying B-factor or RMSF uncertainty data.', 'info', {
+          visible: true, timeoutMs: 3500
+        });
+        updateViewportAnimateState();
+        return false;
+      }
+    }
+    updateViewportAnimateState();
+    return true;
+  }
+
+  function runViewportWiggle(mode, control) {
+    const buttons = Array.from(control.parentElement?.querySelectorAll('[data-wiggle]') || []);
+    for (const button of buttons) button.disabled = true;
+    Promise.resolve(setViewportWiggle(mode))
+      .then(applied => {
+        const active = applied ? mode : viewportWiggleMode();
+        for (const button of buttons) button.setAttribute('aria-pressed', button.dataset.wiggle === active ? 'true' : 'false');
+      })
+      .catch(error => setStatus(`[web] Applying wiggle failed. ${error?.message || error}`, 'error'))
+      .finally(() => {
+        for (const button of buttons) button.disabled = false;
+      });
+  }
+
   // play() with no params leaves each animation on its own defaults, and Mol*
   // defaults Unwind Assembly to looping - a scene that keeps rebuilding itself
   // under every click until someone finds the stop button.
@@ -6959,6 +7147,12 @@
   }
 
   function viewportAnimationApplicability(animation, plugin) {
+    if (animation?.name === 'built-in.animate-model-index'
+      && activeTrajectoryPlaybackControl
+      && !trajectorySmoothingState
+      && !activeTrajectoryPlaybackControl.canInterpolate()) {
+      return { canApply: false, reason: 'Build a smoothed trajectory before animating this format' };
+    }
     if (typeof animation?.canApply !== 'function') return { canApply: true };
     try {
       return animation.canApply(plugin) || { canApply: true };
@@ -6968,11 +7162,51 @@
     }
   }
 
+  function interpolatedTrajectoryFrameCount(sourceFrameCount) {
+    const count = Math.max(2, Math.trunc(Number(sourceFrameCount) || 2));
+    if (count >= 60) return count;
+    return Math.min(600, Math.max(60, (count - 1) * 8 + 1));
+  }
+
+  function cancelViewportTrajectoryAnimation() {
+    viewportTrajectoryAnimationEpoch += 1;
+  }
+
+  async function playViewportTrajectoryAnimation() {
+    const animationEpoch = ++viewportTrajectoryAnimationEpoch;
+    const viewer = activeViewer;
+    let playback = activeTrajectoryPlaybackControl;
+    if (!playback) throw new Error('Trajectory playback controls are unavailable for this scene.');
+    playback.stop();
+    if (trajectorySmoothingState?.view === 'original') {
+      const restored = await setTrajectorySmoothingViewFromAction({ view: 'smoothed' });
+      if (!restored.ok) throw new Error(restored.error?.message || 'The smoothed trajectory could not be restored.');
+    } else if (!trajectorySmoothingState) {
+      if (!playback.canInterpolate()) throw new Error('Build a smoothed trajectory before animating this format.');
+      const smoothed = await applyTrajectorySmoothingFromAction({
+        preset: 'balanced',
+        outputFrames: interpolatedTrajectoryFrameCount(playback.frameCount())
+      });
+      if (!smoothed.ok) throw new Error(smoothed.error?.message || 'The trajectory could not be interpolated.');
+    }
+    if (animationEpoch !== viewportTrajectoryAnimationEpoch || activeViewer !== viewer) return;
+    playback = activeTrajectoryPlaybackControl;
+    if (!playback) throw new Error('Trajectory playback controls were lost while preparing the animation.');
+    playback.play();
+    updateViewportAnimateState();
+  }
+
   function playViewportAnimation(index) {
     const plugin = viewportPlugin();
     const manager = plugin?.managers?.animation;
     const animation = manager?.animations?.[index];
     if (!animation) return;
+    if (animation.name === 'built-in.animate-model-index' && activeTrajectoryPlaybackControl) {
+      Promise.resolve(playViewportTrajectoryAnimation())
+        .catch(error => setStatus(`[web] Trajectory animation failed. ${error?.message || error}`, 'error'));
+      return;
+    }
+    cancelViewportTrajectoryAnimation();
     Promise.resolve(manager.play(animation, viewportAnimationParams(animation, plugin)))
       .then(() => updateViewportAnimateState())
       .catch(error => setStatus(`[web] Animation failed. ${error?.message || error}`, 'error'));
@@ -6982,10 +7216,12 @@
   // because a still frame cannot tell you the scene is in motion.
   function updateViewportAnimateState() {
     const plugin = viewportPlugin();
-    const playing = plugin?.managers?.animation?.state?.animationState === 'playing';
+    const playing = plugin?.managers?.animation?.state?.animationState === 'playing'
+      || activeTrajectoryPlaybackControl?.isPlaying() === true;
     const motion = viewportMotionState().name;
+    const state = playing ? 'playing' : (motion !== 'off' ? motion : (viewportWiggleMode(plugin) === 'clear' ? 'off' : 'wiggle'));
     document.querySelector('[data-buret-viewport-action="animate"]')
-      ?.setAttribute('data-motion', playing ? 'playing' : motion);
+      ?.setAttribute('data-motion', state);
   }
 
   function viewportMotionState() {
@@ -7209,8 +7445,13 @@
     } else if (action === 'animation-play') {
       playViewportAnimation(Number(control.dataset.animationIndex));
     } else if (action === 'animation-stop') {
+      cancelViewportTrajectoryAnimation();
       plugin.managers.animation.stop();
+      activeTrajectoryPlaybackControl?.stop();
       updateViewportAnimateState();
+    } else if (action === 'wiggle') {
+      runViewportWiggle(control.dataset.wiggle, control);
+      return true;
     } else if (action === 'modifier') {
       selectionQueryModifier = control.dataset.modifier || 'set';
       for (const button of control.parentElement?.children || []) {
@@ -7470,6 +7711,8 @@
       plugin?.behaviors?.interaction?.selectionMode?.subscribe?.(updateSelectionBar),
       plugin?.managers?.structure?.selection?.events?.changed?.subscribe?.(updateSelectionBar),
       plugin?.managers?.interactivity?.events?.propsUpdated?.subscribe?.(updateSelectionBar),
+      plugin?.managers?.structure?.component?.events?.optionsUpdated?.subscribe?.(updateViewportAnimateState),
+      plugin?.state?.data?.events?.changed?.subscribe?.(updateViewportAnimateState),
       // Timed animations end on their own, so the button cannot be left holding a
       // state nobody switched off.
       plugin?.behaviors?.state?.isAnimating?.subscribe?.(updateViewportAnimateState)
@@ -13315,6 +13558,7 @@
   let activeSdfCollectionPoseSetter = null;
   let activeStructurePoseSetter = null;
   let activeStructureAlignmentControl = null;
+  let activeTrajectoryPlaybackControl = null;
 
   function isDockingPoseKeyboardTarget(target) {
     const element = target instanceof Element ? target : null;
@@ -13826,6 +14070,7 @@
         format: originalPrepared.format,
         preset: action.preset,
         targetFrames: action.targetFrames,
+        outputFrames: action.outputFrames,
         referenceFrame: action.referenceFrame,
         align: action.align !== false
       });
@@ -14149,6 +14394,7 @@
     activeSdfCollectionPoseSetter = null;
     activeStructurePoseSetter = null;
     activeStructureAlignmentControl = null;
+    activeTrajectoryPlaybackControl = null;
     document.body.classList.remove('buret-docking-pose-controls-active');
     if (!prepared) return;
     const overlayAvailable = structureOverlayAvailable(prepared);
@@ -14498,6 +14744,7 @@
         sourcePath: activeSegment.segment?.sourcePath || prepared.smoothingSourcePath || '',
         playing: loopActive
       });
+      updateViewportAnimateState();
     };
     const setFileListOpen = (open) => {
       if (!fileList) return;
@@ -14547,6 +14794,7 @@
         sourcePath: activeSegment.segment?.sourcePath || prepared.smoothingSourcePath || '',
         playing: loopActive
       });
+      updateViewportAnimateState();
     };
     updateControls();
     updateSpeedMode();
@@ -14591,6 +14839,21 @@
         });
       }, Math.max(minimumTrajectoryLoopTimerDelay(prepared), delayMs));
     };
+    const trajectoryPlaybackControl = {
+      play: () => {
+        if (loopActive) return;
+        setLoopActive(true);
+        scheduleLoopStep();
+      },
+      stop: () => {
+        if (loopActive) setLoopActive(false);
+      },
+      isPlaying: () => loopActive,
+      frameCount: () => prepared.poseCount,
+      canInterpolate: () => (prepared.kind === 'trajectory' || prepared.kind === 'xyz-frame-overlay')
+        && (normalizeFormat(activeMolstarPrepared?.format) === 'pdb' || normalizeFormat(activeMolstarPrepared?.format) === 'xyz')
+    };
+    activeTrajectoryPlaybackControl = trajectoryPlaybackControl;
     const setPose = (index, options = {}) => {
       const requestedIndex = Math.max(0, Math.min(prepared.poseCount - 1, index));
       let queuedOptions = options;
@@ -15050,6 +15313,7 @@
       document.body.classList.remove('buret-docking-pose-controls-active');
       if (activeStructurePoseSetter === setPose) activeStructurePoseSetter = null;
       if (activeSdfCollectionPoseSetter === setPose) activeSdfCollectionPoseSetter = null;
+      if (activeTrajectoryPlaybackControl === trajectoryPlaybackControl) activeTrajectoryPlaybackControl = null;
     };
   }
 
@@ -20688,6 +20952,7 @@
   }
 
   function disposeActiveMolstarViewer() {
+    cancelViewportTrajectoryAnimation();
     cancelScheduledMolstarWaterRepresentation();
     notifyMolstarSelectionChanged(null);
     molstarSelectionHostSignature = '';

--- a/tests/test-trajectory-smoothing.mjs
+++ b/tests/test-trajectory-smoothing.mjs
@@ -46,11 +46,21 @@ assert.throws(() => countXtcFrames(truncatedXtc), /truncated/);
 const xyz = [0, 1, 3, 1, 0].map((x, index) => `2\nframe ${index + 1}\nC ${x} 0 0\nO ${x + 1} 0 0`).join("\n");
 const result = smooth({ data: xyz, format: "xyz", preset: "balanced", targetFrames: 3, referenceFrame: 1, align: false });
 assert.equal(result.frameCount, 5);
+assert.equal(result.sourceFrameCount, 5);
 assert.equal(result.rawSignal.length, 5);
 assert.equal(result.filteredSignal.length, 5);
 assert.equal(result.keyframes[0], 0);
 assert.equal(result.keyframes.at(-1), 4);
 assert.match(result.data, /Smoothed motion frame 5/);
+
+const interpolated = smooth({ data: xyz, format: "xyz", targetFrames: 3, outputFrames: 17, align: false });
+assert.equal(interpolated.frameCount, 17);
+assert.equal(interpolated.sourceFrameCount, 5);
+assert.match(interpolated.data, /Smoothed motion frame 17/);
+
+const twoFrameXyz = "1\nstart\nC 0 0 0\n1\nend\nC 1 0 0";
+const tweened = smooth({ data: twoFrameXyz, format: "xyz", targetFrames: 2, outputFrames: 5, align: false });
+assert.match(tweened.data, /Smoothed motion frame 3\nC 0\.500000 0\.000000 0\.000000/);
 
 assert.throws(
   () => smooth({ data: "", format: "xtc" }),

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5142,6 +5142,12 @@ assert.match(previewViewer, /applyTrajectorySmoothingFromAction\(\{[\s\S]*output
 assert.match(previewViewer, /playback = activeTrajectoryPlaybackControl;[\s\S]*playback\.play\(\);/);
 assert.match(previewViewer, /activeTrajectoryPlaybackControl\?\.stop\(\)/);
 assert.match(previewViewer, /prepared\.kind === 'trajectory' \|\| prepared\.kind === 'xyz-frame-overlay'/);
+assert.match(previewViewer, /const animationEpoch = \+\+viewportTrajectoryAnimationEpoch;/);
+assert.match(previewViewer, /if \(animationEpoch !== viewportTrajectoryAnimationEpoch \|\| activeViewer !== viewer\) return;/);
+assert.match(previewViewer, /action === 'animation-stop'[\s\S]*cancelViewportTrajectoryAnimation\(\);/);
+assert.match(previewViewer, /function disposeActiveMolstarViewer\(\) \{\s*cancelViewportTrajectoryAnimation\(\);/);
+assert.match(previewViewer, /Build a smoothed trajectory before animating this format/);
+assert.match(previewViewer, /!activeTrajectoryPlaybackControl\.canInterpolate\(\)/);
 assert.match(previewViewer, /plugin\?\.behaviors\?\.state\?\.isAnimating\?\.subscribe\?\.\(updateViewportAnimateState\)/);
 // Mol*'s Procedural Animation panel is carried into the same Animate menu with
 // all three upstream actions: a uniform dynamics wiggle, uncertainty-weighted
@@ -5535,7 +5541,7 @@ assert.match(previewViewer, /function embeddedStructureDataByteLength\(\)/);
 assert.match(previewViewer, /async function ensureBrowserDevStructureData\(config, cb\)/);
 assert.match(previewViewer, /window\.BuretteDataBytes = null;\s*window\.BuretteDataBase64 = null;\s*await loadStructureData\(config, cb\);/);
 assert.match(previewViewer, /function disposeActiveMolstarViewer\(\)/);
-assert.match(previewViewer, /function disposeActiveMolstarViewer\(\) \{\s*cancelScheduledMolstarWaterRepresentation\(\);\s*notifyMolstarSelectionChanged\(null\);\s*molstarSelectionHostSignature = '';\s*setMolstarStructureDirty\(false\);/);
+assert.match(previewViewer, /function disposeActiveMolstarViewer\(\) \{\s*cancelViewportTrajectoryAnimation\(\);\s*cancelScheduledMolstarWaterRepresentation\(\);\s*notifyMolstarSelectionChanged\(null\);\s*molstarSelectionHostSignature = '';\s*setMolstarStructureDirty\(false\);/);
 assert.match(previewViewer, /function startMolstar\(config, cb\)/);
 assert.match(previewViewer, /if \(toolbar\.dataset\.panelTogglesBound !== '1'\)/);
 assert.match(previewViewer, /if \(toolbar\.dataset\.dragBound === '1'\) return;/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5132,6 +5132,21 @@ assert.match(previewViewer, /spin: \{ value: 0\.1, min: 0\.01, max: 1, step: 0\.
 assert.match(previewViewer, /if \('playOnce' in params\) params\.playOnce = true;/);
 assert.match(previewViewer, /manager\.play\(animation, viewportAnimationParams\(animation, plugin\)\)/);
 assert.match(previewViewer, /plugin\?\.behaviors\?\.state\?\.isAnimating\?\.subscribe\?\.\(updateViewportAnimateState\)/);
+// Mol*'s Procedural Animation panel is carried into the same Animate menu with
+// all three upstream actions: a uniform dynamics wiggle, uncertainty-weighted
+// B-factor/RMSF wiggle, and a clear state.
+assert.match(previewViewer, /sceneTreeMenuSection\(menu, 'Apply Wiggle'\)/);
+assert.match(previewViewer, /\['dynamics', 'Dynamics', 'Apply procedural molecular motion'\]/);
+assert.match(previewViewer, /\['uncertainty', 'Uncertainty', 'Scale motion by B-factor or RMSF uncertainty'\]/);
+assert.match(previewViewer, /\['clear', 'Clear', 'Remove procedural molecular motion'\]/);
+assert.match(previewViewer, /wiggleSpeed: 7, wiggleAmplitude: 1, wiggleFrequency: 0\.2/);
+assert.match(previewViewer, /wiggleAmplitude: 0, tumbleAmplitude: 0/);
+assert.match(previewViewer, /WiggleStructureRepresentation3DFromBundle/);
+assert.match(previewViewer, /B_iso_or_equiv\.value\(element\)/);
+assert.match(previewViewer, /coarseConformation\.spheres\.rmsf\[element\]/);
+assert.match(previewViewer, /action === 'wiggle'[\s\S]*runViewportWiggle\(control\.dataset\.wiggle, control\)/);
+assert.match(previewViewer, /data-motion', state/);
+assert.match(previewRuntimeCss, /\.buret-rail-button\[data-motion="wiggle"\]/);
 // Motion lives on the animate button now, so the camera menu must not offer it too.
 assert.doesNotMatch(
   previewViewer.slice(previewViewer.indexOf("function viewportCameraMenu"), previewViewer.indexOf("function viewportAnimateMenu")),

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -5106,6 +5106,12 @@ assert.match(previewRuntimeCss, /\.buret-viewport-rail\.hidden,\s*\.buret-rail-b
 assert.match(previewRuntimeCss, /\.buret-rail-button\.buret-clear-selection \{[\s\S]*color: #ff6b5e;[\s\S]*border-color: rgba\(255, 107, 94, 0\.72\);/);
 assert.match(previewRuntimeCss, /\.buret-rail-button\.buret-clear-selection:hover \{[\s\S]*color: #fff;[\s\S]*background: rgba\(255, 107, 94, 0\.88\);/);
 assert.match(previewViewer, /function viewportAnimateMenu\(menu\) \{/);
+const animateMenuSource = previewViewer.slice(
+  previewViewer.indexOf('function viewportAnimateMenu(menu)'),
+  previewViewer.indexOf('function viewportWiggleTransform()'),
+);
+assert.ok(animateMenuSource.indexOf('viewportMotionControls(menu)') < animateMenuSource.indexOf('viewportWiggleControls(menu, plugin)'));
+assert.ok(animateMenuSource.indexOf('viewportWiggleControls(menu, plugin)') < animateMenuSource.indexOf("sceneTreeMenuSection(menu, 'Animations')"));
 // Closing the molecule card drops the selection, and the host has to be told
 // directly because clearing this way does not reach the selection manager events.
 // × parks the card without touching the selection: it latches "suppressed" and
@@ -5131,6 +5137,11 @@ assert.match(previewViewer, /spin: \{ value: 0\.1, min: 0\.01, max: 1, step: 0\.
 // to be told to finish.
 assert.match(previewViewer, /if \('playOnce' in params\) params\.playOnce = true;/);
 assert.match(previewViewer, /manager\.play\(animation, viewportAnimationParams\(animation, plugin\)\)/);
+assert.match(previewViewer, /animation\.name === 'built-in\.animate-model-index' && activeTrajectoryPlaybackControl/);
+assert.match(previewViewer, /applyTrajectorySmoothingFromAction\(\{[\s\S]*outputFrames: interpolatedTrajectoryFrameCount\(playback\.frameCount\(\)\)/);
+assert.match(previewViewer, /playback = activeTrajectoryPlaybackControl;[\s\S]*playback\.play\(\);/);
+assert.match(previewViewer, /activeTrajectoryPlaybackControl\?\.stop\(\)/);
+assert.match(previewViewer, /prepared\.kind === 'trajectory' \|\| prepared\.kind === 'xyz-frame-overlay'/);
 assert.match(previewViewer, /plugin\?\.behaviors\?\.state\?\.isAnimating\?\.subscribe\?\.\(updateViewportAnimateState\)/);
 // Mol*'s Procedural Animation panel is carried into the same Animate menu with
 // all three upstream actions: a uniform dynamics wiggle, uncertainty-weighted


### PR DESCRIPTION
## Why

The viewport animation menu was missing Mol* wiggle controls, and trajectory animation only advanced source model indices instead of presenting continuous coordinate motion.

## What Changed

- place Apply Wiggle between Motion and Animations with Dynamics, Uncertainty, and Clear modes
- route supported PDB/XYZ trajectory animation through a bounded interpolated trajectory and the existing playback controls
- cancel late playback when the user stops, changes animation, or switches documents; require a smoothed trajectory for formats that cannot be interpolated locally
- keep the packaged Burette plugin preview runtime in sync with the app and advance release metadata to 2.1.13

Affected surfaces: desktop app, browser-dev, Quick Look web runtime, and packaged plugin preview. The iPhone source app is unchanged.

## Verification

- `bun run ci:fast`
- `bun tests/test-packaged-plugin-mirror.mjs`
- browser-dev QA with `samples/trajectory.xyz`: 2 source frames became 60 interpolated frames, Smooth became active, and the visible frame counter advanced during playback
