### PR TITLE
Fix PDB opening hang caused by broad folding scan

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.21;
+				MARKETING_VERSION = 2.1.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "base64 0.22.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "base64 0.22.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.1.21"
+version = "2.1.22"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/commands/folding_results.rs
+++ b/apps/desktop/src-tauri/src/commands/folding_results.rs
@@ -2,6 +2,7 @@ use super::numpy_artifact::{read_numpy_arrays, NumpyArraySummary};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashSet;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -812,6 +813,11 @@ fn collect_files(root: &Path, depth: usize, files: &mut Vec<FileEntry>) {
 }
 
 fn candidate_roots(input: &Path) -> Result<Vec<PathBuf>, String> {
+    let home = env::var_os("HOME").map(PathBuf::from);
+    candidate_roots_with_home(input, home.as_deref())
+}
+
+fn candidate_roots_with_home(input: &Path, home: Option<&Path>) -> Result<Vec<PathBuf>, String> {
     let metadata = fs::metadata(input).map_err(|err| format!("{}: {err}", input.display()))?;
     let mut root = if metadata.is_dir() {
         input.to_path_buf()
@@ -823,6 +829,9 @@ fn candidate_roots(input: &Path) -> Result<Vec<PathBuf>, String> {
     };
     let mut roots = Vec::new();
     for _ in 0..=FOLDING_SCAN_DEPTH_LIMIT {
+        if is_user_collection_root(&root, home) {
+            break;
+        }
         roots.push(root.clone());
         let Some(parent) = root.parent() else {
             break;
@@ -830,6 +839,22 @@ fn candidate_roots(input: &Path) -> Result<Vec<PathBuf>, String> {
         root = parent.to_path_buf();
     }
     Ok(roots)
+}
+
+fn is_user_collection_root(root: &Path, home: Option<&Path>) -> bool {
+    let Some(home) = home else {
+        return false;
+    };
+    if root == home {
+        return true;
+    }
+    root.parent() == Some(home)
+        && matches!(
+            root.file_name().and_then(|name| name.to_str()),
+            Some(
+                "Desktop" | "Documents" | "Downloads" | "Movies" | "Music" | "Pictures" | "Public"
+            )
+        )
 }
 
 fn model_index_for_path(path: &Path) -> Option<usize> {
@@ -1030,7 +1055,7 @@ fn file_extension(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::read_folding_result_bundle_impl;
+    use super::{candidate_roots_with_home, read_folding_result_bundle_impl};
     use crate::commands::numpy_artifact::read_numpy_arrays;
     use std::fs;
     use std::path::PathBuf;
@@ -1042,6 +1067,21 @@ mod tests {
         ));
         fs::create_dir_all(&path).expect("fixture dir should create");
         path
+    }
+
+    #[test]
+    fn folding_scan_stops_before_user_collection_directories() {
+        let home = temp_dir("home-boundary");
+        let project = home.join("Desktop").join("folding-project");
+        fs::create_dir_all(&project).expect("project dir should create");
+        let pdb = project.join("ordinary.pdb");
+        fs::write(&pdb, "ATOM      1  N   GLY A   1\n").expect("pdb should write");
+
+        let roots =
+            candidate_roots_with_home(&pdb, Some(&home)).expect("candidate roots should resolve");
+
+        assert_eq!(roots, vec![project]);
+        let _ = fs::remove_dir_all(home);
     }
 
     fn npy_f32(shape: &[usize], values: &[f32]) -> Vec<u8> {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/vite/browser-dev/folding-results.ts
+++ b/apps/desktop/vite/browser-dev/folding-results.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync, type Dirent, type Stats } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { inflateRawSync } from "node:zlib";
 import type { ViteDevServer } from "vite";
@@ -680,14 +681,22 @@ function collectBrowserDevFoldingFiles(root: string, depth: number, files: Array
 function candidateFoldingRoots(inputPath: string) {
   const info = statSync(inputPath);
   let root = info.isDirectory() ? inputPath : dirname(inputPath);
-  const roots = [root];
-  for (let index = 0; index < 6; index += 1) {
+  const roots: string[] = [];
+  const home = homedir();
+  for (let index = 0; index <= 6; index += 1) {
+    if (isUserCollectionRoot(root, home)) break;
+    roots.push(root);
     const parent = dirname(root);
     if (!parent || parent === root) break;
     root = parent;
-    roots.push(root);
   }
   return roots;
+}
+
+function isUserCollectionRoot(root: string, home: string) {
+  if (root === home) return true;
+  return dirname(root) === home
+    && ["Desktop", "Documents", "Downloads", "Movies", "Music", "Pictures", "Public"].includes(fileTitle(root));
 }
 
 function foldingArtifactKind(entry: { title: string; extension: string }) {

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.1.21",
+      "version": "2.1.22",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "private": true,
   "description": "macOS menu bar app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.21",
+  "version": "2.1.22",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why

Opening a PDB inside a Desktop project could freeze the native app and trigger an unrelated Photos permission prompt. The folding-result discovery walked upward from the file and recursively scanned broad user directories, including Pictures.

## What Changed

- stop native folding-result discovery before the home directory and standard user collection roots
- mirror the same boundary in browser-dev discovery
- add a regression test for a PDB nested under Desktop
- bump all release metadata to 2.1.22

Affected surfaces: macOS desktop app, browser-dev, and release metadata. Quick Look, iPhone, and plugin/MCP behavior are unchanged.

## Verification

- reproduced the 2.1.21 hang with the reported 32-model PDB and captured the main-thread directory scan
- opened the same PDB in a dev-flavored native build; the 32-model structure rendered and no Photos/Media Library request occurred
- `bun run ci:fast` (507 Rust tests passed; 7 opt-in GPU tests ignored)
- `bun run check:release`
- `./scripts/release.sh --dry-run`
- `bun tests/test-folding-results-contract.mjs`
- `cargo test commands::folding_results::tests`

## Review

Local correctness, simplification, path-boundary, testing, and security passes found no issues. The optional external-model pass was not run because code submission to an external model was not authorized.