### PR TITLE
Fix hosted Molstar Vercel build

### DIFF
--- a/apps/burette-public-plugin/README.md
+++ b/apps/burette-public-plugin/README.md
@@ -75,11 +75,11 @@ from the model and conversation transcript.
   origin for runtime fetches and resources; the widget does not embed subframes.
 - The hosted shell loads only the plugin's pinned, self-hosted Burette, Mol*,
   and RDKit runtime assets.
-- The Mol* 5.7.0 build is transformed by
-  `scripts/build-molstar-csp.mjs` to remove dynamic code generation that is not
-  allowed by MCP Apps sandbox CSP. The build script verifies the pinned source
-  checksums, defers the disabled MP4 encoder's WASM initialization, and fails
-  closed if the upstream bundle changes.
+- The hosted plugin copies the reviewed Mol* bundle from
+  `PreviewExtension/Web`, whose source and checksum are pinned by
+  `vendor-assets.lock.json`. `scripts/build-molstar-csp.mjs` fails closed if
+  that bundle contains dynamic code generation forbidden by the MCP Apps
+  sandbox CSP.
 - Every string and collection copied into model-visible `structuredContent` is
   bounded by the declared output schema. Raw structure text remains only in
   widget-only `_meta`.

--- a/apps/burette-public-plugin/scripts/build-molstar-csp.mjs
+++ b/apps/burette-public-plugin/scripts/build-molstar-csp.mjs
@@ -1,35 +1,17 @@
-import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = path.resolve(APP_ROOT, "../..");
 const require = createRequire(import.meta.url);
-const SOURCE_ROOT = path.join(
-  path.dirname(require.resolve("molstar/package.json")),
-  "build/viewer",
-);
+// Ship the same reviewed bundle used by the desktop and Quick Look runtimes.
+const SOURCE_ROOT = path.join(REPO_ROOT, "PreviewExtension/Web");
 const OUTPUT_ROOT = path.join(APP_ROOT, "public/burette-viewer");
 
-const MOLSTAR_VERSION = require("molstar/package.json").version;
-
-const EXPECTED_JAVASCRIPT_SHA256 =
-  "7fad5561c74bc900930fb57d6ab028d1aafdda82223a901bf932b1098e84f1f3";
-const EXPECTED_CSS_SHA256 =
-  "5b68ceb6d3642549b4e9b2c071e58e41b98a5350ae269180587b39da86925d55";
-
-function sha256(value) {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function replaceExactlyOnce(source, search, replacement, label) {
-  const first = source.indexOf(search);
-  if (first < 0 || source.indexOf(search, first + search.length) >= 0) {
-    throw new Error(`Expected exactly one Mol* ${label} expression.`);
-  }
-  return source.slice(0, first) + replacement + source.slice(first + search.length);
-}
+const MOLSTAR_VERSION =
+  require(path.join(REPO_ROOT, "package.json")).dependencies?.molstar ?? "unknown";
 
 async function main() {
   const [javascriptSource, cssSource] = await Promise.all([
@@ -37,48 +19,16 @@ async function main() {
     readFile(path.join(SOURCE_ROOT, "molstar.css"), "utf8"),
   ]);
 
-  if (sha256(javascriptSource) !== EXPECTED_JAVASCRIPT_SHA256) {
-    throw new Error("Mol* JavaScript changed; review the CSP patch before building.");
-  }
-  if (sha256(cssSource) !== EXPECTED_CSS_SHA256) {
-    throw new Error("Mol* CSS changed; review the pinned asset before building.");
-  }
-
-  let javascript = javascriptSource;
-  javascript = replaceExactlyOnce(
-    javascript,
-    'new Function("body","return function "+P+`() {\n    "use strict";    return body.apply(this, arguments);\n};\n`)(V)',
-    "function(){return V.apply(this,arguments)}",
-    "named-function",
+  const javascript = javascriptSource.replace(
+    /\n\/\/# sourceMappingURL=molstar\.js\.map\s*$/u,
+    "\n",
   );
-  javascript = replaceExactlyOnce(
-    javascript,
-    'new Function("dynCall","rawFunction",xe+`};\n`)(Z,V)',
-    "function(dynCall,rawFunction){return function(){return dynCall.apply(null,[rawFunction].concat(Array.prototype.slice.call(arguments)))}}(Z,V)",
-    "dynamic-call",
-  );
-  javascript = replaceExactlyOnce(
-    javascript,
-    'new Function(""+d)',
-    'function(){throw new TypeError("String callbacks are not supported")}',
-    "string-callback",
-  );
-  javascript = replaceExactlyOnce(
-    javascript,
-    'new Function(...r,`return \\`${e}\\`;`)(...n)',
-    'e.replace(/\\$\\{([^}]+)\\}/g,(m,k)=>Object.prototype.hasOwnProperty.call(t,k)?String(t[k]):m)',
-    "template-interpolation",
-  );
-  javascript = replaceExactlyOnce(
-    javascript,
-    "let i=r.n(n)()(),a=new Promise(s=>{i.then(()=>{s()})}),A=()=>o(void 0,void 0,void 0,(function*(){yield a;let s=new i.H264MP4Encoder;return s.FS=i.FS,s}))",
-    "let i,a,A=()=>o(void 0,void 0,void 0,(function*(){if(!i){i=r.n(n)()();a=new Promise(s=>{i.then(()=>{s()})})}yield a;let s=new i.H264MP4Encoder;return s.FS=i.FS,s}))",
-    "eager-h264-initialization",
-  );
-  javascript = javascript.replace(/\n\/\/# sourceMappingURL=molstar\.js\.map\s*$/u, "\n");
 
   if (javascript.includes("new Function")) {
-    throw new Error("The generated Mol* asset still contains dynamic code generation.");
+    throw new Error(
+      "The vendored Mol* bundle contains dynamic code generation, which the hosted CSP forbids. " +
+        "Re-run `bun run vendor:molstar`, and if it persists, patch the offending call before building.",
+    );
   }
 
   const css = cssSource.replace(


### PR DESCRIPTION
## Why

Vercel production deployments fail after the Mol* 5.11 upgrade because the hosted plugin still hashes and rewrites the package's obsolete prebuilt viewer bundle.

## What Changed

- copy the reviewed Mol* bundle already vendored under `PreviewExtension/Web`
- retain the fail-closed check that rejects dynamic code generation under the MCP Apps CSP
- update the hosted plugin documentation to describe the shared vendored source of truth

Affected surfaces: hosted plugin/MCP and its Vercel deployment. Desktop, Quick Look, browser-dev, and iPhone runtime behavior are unchanged.

## Verification

- `bun run typecheck` in `apps/burette-public-plugin`
- `bun run test` in `apps/burette-public-plugin` (42 passed)
- `bun run build` in `apps/burette-public-plugin`
- `bun run ci:fast`
- pre-commit plist, JavaScript syntax, and Rust formatting hooks