### PR TITLE
docs: remove unsafe registry install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,6 @@ Check the cask version when you need to confirm a specific release:
 brew info --cask SergeiNikolenko/burette/burette
 ```
 
-For the latest stable GitHub release, use the Burette Bun CLI:
-
-```bash
-bunx burette latest
-bunx burette install
-bunx burette doctor
-```
-
-The Bun installer places Burette in `~/Applications` by default. Use
-`bunx burette install --system` only when you intentionally want the app in
-`/Applications` for all users. If Finder previews do not appear after install,
-run `bunx burette doctor` to check the app bundle, Quick Look extension,
-`qlmanage`, and installed version.
-
 You can also download Burette from the GitHub Releases page:
 
 [Download the latest Burette release](https://github.com/SergeiNikolenko/Burette/releases/latest)
@@ -93,11 +79,9 @@ After installation:
    - `Cmd+P` or `/` opens the command palette.
    - `Cmd+,` opens settings.
    - The sidebar browses project folders, nested structures, and recent files.
-4. If previews do not appear, run:
-
-```bash
-bunx burette doctor
-```
+4. If previews do not appear, open the command palette and run
+   **Reset Quick Look**. **Open Logs Folder** and **Export Diagnostics** are
+   available there as well.
 
 ## Supported Files
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -296,27 +296,16 @@ The release workflow should also push a tap commit named
 stable release, inspect the release job's Homebrew checkout/update steps and the
 `HOMEBREW_TAP_TOKEN` secret before announcing the release channel as updated.
 
-The registry package lives in `packages/burette`. It is a thin CLI installer
-for the macOS app, not the app bundle itself. Publish it from that workspace
-package after registry authentication:
+The private workspace package in `packages/burette` contains the installer and
+doctor implementation used by repository checks. Do not publish it: the
+unscoped `burette` name on npm belongs to an unrelated project. GitHub Releases
+and the Homebrew tap are the public installation channels.
 
-```bash
-cd packages/burette
-bun publish
-```
-
-Bun installs the same published package:
-
-```bash
-bunx burette install
-bunx burette doctor
-```
-
-The CLI installer installs to `~/Applications` by default and to
+The internal installer helper installs to `~/Applications` by default and to
 `/Applications` only with `--system`. It prints each install step, verifies the
 GitHub `sha256:<digest>` asset checksum when release metadata provides one,
 stages replacement through `Burette.app.updating`, and restores the previous app
-bundle if replacement fails. `burette doctor` checks the installed app, embedded
+bundle if replacement fails. Its `doctor` command checks the installed app, embedded
 Quick Look extension, `qlmanage`, and the app version.
 
 ## In-App Updates

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -9,7 +9,7 @@ shared preview runtime they use.
 | `apps/burette-public-plugin` | Hosted public plugin submission, public HTTPS MCP endpoint, bounded attachment/PDB preparation, and CSP-compatible Burette workspace. |
 | `PreviewExtension` | macOS Finder Quick Look preview and thumbnail extension. `PreviewExtension/Web` contains the bundled Mol*, RDKit grid, and viewer runtime assets shared with desktop and Quick Look. |
 | `ios/BuretteMobile` | Source-built iPhone preview app target. It reuses the bundled preview runtime for iOS document handoff and phone-first molecular inspection. |
-| `packages/burette` | Bun CLI installer used by `bunx burette install`, `bunx burette doctor`, and release-channel checks. |
+| `packages/burette` | Private Bun helper used by installer, doctor, and release-channel checks. It is not a public registry package. |
 | `packages/ketcher-agent-contract` | Shared `@burette/ketcher-agent-contract` types consumed by the desktop app and the hosted public plugin. |
 | `plugins/burette-agent` | Codex/Burette plugin, MCP server, skills, and bounded agent workflow contracts. It wraps the repository CLI instead of reimplementing app control. |
 | `crates/burette-core` | Shared Rust crate for native molecular and preview-support logic used by the Tauri app. |

--- a/packages/burette/README.md
+++ b/packages/burette/README.md
@@ -1,20 +1,19 @@
-# Burette CLI installer
+# Internal Burette installer helper
 
-This package provides the `burette` command for installing the Burette macOS
-app from GitHub Releases.
+This private workspace package implements the release and installation helper
+used by repository checks. It is not published to npm: the unscoped `burette`
+package name belongs to an unrelated project.
 
-```bash
-bunx burette install
-bunx burette doctor
-```
+Repository contributors can run it from the repository root with
+`bun packages/burette/bin/burette.mjs <command>`.
 
 The command downloads the latest stable `Burette-<version>.zip`,
 verifies the GitHub release asset SHA-256 digest when GitHub provides one, and
 installs `Burette.app` into `~/Applications` by default.
 
-Use `burette install --system` to install into `/Applications` for all users;
+Use `install --system` to install into `/Applications` for all users;
 without it, the installer uses the current user's `~/Applications` folder.
-Use `burette install --beta` to install from the beta channel instead.
+Use `install --beta` to install from the beta channel instead.
 
-Run `burette doctor` after installation to check that `Burette.app`, the Quick
+Run `doctor` after installation to check that `Burette.app`, the Quick
 Look extension, `qlmanage`, and the installed app version are visible.

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,7 +1,8 @@
 {
   "name": "burette",
   "version": "2.3.8",
-  "description": "CLI installer for the Burette macOS app and Quick Look extension.",
+  "private": true,
+  "description": "Internal release and installation helper for the Burette macOS app and Quick Look extension.",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -28,8 +29,5 @@
   "bugs": {
     "url": "https://github.com/SergeiNikolenko/Burette/issues"
   },
-  "homepage": "https://github.com/SergeiNikolenko/Burette#readme",
-  "publishConfig": {
-    "access": "public"
-  }
+  "homepage": "https://github.com/SergeiNikolenko/Burette#readme"
 }

--- a/tests/test-bun-installer-behavior.mjs
+++ b/tests/test-bun-installer-behavior.mjs
@@ -11,6 +11,14 @@ import {
   selectRelease,
 } from "../packages/burette/bin/burette.mjs";
 
+const packageMetadata = JSON.parse(await readFile(new URL("../packages/burette/package.json", import.meta.url), "utf8"));
+assert.equal(packageMetadata.private, true, "the internal installer package must remain unpublished");
+
+for (const publicDoc of ["../README.md", "../docs/releasing.md", "../docs/repository-layout.md"]) {
+  const source = await readFile(new URL(publicDoc, import.meta.url), "utf8");
+  assert.doesNotMatch(source, /bunx\s+burette\b/u, `${publicDoc} must not direct users to the unrelated npm package`);
+}
+
 const root = await mkdtemp(path.join(tmpdir(), "burette-installer-test-"));
 const sourceApp = path.join(root, "source", "Burette.app");
 const targetApp = path.join(root, "Applications", "Burette.app");

--- a/tests/test-bun-installer-behavior.mjs
+++ b/tests/test-bun-installer-behavior.mjs
@@ -14,7 +14,7 @@ import {
 const packageMetadata = JSON.parse(await readFile(new URL("../packages/burette/package.json", import.meta.url), "utf8"));
 assert.equal(packageMetadata.private, true, "the internal installer package must remain unpublished");
 
-for (const publicDoc of ["../README.md", "../docs/releasing.md", "../docs/repository-layout.md"]) {
+for (const publicDoc of ["../README.md", "../packages/burette/README.md", "../docs/releasing.md", "../docs/repository-layout.md"]) {
   const source = await readFile(new URL(publicDoc, import.meta.url), "utf8");
   assert.doesNotMatch(source, /bunx\s+burette\b/u, `${publicDoc} must not direct users to the unrelated npm package`);
 }


### PR DESCRIPTION
## Why

The unscoped npm package named burette belongs to an unrelated project, so the previous bunx installation instructions could execute third-party code instead of Burette.

## What Changed

- Mark the repository installer workspace private and remove its publish configuration.
- Keep GitHub Releases and the dedicated Homebrew tap as the public installation channels.
- Point Quick Look recovery to the in-app command palette.
- Add a regression test that rejects unsafe public registry guidance.

## Verification

- bun run check:release
- bun run test:update
- pre-push ci-fast: 608 Rust tests passed, 7 ignored; JavaScript and contract suites passed