### PR TITLE
Fix grid rail hover artifacts

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.3.7;
+				MARKETING_VERSION = 2.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.3.7"
+version = "2.3.8"
 dependencies = [
  "base64 0.23.1",
  "burette-compute-core",

--- a/PreviewExtension/Web/grid.css
+++ b/PreviewExtension/Web/grid.css
@@ -1506,11 +1506,6 @@ button.buret-grid-rail-tick:focus-visible {
 body.buret-grid-rail-dragging .buret-grid-rail-tick-pill {
   transition: none;
 }
-.buret-grid-rail-tick:hover + .buret-grid-rail-tick + .buret-grid-rail-tick,
-.buret-grid-rail-tick:has(+ .buret-grid-rail-tick + .buret-grid-rail-tick:hover) {
-  width: 16px;
-  background: color-mix(in srgb, var(--buret-text) 34%, transparent);
-}
 
 .buret-grid-rail-popover {
   position: absolute;

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.3.7"
+version = "2.3.8"
 dependencies = [
  "base64 0.23.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.3.7"
+version = "2.3.8"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -137,7 +137,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "CLI installer for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",

--- a/plugins/burette-agent/preview-web/grid.css
+++ b/plugins/burette-agent/preview-web/grid.css
@@ -1506,11 +1506,6 @@ button.buret-grid-rail-tick:focus-visible {
 body.buret-grid-rail-dragging .buret-grid-rail-tick-pill {
   transition: none;
 }
-.buret-grid-rail-tick:hover + .buret-grid-rail-tick + .buret-grid-rail-tick,
-.buret-grid-rail-tick:has(+ .buret-grid-rail-tick + .buret-grid-rail-tick:hover) {
-  width: 16px;
-  background: color-mix(in srgb, var(--buret-text) 34%, transparent);
-}
 
 .buret-grid-rail-popover {
   position: absolute;

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2094,6 +2094,7 @@ assert.match(gridCss, /\.buret-grid-rail-ticks \{[^}]*z-index: 7;/s);
 assert.match(gridCss, /\.buret-grid-rail-tick \{[^}]*height: 10px;[^}]*min-height: 10px;/s);
 assert.match(gridCss, /button\.buret-grid-rail-tick:not\(:disabled\):hover,[^}]*background: transparent;[^}]*transform: none;/s);
 assert.match(gridCss, /body\.buret-grid-rail-dragging \.buret-grid-rail-tick-pill \{[^}]*transition: none;/s);
+assert.doesNotMatch(gridCss, /\.buret-grid-rail-tick:hover \+ \.buret-grid-rail-tick/);
 assert.match(gridCss, /--buret-grid-rail-popover-surface: #303033;/);
 assert.match(gridCss, /--buret-grid-rail-popover-border: rgba\(255, 255, 255, 0\.20\);/);
 assert.match(gridCss, /\.buret-grid-rail-popover \{[^}]*background: var\(--buret-grid-rail-popover-surface\);/s);


### PR DESCRIPTION
## Why

The molecule navigation rail mixed the JavaScript pill magnification with an obsolete CSS neighbour rule that resized and painted the full tick button. Hovering the rail therefore produced solid gray blocks instead of a continuous thin-line lens.

## What Changed

- Remove the stale full-button neighbour styling from the desktop/Quick Look grid CSS.
- Keep the packaged agent preview CSS mirror aligned.
- Add a regression assertion that prevents the obsolete selector from returning.
- Advance the release metadata to 2.3.8.

## Verification

- `bun run ci:fast` — passed, including 608 Rust tests; 7 ignored.
- `./scripts/release.sh --dry-run` — passed.
- `bun run check:release` — passed in local and pull-request modes.
- Browser verification with the 1,513-row BACE collection: hover leaves every tick button transparent and magnifies only the 2 px pills; no console warnings or errors.