### PR TITLE
Draw the molecule preview on its own paper

### DIFF
--- a/Burette.xcodeproj/project.pbxproj
+++ b/Burette.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -475,7 +475,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Preview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -525,7 +525,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = PreviewExtension/ThumbnailInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks", );
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Thumbnail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -546,7 +546,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -569,7 +569,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = ios/BuretteMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 2.3.8;
+				MARKETING_VERSION = 2.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.local.BuretteV10.Mobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burette"
-version = "2.3.8"
+version = "2.3.9"
 dependencies = [
  "base64 0.23.1",
  "burette-compute-core",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burette"
-version = "2.3.8"
+version = "2.3.9"
 dependencies = [
  "base64 0.23.1",
  "burette-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burette"
-version = "2.3.8"
+version = "2.3.9"
 description = "Tauri/Rust shell for local molecular previews"
 authors = ["Burette"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Burette",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "identifier": "com.local.BuretteV10",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",

--- a/apps/desktop/src/components/grid-hover-molecule.tsx
+++ b/apps/desktop/src/components/grid-hover-molecule.tsx
@@ -96,6 +96,26 @@ function structurePalette(theme: string) {
   return theme === "dark" ? DARK_STRUCTURE_PALETTE : undefined;
 }
 
+// The drawing paints its own paper instead of letting the well show through a
+// transparent SVG: in the packaged runtime the well came out white, and a
+// light-ink structure on white paper is a blank card. The paper is the colour
+// the well is actually painted in, so the two meet without a seam in either
+// theme and a custom theme background is followed without a second source of
+// truth for it.
+const DEFAULT_PAPER: Record<string, [number, number, number]> = {
+  dark: [0.067, 0.067, 0.067],
+  light: [1, 1, 1],
+};
+
+function paperColour(well: HTMLElement | null, theme: string): [number, number, number] {
+  const surface = well ? window.getComputedStyle(well).backgroundColor : "";
+  const match = /^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)(?:[,/\s]+([\d.]+))?\s*\)$/u.exec(surface);
+  if (match && (match[4] === undefined || Number(match[4]) > 0)) {
+    return [Number(match[1]) / 255, Number(match[2]) / 255, Number(match[3]) / 255];
+  }
+  return DEFAULT_PAPER[theme] ?? DEFAULT_PAPER.light;
+}
+
 // The shell publishes the resolved theme, so "auto" is already decided here.
 function useEffectiveTheme(): string {
   const [theme, setTheme] = useState(effectiveTheme);
@@ -156,6 +176,7 @@ export function GridHoverMoleculeCard({
   // for at these numbers so it fills the box at any drag height.
   const [wellSize, setWellSize] = useState<{ width: number; height: number } | null>(null);
   const wellObserverRef = useRef<ResizeObserver | null>(null);
+  const wellNodeRef = useRef<HTMLDivElement | null>(null);
   const renderTokenRef = useRef(0);
   const lastRowRef = useRef<HoveredGridRow | null>(null);
   if (row) lastRowRef.current = row;
@@ -169,6 +190,7 @@ export function GridHoverMoleculeCard({
   // list would run before the well exists and never attach.
   const attachWell = useCallback((node: HTMLDivElement | null) => {
     wellObserverRef.current?.disconnect();
+    wellNodeRef.current = node;
     if (!node) {
       wellObserverRef.current = null;
       return;
@@ -203,7 +225,8 @@ export function GridHoverMoleculeCard({
       setSpec("");
       return;
     }
-    const sizedKey = `${theme} ${wellSize.width}x${wellSize.height} ${source}`;
+    const paper = paperColour(wellNodeRef.current, theme);
+    const sizedKey = `${theme} ${paper.join(",")} ${wellSize.width}x${wellSize.height} ${source}`;
     const cachedSvg = svgCache.get(sizedKey);
     const cachedSpec = specCache.get(source);
     if (cachedSvg !== undefined && cachedSpec !== undefined) {
@@ -228,7 +251,7 @@ export function GridHoverMoleculeCard({
           const rendered = mol.get_svg_with_highlights(JSON.stringify({
             width: wellSize.width,
             height: wellSize.height,
-            clearBackground: false,
+            backgroundColour: paper,
             padding: 0.04,
             ...(palette ? { atomColourPalette: palette } : {}),
           }));
@@ -402,6 +425,13 @@ export function GridHoverMoleculeCard({
   // A lasso answer is reason enough to show the card even before anything has
   // been hovered.
   if (!shown && !showingScaffold) return null;
+  const label = showingScaffold
+    ? "Common scaffold"
+    : shown?.name || `Molecule ${(shown?.index ?? 0) + 1}`;
+  // A put-away card used to leave a bare strip of panel behind: the space it
+  // freed read as a hole with nothing in it, and the handle that brings the
+  // drawing back only appeared once the pointer happened to cross it. The
+  // collapsed card is a bar that says whose structure is waiting instead.
   if (hidden) {
     return (
       <button
@@ -412,16 +442,17 @@ export function GridHoverMoleculeCard({
         onPointerUp={onStrapUp}
         onPointerCancel={onStrapUp}
         aria-label="Show molecule preview"
-        title="Pull up to show the molecule preview"
+        title="Click or pull up to show the molecule preview"
       >
         <span className="grid-hover-molecule-strap-grip" aria-hidden="true" />
+        <span className="grid-hover-molecule-strap-label">{label}</span>
+        <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true" className="grid-hover-molecule-strap-chevron">
+          <path d="M1.5 6.5 5 3l3.5 3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       </button>
     );
   }
   const scaffoldStatus = showingScaffold ? scaffoldStatusLine(scaffold) : null;
-  const label = showingScaffold
-    ? "Common scaffold"
-    : shown?.name || `Molecule ${(shown?.index ?? 0) + 1}`;
   const badge = showingScaffold
     ? (scaffold.kind === "failed" ? "" : `${scaffold.count} molecules`)
     : `row ${(shown?.index ?? 0) + 1}`;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -843,6 +843,7 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
    measured size, so it fills the width edge to edge and the card's own border
    is the only one around it. */
 .grid-hover-molecule-svg {
+  position: relative;
   display: flex;
   flex: 0 1 auto;
   min-height: 120px;
@@ -852,13 +853,25 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
   margin-top: 2px;
   border-radius: 8px;
   cursor: pointer;
+  /* The paper the structure is drawn on, stated rather than borrowed from
+     whatever shows through: the drawing asks RDKit for this same colour, so
+     the two meet without a seam where the rounded size leaves a sliver. */
+  background: var(--bg-base);
 }
 /* The drawing opens the row in Ketcher, so it lights up like the control it is
-   - just enough to invite the click without framing the structure again. */
+   - just enough to invite the click without framing the structure again. The
+   tint rides over the drawing because the drawing is opaque. */
 .grid-hover-molecule-svg:hover,
 .grid-hover-molecule-svg:focus-visible {
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
   outline: none;
+}
+.grid-hover-molecule-svg:hover::after,
+.grid-hover-molecule-svg:focus-visible::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  pointer-events: none;
 }
 .grid-hover-molecule-drawing,
 .grid-hover-molecule-svg svg {
@@ -1032,53 +1045,60 @@ button, select, input, textarea, .tab-shell, .tab, .new-tab, .chrome-button, .ta
 .grid-hover-molecule-prop[data-tone^="outlier"] .grid-hover-molecule-prop-track > span {
   background: var(--accent);
 }
-/* What a collapsed preview leaves behind: a full-width strip flush with the
-   panel's bottom edge, its grip hidden until the pointer comes near. Pull it
-   up to bring the card back at the height you pull to; click to get the last
-   height back. Mirrors the house resize grip so the gesture reads as familiar. */
+/* What a collapsed preview leaves behind: a bar flush with the panel's bottom
+   edge that names the molecule still waiting, so the freed space reads as a
+   put-away card rather than an empty panel. Pull it up to bring the card back
+   at the height you pull to; click to get the last height back. */
 .grid-hover-molecule-strap {
   position: sticky;
   bottom: -12px;
   z-index: 3;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   width: calc(100% + 24px);
   margin: 0 -12px -12px;
-  padding: 0;
-  height: 16px;
+  padding: 0 12px;
+  height: 30px;
   border: 0;
-  background: transparent;
+  border-top: 1px solid var(--line-subtler);
+  background: var(--bg-base);
+  color: var(--text-muted);
   cursor: ns-resize;
   touch-action: none;
 }
-.grid-hover-molecule-strap::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: var(--bg-base);
-  opacity: 0;
-  transition: opacity 140ms ease;
-}
-.grid-hover-molecule-strap:hover::before,
-.grid-hover-molecule-strap:focus-visible::before {
-  opacity: 1;
+.grid-hover-molecule-strap:hover,
+.grid-hover-molecule-strap:focus-visible {
+  color: var(--text-secondary);
+  outline: none;
 }
 .grid-hover-molecule-strap-grip {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 44px;
-  height: 4px;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 3px;
   border-radius: 999px;
-  background: var(--text-muted);
-  opacity: 0;
-  transition: opacity 140ms ease, width 140ms ease;
+  background: currentColor;
+  opacity: 0.6;
+  transition: width 140ms ease;
   pointer-events: none;
 }
 .grid-hover-molecule-strap:hover .grid-hover-molecule-strap-grip,
 .grid-hover-molecule-strap:focus-visible .grid-hover-molecule-strap-grip {
-  opacity: 1;
-  width: 56px;
+  width: 28px;
+}
+/* The name is what tells the bar apart from a divider, so it takes the row and
+   the chevron stays pinned to the trailing edge. */
+.grid-hover-molecule-strap-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11px;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-hover-molecule-strap-chevron {
+  flex: 0 0 auto;
 }
 @media (prefers-reduced-motion: reduce) {
   .activity-indicator-spinner { animation-duration: 2.4s; }

--- a/bun.lock
+++ b/bun.lock
@@ -137,7 +137,7 @@
     },
     "packages/burette": {
       "name": "burette",
-      "version": "2.3.8",
+      "version": "2.3.9",
       "bin": {
         "burette": "bin/burette.mjs",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "private": true,
   "description": "macOS desktop app and Quick Look extension for molecular previews: Mol* 3D, xyzrender SVG, and RDKit grids.",
   "packageManager": "bun@1.3.8",

--- a/packages/burette/package.json
+++ b/packages/burette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burette",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "private": true,
   "description": "Internal release and installation helper for the Burette macOS app and Quick Look extension.",
   "license": "MIT",

--- a/tests/test-ui-shell-contract.mjs
+++ b/tests/test-ui-shell-contract.mjs
@@ -2699,6 +2699,15 @@ assert.doesNotMatch(gridHoverMolecule, /Open molecule details/);
 assert.match(styles, /\.grid-hover-molecule-prop\[data-tone\^="outlier"\] \{/);
 assert.match(gridViewer, /props: hoverRowProps\(row\)/);
 assert.match(styles, /\.grid-hover-molecule \{[^}]*position: sticky;[^}]*bottom: -12px;[^}]*background: var\(--bg-base\);/s);
+// The drawing paints the card's own surface rather than trusting a transparent
+// SVG to show it: a see-through well came out white in the packaged runtime,
+// which hid the light-ink structure completely.
+assert.match(gridHoverMolecule, /backgroundColour: paper,/);
+assert.doesNotMatch(gridHoverMolecule, /clearBackground/);
+assert.match(styles, /\.grid-hover-molecule-svg \{[^}]*background: var\(--bg-base\);/s);
+// A put-away preview leaves a bar that names the molecule waiting, so the
+// space it frees reads as a collapsed card instead of an empty panel.
+assert.match(gridHoverMolecule, /className="grid-hover-molecule-strap-label">\{label\}<\/span>/);
 assert.match(appGridControlMessagesHook, /body\?\.type === "gridRowHover"/);
 assert.match(appGridControlMessagesHook, /smiles: typeof raw\.smiles === "string" \? raw\.smiles : null/);
 // Conformers and xTB share one card shell, and a missing binary has to say what


### PR DESCRIPTION
## What was wrong

The molecular inspector's hover preview asked RDKit for a transparent drawing (`clearBackground: false`) and trusted the card behind it to show through. In the packaged app the well came out white instead, so the dark theme's light-ink structure (`#DDDDDD` carbons, chosen precisely because RDKit's black skeleton is invisible on a dark card) landed on white paper and all but disappeared — only the heteroatom labels read.

Putting the card away left the second problem: a bare 16px strip whose grip only appeared once the pointer happened to cross it, so the space the card freed read as an empty panel with nothing in it and no way back.

## What changed

- The drawing paints its own paper: it asks RDKit for the colour the well is actually painted in (`backgroundColour`), and the well states that colour instead of borrowing whatever shows through. Ink and paper are now chosen together, so the preview cannot land light-on-light again whatever the runtime does with a transparent SVG. A custom theme background is followed without a second source of truth for it.
- The hover tint moves to an overlay, because the drawing is opaque now and would otherwise hide it.
- A collapsed preview is a bar that names the molecule still waiting, with a visible grip and chevron. Pull it up or click it, exactly as before.

## Verification

- `bun run test:ui`, `bun run typecheck`, `bun run ci:fast` (pre-push) — green.
- Checked in the running app, dark and light: dark draws light ink on the card's own `#111111`, light keeps RDKit's black-on-white palette. Collapse and restore round-trip.
- New contract assertions in `tests/test-ui-shell-contract.mjs` pin the paper colour and the named collapse bar.