### PR TITLE
Keep Ketcher inside narrow layouts

### DIFF
--- a/apps/desktop/src/components/ketcher-page.tsx
+++ b/apps/desktop/src/components/ketcher-page.tsx
@@ -82,6 +82,9 @@ const KETCHER_OUTPUT_MAX_HEIGHT = 360;
 const KETCHER_EXPORT_TIMEOUT_MS = 15000;
 const KETCHER_IMPORT_INSTANCE_RETRY_DELAYS_MS = [0, 250, 750, 1500, 2500] as const;
 const KETCHER_IMPORT_REQUEST_RETRY_MS = 5000;
+const KETCHER_CHROME_LAYOUT_WIDTH = 1101;
+const KETCHER_FIT_SCALES = [1, 0.9, 0.8, 0.7, 0.6, 0.5] as const;
+const KETCHER_NARROW_SHELL_WIDTH = 864;
 type KetcherImportResult = "success" | "transient-failure" | "failure";
 const IS_KETCHER_WEB_DEMO = import.meta.env.VITE_BURETTE_WEB_DEMO === "1";
 let ketcherStructServiceReady = false;
@@ -182,6 +185,10 @@ const KETCHER_TOOLTIP_LABELS: Record<string, string> = {
   image: "Add image",
   "template-lib": "Open template library",
 };
+
+function ketcherFitScaleForWidth(width: number) {
+  return KETCHER_FIT_SCALES.find((scale) => width >= Math.ceil(KETCHER_CHROME_LAYOUT_WIDTH * scale)) ?? 0.5;
+}
 const KETCHER_FORMAT_LABELS: Record<KetcherTextFormat | "auto", string> = {
   auto: "Auto",
   smiles: "SMILES",
@@ -402,6 +409,8 @@ export function KetcherPage({
     location.draftKet?.trim() || location.draftMolfile?.trim() || state.ketcherDraftMolfile.trim(),
   ));
   const [ketcherZoom, setKetcherZoom] = useState(DEFAULT_KETCHER_ZOOM);
+  const [ketcherFitScale, setKetcherFitScale] = useState(1);
+  const [ketcherNarrow, setKetcherNarrow] = useState(false);
   const [outputPanelHeight, setOutputPanelHeight] = useState(KETCHER_OUTPUT_DEFAULT_HEIGHT);
   const [dockPortalElement, setDockPortalElement] = useState<HTMLElement | null>(null);
   const [liveImportDirty, setLiveImportDirty] = useState(false);
@@ -431,10 +440,27 @@ export function KetcherPage({
     : "";
   const ketcherUIScaleStyle = useMemo(() => ({
     "--ketcher-ui-scale": String(ketcherZoom),
-  }) as CSSProperties, [ketcherZoom]);
+    "--ketcher-fit-scale": String(ketcherFitScale),
+  }) as CSSProperties, [ketcherFitScale, ketcherZoom]);
   const outputPanelStyle = useMemo(() => ({
     "--ketcher-output-height": `${outputPanelHeight}px`,
   }) as CSSProperties, [outputPanelHeight]);
+
+  useEffect(() => {
+    const shell = editorShellRef.current;
+    if (!shell) return undefined;
+    const update = () => {
+      const width = shell.clientWidth;
+      const nextScale = ketcherFitScaleForWidth(width);
+      const nextNarrow = width <= KETCHER_NARROW_SHELL_WIDTH;
+      setKetcherFitScale((current) => current === nextScale ? current : nextScale);
+      setKetcherNarrow((current) => current === nextNarrow ? current : nextNarrow);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(shell);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (!panelMode) {
@@ -1226,6 +1252,7 @@ export function KetcherPage({
     <section
       className="ketcher-page"
       aria-label="Ketcher"
+      data-narrow={ketcherNarrow || undefined}
       data-drop-active={dropActive || undefined}
       onDragOverCapture={handleDragOver}
       onDragLeaveCapture={handleDragLeave}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -6177,6 +6177,7 @@ input.structure-inspector-composition-search {
   gap: 8px;
 }
 .ketcher-page-body {
+  min-width: 0;
   min-height: 0;
   padding: 0 18px 12px;
   display: grid;
@@ -6187,10 +6188,10 @@ input.structure-inspector-composition-search {
   position: relative;
   min-width: 0;
   min-height: 0;
-  /* Chrome scale follows the header zoom control, floored so the toolbars stay
-     usable at deep zoom-out and capped so zoom-in never outgrows the 100%
-     layout. Canvas drawing zoom is Ketcher's own setZoom, not this scale. */
-  --ketcher-chrome-scale: clamp(0.5, var(--ketcher-ui-scale, 1), 1);
+  /* Chrome scale follows the smaller of the header zoom and measured fit,
+     floored so the toolbars stay usable at deep zoom-out. Canvas drawing zoom
+     is Ketcher's own setZoom, not this scale. */
+  --ketcher-chrome-scale: clamp(0.5, min(var(--ketcher-ui-scale, 1), var(--ketcher-fit-scale)), 1);
   --ketcher-toolbar-button-size: 32px;
   --ketcher-toolbar-icon-size: 22px;
   --ketcher-toolbar-margin: 4px;
@@ -6203,6 +6204,21 @@ input.structure-inspector-composition-search {
   background: var(--surface-primary);
   overflow: hidden;
   isolation: isolate;
+}
+/* ResizeObserver marks the layout narrow from the editor shell's actual width,
+   so sidebar and dock changes are handled independently of the window size. */
+.ketcher-page[data-narrow] .ketcher-page-header {
+  width: 100%;
+  max-width: none;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+}
+.ketcher-page[data-narrow] .ketcher-page-actions {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 .ketcher-editor-scale-frame {
   position: absolute;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2150,7 +2150,7 @@ assert.doesNotMatch(styles, /\.app-shell\[data-runtime="tauri"\]\[data-active-pa
 assert.match(styles, /\.page-surface\[data-page-kind="file"\]:not\(\[data-active\]\),\s*\.page-surface\[data-page-kind="text-file"\]:not\(\[data-active\]\),\s*\.page-surface\[data-page-kind="ketcher"\]:not\(\[data-active\]\) \{ display: block; \}/);
 assert.match(styles, /\.ketcher-page-header\s*\{[^}]*width: fit-content;[^}]*max-width: calc\(100% - 36px\);[^}]*min-height: 48px;[^}]*padding: 8px 18px;/s);
 assert.doesNotMatch(styles, /\.ketcher-page-header\s*\{[^}]*border-bottom:/s);
-assert.match(styles, /\.ketcher-page-body\s*\{[^}]*padding: 0 18px 12px;[^}]*gap: 8px;/s);
+assert.match(styles, /\.ketcher-page-body\s*\{[^}]*min-width: 0;[^}]*padding: 0 18px 12px;[^}]*gap: 8px;/s);
 assert.match(styles, /\.ketcher-editor-shell\s*\{[^}]*overflow: hidden;[^}]*isolation: isolate;/s);
 assert.doesNotMatch(styles, /\.ketcher-editor-shell\s*\{[^}]*contain: layout paint;/s);
 // The header controls are shadcn Buttons/ButtonGroups now: styles.css keeps only
@@ -2174,7 +2174,9 @@ assert.match(styles, /\.ketcher-editor-shell\s*\{[^}]*background: var\(--surface
 // lays out at 1/scale and scales back down (so every toolbar stays visible and
 // fills the shell at every zoom step), while the canvas cell reverses the
 // transform because Ketcher's pointer math cannot handle a scaled canvas.
-assert.match(styles, /\.ketcher-editor-shell\s*\{[^}]*--ketcher-chrome-scale: clamp\(0\.5, var\(--ketcher-ui-scale, 1\), 1\);[^}]*--ketcher-toolbar-button-size: 32px;[^}]*--ketcher-side-rail-width: calc\(var\(--ketcher-toolbar-button-size\) \+ 13px\);/s);
+assert.match(styles, /\.ketcher-editor-shell\s*\{[^}]*--ketcher-chrome-scale: clamp\(0\.5, min\(var\(--ketcher-ui-scale, 1\), var\(--ketcher-fit-scale\)\), 1\);[^}]*--ketcher-toolbar-button-size: 32px;[^}]*--ketcher-side-rail-width: calc\(var\(--ketcher-toolbar-button-size\) \+ 13px\);/s);
+assert.match(styles, /\.ketcher-page\[data-narrow\] \.ketcher-page-header\s*\{[^}]*width: 100%;[^}]*grid-template-columns: minmax\(0, 1fr\);/s);
+assert.match(styles, /\.ketcher-page\[data-narrow\] \.ketcher-page-actions\s*\{[^}]*width: 100%;[^}]*overflow-x: auto;/s);
 assert.match(styles, /--ketcher-top-toolbar-height: 36px/);
 assert.match(styles, /--ketcher-top-toolbar-icon-size: 24px/);
 assert.match(styles, /\.ketcher-editor-scale-frame\s*\{[^}]*position: absolute;[^}]*inset: 0;[^}]*width: calc\(100% \/ var\(--ketcher-chrome-scale\)\);[^}]*height: calc\(100% \/ var\(--ketcher-chrome-scale\)\);[^}]*transform: scale\(var\(--ketcher-chrome-scale\)\);[^}]*transform-origin: top left;/s);
@@ -3155,6 +3157,9 @@ assert.doesNotMatch(ketcherPage, /document\.querySelectorAll<HTMLElement>\(`\[da
 assert.match(ketcherPage, /const \[exportingSketch, setExportingSketch\] = useState\(false\)/);
 assert.match(ketcherPage, /const \[hasSketch, setHasSketch\] = useState\(Boolean\(\s*location\.draftKet\?\.trim\(\) \|\| location\.draftMolfile\?\.trim\(\) \|\| state\.ketcherDraftMolfile\.trim\(\),\s*\)\)/);
 assert.match(ketcherPage, /const \[ketcherZoom, setKetcherZoom\] = useState\(DEFAULT_KETCHER_ZOOM\)/);
+assert.match(ketcherPage, /function ketcherFitScaleForWidth\(width: number\)/);
+assert.match(ketcherPage, /const observer = new ResizeObserver\(update\)/);
+assert.match(ketcherPage, /data-narrow=\{ketcherNarrow \|\| undefined\}/);
 assert.match(ketcherPage, /const \[outputPanelHeight, setOutputPanelHeight\] = useState\(KETCHER_OUTPUT_DEFAULT_HEIGHT\)/);
 assert.match(ketcherPage, /const systemThemeMode = useSystemThemeMode\(\);/);
 assert.match(ketcherPage, /const ketcherThemeMode = resolveThemeMode\(state\.preferences\.theme, systemThemeMode\);/);
@@ -3165,7 +3170,8 @@ assert.match(ketcherPage, /const ketcherZoomPercent = Math\.round\(ketcherZoom \
 assert.match(ketcherPage, /const restoredDraftRef = useRef\(""\)/);
 assert.match(ketcherPage, /const editorShellRef = useRef<HTMLDivElement \| null>\(null\)/);
 assert.match(ketcherPage, /"--ketcher-ui-scale": String\(ketcherZoom\)/);
-assert.match(ketcherPage, /\}\) as CSSProperties, \[ketcherZoom\]\);/);
+assert.match(ketcherPage, /"--ketcher-fit-scale": String\(ketcherFitScale\)/);
+assert.match(ketcherPage, /\}\) as CSSProperties, \[ketcherFitScale, ketcherZoom\]\);/);
 assert.match(ketcherPage, /style=\{ketcherUIScaleStyle\}/);
 assert.match(ketcherPage, /"--ketcher-output-height": `\$\{outputPanelHeight\}px`/);
 assert.match(ketcherPage, /\}\) as CSSProperties, \[outputPanelHeight\]\);/);


### PR DESCRIPTION
## Why

Ketcher's fixed-width chrome overflowed and clipped on narrow app and demo layouts, sending the editor beyond the visible workspace.

## What Changed

- fit Ketcher chrome to the measured editor-shell width while preserving the drawing canvas and pointer-coordinate contract
- stack the page header and keep actions in an internal horizontal scroller when the editor is narrow
- add UI contract coverage for measured scaling and narrow layout behavior

## Verification

- `bun run test:ui`
- `vp build`
- pre-push `ci-fast` (`608 passed, 7 ignored`)
- browser-dev with sidebar and right dock: 641 px editor shell, no visible Ketcher overflow, no console errors
