### PR TITLE
Show molecule hover preview when the right dock is closed

### DIFF
--- a/PreviewExtension/Web/grid-viewer.js
+++ b/PreviewExtension/Web/grid-viewer.js
@@ -198,6 +198,8 @@
     findingSimilar: false,
     exportingClusterRepresentatives: false,
     clusterCutoff: storedClusterCutoff(),
+    tableMoleculePreview: null,
+    rightDockOpen: false,
     railHoveredMarker: null,
     railPopoverSuppressed: false,
     railPopoverHideTimer: null,
@@ -561,6 +563,8 @@
       }
       if (body.type === 'gridViewportCover') {
         setGridViewportCover(Number(body.cover) || 0);
+        state.rightDockOpen = body.rightDockOpen === true;
+        if (state.rightDockOpen) hideTableMoleculePreview();
         return;
       }
       if (body.type === 'workspaceHistoryCommand') {
@@ -7138,14 +7142,66 @@
   }
 
   function installTableMoleculeHover(rowEl, row, cfg) {
-    const picture = rowEl.querySelector('.buret-grid-table-molecule');
-    if (!picture) return;
-    picture.addEventListener('pointerenter', () => {
+    const picture = rowEl.querySelector('td[data-column="molecule"]');
+    if (!picture || !rowHasMolecule(row)) return;
+    picture.addEventListener('pointerenter', event => {
+      if (event.pointerType === 'touch') return;
       postChemicalSpaceHover(Number(row.index));
+      showTableMoleculePreview(event, row, cfg);
+    });
+    picture.addEventListener('pointermove', event => {
+      if (event.pointerType === 'touch') return;
+      if (!state.tableMoleculePreview) showTableMoleculePreview(event, row, cfg);
+      positionTableMoleculePreview(event);
     });
     picture.addEventListener('pointerleave', () => {
       postChemicalSpaceHover(null);
+      hideTableMoleculePreview();
     });
+    picture.addEventListener('contextmenu', hideTableMoleculePreview);
+  }
+
+  function showTableMoleculePreview(event, row, cfg) {
+    hideTableMoleculePreview();
+    if (state.rightDockOpen) return;
+    const label = row.name || `Molecule ${Number(row.index) + 1}`;
+    const popover = document.createElement('div');
+    popover.className = 'buret-grid-table-molecule-popover';
+    popover.setAttribute('role', 'tooltip');
+    popover.innerHTML = `
+      <div class="buret-grid-table-molecule-popover-image" data-buret-molecule-picture>${draw(row, cfg)}</div>
+      <div class="buret-grid-table-molecule-popover-title">${escapeHTML(label)}</div>`;
+    document.body.appendChild(popover);
+    state.tableMoleculePreview = popover;
+    scheduleRdkitCard(popover, row);
+    scheduleXyzrenderCard(popover, row, cfg);
+    window.addEventListener('scroll', hideTableMoleculePreview, true);
+    window.addEventListener('resize', hideTableMoleculePreview, true);
+    positionTableMoleculePreview(event);
+  }
+
+  function positionTableMoleculePreview(event) {
+    const popover = state.tableMoleculePreview;
+    if (!popover) return;
+    const margin = 12;
+    const offset = 16;
+    const rect = popover.getBoundingClientRect();
+    let left = event.clientX + offset;
+    let top = event.clientY + offset;
+    if (left + rect.width + margin > window.innerWidth) left = event.clientX - rect.width - offset;
+    if (top + rect.height + margin > window.innerHeight) top = window.innerHeight - rect.height - margin;
+    left = Math.max(margin, left);
+    top = Math.max(margin, top);
+    popover.style.left = `${Math.round(left)}px`;
+    popover.style.top = `${Math.round(top)}px`;
+  }
+
+  function hideTableMoleculePreview() {
+    if (!state.tableMoleculePreview) return;
+    state.tableMoleculePreview.remove();
+    state.tableMoleculePreview = null;
+    window.removeEventListener('scroll', hideTableMoleculePreview, true);
+    window.removeEventListener('resize', hideTableMoleculePreview, true);
   }
 
   function installCardResizeHandle(card) {

--- a/PreviewExtension/Web/grid.css
+++ b/PreviewExtension/Web/grid.css
@@ -1266,6 +1266,52 @@ body[data-buret-grid-view-mode="table"] .buret-grid {
   line-height: 1.15;
 }
 
+.buret-grid-table-molecule-popover {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1200;
+  width: min(148px, calc(100vw - 24px));
+  box-sizing: border-box;
+  padding: 6px;
+  pointer-events: none;
+  border: 0;
+  border-radius: 8px;
+  background: var(--buret-panel);
+  box-shadow: 0 10px 28px rgba(10, 24, 36, 0.18);
+}
+
+.buret-grid-table-molecule-popover-image {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border: 0;
+  border-radius: 6px;
+  background: var(--buret-picture-bg);
+}
+
+.buret-grid-table-molecule-popover-image svg,
+.buret-grid-table-molecule-popover-image img.buret-rdkit-card-image,
+.buret-grid-table-molecule-popover-image img.buret-xyzrender-card-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.buret-grid-table-molecule-popover-title {
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--buret-text);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Sticky header in the shadcn voice: medium weight, muted, on the blurred
    chrome surface the rest of the viewer uses for floating bars. CSS
    position:sticky cannot pin it — the horizontal scroll box around the table

--- a/apps/desktop/src/components/app-layout.tsx
+++ b/apps/desktop/src/components/app-layout.tsx
@@ -401,9 +401,13 @@ export function AppLayout({
       const dockEl = rightDockOpen ? rightDockElementRef.current : null;
       const dockLeft = dockEl?.getBoundingClientRect().left;
       const cover = dockLeft === undefined ? 0 : Math.max(0, Math.round(iframe.getBoundingClientRect().right - dockLeft));
-      postMessageToViewerSource(win, { source: "burette-grid-host", body: { type: "gridViewportCover", cover } });
+      postMessageToViewerSource(win, { source: "burette-grid-host", body: { type: "gridViewportCover", cover, rightDockOpen } });
     };
     post();
+    const onViewerLoad = (event: Event) => {
+      if (event.target === activeViewerIframeForDocument(activeGridId, "grid2d")) post();
+    };
+    window.addEventListener("load", onViewerLoad, true);
     const dockEl = rightDockElementRef.current;
     const observer = dockEl ? new ResizeObserver(() => post()) : null;
     if (dockEl && observer) observer.observe(dockEl);
@@ -412,6 +416,7 @@ export function AppLayout({
     return () => {
       observer?.disconnect();
       window.clearTimeout(timer);
+      window.removeEventListener("load", onViewerLoad, true);
     };
     // viewportWidth belongs here: when the dock overlaps a floored grid, a window
     // resize moves the dock without changing its size, so the dock's own observer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,11 @@ The desktop shell is a compact molecule workspace:
 Open molecule pages stay mounted while inactive when their renderer state should
 survive tab switches.
 
+Collection tables show a floating molecule preview when hovering the Mol cell
+with the right dock closed. Opening the dock dismisses that preview. The shell
+includes `rightDockOpen` in its `gridViewportCover` message; standalone grid
+previews default to showing the hover preview when this field is absent.
+
 Normal app launch remains a visible full-window launch. Registration-only
 maintenance may opt into `BURETTE_LAUNCH_MODE=register`; file-open and tray/menu
 paths still show the full app. See [Launch modes](launch-modes.md).

--- a/plugins/burette-agent/preview-web/grid-viewer.js
+++ b/plugins/burette-agent/preview-web/grid-viewer.js
@@ -198,6 +198,8 @@
     findingSimilar: false,
     exportingClusterRepresentatives: false,
     clusterCutoff: storedClusterCutoff(),
+    tableMoleculePreview: null,
+    rightDockOpen: false,
     railHoveredMarker: null,
     railPopoverSuppressed: false,
     railPopoverHideTimer: null,
@@ -561,6 +563,8 @@
       }
       if (body.type === 'gridViewportCover') {
         setGridViewportCover(Number(body.cover) || 0);
+        state.rightDockOpen = body.rightDockOpen === true;
+        if (state.rightDockOpen) hideTableMoleculePreview();
         return;
       }
       if (body.type === 'workspaceHistoryCommand') {
@@ -7138,14 +7142,66 @@
   }
 
   function installTableMoleculeHover(rowEl, row, cfg) {
-    const picture = rowEl.querySelector('.buret-grid-table-molecule');
-    if (!picture) return;
-    picture.addEventListener('pointerenter', () => {
+    const picture = rowEl.querySelector('td[data-column="molecule"]');
+    if (!picture || !rowHasMolecule(row)) return;
+    picture.addEventListener('pointerenter', event => {
+      if (event.pointerType === 'touch') return;
       postChemicalSpaceHover(Number(row.index));
+      showTableMoleculePreview(event, row, cfg);
+    });
+    picture.addEventListener('pointermove', event => {
+      if (event.pointerType === 'touch') return;
+      if (!state.tableMoleculePreview) showTableMoleculePreview(event, row, cfg);
+      positionTableMoleculePreview(event);
     });
     picture.addEventListener('pointerleave', () => {
       postChemicalSpaceHover(null);
+      hideTableMoleculePreview();
     });
+    picture.addEventListener('contextmenu', hideTableMoleculePreview);
+  }
+
+  function showTableMoleculePreview(event, row, cfg) {
+    hideTableMoleculePreview();
+    if (state.rightDockOpen) return;
+    const label = row.name || `Molecule ${Number(row.index) + 1}`;
+    const popover = document.createElement('div');
+    popover.className = 'buret-grid-table-molecule-popover';
+    popover.setAttribute('role', 'tooltip');
+    popover.innerHTML = `
+      <div class="buret-grid-table-molecule-popover-image" data-buret-molecule-picture>${draw(row, cfg)}</div>
+      <div class="buret-grid-table-molecule-popover-title">${escapeHTML(label)}</div>`;
+    document.body.appendChild(popover);
+    state.tableMoleculePreview = popover;
+    scheduleRdkitCard(popover, row);
+    scheduleXyzrenderCard(popover, row, cfg);
+    window.addEventListener('scroll', hideTableMoleculePreview, true);
+    window.addEventListener('resize', hideTableMoleculePreview, true);
+    positionTableMoleculePreview(event);
+  }
+
+  function positionTableMoleculePreview(event) {
+    const popover = state.tableMoleculePreview;
+    if (!popover) return;
+    const margin = 12;
+    const offset = 16;
+    const rect = popover.getBoundingClientRect();
+    let left = event.clientX + offset;
+    let top = event.clientY + offset;
+    if (left + rect.width + margin > window.innerWidth) left = event.clientX - rect.width - offset;
+    if (top + rect.height + margin > window.innerHeight) top = window.innerHeight - rect.height - margin;
+    left = Math.max(margin, left);
+    top = Math.max(margin, top);
+    popover.style.left = `${Math.round(left)}px`;
+    popover.style.top = `${Math.round(top)}px`;
+  }
+
+  function hideTableMoleculePreview() {
+    if (!state.tableMoleculePreview) return;
+    state.tableMoleculePreview.remove();
+    state.tableMoleculePreview = null;
+    window.removeEventListener('scroll', hideTableMoleculePreview, true);
+    window.removeEventListener('resize', hideTableMoleculePreview, true);
   }
 
   function installCardResizeHandle(card) {

--- a/plugins/burette-agent/preview-web/grid.css
+++ b/plugins/burette-agent/preview-web/grid.css
@@ -1266,6 +1266,52 @@ body[data-buret-grid-view-mode="table"] .buret-grid {
   line-height: 1.15;
 }
 
+.buret-grid-table-molecule-popover {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1200;
+  width: min(148px, calc(100vw - 24px));
+  box-sizing: border-box;
+  padding: 6px;
+  pointer-events: none;
+  border: 0;
+  border-radius: 8px;
+  background: var(--buret-panel);
+  box-shadow: 0 10px 28px rgba(10, 24, 36, 0.18);
+}
+
+.buret-grid-table-molecule-popover-image {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border: 0;
+  border-radius: 6px;
+  background: var(--buret-picture-bg);
+}
+
+.buret-grid-table-molecule-popover-image svg,
+.buret-grid-table-molecule-popover-image img.buret-rdkit-card-image,
+.buret-grid-table-molecule-popover-image img.buret-xyzrender-card-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.buret-grid-table-molecule-popover-title {
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--buret-text);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Sticky header in the shadcn voice: medium weight, muted, on the blurred
    chrome surface the rest of the viewer uses for floating bars. CSS
    position:sticky cannot pin it — the horizontal scroll box around the table

--- a/tests/test-grid-table-operations.mjs
+++ b/tests/test-grid-table-operations.mjs
@@ -363,4 +363,52 @@ function gridState(overrides = {}) {
   assert.equal(state.dirty, false);
 }
 
+// Hover uses the whole molecule cell, including its padding. The same runtime
+// must suppress the floating drawing while the host's right dock is open.
+{
+  const state = { rightDockOpen: false, tableMoleculePreview: null };
+  const listeners = {};
+  const previews = [];
+  const picture = { addEventListener(type, handler) { listeners[type] = handler; } };
+  const document = {
+    createElement() {
+      return { setAttribute() {}, remove() { this.removed = true; } };
+    },
+    body: { appendChild(node) { previews.push(node); } },
+  };
+  const install = new Function("state", "document", `
+    const window = { addEventListener() {}, removeEventListener() {} };
+    const rowHasMolecule = row => Boolean(row.smiles);
+    const postChemicalSpaceHover = () => {};
+    const draw = () => '<svg></svg>';
+    const escapeHTML = value => value;
+    const scheduleRdkitCard = () => {};
+    const scheduleXyzrenderCard = () => {};
+    const positionTableMoleculePreview = () => {};
+    ${functionSource("hideTableMoleculePreview")}
+    ${functionSource("showTableMoleculePreview")}
+    ${functionSource("installTableMoleculeHover")}
+    return installTableMoleculeHover;
+  `)(state, document);
+  install({ querySelector(selector) {
+    return selector === 'td[data-column="molecule"]' ? picture : null;
+  } }, { index: 0, name: "ethanol", smiles: "CCO" }, {});
+  assert.equal(typeof listeners.pointerenter, "function");
+  listeners.pointerenter({ pointerType: "mouse" });
+  assert.match(previews[0].innerHTML, /<svg><\/svg>/);
+  listeners.pointerleave();
+  assert.equal(previews[0].removed, true);
+  assert.equal(state.tableMoleculePreview, null);
+  state.rightDockOpen = true;
+  listeners.pointerenter({ pointerType: "mouse" });
+  listeners.pointermove({ pointerType: "mouse" });
+  assert.equal(previews.length, 1);
+  state.rightDockOpen = false;
+  listeners.pointermove({ pointerType: "mouse" });
+  assert.equal(previews.length, 2);
+  listeners.pointerleave();
+  listeners.pointerenter({ pointerType: "touch" });
+  assert.equal(state.tableMoleculePreview, null);
+}
+
 console.log("Grid table operation checks passed.");


### PR DESCRIPTION
When the right dock is closed, hovering the Mol cell now shows the molecule beside the pointer. Opening the dock dismisses the floating preview. The hover target includes the cell padding, and touch input does not open the preview.

Restores the existing grid preview implementation on current main, synchronizes the packaged plugin runtime, and forwards dock visibility on layout changes and viewer load. Applies to the shared grid runtime and desktop/browser shell; standalone previews retain hover behavior.

Validation: complete ci:fast passed, including grid table operation tests, UI shell contracts, Clippy and 609 Rust tests (7 ignored). Browser verification covers the dock-open and dock-closed states. Packaged native builds were not run.
