### PR TITLE
Fix the SDF-collection All-background menu: rebuild races, defaults, export, and pose player

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.2.4;
+				MARKETING_VERSION = 2.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "base64 0.23.1",
  "burette-compute-core",

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -1935,7 +1935,10 @@
       documentId: cfg?.documentId || null,
       title,
       extension: 'sdf',
-      textBase64: textToBase64(records.join('\n')),
+      // Records already end with '\n$$$$\n'; joining with '\n' would leave a
+      // blank line after each delimiter, shifting every following record's
+      // header block down one line and losing the molecule names.
+      textBase64: textToBase64(records.join('')),
       controlLabel: 'Molecule',
       receptorPath: receptorPath || null
     });
@@ -2385,10 +2388,41 @@
       return (await Promise.all((rows || []).map(row => sdfRecordTextForMolstar(row))))
         .filter(text => typeof text === 'string' && text.trim().length > 0);
     }
+    // generate_aligned_coords() replaces conformers with a flat 2D depiction,
+    // which destroys docking poses and 3D overlays - records that already
+    // carry 3D coordinates go to Molstar untouched.
+    if (rows.every(row => sdfRowHasEmbedded3dCoordinates(row))) {
+      const original = (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
+        .filter(text => typeof text === 'string' && text.trim().length > 0);
+      if (original.length) return original;
+    }
     const aligned = await alignedSdfRecordTextsForMolstar(rows);
     if (aligned.length) return aligned;
     return (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
       .filter(text => typeof text === 'string' && text.trim().length > 0);
+  }
+
+  function sdfRowHasEmbedded3dCoordinates(row) {
+    const record = gridDragRecord(row);
+    if (!record || record.inputExtension !== 'sdf') return false;
+    const lines = String(record.text || '').split(/\r?\n/u);
+    const countsIndex = lines.findIndex(line => /\bV(2000|3000)\b/u.test(line));
+    if (countsIndex < 0) return false;
+    if (/\bV3000\b/u.test(lines[countsIndex])) {
+      return lines.some(line => {
+        if (!/^\s*M\s+V30\s+\d+\s+\S+\s+/u.test(line)) return false;
+        const z = Number(line.trim().split(/\s+/u)[6]);
+        return Number.isFinite(z) && Math.abs(z) > 1e-6;
+      });
+    }
+    const atomCount = Number.parseInt(lines[countsIndex].slice(0, 3).trim() || lines[countsIndex].trim().split(/\s+/u)[0], 10);
+    if (!Number.isFinite(atomCount) || atomCount <= 0) return false;
+    return lines.slice(countsIndex + 1, countsIndex + 1 + atomCount).some(line => {
+      const parts = line.trim().split(/\s+/u);
+      if (parts.length < 4) return false;
+      const z = Number(parts[2]);
+      return Number.isFinite(z) && Math.abs(z) > 1e-6;
+    });
   }
 
   async function alignedSdfRecordTextsForMolstar(rows) {

--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -2389,9 +2389,10 @@
         .filter(text => typeof text === 'string' && text.trim().length > 0);
     }
     // generate_aligned_coords() replaces conformers with a flat 2D depiction,
-    // which destroys docking poses and 3D overlays - records that already
-    // carry 3D coordinates go to Molstar untouched.
-    if (rows.every(row => sdfRowHasEmbedded3dCoordinates(row))) {
+    // which destroys docking poses and 3D overlays - if any selected record
+    // carries 3D coordinates the whole batch goes to Molstar untouched, or a
+    // 2D template row would flatten the 3D rows behind it.
+    if (rows.some(row => sdfRowHasEmbedded3dCoordinates(row))) {
       const original = (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
         .filter(text => typeof text === 'string' && text.trim().length > 0);
       if (original.length) return original;

--- a/PreviewExtension/Web/viewer-runtime.css
+++ b/PreviewExtension/Web/viewer-runtime.css
@@ -3237,6 +3237,10 @@ body.burette-mobile-host .buret-docking-poses button {
 }
 .buret-docking-poses.buret-docking-poses-animation-open .buret-docking-pose-animation {
   position: static;
+  /* max-content is only for the closed absolute state; once the row is back in
+     the flow it must take the control's width or the slider collapses to its
+     44px minimum instead of filling the space next to the FPS field. */
+  width: auto;
   max-height: 34px;
   margin-top: 6px;
   opacity: 1;

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -14254,7 +14254,13 @@
   function restoreSdfCollectionAlignment(prepared) {
     if (!sdfCollectionAlignment || prepared?.kind !== 'sdf-collection') return;
     if (prepared.collectionMolecules === sdfCollectionAlignment.collection.molecules) return;
-    if (xyzFrameOverlayRawSignature(rawStructureData(activeConfig)) !== sdfCollectionAlignment.signature) return;
+    let signature = '';
+    try {
+      signature = xyzFrameOverlayRawSignature(rawStructureData(activeConfig));
+    } catch (_) {
+      return;
+    }
+    if (signature !== sdfCollectionAlignment.signature) return;
     applySdfCollectionAlignmentLayers(prepared, sdfCollectionAlignment.collection);
   }
 

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -11065,6 +11065,19 @@
     return frames.every(frame => xyzFrameElementSignature(frame) === signature);
   }
 
+  // Matching element order is not enough for SDF collections: two isomers can
+  // share the element sequence with different bonding, and superimposing them
+  // by atom order reports a chemically meaningless RMSD.
+  function sdfCollectionBondSignature(molecule) {
+    return (molecule?.bonds || []).map(bond => `${bond.a}-${bond.b}:${bond.order}`).join(',');
+  }
+
+  function sdfCollectionTopologyUniform(molecules) {
+    if (!Array.isArray(molecules) || molecules.length < 2) return false;
+    const signature = sdfCollectionBondSignature(molecules[0]);
+    return molecules.every(molecule => sdfCollectionBondSignature(molecule) === signature);
+  }
+
   const XYZ_ALIGNMENT_GAIN_THRESHOLD = 0.5;
 
   function xyzFrameAlignmentGain(frames) {
@@ -17999,7 +18012,7 @@
     const alignmentSupported = Boolean(align) && (xyzAlignFrames
       ? xyzFramesAlignable(xyzAlignFrames)
       : sdfCollectionAlignFrames
-        ? xyzFramesAlignable(sdfCollectionAlignFrames)
+        ? xyzFramesAlignable(sdfCollectionAlignFrames) && sdfCollectionTopologyUniform(sdfAlignTarget.collectionMolecules)
         : Boolean(prepared.dockingSceneMode)
           && prepared.poses.length > 1
           && window.molstar?.BuretteSuperposition?.version === 1);
@@ -18461,15 +18474,23 @@
             }
             setTimeout(hideStatus, 2200);
           }).catch(error => {
-            if (enabling) sdfCollectionAlignment = null;
+            revertFailedSdfCollectionAlignment(enabling);
             setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
           }).finally(() => { align.disabled = false; });
         } catch (error) {
-          if (enabling) sdfCollectionAlignment = null;
+          revertFailedSdfCollectionAlignment(enabling);
           align.disabled = false;
           setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
           return Promise.resolve();
         }
+      };
+      // A rebuild that fails after the aligned layers were swapped in must put
+      // the originals back, or the button reads "Align" while the scene keeps
+      // aligned coordinates and the next toggle records them as the original.
+      const revertFailedSdfCollectionAlignment = (enabling) => {
+        if (!enabling) return;
+        if (sdfCollectionAlignment?.original) applySdfCollectionAlignmentLayers(sdfAlignTarget, sdfCollectionAlignment.original);
+        sdfCollectionAlignment = null;
       };
       align.addEventListener('click', () => { void toggleSdfCollectionAlignment(); });
     } else if (align && alignmentSupported) {

--- a/PreviewExtension/Web/viewer.js
+++ b/PreviewExtension/Web/viewer.js
@@ -1683,6 +1683,7 @@
   let activeSdfCollectionVisibilityState = null;
   let activeXyzFrameOverlayState = null;
   let xyzFrameAlignment = null;
+  let sdfCollectionAlignment = null;
   let activeDockingPoseCollectionState = null;
   let activeDockingSceneVisibilityState = null;
   let activeMolstarCacheBuster = null;
@@ -1841,6 +1842,9 @@
   }
 
   function normalizeSdfCollectionContextOpacity(value) {
+    // Number(null) and Number('') are 0, which would clamp a missing stored
+    // preference to the 4% floor instead of the intended 40% default.
+    if (value == null || value === '') return 0.4;
     const opacity = Number(value);
     if (!Number.isFinite(opacity)) return 0.4;
     return Math.max(0.04, Math.min(1, opacity));
@@ -14219,8 +14223,44 @@
     return builder?.struct?.generator?.all?.() || builder?.struct?.generator?.all || null;
   }
 
-  async function applySdfCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+  // Scene visibility rebuilds clear() the plugin and reload every layer, so two
+  // overlapping rebuilds corrupt the scene: each clears the other's half-loaded
+  // layers and both then append theirs, stacking duplicate structures and
+  // representations. Every externally triggered rebuild (context style/opacity/
+  // color actions, pose stepping, toolbar toggles) is serialized through this
+  // queue; callers that already run inside a rebuild use the *Now variants.
+  let molstarSceneRebuildChain = Promise.resolve();
+  function queueMolstarSceneRebuild(run) {
+    const job = molstarSceneRebuildChain.then(() => run(), () => run());
+    molstarSceneRebuildChain = job.then(() => undefined, () => undefined);
+    return job;
+  }
+
+  function applySdfCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applySdfCollectionVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  function applySdfCollectionAlignmentLayers(prepared, layers) {
+    prepared.data = layers.data;
+    prepared.collectionResidues = layers.residues;
+    prepared.collectionSinglePdbs = layers.singlePdbs;
+    prepared.collectionMolecules = layers.molecules;
+  }
+
+  // A theme or format reload rebuilds `prepared` from the raw file, which
+  // silently drops the aligned collection the user toggled on; when the stored
+  // alignment still matches this document, put the aligned layers back before
+  // the scene is built so the button and the scene cannot disagree.
+  function restoreSdfCollectionAlignment(prepared) {
+    if (!sdfCollectionAlignment || prepared?.kind !== 'sdf-collection') return;
+    if (prepared.collectionMolecules === sdfCollectionAlignment.collection.molecules) return;
+    if (xyzFrameOverlayRawSignature(rawStructureData(activeConfig)) !== sdfCollectionAlignment.signature) return;
+    applySdfCollectionAlignmentLayers(prepared, sdfCollectionAlignment.collection);
+  }
+
+  async function applySdfCollectionVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'sdf-collection') return;
+    restoreSdfCollectionAlignment(prepared);
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
       throw new Error('Mol* structure builders are not available in this runtime.');
@@ -14320,7 +14360,11 @@
     ]);
   }
 
-  async function applyDockingPoseCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyDockingPoseCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyDockingPoseCollectionVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyDockingPoseCollectionVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'docking' || prepared?.dockingSceneMode) return;
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
@@ -14388,7 +14432,11 @@
     if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'docking-poses', durationMs: 180 });
   }
 
-  async function applyXyzFrameOverlayVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyXyzFrameOverlayVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyXyzFrameOverlayVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyXyzFrameOverlayVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.xyzFrameOverlayAvailable !== true) return;
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
@@ -14700,7 +14748,11 @@
     return true;
   }
 
-  async function applyDockingSceneVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyDockingSceneVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyDockingSceneVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyDockingSceneVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'docking' || !prepared.dockingSceneMode) return;
     const plugin = viewer.plugin;
     if (activeSdfPoseMode !== 'all' && await applyDockingSceneSinglePose(viewer, prepared, activePose, options)) return;
@@ -14815,7 +14867,11 @@
       return themed({ type: 'spacefill', typeParams: withAlpha({ sizeFactor: ghost ? 0.28 : 0.45 }) });
     }
     if (normalized === 'molecular-surface') {
-      return themed({ type: 'molecular-surface', typeParams: withAlpha({ alpha: ghost ? 0.16 : 0.72 }) });
+      // A translucent background surface over a whole collection is re-sorted
+      // every frame; a coarser grid keeps it interactive without visibly
+      // changing a faded backdrop.
+      const typeParams = withAlpha({ alpha: ghost ? 0.16 : 0.72 });
+      return themed({ type: 'molecular-surface', typeParams: ghost ? { ...typeParams, resolution: 2 } : typeParams });
     }
     return themed({ type: 'ball-and-stick', typeParams: withAlpha({ sizeFactor: ghost ? 0.095 : 0.16 }) });
   }
@@ -15631,12 +15687,12 @@
       return;
     }
     if (prepared.kind === 'sdf-collection') {
-      await applySdfCollectionVisibility(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount));
+      await applySdfCollectionVisibilityNow(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount));
       installDockingPoseControls(viewer, trajectoryControlsForPrepared(prepared));
       return;
     }
     if (prepared.xyzFrameOverlayAvailable === true && (activeSdfPoseMode === 'all' || prepared.nativeTrajectoryControls !== true)) {
-      await applyXyzFrameOverlayVisibility(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount || prepared.xyzFrameCount));
+      await applyXyzFrameOverlayVisibilityNow(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount || prepared.xyzFrameCount));
       return;
     }
     if (prepared.loadPreset === 'all-models') {
@@ -15910,12 +15966,12 @@
     const plugin = viewer.plugin;
     activeDockingPrepared = prepared;
     if (prepared.dockingSceneMode) {
-      await applyDockingSceneVisibility(viewer, prepared, prepared.activePose);
+      await applyDockingSceneVisibilityNow(viewer, prepared, prepared.activePose);
       installDockingPoseControls(viewer, prepared);
       return;
     }
     if (prepared.sdfPoseOverlayAvailable === true) {
-      await applyDockingPoseCollectionVisibility(viewer, prepared, prepared.activePose);
+      await applyDockingPoseCollectionVisibilityNow(viewer, prepared, prepared.activePose);
       installDockingPoseControls(viewer, prepared);
       return;
     }
@@ -17745,6 +17801,15 @@
     let loopTimer = null;
     let loopActive = Boolean(playbackRestore?.playing);
     let loopBusy = false;
+    // Every loop tick rebuilds the active layer through a Mol* state
+    // transaction, which starves camera drags of main-thread time; while the
+    // pointer is held down on the viewport the loop skips ticks (the elapsed-
+    // time frame math catches the playhead up afterwards).
+    let loopPointerHeld = false;
+    const onLoopPointerDown = (event) => {
+      if (event.target instanceof Element && event.target.closest('.msp-viewport')) loopPointerHeld = true;
+    };
+    const onLoopPointerUp = () => { loopPointerHeld = false; };
     let loopEpoch = 0;
     let loopStartedAt = 0;
     let loopStartPose = activePose;
@@ -17852,7 +17917,22 @@
         || xyzFrameAlignmentGain(xyzCandidateFrames) > XYZ_ALIGNMENT_GAIN_THRESHOLD)
       ? xyzCandidateFrames
       : null;
-    const align = prepared.dockingSceneMode || xyzAlignFrames ? document.createElement('button') : null;
+    // The toolbar often receives a control summary from trajectoryControlsForPrepared
+    // rather than the loaded prepared object, and rebuilds run against the real one -
+    // so alignment reads and mutates activeMolstarPrepared, not the summary.
+    const sdfAlignTarget = prepared.kind === 'sdf-collection'
+      ? (activeMolstarPrepared?.kind === 'sdf-collection' ? activeMolstarPrepared : prepared)
+      : null;
+    let sdfAlignSignature = '';
+    if (sdfAlignTarget && Array.isArray(sdfAlignTarget.collectionMolecules)) {
+      try { sdfAlignSignature = xyzFrameOverlayRawSignature(rawStructureData(activeConfig)); } catch (_) {}
+    }
+    const sdfCollectionAlignFrames = sdfAlignSignature
+      ? sdfAlignTarget.collectionMolecules.map(molecule => ({
+        atoms: (molecule.atoms || []).map(atom => ({ symbol: atom.element, x: atom.x, y: atom.y, z: atom.z }))
+      }))
+      : null;
+    const align = prepared.dockingSceneMode || xyzAlignFrames || sdfCollectionAlignFrames ? document.createElement('button') : null;
     const storyAvailable = structureSceneStoryAvailable(prepared);
     const story = storyAvailable ? document.createElement('button') : null;
     const storyPanel = storyAvailable ? document.createElement('aside') : null;
@@ -17912,12 +17992,16 @@
     }
     const alignmentSupported = Boolean(align) && (xyzAlignFrames
       ? xyzFramesAlignable(xyzAlignFrames)
-      : Boolean(prepared.dockingSceneMode)
-        && prepared.poses.length > 1
-        && window.molstar?.BuretteSuperposition?.version === 1);
+      : sdfCollectionAlignFrames
+        ? xyzFramesAlignable(sdfCollectionAlignFrames)
+        : Boolean(prepared.dockingSceneMode)
+          && prepared.poses.length > 1
+          && window.molstar?.BuretteSuperposition?.version === 1);
     const alignmentOn = xyzAlignFrames
       ? xyzFrameAlignment?.signature === xyzAlignSignature
-      : prepared.structureAlignmentEnabled === true;
+      : sdfCollectionAlignFrames
+        ? sdfCollectionAlignment?.signature === sdfAlignSignature
+        : prepared.structureAlignmentEnabled === true;
     if (align) {
       align.type = 'button';
       align.className = 'buret-docking-pose-align';
@@ -17926,10 +18010,14 @@
       align.title = !alignmentSupported
         ? (xyzAlignFrames
           ? 'Alignment needs every structure to list the same atoms in the same order'
-          : 'Superposition needs two or more loaded structures')
+          : sdfCollectionAlignFrames
+            ? 'Alignment needs every molecule to list the same atoms in the same order'
+            : 'Superposition needs two or more loaded structures')
         : xyzAlignFrames
           ? 'Superimpose every structure onto the first one by atom order'
-          : 'Automatically superimpose every structure onto the first one';
+          : sdfCollectionAlignFrames
+            ? 'Superimpose every molecule onto the first one by atom order'
+            : 'Automatically superimpose every structure onto the first one';
       align.disabled = !alignmentSupported;
       align.setAttribute('aria-pressed', alignmentOn ? 'true' : 'false');
     }
@@ -18130,7 +18218,7 @@
       loopTimer = window.setTimeout(() => {
         loopTimer = null;
         if (!loopActive || expectedLoopEpoch !== loopEpoch) return;
-        if (loopBusy) {
+        if (loopBusy || loopPointerHeld) {
           scheduleLoopStep(undefined, expectedLoopEpoch);
           return;
         }
@@ -18320,6 +18408,64 @@
         }
       };
       align.addEventListener('click', () => { void toggleXyzAlignment(); });
+    } else if (align && alignmentSupported && sdfCollectionAlignFrames) {
+      const toggleSdfCollectionAlignment = () => {
+        align.disabled = true;
+        const enabling = sdfCollectionAlignment?.signature !== sdfAlignSignature;
+        try {
+          let result = null;
+          if (enabling) {
+            result = alignXyzFramesToFirst(sdfCollectionAlignFrames);
+            const alignedMolecules = sdfAlignTarget.collectionMolecules.map((molecule, index) => ({
+              ...molecule,
+              atoms: (molecule.atoms || []).map((atom, atomIndex) => {
+                const moved = result.frames[index].atoms[atomIndex];
+                return { ...atom, x: moved.x, y: moved.y, z: moved.z };
+              })
+            }));
+            const collection = sdfMoleculesToPdbCollection(alignedMolecules, sdfAlignTarget.label);
+            if (!collection) throw new Error('Could not rebuild the aligned molecule collection.');
+            sdfCollectionAlignment = {
+              signature: sdfAlignSignature,
+              collection,
+              original: {
+                data: sdfAlignTarget.data,
+                residues: sdfAlignTarget.collectionResidues,
+                singlePdbs: sdfAlignTarget.collectionSinglePdbs,
+                molecules: sdfAlignTarget.collectionMolecules
+              }
+            };
+            applySdfCollectionAlignmentLayers(sdfAlignTarget, collection);
+          } else {
+            const original = sdfCollectionAlignment?.original;
+            if (original) applySdfCollectionAlignmentLayers(sdfAlignTarget, original);
+            sdfCollectionAlignment = null;
+          }
+          resetSdfCollectionVisibilityState(viewer);
+          return applySdfCollectionVisibility(viewer, sdfAlignTarget, activePose, { focus: true }).then(() => {
+            align.textContent = enabling ? 'Aligned' : 'Align';
+            align.classList.toggle('active', enabling);
+            align.setAttribute('aria-pressed', enabling ? 'true' : 'false');
+            if (result) {
+              align.title = `Superimposed onto the first molecule by atom order · ${result.atomCount} atoms · average RMSD ${result.averageRmsd.toFixed(2)} Å`;
+              setStatus(`[web] Aligned ${sdfCollectionAlignFrames.length} molecules onto the first one by atom order (${result.atomCount} atoms, average RMSD ${result.averageRmsd.toFixed(2)} Å).`);
+            } else {
+              align.title = 'Superimpose every molecule onto the first one by atom order';
+              setStatus('[web] Restored original molecule coordinates.');
+            }
+            setTimeout(hideStatus, 2200);
+          }).catch(error => {
+            if (enabling) sdfCollectionAlignment = null;
+            setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
+          }).finally(() => { align.disabled = false; });
+        } catch (error) {
+          if (enabling) sdfCollectionAlignment = null;
+          align.disabled = false;
+          setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
+          return Promise.resolve();
+        }
+      };
+      align.addEventListener('click', () => { void toggleSdfCollectionAlignment(); });
     } else if (align && alignmentSupported) {
       structureAlignmentControl = createStructureSuperpositionController(
         viewer,
@@ -18504,7 +18650,15 @@
       }
     };
     window.addEventListener('keydown', onKeyDown);
-    dockingPoseKeydownDisposer = () => window.removeEventListener('keydown', onKeyDown);
+    window.addEventListener('pointerdown', onLoopPointerDown, true);
+    window.addEventListener('pointerup', onLoopPointerUp, true);
+    window.addEventListener('pointercancel', onLoopPointerUp, true);
+    dockingPoseKeydownDisposer = () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('pointerdown', onLoopPointerDown, true);
+      window.removeEventListener('pointerup', onLoopPointerUp, true);
+      window.removeEventListener('pointercancel', onLoopPointerUp, true);
+    };
     mainRow.append(animation, previous, label, next);
     const smoothAvailable = !xyzAlignFrames
       && (prepared.kind === 'trajectory' || prepared.kind === 'xyz-frame-overlay' || prepared.nativeTrajectoryControls);

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "base64 0.23.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.2.4"
+version = "2.2.5"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/components/structure-info-panel.tsx
+++ b/apps/desktop/src/components/structure-info-panel.tsx
@@ -102,7 +102,10 @@ const SDF_CONTEXT_STYLE_OPTIONS = [
 type SdfContextStyleOption = typeof SDF_CONTEXT_STYLE_OPTIONS[number];
 type SdfContextStyle = SdfContextStyleOption["value"];
 type SdfContextColor = "gray" | "colored";
-const XYZ_FRAME_CONTEXT_STYLE_OPTIONS = [
+// Small molecules have no polymer chains, so a cartoon representation falls
+// back to ball-and-stick inside the viewer; offering the button would just be
+// a second Ball+Stick. XYZ frames and SDF collections both use this subset.
+const SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS = [
   { value: "line", label: "Line" },
   { value: "ball-and-stick", label: "Ball+Stick" },
   { value: "spacefill", label: "Spacefill" },
@@ -110,6 +113,7 @@ const XYZ_FRAME_CONTEXT_STYLE_OPTIONS = [
   { value: "match", label: "Match" },
 ] as const satisfies readonly SdfContextStyleOption[];
 const SDF_CONTEXT_OPACITY_DEFAULT = 0.4;
+const SDF_CONTEXT_OPACITY_SEND_DELAY_MS = 150;
 const SDF_CONTEXT_OPACITY_MIN = 0.04;
 const SDF_CONTEXT_OPACITY_MAX = 1;
 const SDF_CONTEXT_STYLE_DEFAULT: SdfContextStyle = "match";
@@ -1429,6 +1433,7 @@ function structureContextStyleCardFor(
       detail: "Context molecules",
       styleAriaLabel: "All background style",
       opacityAriaLabel: "All background opacity",
+      styleOptions: SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS,
     };
   }
   const maestroEntryCount = maestroPreviewEntryCount(summary);
@@ -1447,7 +1452,7 @@ function structureContextStyleCardFor(
       detail: "Background frames",
       styleAriaLabel: "All background frame style",
       opacityAriaLabel: "All background frame opacity",
-      styleOptions: isXyzStructureDocument(document) ? XYZ_FRAME_CONTEXT_STYLE_OPTIONS : undefined,
+      styleOptions: isXyzStructureDocument(document) ? SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS : undefined,
     };
   }
   return null;
@@ -1788,6 +1793,9 @@ function normalizeSdfContextStyle(value: string | null | undefined): SdfContextS
 }
 
 function normalizeSdfContextOpacity(value: string | number | null | undefined) {
+  // Number(null) and Number("") are 0, which would clamp a missing stored
+  // preference to the 4% floor instead of the intended 40% default.
+  if (value == null || value === "") return SDF_CONTEXT_OPACITY_DEFAULT;
   const opacity = Number(value);
   if (!Number.isFinite(opacity)) return SDF_CONTEXT_OPACITY_DEFAULT;
   return Math.max(SDF_CONTEXT_OPACITY_MIN, Math.min(SDF_CONTEXT_OPACITY_MAX, opacity));
@@ -1948,16 +1956,27 @@ function SdfContextStyleCard({
       style,
     });
   };
+  // Dragging the slider fires input events for every pixel, and each viewer
+  // action rebuilds the whole background layer - so the send (not the local
+  // state) is debounced to the last value of the gesture.
+  const opacitySendTimer = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (opacitySendTimer.current !== null) window.clearTimeout(opacitySendTimer.current);
+  }, [document.id]);
   const applyOpacity = (nextOpacity: number) => {
     const normalized = normalizeSdfContextOpacity(nextOpacity);
     setOpacity(normalized);
     writeSdfContextOpacityPreference(document, normalized);
-    actions.runStructureViewerAction(document, {
-      type: "set_sdf_context_opacity",
-      label: `All background opacity: ${Math.round(normalized * 100)}%`,
-      notify: false,
-      opacity: normalized,
-    });
+    if (opacitySendTimer.current !== null) window.clearTimeout(opacitySendTimer.current);
+    opacitySendTimer.current = window.setTimeout(() => {
+      opacitySendTimer.current = null;
+      actions.runStructureViewerAction(document, {
+        type: "set_sdf_context_opacity",
+        label: `All background opacity: ${Math.round(normalized * 100)}%`,
+        notify: false,
+        opacity: normalized,
+      });
+    }, SDF_CONTEXT_OPACITY_SEND_DELAY_MS);
   };
   const applyColor = (nextColor: SdfContextColor) => {
     const normalized = normalizeSdfContextColor(nextColor);

--- a/apps/desktop/src/lib/structure-composition.ts
+++ b/apps/desktop/src/lib/structure-composition.ts
@@ -1109,7 +1109,18 @@ function parseMolCounts(text: string) {
 }
 
 function parseV2000MolCountsLine(line: string) {
-  const match = line.match(/^\s*(\d{1,3})\s+(\d{1,3})\b.*\bV2000\b/);
+  if (!/\bV2000\b/.test(line)) return null;
+  // The counts line is fixed-width (3 columns each), so atom and bond counts
+  // of 100+ fuse together ("120119  0…") and never match a whitespace split.
+  const fixedAtoms = line.slice(0, 3);
+  const fixedBonds = line.slice(3, 6);
+  if (/^\s*\d+\s*$/.test(fixedAtoms) && /^\s*\d+\s*$/.test(fixedBonds)) {
+    return {
+      atoms: Number.parseInt(fixedAtoms, 10),
+      bonds: Number.parseInt(fixedBonds, 10),
+    };
+  }
+  const match = line.match(/^\s*(\d{1,3})\s+(\d{1,3})\b/);
   if (!match) return null;
   return {
     atoms: Number.parseInt(match[1], 10),

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/plugins/burette-agent/preview-web/grid-viewer.js
+++ b/plugins/burette-agent/preview-web/grid-viewer.js
@@ -1935,7 +1935,10 @@
       documentId: cfg?.documentId || null,
       title,
       extension: 'sdf',
-      textBase64: textToBase64(records.join('\n')),
+      // Records already end with '\n$$$$\n'; joining with '\n' would leave a
+      // blank line after each delimiter, shifting every following record's
+      // header block down one line and losing the molecule names.
+      textBase64: textToBase64(records.join('')),
       controlLabel: 'Molecule',
       receptorPath: receptorPath || null
     });
@@ -2385,10 +2388,41 @@
       return (await Promise.all((rows || []).map(row => sdfRecordTextForMolstar(row))))
         .filter(text => typeof text === 'string' && text.trim().length > 0);
     }
+    // generate_aligned_coords() replaces conformers with a flat 2D depiction,
+    // which destroys docking poses and 3D overlays - records that already
+    // carry 3D coordinates go to Molstar untouched.
+    if (rows.every(row => sdfRowHasEmbedded3dCoordinates(row))) {
+      const original = (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
+        .filter(text => typeof text === 'string' && text.trim().length > 0);
+      if (original.length) return original;
+    }
     const aligned = await alignedSdfRecordTextsForMolstar(rows);
     if (aligned.length) return aligned;
     return (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
       .filter(text => typeof text === 'string' && text.trim().length > 0);
+  }
+
+  function sdfRowHasEmbedded3dCoordinates(row) {
+    const record = gridDragRecord(row);
+    if (!record || record.inputExtension !== 'sdf') return false;
+    const lines = String(record.text || '').split(/\r?\n/u);
+    const countsIndex = lines.findIndex(line => /\bV(2000|3000)\b/u.test(line));
+    if (countsIndex < 0) return false;
+    if (/\bV3000\b/u.test(lines[countsIndex])) {
+      return lines.some(line => {
+        if (!/^\s*M\s+V30\s+\d+\s+\S+\s+/u.test(line)) return false;
+        const z = Number(line.trim().split(/\s+/u)[6]);
+        return Number.isFinite(z) && Math.abs(z) > 1e-6;
+      });
+    }
+    const atomCount = Number.parseInt(lines[countsIndex].slice(0, 3).trim() || lines[countsIndex].trim().split(/\s+/u)[0], 10);
+    if (!Number.isFinite(atomCount) || atomCount <= 0) return false;
+    return lines.slice(countsIndex + 1, countsIndex + 1 + atomCount).some(line => {
+      const parts = line.trim().split(/\s+/u);
+      if (parts.length < 4) return false;
+      const z = Number(parts[2]);
+      return Number.isFinite(z) && Math.abs(z) > 1e-6;
+    });
   }
 
   async function alignedSdfRecordTextsForMolstar(rows) {

--- a/plugins/burette-agent/preview-web/grid-viewer.js
+++ b/plugins/burette-agent/preview-web/grid-viewer.js
@@ -2389,9 +2389,10 @@
         .filter(text => typeof text === 'string' && text.trim().length > 0);
     }
     // generate_aligned_coords() replaces conformers with a flat 2D depiction,
-    // which destroys docking poses and 3D overlays - records that already
-    // carry 3D coordinates go to Molstar untouched.
-    if (rows.every(row => sdfRowHasEmbedded3dCoordinates(row))) {
+    // which destroys docking poses and 3D overlays - if any selected record
+    // carries 3D coordinates the whole batch goes to Molstar untouched, or a
+    // 2D template row would flatten the 3D rows behind it.
+    if (rows.some(row => sdfRowHasEmbedded3dCoordinates(row))) {
       const original = (await Promise.all(rows.map(row => sdfRecordTextForMolstar(row))))
         .filter(text => typeof text === 'string' && text.trim().length > 0);
       if (original.length) return original;

--- a/plugins/burette-agent/preview-web/viewer-runtime.css
+++ b/plugins/burette-agent/preview-web/viewer-runtime.css
@@ -3237,6 +3237,10 @@ body.burette-mobile-host .buret-docking-poses button {
 }
 .buret-docking-poses.buret-docking-poses-animation-open .buret-docking-pose-animation {
   position: static;
+  /* max-content is only for the closed absolute state; once the row is back in
+     the flow it must take the control's width or the slider collapses to its
+     44px minimum instead of filling the space next to the FPS field. */
+  width: auto;
   max-height: 34px;
   margin-top: 6px;
   opacity: 1;

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -14254,7 +14254,13 @@
   function restoreSdfCollectionAlignment(prepared) {
     if (!sdfCollectionAlignment || prepared?.kind !== 'sdf-collection') return;
     if (prepared.collectionMolecules === sdfCollectionAlignment.collection.molecules) return;
-    if (xyzFrameOverlayRawSignature(rawStructureData(activeConfig)) !== sdfCollectionAlignment.signature) return;
+    let signature = '';
+    try {
+      signature = xyzFrameOverlayRawSignature(rawStructureData(activeConfig));
+    } catch (_) {
+      return;
+    }
+    if (signature !== sdfCollectionAlignment.signature) return;
     applySdfCollectionAlignmentLayers(prepared, sdfCollectionAlignment.collection);
   }
 

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -11065,6 +11065,19 @@
     return frames.every(frame => xyzFrameElementSignature(frame) === signature);
   }
 
+  // Matching element order is not enough for SDF collections: two isomers can
+  // share the element sequence with different bonding, and superimposing them
+  // by atom order reports a chemically meaningless RMSD.
+  function sdfCollectionBondSignature(molecule) {
+    return (molecule?.bonds || []).map(bond => `${bond.a}-${bond.b}:${bond.order}`).join(',');
+  }
+
+  function sdfCollectionTopologyUniform(molecules) {
+    if (!Array.isArray(molecules) || molecules.length < 2) return false;
+    const signature = sdfCollectionBondSignature(molecules[0]);
+    return molecules.every(molecule => sdfCollectionBondSignature(molecule) === signature);
+  }
+
   const XYZ_ALIGNMENT_GAIN_THRESHOLD = 0.5;
 
   function xyzFrameAlignmentGain(frames) {
@@ -17999,7 +18012,7 @@
     const alignmentSupported = Boolean(align) && (xyzAlignFrames
       ? xyzFramesAlignable(xyzAlignFrames)
       : sdfCollectionAlignFrames
-        ? xyzFramesAlignable(sdfCollectionAlignFrames)
+        ? xyzFramesAlignable(sdfCollectionAlignFrames) && sdfCollectionTopologyUniform(sdfAlignTarget.collectionMolecules)
         : Boolean(prepared.dockingSceneMode)
           && prepared.poses.length > 1
           && window.molstar?.BuretteSuperposition?.version === 1);
@@ -18461,15 +18474,23 @@
             }
             setTimeout(hideStatus, 2200);
           }).catch(error => {
-            if (enabling) sdfCollectionAlignment = null;
+            revertFailedSdfCollectionAlignment(enabling);
             setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
           }).finally(() => { align.disabled = false; });
         } catch (error) {
-          if (enabling) sdfCollectionAlignment = null;
+          revertFailedSdfCollectionAlignment(enabling);
           align.disabled = false;
           setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
           return Promise.resolve();
         }
+      };
+      // A rebuild that fails after the aligned layers were swapped in must put
+      // the originals back, or the button reads "Align" while the scene keeps
+      // aligned coordinates and the next toggle records them as the original.
+      const revertFailedSdfCollectionAlignment = (enabling) => {
+        if (!enabling) return;
+        if (sdfCollectionAlignment?.original) applySdfCollectionAlignmentLayers(sdfAlignTarget, sdfCollectionAlignment.original);
+        sdfCollectionAlignment = null;
       };
       align.addEventListener('click', () => { void toggleSdfCollectionAlignment(); });
     } else if (align && alignmentSupported) {

--- a/plugins/burette-agent/preview-web/viewer.js
+++ b/plugins/burette-agent/preview-web/viewer.js
@@ -1683,6 +1683,7 @@
   let activeSdfCollectionVisibilityState = null;
   let activeXyzFrameOverlayState = null;
   let xyzFrameAlignment = null;
+  let sdfCollectionAlignment = null;
   let activeDockingPoseCollectionState = null;
   let activeDockingSceneVisibilityState = null;
   let activeMolstarCacheBuster = null;
@@ -1841,6 +1842,9 @@
   }
 
   function normalizeSdfCollectionContextOpacity(value) {
+    // Number(null) and Number('') are 0, which would clamp a missing stored
+    // preference to the 4% floor instead of the intended 40% default.
+    if (value == null || value === '') return 0.4;
     const opacity = Number(value);
     if (!Number.isFinite(opacity)) return 0.4;
     return Math.max(0.04, Math.min(1, opacity));
@@ -14219,8 +14223,44 @@
     return builder?.struct?.generator?.all?.() || builder?.struct?.generator?.all || null;
   }
 
-  async function applySdfCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+  // Scene visibility rebuilds clear() the plugin and reload every layer, so two
+  // overlapping rebuilds corrupt the scene: each clears the other's half-loaded
+  // layers and both then append theirs, stacking duplicate structures and
+  // representations. Every externally triggered rebuild (context style/opacity/
+  // color actions, pose stepping, toolbar toggles) is serialized through this
+  // queue; callers that already run inside a rebuild use the *Now variants.
+  let molstarSceneRebuildChain = Promise.resolve();
+  function queueMolstarSceneRebuild(run) {
+    const job = molstarSceneRebuildChain.then(() => run(), () => run());
+    molstarSceneRebuildChain = job.then(() => undefined, () => undefined);
+    return job;
+  }
+
+  function applySdfCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applySdfCollectionVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  function applySdfCollectionAlignmentLayers(prepared, layers) {
+    prepared.data = layers.data;
+    prepared.collectionResidues = layers.residues;
+    prepared.collectionSinglePdbs = layers.singlePdbs;
+    prepared.collectionMolecules = layers.molecules;
+  }
+
+  // A theme or format reload rebuilds `prepared` from the raw file, which
+  // silently drops the aligned collection the user toggled on; when the stored
+  // alignment still matches this document, put the aligned layers back before
+  // the scene is built so the button and the scene cannot disagree.
+  function restoreSdfCollectionAlignment(prepared) {
+    if (!sdfCollectionAlignment || prepared?.kind !== 'sdf-collection') return;
+    if (prepared.collectionMolecules === sdfCollectionAlignment.collection.molecules) return;
+    if (xyzFrameOverlayRawSignature(rawStructureData(activeConfig)) !== sdfCollectionAlignment.signature) return;
+    applySdfCollectionAlignmentLayers(prepared, sdfCollectionAlignment.collection);
+  }
+
+  async function applySdfCollectionVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'sdf-collection') return;
+    restoreSdfCollectionAlignment(prepared);
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
       throw new Error('Mol* structure builders are not available in this runtime.');
@@ -14320,7 +14360,11 @@
     ]);
   }
 
-  async function applyDockingPoseCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyDockingPoseCollectionVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyDockingPoseCollectionVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyDockingPoseCollectionVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'docking' || prepared?.dockingSceneMode) return;
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
@@ -14388,7 +14432,11 @@
     if (options.focus !== false) scheduleMolstarStructureFocus(viewer, { reason: 'docking-poses', durationMs: 180 });
   }
 
-  async function applyXyzFrameOverlayVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyXyzFrameOverlayVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyXyzFrameOverlayVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyXyzFrameOverlayVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.xyzFrameOverlayAvailable !== true) return;
     const plugin = viewer.plugin;
     if (!plugin?.builders?.data?.rawData || !plugin?.builders?.structure?.parseTrajectory || !plugin?.builders?.structure?.hierarchy?.applyPreset) {
@@ -14700,7 +14748,11 @@
     return true;
   }
 
-  async function applyDockingSceneVisibility(viewer, prepared, activePose = 0, options = {}) {
+  function applyDockingSceneVisibility(viewer, prepared, activePose = 0, options = {}) {
+    return queueMolstarSceneRebuild(() => applyDockingSceneVisibilityNow(viewer, prepared, activePose, options));
+  }
+
+  async function applyDockingSceneVisibilityNow(viewer, prepared, activePose = 0, options = {}) {
     if (!viewer || prepared?.kind !== 'docking' || !prepared.dockingSceneMode) return;
     const plugin = viewer.plugin;
     if (activeSdfPoseMode !== 'all' && await applyDockingSceneSinglePose(viewer, prepared, activePose, options)) return;
@@ -14815,7 +14867,11 @@
       return themed({ type: 'spacefill', typeParams: withAlpha({ sizeFactor: ghost ? 0.28 : 0.45 }) });
     }
     if (normalized === 'molecular-surface') {
-      return themed({ type: 'molecular-surface', typeParams: withAlpha({ alpha: ghost ? 0.16 : 0.72 }) });
+      // A translucent background surface over a whole collection is re-sorted
+      // every frame; a coarser grid keeps it interactive without visibly
+      // changing a faded backdrop.
+      const typeParams = withAlpha({ alpha: ghost ? 0.16 : 0.72 });
+      return themed({ type: 'molecular-surface', typeParams: ghost ? { ...typeParams, resolution: 2 } : typeParams });
     }
     return themed({ type: 'ball-and-stick', typeParams: withAlpha({ sizeFactor: ghost ? 0.095 : 0.16 }) });
   }
@@ -15631,12 +15687,12 @@
       return;
     }
     if (prepared.kind === 'sdf-collection') {
-      await applySdfCollectionVisibility(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount));
+      await applySdfCollectionVisibilityNow(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount));
       installDockingPoseControls(viewer, trajectoryControlsForPrepared(prepared));
       return;
     }
     if (prepared.xyzFrameOverlayAvailable === true && (activeSdfPoseMode === 'all' || prepared.nativeTrajectoryControls !== true)) {
-      await applyXyzFrameOverlayVisibility(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount || prepared.xyzFrameCount));
+      await applyXyzFrameOverlayVisibilityNow(viewer, prepared, readTrajectoryControlIndex(activeConfig, prepared, prepared.poseCount || prepared.xyzFrameCount));
       return;
     }
     if (prepared.loadPreset === 'all-models') {
@@ -15910,12 +15966,12 @@
     const plugin = viewer.plugin;
     activeDockingPrepared = prepared;
     if (prepared.dockingSceneMode) {
-      await applyDockingSceneVisibility(viewer, prepared, prepared.activePose);
+      await applyDockingSceneVisibilityNow(viewer, prepared, prepared.activePose);
       installDockingPoseControls(viewer, prepared);
       return;
     }
     if (prepared.sdfPoseOverlayAvailable === true) {
-      await applyDockingPoseCollectionVisibility(viewer, prepared, prepared.activePose);
+      await applyDockingPoseCollectionVisibilityNow(viewer, prepared, prepared.activePose);
       installDockingPoseControls(viewer, prepared);
       return;
     }
@@ -17745,6 +17801,15 @@
     let loopTimer = null;
     let loopActive = Boolean(playbackRestore?.playing);
     let loopBusy = false;
+    // Every loop tick rebuilds the active layer through a Mol* state
+    // transaction, which starves camera drags of main-thread time; while the
+    // pointer is held down on the viewport the loop skips ticks (the elapsed-
+    // time frame math catches the playhead up afterwards).
+    let loopPointerHeld = false;
+    const onLoopPointerDown = (event) => {
+      if (event.target instanceof Element && event.target.closest('.msp-viewport')) loopPointerHeld = true;
+    };
+    const onLoopPointerUp = () => { loopPointerHeld = false; };
     let loopEpoch = 0;
     let loopStartedAt = 0;
     let loopStartPose = activePose;
@@ -17852,7 +17917,22 @@
         || xyzFrameAlignmentGain(xyzCandidateFrames) > XYZ_ALIGNMENT_GAIN_THRESHOLD)
       ? xyzCandidateFrames
       : null;
-    const align = prepared.dockingSceneMode || xyzAlignFrames ? document.createElement('button') : null;
+    // The toolbar often receives a control summary from trajectoryControlsForPrepared
+    // rather than the loaded prepared object, and rebuilds run against the real one -
+    // so alignment reads and mutates activeMolstarPrepared, not the summary.
+    const sdfAlignTarget = prepared.kind === 'sdf-collection'
+      ? (activeMolstarPrepared?.kind === 'sdf-collection' ? activeMolstarPrepared : prepared)
+      : null;
+    let sdfAlignSignature = '';
+    if (sdfAlignTarget && Array.isArray(sdfAlignTarget.collectionMolecules)) {
+      try { sdfAlignSignature = xyzFrameOverlayRawSignature(rawStructureData(activeConfig)); } catch (_) {}
+    }
+    const sdfCollectionAlignFrames = sdfAlignSignature
+      ? sdfAlignTarget.collectionMolecules.map(molecule => ({
+        atoms: (molecule.atoms || []).map(atom => ({ symbol: atom.element, x: atom.x, y: atom.y, z: atom.z }))
+      }))
+      : null;
+    const align = prepared.dockingSceneMode || xyzAlignFrames || sdfCollectionAlignFrames ? document.createElement('button') : null;
     const storyAvailable = structureSceneStoryAvailable(prepared);
     const story = storyAvailable ? document.createElement('button') : null;
     const storyPanel = storyAvailable ? document.createElement('aside') : null;
@@ -17912,12 +17992,16 @@
     }
     const alignmentSupported = Boolean(align) && (xyzAlignFrames
       ? xyzFramesAlignable(xyzAlignFrames)
-      : Boolean(prepared.dockingSceneMode)
-        && prepared.poses.length > 1
-        && window.molstar?.BuretteSuperposition?.version === 1);
+      : sdfCollectionAlignFrames
+        ? xyzFramesAlignable(sdfCollectionAlignFrames)
+        : Boolean(prepared.dockingSceneMode)
+          && prepared.poses.length > 1
+          && window.molstar?.BuretteSuperposition?.version === 1);
     const alignmentOn = xyzAlignFrames
       ? xyzFrameAlignment?.signature === xyzAlignSignature
-      : prepared.structureAlignmentEnabled === true;
+      : sdfCollectionAlignFrames
+        ? sdfCollectionAlignment?.signature === sdfAlignSignature
+        : prepared.structureAlignmentEnabled === true;
     if (align) {
       align.type = 'button';
       align.className = 'buret-docking-pose-align';
@@ -17926,10 +18010,14 @@
       align.title = !alignmentSupported
         ? (xyzAlignFrames
           ? 'Alignment needs every structure to list the same atoms in the same order'
-          : 'Superposition needs two or more loaded structures')
+          : sdfCollectionAlignFrames
+            ? 'Alignment needs every molecule to list the same atoms in the same order'
+            : 'Superposition needs two or more loaded structures')
         : xyzAlignFrames
           ? 'Superimpose every structure onto the first one by atom order'
-          : 'Automatically superimpose every structure onto the first one';
+          : sdfCollectionAlignFrames
+            ? 'Superimpose every molecule onto the first one by atom order'
+            : 'Automatically superimpose every structure onto the first one';
       align.disabled = !alignmentSupported;
       align.setAttribute('aria-pressed', alignmentOn ? 'true' : 'false');
     }
@@ -18130,7 +18218,7 @@
       loopTimer = window.setTimeout(() => {
         loopTimer = null;
         if (!loopActive || expectedLoopEpoch !== loopEpoch) return;
-        if (loopBusy) {
+        if (loopBusy || loopPointerHeld) {
           scheduleLoopStep(undefined, expectedLoopEpoch);
           return;
         }
@@ -18320,6 +18408,64 @@
         }
       };
       align.addEventListener('click', () => { void toggleXyzAlignment(); });
+    } else if (align && alignmentSupported && sdfCollectionAlignFrames) {
+      const toggleSdfCollectionAlignment = () => {
+        align.disabled = true;
+        const enabling = sdfCollectionAlignment?.signature !== sdfAlignSignature;
+        try {
+          let result = null;
+          if (enabling) {
+            result = alignXyzFramesToFirst(sdfCollectionAlignFrames);
+            const alignedMolecules = sdfAlignTarget.collectionMolecules.map((molecule, index) => ({
+              ...molecule,
+              atoms: (molecule.atoms || []).map((atom, atomIndex) => {
+                const moved = result.frames[index].atoms[atomIndex];
+                return { ...atom, x: moved.x, y: moved.y, z: moved.z };
+              })
+            }));
+            const collection = sdfMoleculesToPdbCollection(alignedMolecules, sdfAlignTarget.label);
+            if (!collection) throw new Error('Could not rebuild the aligned molecule collection.');
+            sdfCollectionAlignment = {
+              signature: sdfAlignSignature,
+              collection,
+              original: {
+                data: sdfAlignTarget.data,
+                residues: sdfAlignTarget.collectionResidues,
+                singlePdbs: sdfAlignTarget.collectionSinglePdbs,
+                molecules: sdfAlignTarget.collectionMolecules
+              }
+            };
+            applySdfCollectionAlignmentLayers(sdfAlignTarget, collection);
+          } else {
+            const original = sdfCollectionAlignment?.original;
+            if (original) applySdfCollectionAlignmentLayers(sdfAlignTarget, original);
+            sdfCollectionAlignment = null;
+          }
+          resetSdfCollectionVisibilityState(viewer);
+          return applySdfCollectionVisibility(viewer, sdfAlignTarget, activePose, { focus: true }).then(() => {
+            align.textContent = enabling ? 'Aligned' : 'Align';
+            align.classList.toggle('active', enabling);
+            align.setAttribute('aria-pressed', enabling ? 'true' : 'false');
+            if (result) {
+              align.title = `Superimposed onto the first molecule by atom order · ${result.atomCount} atoms · average RMSD ${result.averageRmsd.toFixed(2)} Å`;
+              setStatus(`[web] Aligned ${sdfCollectionAlignFrames.length} molecules onto the first one by atom order (${result.atomCount} atoms, average RMSD ${result.averageRmsd.toFixed(2)} Å).`);
+            } else {
+              align.title = 'Superimpose every molecule onto the first one by atom order';
+              setStatus('[web] Restored original molecule coordinates.');
+            }
+            setTimeout(hideStatus, 2200);
+          }).catch(error => {
+            if (enabling) sdfCollectionAlignment = null;
+            setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
+          }).finally(() => { align.disabled = false; });
+        } catch (error) {
+          if (enabling) sdfCollectionAlignment = null;
+          align.disabled = false;
+          setStatus(`[web] Could not align molecules.\n\n${error?.message || String(error)}`, 'error');
+          return Promise.resolve();
+        }
+      };
+      align.addEventListener('click', () => { void toggleSdfCollectionAlignment(); });
     } else if (align && alignmentSupported) {
       structureAlignmentControl = createStructureSuperpositionController(
         viewer,
@@ -18504,7 +18650,15 @@
       }
     };
     window.addEventListener('keydown', onKeyDown);
-    dockingPoseKeydownDisposer = () => window.removeEventListener('keydown', onKeyDown);
+    window.addEventListener('pointerdown', onLoopPointerDown, true);
+    window.addEventListener('pointerup', onLoopPointerUp, true);
+    window.addEventListener('pointercancel', onLoopPointerUp, true);
+    dockingPoseKeydownDisposer = () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('pointerdown', onLoopPointerDown, true);
+      window.removeEventListener('pointerup', onLoopPointerUp, true);
+      window.removeEventListener('pointercancel', onLoopPointerUp, true);
+    };
     mainRow.append(animation, previous, label, next);
     const smoothAvailable = !xyzAlignFrames
       && (prepared.kind === 'trajectory' || prepared.kind === 'xyz-frame-overlay' || prepared.nativeTrajectoryControls);

--- a/tests/test-structure-brief.mjs
+++ b/tests/test-structure-brief.mjs
@@ -258,6 +258,31 @@ assert.ok(duplicateTitleSdfComposition);
 assert.equal(rowValue(duplicateTitleSdfComposition.componentRows, "Molecule 1"), "1 atom / 0 bonds");
 assert.equal(rowValue(duplicateTitleSdfComposition.componentRows, "Molecule 2"), "1 atom / 0 bonds");
 
+// The V2000 counts line is fixed-width: 100+ atoms and 100+ bonds fuse into
+// "120119", which a whitespace split misreads as zero atoms.
+const fusedCountsSdfComposition = parseStructureComposition([
+  "Big molecule",
+  "  Burette",
+  "",
+  "120119  0  0  0  0  0  0  0  0999 V2000",
+  "    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",
+  "M  END",
+  "$$$$",
+  "Small molecule",
+  "  Burette",
+  "",
+  "  2  1  0  0  0  0            999 V2000",
+  "    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",
+  "    1.2000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0",
+  "  1  2  1  0  0  0  0",
+  "M  END",
+  "$$$$",
+].join("\n"), "sdf");
+assert.ok(fusedCountsSdfComposition);
+assert.equal(rowValue(fusedCountsSdfComposition.componentRows, "Big molecule"), "120 atoms / 119 bonds");
+assert.equal(rowValue(fusedCountsSdfComposition.componentRows, "Small molecule"), "2 atoms / 1 bond");
+assert.equal(rowValue(fusedCountsSdfComposition.rows, "Atoms"), "122");
+
 for (const extension of ["csv", "tsv"]) {
   assert.equal(documentKind(document(extension)), "Molecule collection", extension);
   assert.equal(rowValue(usefulElements(document(extension)), "Table"), "Rows and columns available in grid", extension);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -6708,7 +6708,14 @@ assert.match(previewViewer, /type: 'molecular-surface', typeParams: ghost \? \{ 
 // reload rebuilds `prepared` from the raw file.
 assert.match(previewViewer, /const sdfCollectionAlignFrames = sdfAlignSignature/);
 assert.match(previewViewer, /const align = prepared\.dockingSceneMode \|\| xyzAlignFrames \|\| sdfCollectionAlignFrames \? document\.createElement\('button'\) : null/);
-assert.match(previewViewer, /sdfCollectionAlignFrames\s*\? xyzFramesAlignable\(sdfCollectionAlignFrames\)/);
+// Element order alone is not enough: isomers share the element sequence with
+// different bonding, so SDF alignment also requires uniform bond topology.
+assert.match(previewViewer, /sdfCollectionAlignFrames\s*\? xyzFramesAlignable\(sdfCollectionAlignFrames\) && sdfCollectionTopologyUniform\(sdfAlignTarget\.collectionMolecules\)/);
+assert.match(previewViewer, /function sdfCollectionTopologyUniform\(molecules\)/);
+// A rebuild that fails after aligned layers were swapped in must restore the
+// originals, or the scene keeps aligned coordinates behind an "Align" button.
+assert.match(previewViewer, /const revertFailedSdfCollectionAlignment = \(enabling\) => \{/);
+assert.match(previewViewer, /if \(sdfCollectionAlignment\?\.original\) applySdfCollectionAlignmentLayers\(sdfAlignTarget, sdfCollectionAlignment\.original\);/);
 assert.match(previewViewer, /'Alignment needs every molecule to list the same atoms in the same order'/);
 assert.match(previewViewer, /else if \(align && alignmentSupported && sdfCollectionAlignFrames\) \{/);
 assert.match(previewViewer, /function restoreSdfCollectionAlignment\(prepared\)/);
@@ -7856,10 +7863,11 @@ assert.match(gridViewer, /function selectedMolstarRows\(\)/);
 assert.match(gridViewer, /function sdfRecordTextForMolstar\(row\)/);
 assert.match(gridViewer, /function smilesRecordTextForMolstar\(row\)/);
 assert.match(gridViewer, /function sdfRecordTextsForMolstar\(rows\)/);
-// generate_aligned_coords() flattens conformers to a 2D depiction, so records
-// that already carry 3D coordinates are exported to Molstar untouched.
+// generate_aligned_coords() flattens conformers to a 2D depiction; if any
+// selected record carries 3D coordinates the whole batch skips the 2D align,
+// or a 2D template row would flatten the 3D rows behind it.
 assert.match(gridViewer, /function sdfRowHasEmbedded3dCoordinates\(row\)/);
-assert.match(gridViewer, /if \(rows\.every\(row => sdfRowHasEmbedded3dCoordinates\(row\)\)\) \{/);
+assert.match(gridViewer, /if \(rows\.some\(row => sdfRowHasEmbedded3dCoordinates\(row\)\)\) \{/);
 assert.match(gridViewer, /function alignedSdfRecordTextsForMolstar\(rows\)/);
 assert.match(gridViewer, /function rdkitMolForMolstarRow\(rdkit, row\)/);
 assert.match(gridViewer, /function alignedMolblockForMolstar\(mol, templateMol\)/);

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2686,9 +2686,12 @@ assert.match(structureInfoPanel, /const SDF_CONTEXT_STYLE_OPTIONS = \[/);
 assert.match(structureInfoPanel, /\{ value: "line", label: "Line" \}/);
 assert.match(structureInfoPanel, /\{ value: "cartoon", label: "Cartoon" \}/);
 assert.match(structureInfoPanel, /\{ value: "match", label: "Match" \}/);
-assert.match(structureInfoPanel, /const XYZ_FRAME_CONTEXT_STYLE_OPTIONS = \[/);
+assert.match(structureInfoPanel, /const SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS = \[/);
 assert.match(structureInfoPanel, /\{ value: "molecular-surface", label: "Surface" \},\s*\{ value: "match", label: "Match" \},\s*\] as const satisfies readonly SdfContextStyleOption\[\]/);
-assert.match(structureInfoPanel, /styleOptions: isXyzStructureDocument\(document\) \? XYZ_FRAME_CONTEXT_STYLE_OPTIONS : undefined/);
+assert.match(structureInfoPanel, /styleOptions: isXyzStructureDocument\(document\) \? SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS : undefined/);
+// Cartoon falls back to ball-and-stick for small molecules, so SDF collections
+// offer the small-molecule subset instead of a second Ball+Stick button.
+assert.match(structureInfoPanel, /detail: "Context molecules",[\s\S]*?styleOptions: SMALL_MOLECULE_CONTEXT_STYLE_OPTIONS,/);
 assert.doesNotMatch(structureInfoPanel, /option\.value !== "match" && option\.value !== "cartoon" && option\.value !== "spacefill"/);
 assert.match(structureInfoPanel, /const SDF_CONTEXT_OPACITY_MAX = 1/);
 assert.match(structureInfoPanel, /const INFO_TRAJECTORY_CONTROL_LIMIT = 200/);
@@ -5930,7 +5933,7 @@ assert.match(previewViewer, /kind: 'docking'/);
 assert.match(previewViewer, /function loadDockingPreparedStructure\(viewer, prepared\)/);
 assert.match(previewViewer, /const hasStoryKey = entries\.some\(entry => typeof entry\?\.key === 'string' && entry\.key\.trim\(\)\)/);
 assert.match(previewViewer, /activeMolstarPrepared\.mvsKind === 'multiple' \|\| entries\.length > 1 \|\| hasStoryKey/);
-assert.match(previewViewer, /if \(prepared\.dockingSceneMode\) \{\s*await applyDockingSceneVisibility\(viewer, prepared, prepared\.activePose\);\s*installDockingPoseControls\(viewer, prepared\);\s*return;\s*\}/);
+assert.match(previewViewer, /if \(prepared\.dockingSceneMode\) \{\s*await applyDockingSceneVisibilityNow\(viewer, prepared, prepared\.activePose\);\s*installDockingPoseControls\(viewer, prepared\);\s*return;\s*\}/);
 assert.match(previewViewer, /function installDockingPoseControls\(viewer, prepared\)/);
 assert.match(previewViewer, /className = 'buret-docking-poses'/);
 assert.match(previewViewer, /document\.body\.classList\.add\('buret-docking-pose-controls-active'\)/);
@@ -6588,11 +6591,11 @@ for (const runtimeSource of [previewViewer]) {
   assert.match(runtimeSource, /function xyzFrameBackgroundLayerOpacity\(contextOpacity, layerCount\)/);
   assert.match(runtimeSource, /return 1 - Math\.pow\(1 - opacity, 1 \/ count\)/);
   assert.match(runtimeSource, /function readXyzFrameContextColor\(config\)/);
-  assert.match(runtimeSource, /async function applySdfCollectionVisibility\(viewer, prepared, activePose = 0, options = \{\}\)[\s\S]*?const contextColor = options\.contextColor \?\? readSdfCollectionContextColor\(activeConfig\)/);
+  assert.match(runtimeSource, /async function applySdfCollectionVisibilityNow\(viewer, prepared, activePose = 0, options = \{\}\)[\s\S]*?const contextColor = options\.contextColor \?\? readSdfCollectionContextColor\(activeConfig\)/);
   assert.match(runtimeSource, /async function applyXyzFrameMolstarStyle\(viewer, style, structures = null, alpha = 1, colorMode = 'gray', minAlpha = 0\.04\)/);
   assert.match(runtimeSource, /const foregroundStyle = xyzFrameForegroundStyle\(style\)/);
   assert.match(runtimeSource, /const resolvedContextStyle = xyzFrameBackgroundStyle\(contextStyle, foregroundStyle\)/);
-  assert.match(runtimeSource, /async function applyXyzFrameOverlayVisibility\(viewer, prepared, activePose = 0, options = \{\}\)[\s\S]*?const contextColor = options\.contextColor \?\? readXyzFrameContextColor\(activeConfig\)/);
+  assert.match(runtimeSource, /async function applyXyzFrameOverlayVisibilityNow\(viewer, prepared, activePose = 0, options = \{\}\)[\s\S]*?const contextColor = options\.contextColor \?\? readXyzFrameContextColor\(activeConfig\)/);
   assert.match(runtimeSource, /if \(activeSdfPoseMode !== 'all' \|\| !structureOverlayToggleAvailable\(prepared\)\) \{[\s\S]*?resetXyzFrameOverlayState\(viewer\);[\s\S]*?const activeEntry = xyzFrameEntry\(frames\[activeIndex\]/);
   assert.match(runtimeSource, /await loadMolstarEntryWithStructureRefs\(viewer, activeEntry, \{ representationPreset: 'empty' \}\)/);
   assert.match(runtimeSource, /await applyXyzFrameMolstarStyle\(viewer, foregroundStyle, activeStructures, 1, 'colored'\)/);
@@ -6613,7 +6616,7 @@ for (const runtimeSource of [previewViewer]) {
 }
 assert.match(previewViewer, /const label = prepared\?\.controlLabel \|\| \(activeConfig\?\.sdfPosePager === true \? 'Pose' : 'Model'\)/);
 assert.match(previewViewer, /installDockingPoseControls\(viewer, trajectoryControlsForPrepared\(prepared\)\)/);
-assert.match(previewViewer, /if \(prepared\.xyzFrameOverlayAvailable === true && \(activeSdfPoseMode === 'all' \|\| prepared\.nativeTrajectoryControls !== true\)\) \{\s*await applyXyzFrameOverlayVisibility\(viewer, prepared, readTrajectoryControlIndex\(activeConfig, prepared, prepared\.poseCount \|\| prepared\.xyzFrameCount\)\);\s*return;\s*\}/);
+assert.match(previewViewer, /if \(prepared\.xyzFrameOverlayAvailable === true && \(activeSdfPoseMode === 'all' \|\| prepared\.nativeTrajectoryControls !== true\)\) \{\s*await applyXyzFrameOverlayVisibilityNow\(viewer, prepared, readTrajectoryControlIndex\(activeConfig, prepared, prepared\.poseCount \|\| prepared\.xyzFrameCount\)\);\s*return;\s*\}/);
 assert.match(previewViewer, /async function reloadActiveMolstarStructure\(\)/);
 assert.match(previewViewer, /const prepared = structureDataForMolstar\(config\)/);
 assert.match(previewViewer, /activeMolstarPrepared\?\.kind === 'docking' && activeMolstarPrepared\?\.dockingSceneMode[\s\S]*await applyDockingSceneVisibility\(activeViewer, activeMolstarPrepared, activePose, \{ focus: false \}\);/);
@@ -6675,6 +6678,50 @@ assert.match(previewViewer, /const SDF_CONTEXT_OPACITY_STORAGE_KEY = 'buret\.sdf
 assert.match(previewViewer, /function normalizeSdfCollectionContextStyle\(value\)/);
 assert.match(previewViewer, /\['line', 'ball-and-stick', 'cartoon', 'spacefill', 'molecular-surface', 'match'\]\.includes\(normalized\)/);
 assert.match(previewViewer, /function normalizeSdfCollectionContextOpacity\(value\)/);
+// Number(null) is 0, so a missing stored preference must return the 40%
+// default instead of clamping to the 4% floor - on both sides of the bridge.
+assert.match(previewViewer, /function normalizeSdfCollectionContextOpacity\(value\) \{[\s\S]*?if \(value == null \|\| value === ''\) return 0\.4;/);
+assert.match(structureInfoPanel, /function normalizeSdfContextOpacity\(value: string \| number \| null \| undefined\) \{[\s\S]*?if \(value == null \|\| value === ""\) return SDF_CONTEXT_OPACITY_DEFAULT;/);
+// Scene rebuilds clear() the plugin and reload every layer, so concurrent
+// rebuilds (slider drags, rapid style clicks) must run through one queue -
+// while loadPreparedStructure keeps calling the *Now variants to avoid
+// deadlocking the queue from inside a running rebuild.
+assert.match(previewViewer, /function queueMolstarSceneRebuild\(run\)/);
+assert.match(previewViewer, /function applySdfCollectionVisibility\(viewer, prepared, activePose = 0, options = \{\}\) \{\s*return queueMolstarSceneRebuild\(\(\) => applySdfCollectionVisibilityNow\(viewer, prepared, activePose, options\)\);/);
+assert.match(previewViewer, /function applyDockingPoseCollectionVisibility\(viewer, prepared, activePose = 0, options = \{\}\) \{\s*return queueMolstarSceneRebuild\(\(\) => applyDockingPoseCollectionVisibilityNow\(viewer, prepared, activePose, options\)\);/);
+assert.match(previewViewer, /function applyXyzFrameOverlayVisibility\(viewer, prepared, activePose = 0, options = \{\}\) \{\s*return queueMolstarSceneRebuild\(\(\) => applyXyzFrameOverlayVisibilityNow\(viewer, prepared, activePose, options\)\);/);
+assert.match(previewViewer, /function applyDockingSceneVisibility\(viewer, prepared, activePose = 0, options = \{\}\) \{\s*return queueMolstarSceneRebuild\(\(\) => applyDockingSceneVisibilityNow\(viewer, prepared, activePose, options\)\);/);
+assert.match(previewViewer, /if \(prepared\.kind === 'sdf-collection'\) \{\s*await applySdfCollectionVisibilityNow\(viewer, prepared,/);
+assert.match(previewViewer, /await applyXyzFrameOverlayVisibilityNow\(viewer, prepared, readTrajectoryControlIndex\(/);
+assert.match(previewViewer, /if \(prepared\.dockingSceneMode\) \{\s*await applyDockingSceneVisibilityNow\(viewer, prepared, prepared\.activePose\);/);
+assert.match(previewViewer, /if \(prepared\.sdfPoseOverlayAvailable === true\) \{\s*await applyDockingPoseCollectionVisibilityNow\(viewer, prepared, prepared\.activePose\);/);
+// The slider fires per pixel; the send is debounced while local state and the
+// stored preference update immediately.
+assert.match(structureInfoPanel, /const SDF_CONTEXT_OPACITY_SEND_DELAY_MS = 150/);
+assert.match(structureInfoPanel, /opacitySendTimer\.current = window\.setTimeout\(\(\) => \{[\s\S]*?type: "set_sdf_context_opacity",[\s\S]*?opacity: normalized,[\s\S]*?\}, SDF_CONTEXT_OPACITY_SEND_DELAY_MS\)/);
+// A ghost background surface over a whole collection would be re-sorted every
+// frame at full grid resolution; the coarser grid keeps it interactive.
+assert.match(previewViewer, /type: 'molecular-surface', typeParams: ghost \? \{ \.\.\.typeParams, resolution: 2 \} : typeParams/);
+// SDF collections get the same atom-order Align toggle the XYZ overlay has:
+// enabled for homogeneous collections (conformers/poses of one molecule),
+// visible-but-disabled with an explanation otherwise, and re-applied when a
+// reload rebuilds `prepared` from the raw file.
+assert.match(previewViewer, /const sdfCollectionAlignFrames = sdfAlignSignature/);
+assert.match(previewViewer, /const align = prepared\.dockingSceneMode \|\| xyzAlignFrames \|\| sdfCollectionAlignFrames \? document\.createElement\('button'\) : null/);
+assert.match(previewViewer, /sdfCollectionAlignFrames\s*\? xyzFramesAlignable\(sdfCollectionAlignFrames\)/);
+assert.match(previewViewer, /'Alignment needs every molecule to list the same atoms in the same order'/);
+assert.match(previewViewer, /else if \(align && alignmentSupported && sdfCollectionAlignFrames\) \{/);
+assert.match(previewViewer, /function restoreSdfCollectionAlignment\(prepared\)/);
+assert.match(previewViewer, /restoreSdfCollectionAlignment\(prepared\);/);
+// Loop ticks rebuild the active layer through Mol* state transactions, which
+// starves camera drags; while the pointer is held on the viewport the loop
+// skips ticks and the elapsed-time frame math catches up afterwards.
+assert.match(previewViewer, /let loopPointerHeld = false/);
+assert.match(previewViewer, /if \(loopBusy \|\| loopPointerHeld\) \{/);
+assert.match(previewViewer, /window\.addEventListener\('pointerdown', onLoopPointerDown, true\)/);
+// The playback row keeps max-content only while closed; open it must take the
+// control's width or the slider collapses to its 44px minimum.
+assert.match(previewRuntimeCss, /buret-docking-poses-animation-open \.buret-docking-pose-animation \{\s*position: static;[\s\S]*?width: auto;/);
 assert.match(previewViewer, /if \(!Number\.isFinite\(opacity\)\) return 0\.4/);
 assert.match(previewViewer, /function readSdfCollectionContextStyle\(config\)/);
 assert.match(previewViewer, /function readSdfCollectionContextOpacity\(config\)/);
@@ -6708,7 +6755,7 @@ assert.match(previewViewer, /await applySdfCollectionMolstarStyle\(\s*viewer,\s*
 assert.match(previewViewer, /const structures = await loadSdfCollectionPdbLayer\(viewer, activeData, label\)/);
 assert.match(previewViewer, /await applySdfCollectionMolstarStyle\(viewer, style, structures, 1, 'colored'\)/);
 assert.match(previewViewer, /function dockingPoseCollectionStateKey\(prepared, style, allMode, contextStyle, contextOpacity, contextColor\)/);
-assert.match(previewViewer, /async function applyDockingPoseCollectionVisibility\(viewer, prepared, activePose = 0, options = \{\}\)/);
+assert.match(previewViewer, /async function applyDockingPoseCollectionVisibilityNow\(viewer, prepared, activePose = 0, options = \{\}\)/);
 assert.match(previewViewer, /const allMode = activeSdfPoseMode === 'all' && prepared\.sdfPoseOverlayAvailable === true/);
 assert.match(previewViewer, /backgroundStructures\.push\(\.\.\.await loadMolstarEntryWithStructureRefs\(viewer, entry, \{ representationPreset: 'empty' \}\)\)/);
 assert.match(previewViewer, /async function loadMolstarEntry\(viewer, entry, presetOptions = undefined\)/);
@@ -6717,7 +6764,7 @@ assert.match(previewViewer, /async function loadMolstarEntryWithStructureRefs\(v
 assert.match(previewViewer, /await loadMolstarEntry\(viewer, entry, presetOptions\)/);
 assert.match(previewViewer, /const before = molstarStructureCellRefs\(viewer\);\s*await loadMolstarEntry\(viewer, entry, presetOptions\);/);
 assert.match(previewViewer, /\.filter\(structure => !before\.has\(structure\?\.cell\?\.transform\?\.ref\)\)/);
-assert.match(previewViewer, /async function applyDockingSceneVisibility\(viewer, prepared, activePose = 0, options = \{\}\)/);
+assert.match(previewViewer, /async function applyDockingSceneVisibilityNow\(viewer, prepared, activePose = 0, options = \{\}\)/);
 assert.match(previewViewer, /const resolvedContextStyle = dockingSceneBackgroundStyle\(contextStyle, style\)/);
 assert.match(previewViewer, /const backgroundEntries = poses\.filter\(\(_, index\) => index !== activeIndex\)/);
 assert.match(previewViewer, /if \(resolvedContextStyle === 'default' \|\| resolvedContextStyle === 'illustrative'\) \{/);
@@ -6744,7 +6791,7 @@ assert.doesNotMatch(previewViewer, /if \(normalized === 'illustrative' \|\| norm
 assert.match(previewViewer, /if \(normalized === 'default' \|\| normalized === 'illustrative' \|\| normalized === 'cartoon' \|\| normalized === 'polymer-ligand'\) \{\s*await applyMolstarPolymerLigandRepresentationToStructures\(/s);
 assert.match(previewViewer, /await applyMolstarRepresentationsToStructures\(viewer, targets, sdfCollectionRepresentationForStyle\(normalized, alpha, colorMode\)\)/);
 assert.match(previewViewer, /if \(normalized === 'spacefill'\) \{\s*return themed\(\{ type: 'spacefill'/s);
-assert.match(previewViewer, /if \(normalized === 'molecular-surface'\) \{\s*return themed\(\{ type: 'molecular-surface'/s);
+assert.match(previewViewer, /if \(normalized === 'molecular-surface'\) \{[\s\S]*?return themed\(\{ type: 'molecular-surface'/);
 assert.doesNotMatch(previewViewer, /visuals: \['structure-gaussian-surface-mesh'\]/);
 assert.match(previewViewer, /function sdfCollectionAlphaHelpers\(alpha = 1, colorMode = 'gray', minAlpha = 0\.04\)/);
 assert.match(previewViewer, /const ghost = Number\.isFinite\(Number\(alpha\)\) && Number\(alpha\) < 1/);
@@ -7799,13 +7846,20 @@ assert.match(gridViewer, /\['sdf', 'sd', 'mol', 'smi', 'smiles'\]\.includes/);
 assert.match(gridViewer, /function setGridGenerate3DPending\(pending\)/);
 assert.match(gridViewer, /function syncGridGenerate3DControls\(\)/);
 assert.match(gridViewer, /documentId: cfg\?\.documentId \|\| null/);
-assert.match(gridViewer, /textBase64: textToBase64\(records\.join\('\\n'\)\)/);
+// Records already end with '\n$$$$\n'; joining with '\n' left a blank line
+// after each delimiter, shifting the next record's header and losing names.
+assert.match(gridViewer, /textBase64: textToBase64\(records\.join\(''\)\)/);
+assert.doesNotMatch(gridViewer, /records\.join\('\\n'\)/);
 assert.match(gridViewer, /controlLabel: 'Molecule'/);
 assert.match(gridViewer, /receptorPath: receptorPath \|\| null/);
 assert.match(gridViewer, /function selectedMolstarRows\(\)/);
 assert.match(gridViewer, /function sdfRecordTextForMolstar\(row\)/);
 assert.match(gridViewer, /function smilesRecordTextForMolstar\(row\)/);
 assert.match(gridViewer, /function sdfRecordTextsForMolstar\(rows\)/);
+// generate_aligned_coords() flattens conformers to a 2D depiction, so records
+// that already carry 3D coordinates are exported to Molstar untouched.
+assert.match(gridViewer, /function sdfRowHasEmbedded3dCoordinates\(row\)/);
+assert.match(gridViewer, /if \(rows\.every\(row => sdfRowHasEmbedded3dCoordinates\(row\)\)\) \{/);
 assert.match(gridViewer, /function alignedSdfRecordTextsForMolstar\(rows\)/);
 assert.match(gridViewer, /function rdkitMolForMolstarRow\(rdkit, row\)/);
 assert.match(gridViewer, /function alignedMolblockForMolstar\(mol, templateMol\)/);


### PR DESCRIPTION
The All-background menu on SDF collections was effectively unusable: every style/color/opacity change cleared the whole Mol* scene and reloaded all molecules, nothing serialized concurrent rebuilds, and several smaller defects piled on top. Reproduced on a 480-molecule / 19k-atom collection in browser dev; every fix below was verified live before and after.

## What was broken → fixed

**Scene rebuild race (the "everything glitches" report).** The agent-action handler ran every action immediately, and each context change rebuilt the scene via `plugin.clear()`. One slider drag stacked 8 copies of the scene (16 structures × 8 representations each); three rapid style clicks left every layer wearing Spacefill+Line+Ball&Stick at once. All externally triggered rebuilds now run through `queueMolstarSceneRebuild`; `loadPreparedStructure` calls the `*Now` variants so a rebuild cannot deadlock the queue from inside itself. After the fix the same gestures leave exactly 2 structures with 1 representation each.

**Opacity slider.** Sent one action per dragged pixel — now the send is debounced (150 ms) to the gesture's last value while local state and the stored preference update immediately.

**40% default became 4%.** `Number(null)` is `0`, so a missing stored preference clamped to the 4% floor on both sides of the bridge. Missing values now fall back to the intended 40%.

**Surface froze the app for minutes and persisted the freeze.** A translucent molecular surface over 19k atoms was rebuilt per change and re-sorted per frame, and the style was written to localStorage before applying — so reopening the document froze again. Ghost background surfaces now build at grid resolution 2, and rebuilds no longer multiply.

**Cartoon button was a lie.** Small molecules have no polymer chains, so cartoon fell back to ball-and-stick; SDF collections now offer the small-molecule style subset (shared with XYZ frames).

**"Molecule 1 — 0 atoms".** The V2000 counts parser required whitespace between the atom and bond columns, but the counts line is fixed-width — 100+ atoms and 100+ bonds fuse ("120119"). Fixed-width parse first, regex fallback second; totals are no longer undercounted. Unit test added.

**Grid → Molstar export corrupted the collection.** `records.join('\n')` left a blank line after each `$$$$`, shifting every following header block and losing molecule names; and `generate_aligned_coords` flattened 3D poses into a 2D depiction row. Records already ending with `$$$$` join with `''`, and records that carry 3D coordinates skip the RDKit 2D align entirely — the exported background is a real 3D cloud again.

**Pose player.** The open playback row inherited `width: max-content` from its closed state and collapsed the frame slider to its 44px minimum — it now takes the control's width. SDF collections get the same atom-order **Align** toggle XYZ overlays have (enabled for homogeneous collections — conformers/poses of one molecule — with an RMSD readout; visible but disabled with an explanation for heterogeneous sets), and it survives theme reloads. Loop ticks skip while the pointer is held on the viewport, so camera drags stop fighting playback rebuilds; the elapsed-time frame math catches the playhead up afterwards.

## Verification

- Full `bun run test:ui`, `typecheck`, `check:js`, packaged-plugin-mirror, and the new structure-brief unit all pass.
- Browser-dev verification on a 480-molecule collection: slider drag → 2 structures / 1 representation (was 16/64); three rapid style clicks → last style wins, UI consistent; default opacity 40%; Align disabled with tooltip on the heterogeneous set.
- 30-conformer collection: Align enabled, reports "Aligned · 24 atoms · average RMSD 0.16 Å"; loop pauses while the pointer is held and resumes on release.
- Contract pins in `test-ui-shell-contract.mjs` updated to the new sources.
