### PR TITLE
Handle unavailable before SHAs in CI scope detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
             changed="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
           else
             before="${{ github.event.before }}"
-            if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]]; then
-              changed="$(git diff --name-only HEAD~1 HEAD)"
+            if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]] \
+              || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+              changed="$(git ls-tree -r --name-only HEAD)"
             else
               changed="$(git diff --name-only "$before" HEAD)"
             fi


### PR DESCRIPTION
## Why

A force-push can make `github.event.before` unavailable in the checkout. The build-scope job then failed before it could decide whether native packaging was required.

## What Changed

- Verify that the push `before` SHA resolves to a commit before diffing.
- When it is missing or zero, conservatively treat the full current tree as changed so native/package checks are not skipped.

Affected surface: GitHub Actions CI only.

## Verification

- Simulated an unavailable `before` SHA; the fallback selected all 1,366 tracked files and set `native=true`.
- `bun tests/test-install-health-contract.mjs`
- `bun run ci:fast` (including Rust fmt/clippy, frontend and agent contracts, and 507 passing Rust tests; 7 manual GPU tests ignored by contract)
- Repository pre-commit and pre-push hooks