### PR TITLE
Pin PR release checks to the base commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  BURETTE_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
 jobs:
   changes:
     name: Detect Build Scope

--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.1.28;
+				MARKETING_VERSION = 2.1.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "base64 0.23.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.1.28"
+version = "2.1.29"
 dependencies = [
  "base64 0.23.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.1.28"
+version = "2.1.29"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.1.28",
+      "version": "2.1.29",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -50,13 +50,17 @@ if (mismatchedMarketingVersion) {
 
 if (process.env.GITHUB_EVENT_NAME === 'pull_request' && process.env.GITHUB_BASE_REF) {
   const base = process.env.GITHUB_BASE_REF;
-  try {
-    git(['fetch', '--quiet', 'origin', `+refs/heads/${base}:refs/remotes/origin/${base}`, '--tags']);
-  } catch (error) {
-    fail(`could not fetch base branch ${base}: ${error.stderr || error.message}`);
+  let baseRevision = process.env.BURETTE_PR_BASE_SHA?.trim();
+  if (!baseRevision) {
+    try {
+      git(['fetch', '--quiet', 'origin', `+refs/heads/${base}:refs/remotes/origin/${base}`, '--tags']);
+    } catch (error) {
+      fail(`could not fetch base branch ${base}: ${error.stderr || error.message}`);
+    }
+    baseRevision = `origin/${base}`;
   }
 
-  const basePackage = JSON.parse(git(['show', `origin/${base}:package.json`]));
+  const basePackage = JSON.parse(git(['show', `${baseRevision}:package.json`]));
   if (basePackage.version === packageVersion) {
     fail(`every merged PR creates a release, so this PR must bump package.json beyond ${basePackage.version}`);
   }

--- a/tests/test-tauri-structure.mjs
+++ b/tests/test-tauri-structure.mjs
@@ -917,6 +917,8 @@ assert.match(previewEntitlements, /com\.apple\.security\.files\.user-selected\.r
 assert.match(previewEntitlements, /com\.apple\.security\.files\.user-selected\.executable/);
 assert.match(appInfoPlist, /<key>LSUIElement<\/key>\s*<false\/>/);
 assert.match(releaseVersionCheck, /semver release or prerelease/);
+assert.match(releaseVersionCheck, /process\.env\.BURETTE_PR_BASE_SHA/);
+assert.match(ciWorkflow, /BURETTE_PR_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
 assert.doesNotMatch(appMetadata, /<key>LSHandlerRank<\/key>\s*<string>Alternate<\/string>/);
 assert.match(appMetadata, /<key>CFBundleTypeName<\/key>\s*<string>Molecular grid tables<\/string>/);
 assert.match(appMetadata, /<key>LSHandlerRank<\/key>\s*<string>Owner<\/string>/);


### PR DESCRIPTION
## Summary

- pin release-version validation to the immutable pull request base commit
- keep the live base-branch fetch as a fallback outside GitHub Actions
- add contract coverage for the workflow-to-script base SHA handoff
- sync release metadata to 2.1.29

This fixes the post-merge race observed in #577: Native Bundle Build started before merge but fetched `main` after merge, then incorrectly compared 2.1.28 against itself.

## Validation

- pre-push `ci:fast`: 515 Rust tests passed, 0 failed; JS contracts, clippy, rustfmt, plist and release checks passed
- `bun tests/test-tauri-structure.mjs`
- `bun run check:release`
- release check with `BURETTE_PR_BASE_SHA` set to the actual #577 base commit
