### PR TITLE
Fix menu pins and persist application icons in browser previews

### DIFF
--- a/apps/desktop/src/components/open-in-editor-menu.tsx
+++ b/apps/desktop/src/components/open-in-editor-menu.tsx
@@ -7,6 +7,7 @@ import type { MenuItemSpec } from "./menu-types";
 import { isTauriRuntime } from "../lib/tauri";
 import { useFinderIconUrl } from "../hooks/use-finder-icon-url";
 import { useDefaultApplicationIconUrl } from "../hooks/use-default-application-icon-url";
+import { AppImageIcon } from "./ui/app-image-icon";
 
 type ActiveFile = {
   path: string;
@@ -122,7 +123,7 @@ export function OpenInEditorMenu({ state, actions }: { state: ShellViewState; ac
         >
           <span className={preferredIconUrl ? "open-editor-trigger-icon open-editor-trigger-icon-image" : "open-editor-trigger-icon"} aria-hidden="true">
             {preferredIconUrl ? (
-              <img src={preferredIconUrl} alt="" aria-hidden="true" />
+              <AppImageIcon src={preferredIconUrl} fallback={openDestinationIconText(state.preferences.openInDefaultDestination, preferredTarget)} />
             ) : openDestinationIconText(state.preferences.openInDefaultDestination, preferredTarget)}
           </span>
           <svg className="open-editor-chevron" width="13" height="13" viewBox="0 0 13 13" aria-hidden="true">

--- a/apps/desktop/src/components/radix-menu.tsx
+++ b/apps/desktop/src/components/radix-menu.tsx
@@ -30,6 +30,7 @@ import { ScrubNumberField } from "@/components/ui/scrub-number-input";
 import type { MenuItemSpec } from "./menu-types";
 import { HugeiconsIcon } from "@hugeicons/react";
 import * as appIconData from "./ui/app-icon-data";
+import { AppImageIcon } from "./ui/app-image-icon";
 
 type RadixDropdownProps = {
   items: MenuItemSpec[];
@@ -302,7 +303,7 @@ function renderItemBody(item: Extract<MenuItemSpec, { kind: "item" | "checkbox" 
   return (
     <span className="radix-menu-item-body" title={tooltip}>
       {iconUrl ? (
-        <img className="radix-menu-item-icon" src={iconUrl} alt="" aria-hidden="true" />
+        <AppImageIcon className="radix-menu-item-icon" src={iconUrl} fallback={iconText ?? item.text.slice(0, 2).toUpperCase()} />
       ) : item.icon ? (
         <HugeiconsIcon className="radix-menu-item-icon" icon={appIconData[item.icon]} size={16} aria-hidden="true" />
       ) : iconText ? (

--- a/apps/desktop/src/components/ui/app-image-icon.tsx
+++ b/apps/desktop/src/components/ui/app-image-icon.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+/** Keep unavailable application artwork from rendering a broken-image symbol. */
+export function AppImageIcon({ src, fallback, className }: {
+  src: string;
+  fallback: string;
+  className?: string;
+}) {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  if (failedSrc === src) {
+    return <span className={className} aria-hidden="true">{fallback}</span>;
+  }
+  return (
+    <img
+      className={className}
+      src={src}
+      alt=""
+      aria-hidden="true"
+      onError={() => setFailedSrc(src)}
+    />
+  );
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2150,6 +2150,12 @@ kbd span { margin-left: 2px; }
   overflow: hidden;
 }
 .radix-menu-item-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  color: var(--text-secondary);
+}
+span.radix-menu-item-icon {
   width: 20px;
   height: 20px;
   flex: 0 0 20px;
@@ -2165,6 +2171,9 @@ kbd span { margin-left: 2px; }
   object-fit: cover;
 }
 img.radix-menu-item-icon {
+  width: 20px;
+  height: 20px;
+  flex-basis: 20px;
   display: block;
   background: transparent;
   border-radius: 0;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -86,10 +86,16 @@ const defaultFsAllow = defaultDevFileSources.map((path) => {
   }
 });
 const execFileAsync = promisify(execFile);
-const BROWSER_DEV_APP_ICONS: Record<string, string> = {
+const BROWSER_DEV_APP_ICONS = {
   "default-app": join(repoRoot, "apps", "desktop", "src-tauri", "icons", "icon.png"),
   finder: "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/FinderIcon.icns",
-  maestro: "/Applications/SchrodingerSuites2026-1/Maestro.app/Contents/Resources/Maestro.icns",
+  maestro: async () => {
+    const suites = (await readdir("/Applications"))
+      .filter((name) => /^SchrodingerSuites\d{4}-\d+$/u.test(name))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    return suites.map((suite) => join("/Applications", suite, "Maestro.app/Contents/Resources/Maestro.icns"))
+      .find((path) => existsSync(path));
+  },
   chimerax: "/Applications/ChimeraX-1.10.app/Contents/Resources/chimerax-icon.icns",
   pymol: "/Applications/PyMOL.app/Contents/Resources/pymol.icns",
   avogadro2: "/Applications/Avogadro2.app/Contents/Resources/avogadro.icns",

--- a/apps/desktop/vite/README.md
+++ b/apps/desktop/vite/README.md
@@ -26,6 +26,13 @@ route modules, but route bodies belong under `apps/desktop/vite/`.
 
 ## Contract Rules
 
+The browser-dev app icon route keeps converted PNGs under
+`~/Library/Caches/Burette/app-icons` on macOS (`~/.cache/Burette/app-icons`
+elsewhere). It reads a saved icon before looking for the application, so suite
+updates and repeated dev sessions do not trigger discovery or conversion.
+Delete an individual PNG to refresh that application's artwork. Missing images
+fall back to initials in menus and the Open In trigger.
+
 - Do not change browser-dev endpoint paths, methods, status codes, query
   parameters, or response shapes as part of a mechanical refactor.
 - Keep job lifecycle logic auditable: process registration, status reads,

--- a/apps/desktop/vite/browser-dev/assets.ts
+++ b/apps/desktop/vite/browser-dev/assets.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, rename, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import type { ViteDevServer } from "vite";
 
@@ -25,7 +26,7 @@ export function registerBrowserDevRdkitWasmRoute(server: ViteDevServer, rdkitWas
 
 export function registerBrowserDevAppIconRoute(
   server: ViteDevServer,
-  appIcons: Record<string, string>,
+  appIcons: Record<string, string | (() => Promise<string | undefined>)>,
   execFileAsync: ExecFileAsync,
 ) {
   server.middlewares.use("/__burette/app-icon/", async (req, res) => {
@@ -37,16 +38,27 @@ export function registerBrowserDevAppIconRoute(
     try {
       const url = new URL(req.url || "", "http://127.0.0.1");
       const id = decodeURIComponent(url.pathname.replace(/^\/+/, "")).replace(/\.png$/u, "");
-      const iconPath = appIcons[id];
-      if (!iconPath || !existsSync(iconPath)) {
+      if (!/^[a-z0-9-]+$/u.test(id) || !Object.hasOwn(appIcons, id)) {
         sendJson(res, 404, { error: "Icon not found" });
         return;
       }
-      const cacheDir = join(tmpdir(), "burette-app-icons");
+      const cacheDir = join(homedir(), process.platform === "darwin" ? "Library/Caches" : ".cache", "Burette", "app-icons");
       const outputPath = join(cacheDir, `${id}.png`);
       if (!existsSync(outputPath)) {
+        const source = appIcons[id];
+        const iconPath = typeof source === "function" ? await source() : source;
+        if (!iconPath || !existsSync(iconPath)) {
+          sendJson(res, 404, { error: "Icon not found" });
+          return;
+        }
         await mkdir(cacheDir, { recursive: true });
-        await execFileAsync("/usr/bin/sips", ["-s", "format", "png", iconPath, "--out", outputPath]);
+        const pendingPath = join(cacheDir, `${id}-${randomUUID()}.png`);
+        try {
+          await execFileAsync("/usr/bin/sips", ["-s", "format", "png", iconPath, "--out", pendingPath]);
+          await rename(pendingPath, outputPath);
+        } finally {
+          await rm(pendingPath, { force: true });
+        }
       }
       const bytes = await readFile(outputPath);
       res.statusCode = 200;

--- a/tests/test-open-in-editor-menu-contract.mjs
+++ b/tests/test-open-in-editor-menu-contract.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { registerBrowserDevAppIconRoute } from "../apps/desktop/vite/browser-dev/assets.ts";
 
 const menu = await readFile("apps/desktop/src/components/open-in-editor-menu.tsx", "utf8");
 const finderHook = await readFile("apps/desktop/src/hooks/use-finder-icon-url.ts", "utf8");
@@ -30,4 +33,49 @@ assert.match(tauriCommands, /URLForApplicationToOpenURL/);
 assert.match(tauriLib, /commands::chemical_editors::default_application_icon_path/);
 assert.match(tauriPermissions, /"default_application_icon_path"/);
 
-console.log("open-in-editor menu contract ok");
+// A new route instance must reuse the persistent icon without resolving the app
+// or invoking conversion again, even when the original app is no longer there.
+const iconId = `test-${randomUUID()}`;
+const sourceIcon = "apps/desktop/src-tauri/icons/icon.png";
+const expectedIcon = await readFile(sourceIcon);
+let discoveries = 0;
+let conversions = 0;
+let outputPath;
+let handler;
+const fakeVite = { middlewares: { use(_path, callback) { handler = callback; } } };
+registerBrowserDevAppIconRoute(fakeVite, {
+  [iconId]: async () => { discoveries++; return sourceIcon; },
+}, async (_command, args) => {
+  conversions++;
+  const pendingPath = args.at(-1);
+  outputPath = pendingPath.replace(/-[a-f0-9-]{36}\.png$/u, ".png");
+  await writeFile(pendingPath, expectedIcon);
+});
+const server = createServer((req, res) => { void handler(req, res); });
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const baseUrl = `http://127.0.0.1:${server.address().port}`;
+try {
+  const first = await fetch(`${baseUrl}/${iconId}.png`);
+  assert.equal(first.status, 200);
+  assert.equal(first.headers.get("content-type"), "image/png");
+  assert.deepEqual(Buffer.from(await first.arrayBuffer()), expectedIcon);
+  registerBrowserDevAppIconRoute(fakeVite, {
+    [iconId]: async () => { throw new Error("Cached icons must skip discovery"); },
+  }, async () => { throw new Error("Cached icons must skip conversion"); });
+  const cached = await fetch(`${baseUrl}/${iconId}.png`);
+  assert.equal(cached.status, 200);
+  assert.deepEqual(Buffer.from(await cached.arrayBuffer()), expectedIcon);
+  const head = await fetch(`${baseUrl}/${iconId}.png`, { method: "HEAD" });
+  assert.equal(head.status, 200);
+  assert.equal(await head.text(), "");
+  assert.equal((await fetch(`${baseUrl}/constructor.png`)).status, 404);
+  assert.equal((await fetch(`${baseUrl}/..%2F${iconId}.png`)).status, 404);
+  assert.equal((await fetch(`${baseUrl}/${iconId}.png`, { method: "POST" })).status, 405);
+  assert.deepEqual({ discoveries, conversions }, { discoveries: 1, conversions: 1 });
+} finally {
+  server.closeAllConnections();
+  await new Promise((resolve) => server.close(resolve));
+  if (outputPath) await rm(outputPath, { force: true });
+}
+
+console.log("open-in-editor menu and persistent icon cache contract ok");


### PR DESCRIPTION
Menu glyphs inherited application-icon badge styling, which enlarged the project pin and added a gray background. Browser-dev artwork also depended on an outdated Maestro suite path and a temporary cache.

This keeps menu glyphs at 16 px without a badge, adds initials when application images fail, discovers the installed Maestro suite, and stores converted icons in a persistent browser-dev cache. Saved icons are served before app discovery or conversion, including after a new dev session or removal of the original source. Cache writes are atomic and icon IDs remain allowlisted. Desktop menu styling and image fallbacks are shared; native discovery, Quick Look, and the tokenized preview server are unchanged.

Validation: focused menu/cache HTTP integration and UI shell contracts pass, including cache reuse without discovery/conversion, GET/HEAD, and rejected unknown/traversal IDs. In-app Browser verification confirmed a transparent 16 px project pin and all seven visible mini.pdb menu images loaded with no console errors. All eight configured icon endpoints returned PNGs. Commit hooks and the full Fast PR Validation job passed on the final commit. GitGuardian, blob-size checks, and Vercel are green; native bundle CI was correctly skipped because this patch does not touch native build scope. No version bump, release, or installation is included.
