### PR TITLE
Keep table filters and dropped files visible

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "base64 0.23.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "base64 0.23.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.2.1"
+version = "2.2.2"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -285,6 +285,20 @@ export default function App() {
     setGridColumnFilter,
     clearGridColumnFilters,
   } = useAppGridFilterModel(activeDocument, documents, postMessageToViewerSource);
+  const openedGridFilterDockRef = useRef<string | null>(null);
+  useEffect(() => {
+    const documentId = activeDocument?.renderer === "grid2d" && activeGridFilterModel?.columns.length
+      ? activeDocument.id
+      : null;
+    if (!documentId) {
+      openedGridFilterDockRef.current = null;
+      return;
+    }
+    if (openedGridFilterDockRef.current === documentId) return;
+    openedGridFilterDockRef.current = documentId;
+    setDockOpen("right", true);
+    setDockActiveTab("right", "inspector");
+  }, [activeDocument, activeGridFilterModel?.columns.length, setDockActiveTab, setDockOpen]);
   const [poseReviewSelections, setPoseReviewSelections] = useState<Record<string, number>>({});
   const [viewerLigandSelections, setViewerLigandSelections] = useState<Record<string, ViewerLigandSelection | null>>({});
   const [structureOverlayModes, setStructureOverlayModes] = useState<Record<string, StructureOverlayMode>>({});
@@ -408,16 +422,18 @@ export default function App() {
     openQuickLookDocument,
     pushErrorStatus,
   });
+  const activeTextDocument = useAppActiveTextDocument({ activeTab, textDocuments });
   const {
     activeProject,
     setWorkspacePath,
     sidebarProjects,
     workspacePath,
   } = useAppSidebarProjects({
-    activeDocumentId: activeDocument?.id ?? null,
+    activeDocumentId: activeDocument?.id ?? activeTextDocument?.id ?? null,
     browserDevExplicitFolders,
     browserDevHasExplicitWorkspace: browserDevHasExplicitWorkspaceQuery,
     documents,
+    textDocuments,
     expandedProjectIds,
     hiddenProjectRoots,
     pinnedProjectRoots,
@@ -432,7 +448,6 @@ export default function App() {
     sidebarQuery,
   });
 
-  const activeTextDocument = useAppActiveTextDocument({ activeTab, textDocuments });
   const sourceEditing = useSourceEditingController({
     activeDocument,
     preferences,

--- a/apps/desktop/src/components/grid-filter-section.tsx
+++ b/apps/desktop/src/components/grid-filter-section.tsx
@@ -6,7 +6,7 @@ import type { GridFilterColumn, GridFilterModel, ShellActions } from "./types";
 
 const MAX_COLUMNS = 40;
 
-const CHART_CONFIG = { count: { label: "Molecules", color: "var(--accent)" } } satisfies ChartConfig;
+const CHART_CONFIG = { count: { label: "Rows", color: "var(--accent)" } } satisfies ChartConfig;
 
 function formatNumber(value: number) {
   if (Number.isInteger(value)) return String(value);
@@ -193,7 +193,7 @@ function NumericFilter({
                       const bin = payload?.[0]?.payload as Bin | undefined;
                       return bin ? `${formatNumber(bin.start)} – ${formatNumber(bin.end)}` : "";
                     }}
-                    formatter={(value) => `${Number(value).toLocaleString()} molecules`}
+                    formatter={(value) => `${Number(value).toLocaleString()} rows`}
                   />
                 }
               />
@@ -330,7 +330,7 @@ export function GridFilterSection({ model, actions }: { model: GridFilterModel; 
       </div>
       {open ? <>
       <div className="grid-filter-count">
-        {model.visible.toLocaleString()} of {model.total.toLocaleString()} molecules
+        {model.visible.toLocaleString()} of {model.total.toLocaleString()} rows
       </div>
       <input
         type="search"

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -442,6 +442,12 @@ export function StructureInfoPanel({ gridFilterModel, document, textDocument, do
         <InspectorHeaderStats document={document} summary={compositionSummary} pending={compositionPending} />
       </section>
 
+      {gridFilterModel ? (
+        <Suspense fallback={null}>
+          <GridFilterSection model={gridFilterModel} actions={actions} />
+        </Suspense>
+      ) : null}
+
       {assemblySymmetry.available ? (
         <AssemblySymmetryCard
           shown={assemblySymmetry.shown}
@@ -487,13 +493,7 @@ export function StructureInfoPanel({ gridFilterModel, document, textDocument, do
 
       {!hostedMcpWidget && !trajectoryDocument && !derivedTopology && !virtualScene ? <>
         {/* The conformer card and the standalone descriptor card are gone: both
-            are tool rows inside Tools now. GridFilterSection is lazy upstream,
-            so it keeps the Suspense boundary main gave it. */}
-        {gridFilterModel ? (
-          <Suspense fallback={null}>
-            <GridFilterSection model={gridFilterModel} actions={actions} />
-          </Suspense>
-        ) : null}
+            are tool rows inside Tools now. */}
         <InspectorEngineCard
           className="structure-inspector-xtb-card"
           title="Tools"

--- a/apps/desktop/src/hooks/use-app-sidebar-projects.ts
+++ b/apps/desktop/src/hooks/use-app-sidebar-projects.ts
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { buildSidebarProjects, type SidebarProjectStructure } from "../lib/sidebar-projects";
 import { scanBrowserDevFolders } from "../lib/browser-dev-startup";
 import { isTauriRuntime } from "../lib/tauri";
-import type { RecentStructure, ViewerDocument } from "../types";
+import type { RecentStructure, TextFileDocument, ViewerDocument } from "../types";
 import {
   isWebDemoWorkspace,
   subscribeWebDemoWorkspace,
@@ -50,6 +50,7 @@ type UseAppSidebarProjectsArgs = {
   browserDevExplicitFolders: string[];
   browserDevHasExplicitWorkspace: boolean;
   documents: ViewerDocument[];
+  textDocuments: TextFileDocument[];
   expandedProjectIds: string[];
   hiddenProjectRoots: string[];
   pinnedProjectRoots: string[];
@@ -72,6 +73,7 @@ export function useAppSidebarProjects({
   browserDevExplicitFolders,
   browserDevHasExplicitWorkspace,
   documents,
+  textDocuments,
   expandedProjectIds,
   hiddenProjectRoots,
   pinnedProjectRoots,
@@ -135,6 +137,7 @@ export function useAppSidebarProjects({
 
   const sidebarProjects = useMemo(() => buildSidebarProjects({
     documents,
+    textDocuments,
     recentStructures: sidebarRecentStructures,
     projectRoots: sidebarProjectRoots,
     projectStructures: sidebarProjectStructures,
@@ -143,7 +146,7 @@ export function useAppSidebarProjects({
     activeDocumentId,
     hiddenProjectRoots,
     pinnedStructurePaths,
-  }), [activeDocumentId, documents, hiddenProjectRoots, pinnedProjectRoots, pinnedStructurePaths, projectNameOverrides, sidebarProjectRoots, sidebarProjectStructures, sidebarRecentStructures]);
+  }), [activeDocumentId, documents, hiddenProjectRoots, pinnedProjectRoots, pinnedStructurePaths, projectNameOverrides, sidebarProjectRoots, sidebarProjectStructures, sidebarRecentStructures, textDocuments]);
 
   useEffect(() => {
     if (!isTauriRuntime()) {

--- a/apps/desktop/src/lib/sidebar-projects.ts
+++ b/apps/desktop/src/lib/sidebar-projects.ts
@@ -1,4 +1,4 @@
-import type { RecentStructure, ViewerDocument } from "../types";
+import type { RecentStructure, TextFileDocument, ViewerDocument } from "../types";
 import { isPersistentViewerDocument, isTemporaryDocumentPath, normalizeDocumentPath } from "./temporary-documents";
 
 export type SidebarProjectItem = {
@@ -38,6 +38,7 @@ type SidebarStructure = SidebarProjectStructure;
 
 export function buildSidebarProjects({
   documents,
+  textDocuments = [],
   recentStructures,
   projectRoots,
   projectStructures = [],
@@ -48,6 +49,7 @@ export function buildSidebarProjects({
   pinnedStructurePaths = [],
 }: {
   documents: ViewerDocument[];
+  textDocuments?: TextFileDocument[];
   recentStructures: RecentStructure[];
   projectRoots: string[];
   projectStructures?: SidebarProjectStructure[];
@@ -70,7 +72,12 @@ export function buildSidebarProjects({
       .map((path) => normalizePath(path)),
   );
   const projectDocuments = documents.filter(isPersistentViewerDocument);
-  const openPaths = new Set(projectDocuments.map((document) => normalizePath(document.path)));
+  const projectTextDocuments = textDocuments.filter((document) => !isTemporaryDocumentPath(document.path));
+  const projectDocumentPaths = new Set(projectDocuments.map((document) => normalizePath(document.path)));
+  const openPaths = new Set([
+    ...projectDocumentPaths,
+    ...projectTextDocuments.map((document) => normalizePath(document.path)),
+  ]);
   const knownPaths = new Set(openPaths);
   const projects = new Map<string, SidebarProject>();
 
@@ -80,6 +87,15 @@ export function buildSidebarProjects({
   }
 
   for (const document of projectDocuments) {
+    addStructureToProjects(projects, normalizedRoots, hiddenRoots, pinnedPaths, {
+      structure: document,
+      activeDocumentId,
+      source: "open",
+    });
+  }
+
+  for (const document of projectTextDocuments) {
+    if (projectDocumentPaths.has(normalizePath(document.path))) continue;
     addStructureToProjects(projects, normalizedRoots, hiddenRoots, pinnedPaths, {
       structure: document,
       activeDocumentId,
@@ -163,7 +179,7 @@ function addStructureToProjects(
     activeDocumentId,
     source,
   }: {
-    structure: ViewerDocument | SidebarStructure;
+    structure: ViewerDocument | TextFileDocument | SidebarStructure;
     activeDocumentId: string | null;
     source: "open" | "recent" | "project";
   },
@@ -184,7 +200,7 @@ function addStructureToProjects(
     title: itemTitle,
     relativePath,
     extension: "extension" in structure ? structure.extension : "",
-    renderer: structure.renderer,
+    renderer: "renderer" in structure ? structure.renderer : "text",
     byteCount: structure.byteCount,
     openedAt: source === "recent" && "openedAt" in structure ? structure.openedAt ?? null : null,
     source,

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/tests/fixtures/file-kinds/README.md
+++ b/tests/fixtures/file-kinds/README.md
@@ -7,9 +7,10 @@ something to open and close while judging the sidebar icons.
 They do not all become sidebar rows, and that is a property of the app rather
 than of these files. The project scan in `list_project_structure_files`
 (`apps/desktop/src-tauri/src/commands/documents.rs`) admits a file only if its
-extension is a registered preview format whose strategy is not `text`, and text
-files open into a separate `textDocuments` store that the sidebar never reads.
-The "row" column below says which side of that line each file falls on.
+extension is a registered preview format whose strategy is not `text`. Text
+files are absent from the initial folder scan, but appear in the sidebar after
+they are opened from their separate `textDocuments` store. The "row" column
+below describes the initial folder scan.
 
 | File | Kind | Row | Notes |
 | --- | --- | --- | --- |

--- a/tests/test-sidebar-projects.mjs
+++ b/tests/test-sidebar-projects.mjs
@@ -51,6 +51,18 @@ const recentStructures = [
 
 const projects = buildSidebarProjects({
   documents,
+  textDocuments: [
+    {
+      id: "text-1",
+      path: "/Users/test/Matcha/notes/readme.md",
+      title: "readme.md",
+      extension: "md",
+      language: "markdown",
+      byteCount: 24,
+      content: "# Notes",
+      truncated: false,
+    },
+  ],
   recentStructures,
   projectRoots: ["/Users/test/Matcha", "/Users/test/Burette", "/Users/test/Empty"],
   activeDocumentId: "doc-1",
@@ -67,7 +79,7 @@ assert.ok(matchaProject);
 assert.equal(buretteProject.items[0].relativePath, "mini.sdf");
 assert.equal(emptyProject.items.length, 0);
 assert.equal(matchaProject.isActive, true);
-assert.equal(matchaProject.items.length, 3);
+assert.equal(matchaProject.items.length, 4);
 assert.deepEqual(
   matchaProject.items.map((item) => ({ path: item.path, relativePath: item.relativePath, source: item.source, isPinned: item.isPinned })),
   [
@@ -80,6 +92,12 @@ assert.deepEqual(
     {
       path: "/Users/test/Matcha/ligands/mini.pdb",
       relativePath: "ligands/mini.pdb",
+      source: "open",
+      isPinned: false,
+    },
+    {
+      path: "/Users/test/Matcha/notes/readme.md",
+      relativePath: "notes/readme.md",
       source: "open",
       isPinned: false,
     },

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -1308,7 +1308,8 @@ assert.match(appOpenDropControllerHook, /useOpenEvents\(openPaths, pushErrorStat
 assert.doesNotMatch(app, /isTauriRuntime\(\) && !startupOpenSettled/);
 assert.match(app, /useAppSidebarProjects/);
 assert.match(appSidebarProjectsHook, /buildSidebarProjects/);
-assert.match(appSidebarProjectsHook, /buildSidebarProjects\(\{\s*documents,\s*recentStructures: sidebarRecentStructures,/);
+assert.match(appSidebarProjectsHook, /buildSidebarProjects\(\{\s*documents,\s*textDocuments,\s*recentStructures: sidebarRecentStructures,/);
+assert.match(app, /activeDocumentId: activeDocument\?\.id \?\? activeTextDocument\?\.id \?\? null/);
 assert.doesNotMatch(app, /recentStructures:\s*documents\.length === 0 \? recentStructures : \[\]/);
 assert.doesNotMatch(app, /from "\.\/lib\/temporary-documents"/);
 assert.doesNotMatch(app, /!isTemporaryDocumentPath\(activeTab\.location\.path\)/);
@@ -2641,6 +2642,13 @@ assert.match(structureInfoPanel, /<ToggleGroup\s+type="single"/);
 // A radio group is never empty: re-clicking the active option must not clear it.
 assert.match(structureInfoPanel, /onValueChange=\{\(next\) => \{ if \(next\) onChange\(next\); \}\}/);
 assert.match(structureInfoPanel, /<Badge variant="secondary">\{brief\.format\}<\/Badge>/);
+assert.ok(
+  structureInfoPanel.indexOf("<GridFilterSection model={gridFilterModel} actions={actions} />")
+    < structureInfoPanel.indexOf("{assemblySymmetry.available ? ("),
+  "grid filters should be the first inspector section after the document header",
+);
+assert.match(app, /activeDocument\?\.renderer === "grid2d" && activeGridFilterModel\?\.columns\.length/);
+assert.match(app, /setDockOpen\("right", true\);\s*setDockActiveTab\("right", "inspector"\);/);
 // The scene stepper is identified by the scene itself, not by the parser failing.
 assert.match(structureInfoPanel, /if \(sceneStructureCount > 1 && sceneStructureCount <= INFO_TRAJECTORY_CONTROL_LIMIT\)/);
 assert.match(structureInfoPanel, /function InlineSettingsSection\(\{ title, children \}/);
@@ -3784,7 +3792,10 @@ assert.match(sidebarProjects, /hiddenProjectRoots = \[\]/);
 assert.match(sidebarProjects, /const hiddenRoots = dedupeRoots\(hiddenProjectRoots\.filter\(\(root\) => !isTemporaryDocumentPath\(root\)\)\)/);
 assert.match(sidebarProjects, /if \(!explicitRootPath && resolveProjectRoot\(normalizedPath, hiddenProjectRoots\)\) return;/);
 assert.match(sidebarProjects, /const projectDocuments = documents\.filter\(isPersistentViewerDocument\)/);
-assert.match(sidebarProjects, /const openPaths = new Set\(projectDocuments\.map\(\(document\) => normalizePath\(document\.path\)\)\)/);
+assert.match(sidebarProjects, /const projectTextDocuments = textDocuments\.filter\(\(document\) => !isTemporaryDocumentPath\(document\.path\)\)/);
+assert.match(sidebarProjects, /const projectDocumentPaths = new Set\(projectDocuments\.map/);
+assert.match(sidebarProjects, /const openPaths = new Set\(\[\s*\.\.\.projectDocumentPaths,[\s\S]*\.\.\.projectTextDocuments\.map/);
+assert.match(sidebarProjects, /renderer: "renderer" in structure \? structure\.renderer : "text"/);
 assert.match(sidebarProjects, /for \(const document of projectDocuments\)/);
 assert.match(sidebarProjects, /recentStructures\.filter\(\(structure\) => !isTemporaryDocumentPath\(structure\.path\)\)/);
 assert.match(sidebarProjects, /function compareProjects\(left: SidebarProject, right: SidebarProject\) \{\s*if \(left\.isPinned !== right\.isPinned\) return left\.isPinned \? -1 : 1;\s*return left\.title\.localeCompare\(right\.title\);\s*\}/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -133,6 +133,7 @@ const [
   settingControl,
   dockPanel,
   structureInfoPanel,
+  gridFilterSection,
   foldingResultsPanel,
   foldingResultsLib,
   closeIcon,
@@ -340,6 +341,7 @@ const [
   source('apps/desktop/src/components/settings-panel/setting-control.tsx'),
   source('apps/desktop/src/components/dock-panel.tsx'),
   source('apps/desktop/src/components/structure-info-panel.tsx'),
+  source('apps/desktop/src/components/grid-filter-section.tsx'),
   source('apps/desktop/src/components/folding-results-panel.tsx'),
   source('apps/desktop/src/lib/folding-results.ts'),
   source('apps/desktop/src/components/close-icon.tsx'),
@@ -2649,6 +2651,8 @@ assert.ok(
 );
 assert.match(app, /activeDocument\?\.renderer === "grid2d" && activeGridFilterModel\?\.columns\.length/);
 assert.match(app, /setDockOpen\("right", true\);\s*setDockActiveTab\("right", "inspector"\);/);
+assert.match(gridFilterSection, /CHART_CONFIG = \{ count: \{ label: "Rows"/);
+assert.match(gridFilterSection, /model\.visible\.toLocaleString\(\)\} of \{model\.total\.toLocaleString\(\)\} rows/);
 // The scene stepper is identified by the scene itself, not by the parser failing.
 assert.match(structureInfoPanel, /if \(sceneStructureCount > 1 && sceneStructureCount <= INFO_TRAJECTORY_CONTROL_LIMIT\)/);
 assert.match(structureInfoPanel, /function InlineSettingsSection\(\{ title, children \}/);


### PR DESCRIPTION
## Why

Table filters were available only after manually opening the right dock and were buried below molecular-only inspector content. Files routed through the text document store could open successfully but never appeared in Projects.

## What Changed

- open the right-side Info dock when a table publishes filterable columns
- place column filters first in the inspector for molecular and generic CSV/TSV tables
- use neutral row counts for non-molecular tables
- include open text, code, and configuration documents in Projects without duplicating grid documents
- prepare the patch release metadata for 2.2.2

## Verification

- `bun run ci:fast` (518 Rust tests passed, 7 manual GPU tests ignored; all JS/contract suites passed)
- `bun tests/test-sidebar-projects.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `vp build`
- `bun run check:release`
- `./scripts/release.sh --dry-run`

## Notes

The in-app Browser rejected control of the localhost verification URL under its URL policy, so the visual interaction was not claimed as verified. Source contracts, focused behavior tests, the production frontend build, and the complete fast CI gate passed.
