### PR TITLE
Add window content zoom (Cmd+= / Cmd+- / Cmd+0)

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.24;
+				MARKETING_VERSION = 2.1.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "base64 0.22.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.1.24"
+version = "2.1.25"
 dependencies = [
  "base64 0.22.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.1.24"
+version = "2.1.25"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -64,6 +64,11 @@ pub fn run() {
         .manage(RecentDocumentsRegistry::default())
         .manage(startup::PendingOpenDocuments::default())
         .manage(zoom::WindowZoom::default())
+        .on_page_load(|webview, payload| {
+            if payload.event() == tauri::webview::PageLoadEvent::Finished {
+                zoom::sync_on_page_load(webview);
+            }
+        })
         .setup(|app| {
             let compute_coordinator = app
                 .path()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod preview;
 mod startup;
 mod tray;
 mod windows;
+mod zoom;
 
 use commands::descriptors::DescriptorGridJobRegistry;
 use commands::recent_documents::RecentDocumentsRegistry;
@@ -62,6 +63,7 @@ pub fn run() {
         .manage(SourceEditRegistry::default())
         .manage(RecentDocumentsRegistry::default())
         .manage(startup::PendingOpenDocuments::default())
+        .manage(zoom::WindowZoom::default())
         .setup(|app| {
             let compute_coordinator = app
                 .path()

--- a/apps/desktop/src-tauri/src/menu/build.rs
+++ b/apps/desktop/src-tauri/src/menu/build.rs
@@ -207,6 +207,15 @@ pub(crate) fn configure_menu<R: Runtime>(app: &tauri::App<R>) -> tauri::Result<(
     let command_palette = MenuItemBuilder::with_id("view.command-palette", "Command Palette…")
         .accelerator("CmdOrCtrl+P")
         .build(app)?;
+    let zoom_actual = MenuItemBuilder::with_id("view.zoom-actual", "Actual Size")
+        .accelerator("CmdOrCtrl+0")
+        .build(app)?;
+    let zoom_in = MenuItemBuilder::with_id("view.zoom-in", "Zoom In")
+        .accelerator("CmdOrCtrl+=")
+        .build(app)?;
+    let zoom_out = MenuItemBuilder::with_id("view.zoom-out", "Zoom Out")
+        .accelerator("CmdOrCtrl+-")
+        .build(app)?;
     let view_menu = SubmenuBuilder::new(app, "View")
         .items(&[
             &show_sidebar,
@@ -217,6 +226,10 @@ pub(crate) fn configure_menu<R: Runtime>(app: &tauri::App<R>) -> tauri::Result<(
             &table,
             &properties,
             &molecule_renderer,
+            &PredefinedMenuItem::separator(app)?,
+            &zoom_actual,
+            &zoom_in,
+            &zoom_out,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::fullscreen(app, None)?,
             &PredefinedMenuItem::separator(app)?,

--- a/apps/desktop/src-tauri/src/menu/events.rs
+++ b/apps/desktop/src-tauri/src/menu/events.rs
@@ -150,6 +150,10 @@ pub(crate) fn handle_event<R: Runtime>(app: &tauri::AppHandle<R>, id: &str) {
         return;
     }
 
+    if crate::zoom::handle_menu_command(app, id) {
+        return;
+    }
+
     if is_recent_menu_item_id(id) {
         if let Some(path) = recent_path(app, id) {
             let preferred_label = crate::windows::focused_window_label(app);

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -151,6 +151,7 @@ fn create_workspace_window<R: Runtime>(
         return Err("Workspace creation was cancelled during an exit transition.".into());
     }
     attach_window_cleanup(app, &window);
+    crate::zoom::apply_current_zoom(&window);
     Ok(window)
 }
 

--- a/apps/desktop/src-tauri/src/zoom.rs
+++ b/apps/desktop/src-tauri/src/zoom.rs
@@ -1,0 +1,146 @@
+use std::sync::Mutex;
+
+use tauri::{Manager, Runtime};
+
+const ZOOM_LEVELS: [f64; 13] = [
+    0.5, 0.67, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0,
+];
+const DEFAULT_ZOOM_INDEX: usize = 5;
+
+pub(crate) struct WindowZoom {
+    level_index: Mutex<usize>,
+}
+
+impl Default for WindowZoom {
+    fn default() -> Self {
+        Self {
+            level_index: Mutex::new(DEFAULT_ZOOM_INDEX),
+        }
+    }
+}
+
+fn zoomed_in(index: usize) -> usize {
+    index.saturating_add(1).min(ZOOM_LEVELS.len() - 1)
+}
+
+fn zoomed_out(index: usize) -> usize {
+    index.saturating_sub(1)
+}
+
+fn command_target_index(command: &str, current: usize) -> Option<usize> {
+    match command {
+        "view.zoom-actual" => Some(DEFAULT_ZOOM_INDEX),
+        "view.zoom-in" => Some(zoomed_in(current)),
+        "view.zoom-out" => Some(zoomed_out(current)),
+        _ => None,
+    }
+}
+
+fn apply_zoom_to_window<R: Runtime>(window: &tauri::WebviewWindow<R>, factor: f64) {
+    if let Err(error) = window.set_zoom(factor) {
+        eprintln!(
+            "failed to apply zoom factor {factor} to window {}: {error}",
+            window.label()
+        );
+    }
+}
+
+/// Handles the View menu zoom commands. Returns `false` for unrelated ids so
+/// the menu dispatcher can fall through to the forwarding path.
+pub(crate) fn handle_menu_command<R: Runtime>(app: &tauri::AppHandle<R>, command: &str) -> bool {
+    let Some(zoom) = app.try_state::<WindowZoom>() else {
+        return false;
+    };
+    let factor = {
+        let mut index = zoom
+            .level_index
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(target) = command_target_index(command, *index) else {
+            return false;
+        };
+        *index = target;
+        ZOOM_LEVELS[target]
+    };
+    for window in app.webview_windows().values() {
+        apply_zoom_to_window(window, factor);
+    }
+    true
+}
+
+/// Brings a newly created window to the shared zoom factor.
+pub(crate) fn apply_current_zoom<R: Runtime>(window: &tauri::WebviewWindow<R>) {
+    let Some(zoom) = window.app_handle().try_state::<WindowZoom>() else {
+        return;
+    };
+    let index = *zoom
+        .level_index
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if index == DEFAULT_ZOOM_INDEX {
+        return;
+    }
+    apply_zoom_to_window(window, ZOOM_LEVELS[index]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_level_is_actual_size() {
+        assert_eq!(ZOOM_LEVELS[DEFAULT_ZOOM_INDEX], 1.0);
+    }
+
+    #[test]
+    fn ladder_is_strictly_increasing() {
+        for pair in ZOOM_LEVELS.windows(2) {
+            assert!(pair[0] < pair[1]);
+        }
+    }
+
+    #[test]
+    fn zoom_in_steps_up_and_clamps_at_top() {
+        let top = ZOOM_LEVELS.len() - 1;
+        assert_eq!(zoomed_in(0), 1);
+        assert_eq!(zoomed_in(top - 1), top);
+        assert_eq!(zoomed_in(top), top);
+    }
+
+    #[test]
+    fn zoom_out_steps_down_and_clamps_at_bottom() {
+        assert_eq!(zoomed_out(2), 1);
+        assert_eq!(zoomed_out(1), 0);
+        assert_eq!(zoomed_out(0), 0);
+    }
+
+    #[test]
+    fn actual_size_returns_to_default_from_either_end() {
+        assert_eq!(
+            command_target_index("view.zoom-actual", 0),
+            Some(DEFAULT_ZOOM_INDEX)
+        );
+        assert_eq!(
+            command_target_index("view.zoom-actual", ZOOM_LEVELS.len() - 1),
+            Some(DEFAULT_ZOOM_INDEX)
+        );
+    }
+
+    #[test]
+    fn menu_commands_map_to_their_directions() {
+        assert_eq!(command_target_index("view.zoom-in", 5), Some(6));
+        assert_eq!(command_target_index("view.zoom-out", 5), Some(4));
+    }
+
+    #[test]
+    fn round_trip_returns_to_the_starting_level() {
+        let stepped = zoomed_out(zoomed_in(DEFAULT_ZOOM_INDEX));
+        assert_eq!(stepped, DEFAULT_ZOOM_INDEX);
+    }
+
+    #[test]
+    fn unrelated_commands_are_ignored() {
+        assert_eq!(command_target_index("view.toggle-sidebar", 3), None);
+        assert_eq!(command_target_index("file.new-window", 0), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/zoom.rs
+++ b/apps/desktop/src-tauri/src/zoom.rs
@@ -43,6 +43,16 @@ fn apply_zoom_to_window<R: Runtime>(window: &tauri::WebviewWindow<R>, factor: f6
             window.label()
         );
     }
+    // Native chrome (macOS traffic lights) does not scale with the webview
+    // zoom, so the frontend compensates its reserved areas via this variable.
+    let script =
+        format!("document.documentElement.style.setProperty('--window-zoom', '{factor}');");
+    if let Err(error) = window.eval(script) {
+        eprintln!(
+            "failed to sync the zoom css variable on window {}: {error}",
+            window.label()
+        );
+    }
 }
 
 /// Handles the View menu zoom commands. Returns `false` for unrelated ids so
@@ -66,6 +76,15 @@ pub(crate) fn handle_menu_command<R: Runtime>(app: &tauri::AppHandle<R>, command
         apply_zoom_to_window(window, factor);
     }
     true
+}
+
+/// Re-syncs the shared zoom factor after a page load, so freshly loaded
+/// documents pick up both the webview zoom and the css compensation variable.
+pub(crate) fn sync_on_page_load<R: Runtime>(webview: &tauri::Webview<R>) {
+    let Some(window) = webview.app_handle().get_webview_window(webview.label()) else {
+        return;
+    };
+    apply_current_zoom(&window);
 }
 
 /// Brings a newly created window to the shared zoom factor.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -322,7 +322,12 @@ export function AppLayout({
   // How far the leading window controls reach: the tab strip starts past them
   // when the sidebar is narrower than they are (or closed). The sidebar's own
   // edge comes from `--sidebar-edge`, measured rather than stored.
-  const chromeLeadingInset = compactLeadingChrome ? 112 : 192;
+  // The desktop inset splits into 92px of native traffic-light clearance
+  // (constant on screen, so divided by the window zoom like
+  // `.chrome-leading-controls`) plus 100px of zoomable toggle-and-gap space.
+  const chromeLeadingInset = compactLeadingChrome
+    ? "112px"
+    : "calc(92px / var(--window-zoom, 1) + 100px)";
   const rightDockOpen = !settingsMode && !hostedMcpWidget && state.rightDockOpen;
   const bottomDockOpen = !settingsMode && !hostedMcpWidget && state.bottomDockOpen;
   // Toggle-animation hooks must come before the collapse/expand sync hooks:
@@ -414,7 +419,7 @@ export function AppLayout({
     ...buildThemeStyle(state.preferences, systemThemeMode),
     "--sidebar-layout-width": `${sidebarLayoutWidth}px`,
     "--right-dock-width": `${rightDockOpen ? rightDockWidth : 0}px`,
-    "--chrome-leading-inset": `${chromeLeadingInset}px`,
+    "--chrome-leading-inset": chromeLeadingInset,
     "--chrome-height": hostedMcpWidget ? "0px" : undefined,
   } as CSSProperties;
   const effectiveTheme = resolveThemeMode(state.preferences.theme, systemThemeMode);

--- a/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
+++ b/apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx
@@ -59,6 +59,21 @@ const keyboardShortcutRows: ShortcutRow[] = [
     keybindings: ["⌥⌘B"],
   },
   {
+    command: "Zoom in",
+    description: "Scale all window content up one step.",
+    keybindings: ["⌘="],
+  },
+  {
+    command: "Zoom out",
+    description: "Scale all window content down one step.",
+    keybindings: ["⌘-"],
+  },
+  {
+    command: "Actual size",
+    description: "Reset window content scaling to 100%.",
+    keybindings: ["⌘0"],
+  },
+  {
     command: "Open Settings",
     description: "Open the settings workspace.",
     keybindings: ["⌘,"],

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -302,7 +302,10 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 .topbar, .chrome-leading-controls, .chrome-trailing-controls, .sidebar-toggle-root, .tab-strip, .tab-strip-spacer, .chrome-button, .new-tab, .tab-shell, .tab, .sidebar, .sidebar-footer, .project, .sidebar-search-row, .sidebar-search-action-row, .settings-sidebar, .settings-back-button, .settings-search, .settings-nav-item, .dock-panel { pointer-events: auto; }
 .chrome-leading-controls {
   position: absolute;
-  left: 92px;
+  /* The macOS traffic lights stay at their native position while the page
+     zooms, so the reserved gap shrinks by the zoom factor to keep a constant
+     on-screen clearance. */
+  left: calc(92px / var(--window-zoom, 1));
   top: 0;
   z-index: 5;
   height: var(--chrome-height);
@@ -8380,7 +8383,7 @@ img.settings-open-destination-icon {
   .settings-range-control input { width: 100%; }
 }
 @media (max-width: 760px) {
-  .chrome-leading-controls { left: 82px; }
+  .chrome-leading-controls { left: calc(82px / var(--window-zoom, 1)); }
   .topbar .tab-history-controls { display: none; }
   .sidebar-search-row { padding: 0 28px 0 32px; }
   .settings-panel-content { width: 100%; padding: 80px 16px 64px; }

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.1.24",
+      "version": "2.1.25",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -33,6 +33,9 @@ or the hosted MCP widget is open.
 | Cmd+Option+B | Toggle Inspector (right dock) |
 | Cmd+J | Toggle bottom panel |
 | Cmd+\ | Toggle sidebar (browser runtime) |
+| Cmd+= | Zoom in window content (desktop app) |
+| Cmd+- | Zoom out window content (desktop app) |
+| Cmd+0 | Reset window content to actual size (desktop app) |
 | Cmd+, | Open Settings |
 | Cmd+W | Close the active tab |
 | Cmd+Shift+W | Close the active window |

--- a/docs/superpowers/specs/2026-08-10-window-zoom-design.md
+++ b/docs/superpowers/specs/2026-08-10-window-zoom-design.md
@@ -1,0 +1,115 @@
+# Window Content Zoom Design
+
+**Status:** Approved direction as of 2026-08-10, based on branch
+`claude/screen-scaling-feature-7fafe4` at `21d05ec6`.
+
+## Goal
+
+Let the user scale the whole application content with standard keyboard
+shortcuts, the way browsers do:
+
+- **Zoom In** `⌘=`, **Zoom Out** `⌘-`, **Actual Size** `⌘0`;
+- the zoom applies to everything rendered in the window — workspace chrome,
+  text, panels, and embedded viewers (Mol*, Ketcher) alike;
+- one shared zoom factor for all workspace windows: changing it in any window
+  changes every open window, and new windows open at the current factor;
+- the factor is ephemeral: every app launch starts at 100%.
+
+## Non-goals
+
+- No persistence of the zoom factor across launches.
+- No per-window zoom.
+- No UI-chrome-only scaling (IDE-style "UI scale"); the 3D viewers zoom too.
+- No zoom percentage indicator, toast, or status readout.
+- No pinch-gesture zoom and no command-palette entry.
+- No CSS `zoom` on the document root — the app relies on measured-pixel layout
+  (resizable panels, pixel guards), which CSS zoom would skew.
+
+## Approach
+
+Handle zoom entirely on the Rust side. The native menu already owns the
+keyboard accelerators, and Tauri's `Webview::set_zoom` maps to WKWebView
+`pageZoom` on macOS, which scales all webview content natively. Menu commands
+for zoom are *not* forwarded to the frontend; they short-circuit in the Rust
+menu event handler, mirroring how `file.new-window` is handled. This keeps the
+change free of new capabilities/ACL permissions and makes the all-windows
+broadcast trivial.
+
+Native menu accelerators fire regardless of focus — including when focus is
+inside the Mol* or Ketcher iframe, where a JS `keydown` listener would never
+see the event.
+
+### Accelerator choice: `⌘=` rather than `⌘+`
+
+muda 0.19 rejects `+`/`Plus` as an accelerator key (`UnsupportedKey`), and the
+physical gesture browsers respond to is `⌘` plus the unshifted `=/+` key —
+i.e. `Cmd+=`. The menu therefore uses `CmdOrCtrl+=` and macOS renders `⌘=` next
+to Zoom In. `CmdOrCtrl+-` and `CmdOrCtrl+0` parse and render as expected.
+
+## Design
+
+### Menu (apps/desktop/src-tauri/src/menu/build.rs)
+
+New section in the View menu, placed before the Enter Full Screen item,
+following the Safari ordering:
+
+| Item        | Id                 | Accelerator   |
+| ----------- | ------------------ | ------------- |
+| Actual Size | `view.zoom-actual` | `CmdOrCtrl+0` |
+| Zoom In     | `view.zoom-in`     | `CmdOrCtrl+=` |
+| Zoom Out    | `view.zoom-out`    | `CmdOrCtrl+-` |
+
+All three are always enabled. At the ladder bounds, Zoom In/Out become no-ops
+(clamped) instead of disabling menu items — this avoids coupling zoom to the
+native-menu state sync machinery.
+
+### Zoom module (apps/desktop/src-tauri/src/zoom.rs, new)
+
+- `ZOOM_LEVELS: [f64; 13] = [0.5, 0.67, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5,
+  1.75, 2.0, 2.5, 3.0]` — Chrome-style discrete ladder. An index into the
+  ladder, not float multiplication, is the source of truth, so repeated in/out
+  steps stay on round levels and return to exactly 1.0.
+- `DEFAULT_ZOOM_INDEX` — index of `1.0`.
+- Pure transition functions over indices (`zoomed_in`, `zoomed_out`), clamping
+  at the ends; unit-tested.
+- `WindowZoom` managed state: `Mutex<usize>` holding the current index,
+  registered via `app.manage()` in `lib.rs` alongside the other registries.
+- `handle_menu_command(app, id) -> bool`: recognizes the three menu ids,
+  updates the index, and applies the resulting factor to every webview window.
+  Returns `false` for unrelated ids so the menu handler falls through.
+- `apply_current_zoom(window)`: applies the current factor to a single window
+  when it is not the default; called for newly created workspace windows in
+  `windows.rs::create_workspace_window`.
+
+### Menu event handling (apps/desktop/src-tauri/src/menu/events.rs)
+
+`handle_event` delegates to `zoom::handle_menu_command` before the
+`FORWARDED_COMMANDS` lookup, in the same style as the `file.new-window`
+special case. The zoom ids are not added to `FORWARDED_COMMANDS`.
+
+## Error handling
+
+- `set_zoom` failure on one window: log a warning with the window label and
+  continue applying to the remaining windows. Zoom must never crash or abort
+  the broadcast midway.
+- Poisoned zoom mutex: recover the inner value and continue; zoom state is a
+  single `usize` with no invariants to violate.
+
+## Testing
+
+- Unit tests in `zoom.rs` for the ladder logic: clamping at both ends,
+  in/out round-trips returning to the default, default level being `1.0`,
+  ladder strictly increasing.
+- `tests/test-tauri-structure.mjs`: assert the three menu ids and their
+  accelerators exist in the menu build source, following the existing
+  native-menu contract assertions.
+- Manual dev-run check: `⌘=`/`⌘-`/`⌘0` with focus in the main UI and with
+  focus inside the Mol* viewer; a second window picks up the current factor
+  on open; relaunch starts back at 100%.
+
+## Documentation
+
+- `docs/keyboard-shortcuts.md`: add the three shortcuts.
+- `apps/desktop/src/components/settings-panel/keyboard-shortcuts-section.tsx`:
+  add matching entries (`⌘=`, `⌘-`, `⌘0`) so the in-app shortcut list stays
+  complete.

--- a/docs/superpowers/specs/2026-08-10-window-zoom-design.md
+++ b/docs/superpowers/specs/2026-08-10-window-zoom-design.md
@@ -87,6 +87,28 @@ native-menu state sync machinery.
 `FORWARDED_COMMANDS` lookup, in the same style as the `file.new-window`
 special case. The zoom ids are not added to `FORWARDED_COMMANDS`.
 
+### Native chrome alignment
+
+The macOS traffic lights are native overlay chrome pinned at a fixed logical
+position (`windows.rs` sets `traffic_light_position(20, 29)`); `pageZoom`
+scales the web content but not them. The frontend reserves room for the
+buttons in `.chrome-leading-controls` with a fixed pixel inset, which would
+otherwise scale with the zoom and drift away from the buttons (VS Code-style
+behavior applies: native chrome stays put while content scales).
+
+To keep the on-screen clearance constant, the Rust side mirrors the current
+factor into the webview as a CSS variable — `apply_zoom_to_window` runs
+`document.documentElement.style.setProperty('--window-zoom', factor)` after
+`set_zoom`, and a `Builder::on_page_load(Finished)` hook re-syncs both the
+zoom and the variable after any page (re)load. The stylesheet divides the
+reserved inset by the factor: `left: calc(92px / var(--window-zoom, 1))`
+(and the 82px narrow-viewport variant). The tab strip's
+`--chrome-leading-inset` (app-layout.tsx) splits the same way — 92px of
+native clearance divided by the factor plus 100px of zoomable toggle space —
+so the strip keeps clearing the pinned controls at zoomed-out levels. In the
+browser shell the variable is never set and the fallback of `1` preserves the
+original layout.
+
 ## Error handling
 
 - `set_zoom` failure on one window: log a warning with the window label and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -1156,6 +1156,9 @@ assertSourceIncludesAll(nativeMenuSource, [
   'view.grid-properties',
   'view.grid-renderer-rdkit',
   'view.grid-renderer-xyzrender',
+  'view.zoom-actual',
+  'view.zoom-in',
+  'view.zoom-out',
   'view.command-palette',
   'structure.open-in-molstar',
   'structure.edit-in-ketcher',
@@ -1222,11 +1225,15 @@ for (const [id, accelerator] of [
   ['edit.find', 'CmdOrCtrl+F'],
   ['edit.undo-grid', 'CmdOrCtrl+Z'],
   ['edit.redo-grid', 'CmdOrCtrl+Shift+Z'],
+  ['view.zoom-actual', 'CmdOrCtrl+0'],
+  ['view.zoom-in', 'CmdOrCtrl+='],
+  ['view.zoom-out', 'CmdOrCtrl+-'],
   ['window.previous-tab', 'Ctrl+Shift+Tab'],
   ['window.next-tab', 'Ctrl+Tab'],
 ]) {
   assertMenuItemAccelerator(nativeMenuSource, id, accelerator);
 }
+assert.match(menuEvents, /crate::zoom::handle_menu_command/);
 assert.doesNotMatch(nativeMenuSource, /accelerator\("CmdOrCtrl\+Shift\+N"\)/);
 assert.match(nativeMenuSource, /accelerator\("CmdOrCtrl\+P"\)/);
 assert.doesNotMatch(nativeMenuSource, /accelerator\("CmdOrCtrl\+U"\)/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1449,8 +1449,8 @@ assert.match(appLayout, /const compactLeadingChrome = !tauriRuntime \|\| windowF
 // only reaches the DOM a render after the drag frame that produced it. React
 // contributes the leading-chrome inset (traffic lights) and the first-paint
 // seeds; `--sidebar-edge` / `--right-dock-edge` come from the observer.
-assert.match(appLayout, /const chromeLeadingInset = compactLeadingChrome \? 112 : 192;/);
-assert.match(appLayout, /"--chrome-leading-inset": `\$\{chromeLeadingInset\}px`/);
+assert.match(appLayout, /const chromeLeadingInset = compactLeadingChrome\s*\?\s*"112px"\s*:\s*"calc\(92px \/ var\(--window-zoom, 1\) \+ 100px\)"/);
+assert.match(appLayout, /"--chrome-leading-inset": chromeLeadingInset/);
 assert.doesNotMatch(appLayout, /tabChromeLeft/);
 assert.match(appLayout, /function usePanelEdgeVariables/);
 assert.match(appLayout, /\{ elementRef: sidebarElementRef, property: "--sidebar-edge" \}/);


### PR DESCRIPTION
## Summary

- Adds browser-style window content zoom to the desktop app: **Zoom In ⌘=**, **Zoom Out ⌘-**, **Actual Size ⌘0**, plus matching items in the native View menu.
- The zoom applies to everything in the window (workspace chrome, grids, Mol*, Ketcher) via WKWebView `pageZoom` (Tauri `set_zoom`); the factor is shared across all workspace windows, new windows inherit it, and every launch starts back at 100%.
- Zoom commands short-circuit in the Rust menu dispatcher (like `file.new-window`): no forwarded commands, no new capabilities/ACL surface. State is a Chrome-style discrete level ladder (50%–300%) held as an index in managed state.
- Native macOS traffic lights do not scale with the page, so the Rust side mirrors the factor into a `--window-zoom` CSS variable (on zoom change and on every page load); `.chrome-leading-controls` and the tab strip's `--chrome-leading-inset` divide their native-clearance portion by the factor to keep a constant on-screen gap at every zoom level.

## Why ⌘= rather than ⌘+

muda rejects `+`/`Plus` as an accelerator key, and the physical gesture browsers respond to is ⌘ with the unshifted `=/+` key. `CmdOrCtrl+=` matches that and renders as ⌘= in the menu.

## Testing

- `cargo fmt` / `clippy` / `cargo test` on the rebased branch: 515 passed.
- `tests/test-tauri-structure.mjs` pins the three menu ids, their accelerators, and the zoom dispatch; `tests/test-ui-shell-contract.mjs` pins the compensated inset; `tsc --noEmit` clean.
- Manual dev-run: ⌘=/⌘-/⌘0 from the main UI and with focus inside the Mol* iframe, second window inheriting the factor, relaunch resetting to 100%, traffic-light clearance stable across levels.
- Independent cross-model review (`codex review`) found one P1 (tab strip overlap at zoom-out levels); fixed by compensating `--chrome-leading-inset` with the same geometry.

Design spec: `docs/superpowers/specs/2026-08-10-window-zoom-design.md`