### PR TITLE
Expand the demo project tree by default

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -849,6 +849,7 @@ export default function App() {
     openPaths,
     pushErrorStatus,
     setActiveTab,
+    setExpandedProjectIds,
     setWorkspacePath,
     tabs,
   });

--- a/apps/desktop/src/components/sidebar/file-browser.tsx
+++ b/apps/desktop/src/components/sidebar/file-browser.tsx
@@ -6,6 +6,7 @@ import { isRemoteStructureUrl } from "../../lib/remote-structure";
 import { filterSidebarProjects } from "../../lib/sidebar-projects";
 import { buildShellCommands, filterShellCommands } from "../../lib/shell-commands";
 import { hasStructureDrag, readStructureDragPayload } from "../../lib/structure-drag";
+import { isWebDemoWorkspace, webDemoProjectRoot } from "../../lib/web-demo-workspace";
 import { runShellDropActionChoices, shellDropActionChoices } from "../drop-action-executor";
 import { RadixDropdownMenu } from "../radix-menu";
 import { ScrollFade } from "../scroll-fade";
@@ -348,6 +349,7 @@ export function FileBrowser({
                   project={project}
                   state={state}
                   actions={actions}
+                  expandFoldersByDefault={isWebDemoWorkspace() && project.rootPath === webDemoProjectRoot()}
                 />
               ))}
             </div>

--- a/apps/desktop/src/components/sidebar/file-tree-node.tsx
+++ b/apps/desktop/src/components/sidebar/file-tree-node.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
 import {
   Folder01Icon,
   Folder02Icon,
@@ -63,23 +63,30 @@ export function ProjectGroup({
   project,
   state,
   actions,
+  expandFoldersByDefault = false,
 }: {
   project: SidebarProject;
   state: ShellViewState;
   actions: ShellActions;
+  expandFoldersByDefault?: boolean;
 }) {
+  const projectTree = useMemo(() => buildProjectTree(project.items), [project.items]);
+  const defaultExpandedFolderPaths = useMemo(
+    () => expandFoldersByDefault ? collectProjectFolderPaths(projectTree) : [],
+    [expandFoldersByDefault, projectTree],
+  );
   const [showAllItems, setShowAllItems] = useState(false);
-  const [expandedFolderPaths, setExpandedFolderPaths] = useState<Set<string>>(() => new Set());
+  const [expandedFolderPaths, setExpandedFolderPaths] = useState<Set<string>>(() => new Set(defaultExpandedFolderPaths));
   const [showAllFolderPaths, setShowAllFolderPaths] = useState<Set<string>>(() => new Set());
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState(project.title);
+  const folderExpansionChangedRef = useRef(false);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const skipRenameCommitRef = useRef(false);
   const sidebarQuery = state.sidebarQuery.trim();
   const hasSidebarQuery = sidebarQuery.length > 0;
   const expanded = hasSidebarQuery || state.expandedProjectIds.includes(project.id);
   const canRenameProject = Boolean(project.rootPath);
-  const projectTree = buildProjectTree(project.items);
   const shouldLimitItems = !hasSidebarQuery
     && projectTree.length > COLLAPSED_PROJECT_ITEM_LIMIT
     && !showAllItems;
@@ -97,6 +104,11 @@ export function ProjectGroup({
   useEffect(() => {
     if (!renaming) setRenameDraft(project.title);
   }, [project.title, renaming]);
+
+  useEffect(() => {
+    if (!expandFoldersByDefault || folderExpansionChangedRef.current) return;
+    setExpandedFolderPaths(new Set(defaultExpandedFolderPaths));
+  }, [defaultExpandedFolderPaths, expandFoldersByDefault]);
 
   useEffect(() => {
     if (!renaming) return;
@@ -151,6 +163,7 @@ export function ProjectGroup({
 
   const handleRecursiveToggle = () => {
     const folderPaths = collectProjectFolderPaths(projectTree);
+    folderExpansionChangedRef.current = true;
     setExpandedFolderPaths((current) => {
       const next = new Set(current);
       for (const folderPath of folderPaths) {
@@ -182,6 +195,7 @@ export function ProjectGroup({
   };
   const toggleFolderPath = (path: string) => {
     const descendantPaths = collectProjectFolderPathsFor(projectTree, path).slice(1);
+    folderExpansionChangedRef.current = true;
     setExpandedFolderPaths((current) => {
       const next = new Set(current);
       if (next.has(path)) {
@@ -195,6 +209,7 @@ export function ProjectGroup({
   };
   const toggleFolderPathRecursive = (path: string) => {
     const folderPaths = collectProjectFolderPathsFor(projectTree, path);
+    folderExpansionChangedRef.current = true;
     setExpandedFolderPaths((current) => {
       const next = new Set(current);
       if (next.has(path)) {

--- a/apps/desktop/src/hooks/use-app-startup-effects.ts
+++ b/apps/desktop/src/hooks/use-app-startup-effects.ts
@@ -35,6 +35,7 @@ type UseAppStartupEffectsOptions = {
   openPaths: OpenPaths;
   pushErrorStatus: PushErrorStatus;
   setActiveTab: (id: string) => void;
+  setExpandedProjectIds: (projectIds: string[]) => void;
   setWorkspacePath: (path: string | null) => void;
   tabs: MoleculeTab[];
 };
@@ -56,6 +57,7 @@ export function useAppStartupEffects({
   openPaths,
   pushErrorStatus,
   setActiveTab,
+  setExpandedProjectIds,
   setWorkspacePath,
   tabs,
 }: UseAppStartupEffectsOptions) {
@@ -90,6 +92,9 @@ export function useAppStartupEffects({
       for (const root of browserDevProjectRoots) {
         addProjectRoot(root);
       }
+      if (isWebDemoWorkspace()) {
+        setExpandedProjectIds(browserDevProjectRoots.map((root) => `project:${root}`));
+      }
       closeAllDocuments();
       const trajectoryDockingRequest = browserDevTrajectoryDockingRequest(paths);
       if (trajectoryDockingRequest) {
@@ -105,7 +110,7 @@ export function useAppStartupEffects({
     return () => {
       cancelled = true;
     };
-  }, [addProjectRoot, browserDevExplicitFolders, closeAllDocuments, documents, openDockingDocument, openPaths, pushErrorStatus, setWorkspacePath]);
+  }, [addProjectRoot, browserDevExplicitFolders, closeAllDocuments, documents, openDockingDocument, openPaths, pushErrorStatus, setExpandedProjectIds, setWorkspacePath]);
 
   useEffect(() => {
     if (refreshedPersistedSessionRef.current) return;

--- a/apps/desktop/src/lib/web-demo-workspace.ts
+++ b/apps/desktop/src/lib/web-demo-workspace.ts
@@ -87,6 +87,7 @@ export function initializeWebDemoWorkspace() {
       registerText(`${WEB_DEMO_ROOT}/${relativePath}`, text);
     }
     registerText(`${WEB_DEMO_ROOT}/notes/README.md`, "# Burette browser workspace\n\nOpen a structure or choose a local project folder.\n");
+    emitChange();
   }
   return [`${WEB_DEMO_ROOT}/proteins/1HTB.pdb`];
 }

--- a/tests/test-sidebar-tree-render.mjs
+++ b/tests/test-sidebar-tree-render.mjs
@@ -51,6 +51,14 @@ for (const expected of [
   assert.match(html, new RegExp(escapeRegExp(expected)));
 }
 
+const expandedDemoHtml = renderToStaticMarkup(React.createElement(ProjectGroup, {
+  project,
+  state,
+  actions,
+  expandFoldersByDefault: true,
+}));
+assert.doesNotMatch(expandedDemoHtml, /data-expanded="false"/);
+
 const crowdedFolderProject = {
   ...project,
   id: "project:/fixtures/crowded",


### PR DESCRIPTION
## Why

The public web demo initially showed the BuretteDemo project and its nested folders collapsed, hiding the sample files that make the demo useful.

## What Changed

- expand the BuretteDemo project and its nested folders during web-demo startup
- publish the complete 27-file virtual demo workspace before the sidebar renders
- preserve manual folder collapse/expand choices after the initial default is applied
- keep non-demo projects and native surfaces unchanged

## Verification

- `bun tests/test-sidebar-tree-render.mjs`
- `bun tests/test-ui-shell-contract.mjs`
- `bun tests/test-web-demo-analytics.mjs`
- production web-demo Vite build
- local Browser verification: 27 files visible, project and nested folders expanded, manual collapse preserved, no console warnings or errors
- pre-commit plist, JS syntax, and Rust formatting checks

## Notes

The local `ci:fast` run passed dependency, JS syntax, vendor asset, preview format, and Rust formatting gates, then waited indefinitely for a shared Cargo build lock before clippy could start. GitHub CI remains required before merge.